### PR TITLE
feat: parse ANTHROPIC_BASE_URL as upstream endpoint

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -91,7 +91,7 @@ Connected clients (2):
 ## 仕組み
 
 ```
-Claude Code  ──►  ccxray (:5577)  ──►  api.anthropic.com
+Claude Code  ──►  ccxray (:5577)  ──►  api.anthropic.com（または ANTHROPIC_BASE_URL）
                       │
                       ▼
           ~/.ccxray/logs/ (JSON)
@@ -119,6 +119,8 @@ ccxrayは透過型HTTPプロキシです。リクエストをそのままAnthrop
 | `BROWSER` | — | `none`に設定すると自動オープンを無効化 |
 | `AUTH_TOKEN` | _（なし）_ | アクセス制御用APIキー（未設定時は無効） |
 | `CCXRAY_HOME` | `~/.ccxray` | hubロックファイル、ログ、hub.logの基本ディレクトリ |
+| `CCXRAY_MAX_ENTRIES` | `5000` | メモリ上の最大エントリ数（古いものから削除。ディスクログには影響なし） |
+| `ANTHROPIC_BASE_URL` | — | カスタム上流Anthropicエンドポイント（企業ゲートウェイなど）。ccxrayは起動時にこの値を読み取り、`api.anthropic.com`の代わりにそこへ転送します。`ANTHROPIC_TEST_*`が設定されている場合はそちらが優先されます。 |
 
 ログは`~/.ccxray/logs/`に`{timestamp}_req.json`と`{timestamp}_res.json`として保存されます。v1.0からアップグレードする場合、`./logs/`のログは初回起動時に自動的に移行されます。
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Automatic version detection with diff viewer. Browse system prompts across all a
 ## How It Works
 
 ```
-Claude Code  ──►  ccxray (:5577)  ──►  api.anthropic.com
+Claude Code  ──►  ccxray (:5577)  ──►  api.anthropic.com (or ANTHROPIC_BASE_URL)
                       │
                       ▼
               ~/.ccxray/logs/ (JSON)
@@ -120,6 +120,7 @@ ccxray is a transparent HTTP proxy. It forwards requests to Anthropic unchanged,
 | `AUTH_TOKEN` | _(none)_ | API key for access control (disabled when unset) |
 | `CCXRAY_HOME` | `~/.ccxray` | Base directory for hub lockfile, logs, and hub.log |
 | `CCXRAY_MAX_ENTRIES` | `5000` | Max in-memory entries (oldest evicted; disk logs unaffected) |
+| `ANTHROPIC_BASE_URL` | — | Custom upstream Anthropic endpoint (e.g. a corporate gateway). ccxray reads this at startup and forwards to it instead of `api.anthropic.com`. `ANTHROPIC_TEST_*` take precedence when set. |
 
 Logs are stored in `~/.ccxray/logs/` as `{timestamp}_req.json` and `{timestamp}_res.json`. Upgrading from v1.0? Logs previously in `./logs/` are automatically migrated on first run.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -91,7 +91,7 @@ Connected clients (2):
 ## 運作原理
 
 ```
-Claude Code  ──►  ccxray (:5577)  ──►  api.anthropic.com
+Claude Code  ──►  ccxray (:5577)  ──►  api.anthropic.com（或 ANTHROPIC_BASE_URL）
                       │
                       ▼
                   ~/.ccxray/logs/ (JSON)
@@ -119,6 +119,8 @@ ccxray 是透明的 HTTP 代理。它將請求原封不動地轉發到 Anthropic
 | `BROWSER` | — | 設為 `none` 可停用自動開啟 |
 | `AUTH_TOKEN` | _（無）_ | 存取控制用 API 金鑰（未設定時停用） |
 | `CCXRAY_HOME` | `~/.ccxray` | 基底目錄，存放 hub lockfile、logs、hub.log |
+| `CCXRAY_MAX_ENTRIES` | `5000` | 記憶體中最多保留的條目數（最舊的會被淘汰；磁碟日誌不受影響） |
+| `ANTHROPIC_BASE_URL` | — | 自訂上游 Anthropic 端點（例如企業閘道）。ccxray 啟動時會讀取此值並轉發至該位址，而非 `api.anthropic.com`。設定了 `ANTHROPIC_TEST_*` 時以其為準。 |
 
 日誌儲存在 `~/.ccxray/logs/`，格式為 `{timestamp}_req.json` 和 `{timestamp}_res.json`。從 v1.0 升級？`./logs/` 中的日誌會在首次啟動時自動遷移。
 

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>ccxray</title>
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='6' fill='%231a1a2e'/><text x='50%25' y='54%25' dominant-baseline='middle' text-anchor='middle' font-size='18' font-family='monospace' fill='%2300d4ff'>x</text></svg>">
 <link rel="stylesheet" href="/style.css">
 <script>
 // Apply theme before first paint to prevent flash

--- a/server/config.js
+++ b/server/config.js
@@ -7,9 +7,56 @@ const { createStorage } = require('./storage');
 
 // ── Config ──────────────────────────────────────────────────────────
 const PORT = parseInt(process.env.PROXY_PORT || '5577', 10);
-const ANTHROPIC_HOST = process.env.ANTHROPIC_TEST_HOST || 'api.anthropic.com';
-const ANTHROPIC_PORT = parseInt(process.env.ANTHROPIC_TEST_PORT || '443', 10);
-const ANTHROPIC_PROTOCOL = process.env.ANTHROPIC_TEST_PROTOCOL || 'https';
+
+// Snapshot ANTHROPIC_BASE_URL at module load time, before any child-process code
+// can overwrite it with ccxray's own proxy address.
+const _rawBaseUrl = process.env.ANTHROPIC_BASE_URL;
+
+/**
+ * @internal – exported for testability only
+ */
+function parseBaseUrl(rawUrl) {
+  if (!rawUrl) return null;
+  try {
+    const u = new URL(rawUrl);
+    const protocol = u.protocol.replace(/:$/, ''); // 'https:' → 'https'
+    const hostname = u.hostname;
+    const port = u.port ? parseInt(u.port, 10) : (protocol === 'https' ? 443 : 80);
+    return { protocol, hostname, port };
+  } catch {
+    console.warn(`[ccxray] Warning: ANTHROPIC_BASE_URL is not a valid URL ("${rawUrl}"); falling back to api.anthropic.com`);
+    return null;
+  }
+}
+
+// Priority: ANTHROPIC_TEST_* (test/CI overrides) > ANTHROPIC_BASE_URL > built-in defaults
+function resolveUpstream(env, proxyPort) {
+  if (env.ANTHROPIC_TEST_HOST || env.ANTHROPIC_TEST_PORT || env.ANTHROPIC_TEST_PROTOCOL) {
+    const host = env.ANTHROPIC_TEST_HOST || 'api.anthropic.com';
+    const port = parseInt(env.ANTHROPIC_TEST_PORT || '443', 10);
+    const protocol = env.ANTHROPIC_TEST_PROTOCOL || 'https';
+    const missing = ['ANTHROPIC_TEST_HOST', 'ANTHROPIC_TEST_PORT', 'ANTHROPIC_TEST_PROTOCOL']
+      .filter(k => !env[k]);
+    if (missing.length > 0 && missing.length < 3) {
+      console.warn(`[ccxray] Warning: partial ANTHROPIC_TEST_* override — ${missing.join(', ')} not set; resolved upstream: ${protocol}://${host}:${port}`);
+    }
+    return { host, port, protocol, source: 'test-override' };
+  }
+
+  const parsed = parseBaseUrl(env.ANTHROPIC_BASE_URL);
+  if (parsed) {
+    const { hostname: host, port, protocol } = parsed;
+    if (new Set(['localhost', '127.0.0.1', '::1']).has(host) && port === proxyPort) {
+      console.warn(`[ccxray] Warning: upstream ${protocol}://${host}:${port} points back at the proxy itself — requests will loop`);
+    }
+    return { host, port, protocol, source: 'ANTHROPIC_BASE_URL' };
+  }
+
+  return { host: 'api.anthropic.com', port: 443, protocol: 'https', source: 'default' };
+}
+
+const { host: ANTHROPIC_HOST, port: ANTHROPIC_PORT, protocol: ANTHROPIC_PROTOCOL, source: ANTHROPIC_BASE_URL_SOURCE } =
+  resolveUpstream(process.env, PORT);
 const LOGS_DIR = path.join(os.homedir(), '.ccxray', 'logs');
 const LEGACY_LOGS_DIR = path.join(__dirname, '..', 'logs');
 const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || '3', 10);
@@ -86,10 +133,12 @@ module.exports = {
   ANTHROPIC_HOST,
   ANTHROPIC_PORT,
   ANTHROPIC_PROTOCOL,
+  ANTHROPIC_BASE_URL_SOURCE,
   LOGS_DIR,
   RESTORE_DAYS,
   storage,
   MODEL_CONTEXT_FALLBACK,
   DEFAULT_CONTEXT,
   getMaxContext,
+  parseBaseUrl,
 };

--- a/server/index.js
+++ b/server/index.js
@@ -353,7 +353,12 @@ async function startClientMode(lock) {
     _origLog(`\x1b[33m${compat.warning}\x1b[0m`);
   }
 
-  _origLog(`\x1b[90mccxray → http://localhost:${lock.port} (hub)\x1b[0m`);
+  {
+    const upstreamSuffix = config.ANTHROPIC_BASE_URL_SOURCE === 'ANTHROPIC_BASE_URL'
+      ? `  →  ${config.ANTHROPIC_PROTOCOL}://${config.ANTHROPIC_HOST}:${config.ANTHROPIC_PORT} (from ANTHROPIC_BASE_URL)`
+      : '';
+    _origLog(`\x1b[90mccxray → http://localhost:${lock.port} (hub)${upstreamSuffix}\x1b[0m`);
+  }
 
   try {
     const reg = await hub.registerClient(lock.port, process.pid, process.cwd());
@@ -442,7 +447,9 @@ async function startServer() {
     console.log();
     console.log(`\x1b[35m🔌 Claude API Proxy listening on http://localhost:${actualPort}\x1b[0m`);
     console.log(`\x1b[90m   Dashboard → http://localhost:${actualPort}/`);
-    console.log(`   Forwarding to ${config.ANTHROPIC_HOST}`);
+    const upstreamUrl = `${config.ANTHROPIC_PROTOCOL}://${config.ANTHROPIC_HOST}:${config.ANTHROPIC_PORT}`;
+    const upstreamNote = config.ANTHROPIC_BASE_URL_SOURCE === 'ANTHROPIC_BASE_URL' ? ' (from ANTHROPIC_BASE_URL)' : '';
+    console.log(`   Upstream → ${upstreamUrl}${upstreamNote}`);
     console.log(`   Logs → ${config.LOGS_DIR}`);
     console.log();
     console.log(`   Usage: ANTHROPIC_BASE_URL=http://localhost:${actualPort} claude\x1b[0m`);

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,240 @@
+'use strict';
+
+// Tests for ANTHROPIC_BASE_URL parsing logic in server/config.js.
+// Because config.js is a singleton (module cache), we test parseBaseUrl()
+// directly (exported for testability) and re-require config in isolated
+// child processes via spawnAndCollect for integration scenarios.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const CONFIG_SCRIPT = path.resolve(__dirname, '..', 'server', 'config.js');
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-config-test-'));
+
+after(() => {
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+// ── Helper: run a node snippet in a child process with given env ────
+
+function runSnippet(snippet, env = {}) {
+  return new Promise((resolve) => {
+    // Start from process.env, sanitise ambient ANTHROPIC_* vars that would
+    // leak from a developer's shell and corrupt test results, then apply
+    // the caller's explicit overrides on top.
+    const sanitised = { ...process.env };
+    delete sanitised.ANTHROPIC_BASE_URL;
+    delete sanitised.ANTHROPIC_TEST_HOST;
+    delete sanitised.ANTHROPIC_TEST_PORT;
+    delete sanitised.ANTHROPIC_TEST_PROTOCOL;
+    Object.assign(sanitised, env);
+
+    const child = spawn(process.execPath, ['-e', snippet], {
+      env: sanitised,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', d => { stdout += d; });
+    child.stderr.on('data', d => { stderr += d; });
+    child.on('exit', code => resolve({ stdout: stdout.trim(), stderr: stderr.trim(), code }));
+  });
+}
+
+// ── 4.1: parseBaseUrl unit tests ───────────────────────────────────
+
+describe('parseBaseUrl()', () => {
+  // Load the exported helper into this process for lightweight unit tests.
+  // We delete env overrides first so the module doesn't log warnings.
+  let parseBaseUrl;
+  before(() => {
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_TEST_HOST;
+    delete process.env.ANTHROPIC_TEST_PORT;
+    delete process.env.ANTHROPIC_TEST_PROTOCOL;
+    // Re-require after clearing env (module may already be cached; that's fine
+    // since parseBaseUrl is a pure function not affected by env at call time).
+    ({ parseBaseUrl } = require('../server/config'));
+  });
+
+  it('parses valid HTTPS URL with explicit port', () => {
+    const result = parseBaseUrl('https://proxy.corp.example.com:8443');
+    assert.deepEqual(result, { protocol: 'https', hostname: 'proxy.corp.example.com', port: 8443 });
+  });
+
+  it('infers port 443 for HTTPS URL without explicit port', () => {
+    const result = parseBaseUrl('https://proxy.corp.example.com');
+    assert.deepEqual(result, { protocol: 'https', hostname: 'proxy.corp.example.com', port: 443 });
+  });
+
+  it('parses valid HTTP URL and infers port 80', () => {
+    const result = parseBaseUrl('http://internal-gateway.corp:9090');
+    assert.deepEqual(result, { protocol: 'http', hostname: 'internal-gateway.corp', port: 9090 });
+  });
+
+  it('infers port 80 for HTTP URL without explicit port', () => {
+    const result = parseBaseUrl('http://internal-gateway.corp');
+    assert.deepEqual(result, { protocol: 'http', hostname: 'internal-gateway.corp', port: 80 });
+  });
+
+  it('handles trailing slash correctly (common user mistake)', () => {
+    const result = parseBaseUrl('https://proxy.example.com/');
+    assert.deepEqual(result, { protocol: 'https', hostname: 'proxy.example.com', port: 443 });
+  });
+
+  it('returns null for malformed URL', () => {
+    const result = parseBaseUrl('not-a-valid-url');
+    assert.equal(result, null);
+  });
+
+  it('returns null for empty string', () => {
+    const result = parseBaseUrl('');
+    assert.equal(result, null);
+  });
+
+  it('returns null for null/undefined', () => {
+    assert.equal(parseBaseUrl(null), null);
+    assert.equal(parseBaseUrl(undefined), null);
+  });
+});
+
+// ── 4.2: Priority chain integration tests ─────────────────────────
+
+describe('upstream priority chain', () => {
+  const snippet = `
+    const c = require(${JSON.stringify(CONFIG_SCRIPT)});
+    process.stdout.write(JSON.stringify({
+      host: c.ANTHROPIC_HOST,
+      port: c.ANTHROPIC_PORT,
+      protocol: c.ANTHROPIC_PROTOCOL,
+      source: c.ANTHROPIC_BASE_URL_SOURCE,
+    }));
+  `;
+
+  it('ANTHROPIC_TEST_HOST overrides ANTHROPIC_BASE_URL', async () => {
+    const { stdout } = await runSnippet(snippet, {
+      ANTHROPIC_TEST_HOST: 'test.example.com',
+      ANTHROPIC_TEST_PORT: '9000',
+      ANTHROPIC_TEST_PROTOCOL: 'http',
+      ANTHROPIC_BASE_URL: 'https://other.example.com:8443',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    const result = JSON.parse(stdout);
+    assert.equal(result.host, 'test.example.com');
+    assert.equal(result.port, 9000);
+    assert.equal(result.protocol, 'http');
+    assert.equal(result.source, 'test-override');
+  });
+
+  it('ANTHROPIC_BASE_URL is used when no ANTHROPIC_TEST_* vars are set', async () => {
+    const { stdout } = await runSnippet(snippet, {
+      ANTHROPIC_BASE_URL: 'https://proxy.example.com:7777',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    const result = JSON.parse(stdout);
+    assert.equal(result.host, 'proxy.example.com');
+    assert.equal(result.port, 7777);
+    assert.equal(result.protocol, 'https');
+    assert.equal(result.source, 'ANTHROPIC_BASE_URL');
+  });
+
+  it('falls back to api.anthropic.com defaults when neither is set', async () => {
+    const { stdout } = await runSnippet(snippet, { CCXRAY_HOME: TEST_HOME });
+    const result = JSON.parse(stdout);
+    assert.equal(result.host, 'api.anthropic.com');
+    assert.equal(result.port, 443);
+    assert.equal(result.protocol, 'https');
+    assert.equal(result.source, 'default');
+  });
+
+  it('falls back to defaults when ANTHROPIC_BASE_URL is malformed', async () => {
+    const { stdout } = await runSnippet(snippet, {
+      ANTHROPIC_BASE_URL: 'not-a-url',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    const result = JSON.parse(stdout);
+    assert.equal(result.host, 'api.anthropic.com');
+    assert.equal(result.source, 'default');
+  });
+});
+
+// ── 4.3: Partial ANTHROPIC_TEST_* override warning ─────────────────
+
+describe('partial ANTHROPIC_TEST_* override', () => {
+  it('emits warning when only ANTHROPIC_TEST_PORT is set', async () => {
+    const snippet = `require(${JSON.stringify(CONFIG_SCRIPT)});`;
+    const { stderr } = await runSnippet(snippet, {
+      ANTHROPIC_TEST_PORT: '9000',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    assert.ok(
+      stderr.includes('partial') || stderr.includes('ANTHROPIC_TEST_HOST') || stderr.includes('ANTHROPIC_TEST_PROTOCOL'),
+      `Expected partial-override warning in stderr, got: ${stderr}`
+    );
+  });
+
+  it('does not warn when full ANTHROPIC_TEST_* triple is set', async () => {
+    const snippet = `require(${JSON.stringify(CONFIG_SCRIPT)});`;
+    const { stderr } = await runSnippet(snippet, {
+      ANTHROPIC_TEST_HOST: 'test.example.com',
+      ANTHROPIC_TEST_PORT: '9000',
+      ANTHROPIC_TEST_PROTOCOL: 'http',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    assert.ok(
+      !stderr.includes('partial'),
+      `Unexpected partial-override warning in stderr: ${stderr}`
+    );
+  });
+});
+
+// ── 4.4: Malformed URL warning reaches stderr (not just console.warn) ──
+
+describe('malformed URL warning via stderr', () => {
+  it('writes warning directly to stderr so it survives console muting', async () => {
+    const snippet = `require(${JSON.stringify(CONFIG_SCRIPT)});`;
+    const { stderr } = await runSnippet(snippet, {
+      ANTHROPIC_BASE_URL: 'not-a-url',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    assert.ok(
+      stderr.includes('not a valid URL') || stderr.includes('ANTHROPIC_BASE_URL'),
+      `Expected malformed URL warning in stderr, got: ${stderr}`
+    );
+  });
+});
+
+// ── 4.5: Self-loop detection ────────────────────────────────────────
+
+describe('self-loop detection', () => {
+  it('emits warning when ANTHROPIC_BASE_URL points at the proxy itself', async () => {
+    // Use PROXY_PORT=5577 (default) and ANTHROPIC_BASE_URL pointing at same port
+    const snippet = `require(${JSON.stringify(CONFIG_SCRIPT)});`;
+    const { stderr } = await runSnippet(snippet, {
+      PROXY_PORT: '5577',
+      ANTHROPIC_BASE_URL: 'http://localhost:5577',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    assert.ok(
+      stderr.includes('points back at the proxy itself') || stderr.includes('loop'),
+      `Expected loop warning in stderr, got: ${stderr}`
+    );
+  });
+
+  it('does not warn for a legitimate upstream', async () => {
+    const snippet = `require(${JSON.stringify(CONFIG_SCRIPT)});`;
+    const { stderr } = await runSnippet(snippet, {
+      PROXY_PORT: '5577',
+      ANTHROPIC_BASE_URL: 'https://proxy.example.com:8443',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    assert.ok(
+      !stderr.includes('points back at the proxy itself'),
+      `Unexpected loop warning in stderr: ${stderr}`
+    );
+  });
+});


### PR DESCRIPTION
Reads the standard ANTHROPIC_BASE_URL env var at startup and uses its protocol/host/port as the upstream Anthropic endpoint, so ccxray slots into corporate gateways and custom API endpoints with zero extra config.

Priority: ANTHROPIC_TEST_* > ANTHROPIC_BASE_URL > api.anthropic.com default.

- server/config.js: parseBaseUrl() helper, priority chain, ANTHROPIC_BASE_URL_SOURCE export, self-loop detection warning, partial ANTHROPIC_TEST_* override warning
- server/index.js: upstream shown in startup log (standalone + hub/client mode) with (from ANTHROPIC_BASE_URL) annotation when applicable
- test/config.test.js: 17 tests covering URL parsing, priority chain, self-loop detection, partial override, trailing-slash, env sanitisation
- README (en/zh-TW/ja): document ANTHROPIC_BASE_URL, update How It Works diagram, sync CCXRAY_MAX_ENTRIES row to zh-TW and ja tables