### PR TITLE
feat(turn-card): V3 五行版型重設計

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,83 @@
+# Data Model
+
+Reference for the entry summary objects broadcast from server to dashboard via SSE, and persisted to `~/.ccxray/logs/index.ndjson`.
+
+## Entry summary
+
+Produced by `server/sse-broadcast.js` `summarizeEntry()`. The full request/response payloads are NOT included — they live on disk and are lazy-loaded when a turn is selected.
+
+### Core identity
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Turn ID, format `YYYY-MM-DDTHH-MM-SS-mmm` |
+| `ts` | number | Unix ms, when proxy first received the request |
+| `receivedAt` | number \| null | Alias of `ts` retained for client-side gap timing |
+| `sessionId` | string | Session ID (from request `metadata.user_id`, or inferred) |
+| `sessionInferred` | boolean | true if session was attributed by inference (no explicit ID) |
+| `method` | string | HTTP method (always `POST` for /v1/messages) |
+| `url` | string | Request path |
+| `cwd` | string \| null | Working dir extracted from system prompt |
+| `isSubagent` | boolean | true if request has no cwd in system prompt (spawned via Agent tool) |
+
+### Request shape
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `model` | string \| null | Model ID from request body (e.g., `claude-opus-4-6`) |
+| `msgCount` | number | Length of `messages[]` |
+| `toolCount` | number | Length of `tools[]` |
+| `toolCalls` | object | `{ toolName: count }` — tool_use blocks across messages |
+
+### Response outcome
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | number | HTTP status code |
+| `elapsed` | string | Seconds as 1-decimal string (e.g., `"4.3"`) |
+| `isSSE` | boolean | true if upstream response was streaming |
+| `stopReason` | string | API `stop_reason` (`end_turn` \| `tool_use` \| `max_tokens` \| …) |
+| `title` | string \| null | Turn description. Cascade: response text → last user text → tool-result summary (`↩ ToolA · ToolB`) → subagent's first user text |
+| `thinkingDuration` | number \| null | Extended-thinking seconds if captured from SSE |
+
+### Usage & cost
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `usage` | object \| null | `{ input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens }` |
+| `cost` | object \| null | `{ cost, inputCost, outputCost, cacheReadCost, cacheWriteCost }` |
+| `maxContext` | number | Model context window (200K / 1M based on `[1m]` suffix in system prompt) |
+| `tokens` | object \| null | `{ system, tools, messages, total, contextBreakdown, perMessage }` — structural breakdown from `tokenizeRequest` |
+
+### Risk signals
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `toolFail` | boolean | At least one `tool_result` in the request had `is_error: true` |
+| `duplicateToolCalls` | object \| null | `{ toolName: extraCount }` — repeated tool_use with same input |
+| `hasCredential` | boolean \| undefined | Credential pattern (API key, SSH key, etc.) detected in response or messages |
+| `toolSources` | object \| undefined | `{ tool_use_id: 'network' \| 'local' \| 'local:sensitive' }` — taint classification |
+
+## Backward compatibility
+
+Older `index.ndjson` entries may lack newer fields. Consumers SHOULD use nullish-coalescing defaults:
+
+```js
+const toolFail = entry.toolFail ?? false;
+const duplicateToolCalls = entry.duplicateToolCalls ?? null;
+const hasCredential = entry.hasCredential ?? false;
+```
+
+## Where fields are computed
+
+| Field | Source file |
+|-------|-------------|
+| `usage`, `cost` | `server/pricing.js` |
+| `maxContext` | `server/config.js` `getMaxContext()` |
+| `title` | `server/forward.js` title cascade using `server/helpers.js` extractors |
+| `tokens` | `server/helpers.js` `tokenizeRequest()` |
+| `toolCalls`, `duplicateToolCalls` | `server/helpers.js` `extractToolCalls()` / `extractDuplicateToolCalls()` |
+| `toolFail` | `server/helpers.js` `hasToolFail()` |
+| `hasCredential` | `server/helpers.js` `entryHasCredential()` |
+| `toolSources` | `server/helpers.js` `buildToolSources()` |
+| `isSubagent`, `cwd` | `server/store.js` `extractCwd()` |

--- a/openspec/changes/turn-card-v2-expert-redesign/.openspec.yaml
+++ b/openspec/changes/turn-card-v2-expert-redesign/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/turn-card-v2-expert-redesign/design.md
+++ b/openspec/changes/turn-card-v2-expert-redesign/design.md
@@ -31,7 +31,8 @@
 ```
 │ #65  sonnet-4-6  ●  !max            $0.03 │  Line 1: 識別 + critical risk + 成本
 │ Refactor auth middleware for GitHub login  │  Line 2: title（null 時省略）
-│ ████████████████▓▒░░░░  ctx:42%  hit:86%  │  Line 3: ctx bar（全寬）+ 雙標籤
+│ ██████████████████████████████████████████│  Line 3: ctx bar 全寬
+│                          ctx:42%  hit:86% │         標籤小字右下角
 │ 9.6s  wait:11s  think:4.4s  Bash Read     │  Line 4: 時間 + tools
 │ cred  tool-fail  dupes×3                  │  Line 5: warning/notice risk（有才顯示）
 ```
@@ -41,7 +42,8 @@
 ```
 │ #65  sonnet-4-6  ●                  $0.03 │
 │ Refactor auth middleware for GitHub login  │
-│ ████████████████▓▒░░░░  ctx:42%  hit:86%  │
+│ ██████████████████████████████████████████│
+│                          ctx:42%  hit:86% │
 │ 9.6s  wait:11s  Bash Read                 │
 │ cred  tool-fail                           │
 ```
@@ -51,7 +53,8 @@
 ```
 │ #65  sonnet-4-6  ●                  $0.03 │
 │ Refactor auth middleware for GitHub login  │
-│ ████████████████▓▒░░░░  ctx:42%  hit:86%  │
+│ ██████████████████████████████████████████│
+│                          ctx:42%  hit:86% │
 │ 9.6s  Bash Read                           │
 ```
 
@@ -62,7 +65,8 @@ title 為 null 時 line 2 省略（card 最少兩行）。
 ```
 │ ↳s1  sonnet-4-6  ●                  $0.01 │  ↳ 代表從屬關係
 │   Agent invocation                         │
-│   ████████░░░░░░░  ctx:12%  hit:94%        │  bar 與 ↳ 對齊縮排
+│   ████████████████████████████████████████│  bar 與 ↳ 對齊縮排
+│                         ctx:12%  hit:94%   │  標籤小字右下角
 │   5.2s  Bash Read                          │
 ```
 
@@ -98,9 +102,9 @@ Critical 訊號升到 line 1，緊跟在 `●` 後面、成本左邊。Warning /
 | Signal | Marker |
 |--------|--------|
 | `stopReason === 'max_tokens'` | `!max` |
-| `stopReason === 'content_filter'` | `!filter` |
 | `stopReason === 'length'` | `!len` |
 | 其他非 `end_turn`/`tool_use` | `!stop` |
+| `stopReason === 'content_filter'` | `!filter` |
 | HTTP 非 2xx | `!http` |
 
 - 最多顯示一個 critical marker（最高優先序）；若有多個 critical 以優先序取第一個，其餘摺疊進 line 5
@@ -124,13 +128,15 @@ Critical 訊號升到 line 1，緊跟在 `●` 後面、成本左邊。Warning /
 
 ### 4. 全寬 ctx bar（Line 3）
 
-Line 3 是一條佔滿 card 寬度的 3px 高彩色橫條 + 右側雙標籤：
+Line 3 是一條佔滿 card 寬度的彩色橫條，標籤以小字沉在 bar 右下角：
 
 ```
-████████████████████▓▒░░░░  ctx:42%  hit:86%
+██████████████████████████████████████████████
+                                ctx:42% hit:86%
 ```
 
-- 三色 segment：cache-read（青）/ cache-write（橙）/ input（紫）
+- Bar 全寬延伸，三色 segment：cache-read（青）/ cache-write（橙）/ input（紫）
+- 標籤位於 bar 正下方右對齊，字級比 bar 更小（輔助確認用）
 - `ctx:NN%` = 當前 context window 使用率（`ctxUsed / maxContext`），顏色隨 severity tier 變色
 - `hit:NN%` = cache hit rate（`cache_read / total_tokens`），固定青色（與 bar 同色系）
 - Tooltip on bar：精確 token 數 + 各類百分比

--- a/openspec/changes/turn-card-v2-expert-redesign/design.md
+++ b/openspec/changes/turn-card-v2-expert-redesign/design.md
@@ -1,0 +1,176 @@
+## Context
+
+四位資訊設計專家（Tufte / Few / Ware / Victor）獨立評審後的共識：
+
+- **Ware**：status 應編碼到 position channel（左邊）而非小 dot，利用 peripheral vision
+- **Tufte**：移除 chartjunk（emoji、`·` 分隔符）、直接 label 勝過圖例
+- **Few**：color 是稀缺資源、應給 exception；normal state 必須 recede
+- **Victor**：cache composition 是 cost 的成因訊號，不該消失
+
+前版 `turn-card-redesign` 在視覺層次上有進步，但在 pre-attentive、composition、時間語意三個維度仍有缺口。v2 在此基礎上追加 UX 評審，確立最終規格。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 成本在第一行右側，掃描路徑必然經過
+- 全寬 ctx bar 同時顯示 context 佔用與 cache hit rate，兩者有明確微標籤
+- Critical 風險升到第一行（不漏看）；warning/notice 留在底部（降低噪音）
+- 時間資訊明確：elapsed / wait / think 各自有語意前綴
+- Subagent 以 `↳` 明示「從屬關係」，不只是縮排
+- 無 emoji（risk 改用純文字標籤）
+
+**Non-Goals:**
+- 不實作 session KPI 條（先不做）
+- 不實作 trajectory sparkline（延後）
+- 不改 server 端資料結構
+
+## Layout
+
+### 主 agent turn（最多五行）
+
+```
+│ #65  sonnet-4-6  ●  !max            $0.03 │  Line 1: 識別 + critical risk + 成本
+│ Refactor auth middleware for GitHub login  │  Line 2: title（null 時省略）
+│ ████████████████▓▒░░░░  ctx:42%  hit:86%  │  Line 3: ctx bar（全寬）+ 雙標籤
+│ 9.6s  wait:11s  think:4.4s  Bash Read     │  Line 4: 時間 + tools
+│ cred  tool-fail  dupes×3                  │  Line 5: warning/notice risk（有才顯示）
+```
+
+無 critical 時 line 1 不含 risk 標籤：
+
+```
+│ #65  sonnet-4-6  ●                  $0.03 │
+│ Refactor auth middleware for GitHub login  │
+│ ████████████████▓▒░░░░  ctx:42%  hit:86%  │
+│ 9.6s  wait:11s  Bash Read                 │
+│ cred  tool-fail                           │
+```
+
+無任何 risk 時 line 5 整行省略：
+
+```
+│ #65  sonnet-4-6  ●                  $0.03 │
+│ Refactor auth middleware for GitHub login  │
+│ ████████████████▓▒░░░░  ctx:42%  hit:86%  │
+│ 9.6s  Bash Read                           │
+```
+
+title 為 null 時 line 2 省略（card 最少兩行）。
+
+### Subagent turn
+
+```
+│ ↳s1  sonnet-4-6  ●                  $0.01 │  ↳ 代表從屬關係
+│   Agent invocation                         │
+│   ████████░░░░░░░  ctx:12%  hit:94%        │  bar 與 ↳ 對齊縮排
+│   5.2s  Bash Read                          │
+```
+
+## Decisions
+
+### 1. 五行版型
+
+- **Line 1** turn#（主用 `#N`、subagent 用 `↳sN`）、model、status dot `●`、critical risk 標籤（有才顯示）、成本（右對齊）
+- **Line 2** 僅 title；null 則整行省略
+- **Line 3** 全寬 ctx bar + `ctx:NN%  hit:NN%`
+- **Line 4** 時間欄位 + tools
+- **Line 5** warning/notice risk 標籤；無 risk 則整行省略
+
+### 2. Severity 三層與左色條
+
+三層 severity taxonomy，同時作用於左色條與 context% 顏色：
+
+| Tier | CSS token | 觸發條件 |
+|------|-----------|---------|
+| `critical` | `.risk-critical`（紅） | ctx > 95% / HTTP 非 2xx / abnormal stop |
+| `warning` | `.risk-warning`（橙） | ctx 85–95% / `hasCredential` / `toolFail` |
+| `notice` | `.risk-notice`（黃） | `duplicateToolCalls` |
+| — | 無 | 以上皆無 |
+
+左色條：2px 寬、整張 card 高度、靠左。
+
+### 3. Risk 訊號分層呈現（方案 C）
+
+Critical 訊號升到 line 1，緊跟在 `●` 後面、成本左邊。Warning / notice 留在 line 5。
+
+**Critical markers（出現在 line 1）：**
+
+| Signal | Marker |
+|--------|--------|
+| `stopReason === 'max_tokens'` | `!max` |
+| `stopReason === 'content_filter'` | `!filter` |
+| `stopReason === 'length'` | `!len` |
+| 其他非 `end_turn`/`tool_use` | `!stop` |
+| HTTP 非 2xx | `!http` |
+
+- 最多顯示一個 critical marker（最高優先序）；若有多個 critical 以優先序取第一個，其餘摺疊進 line 5
+- 無 critical 時 line 1 的 marker 位置完全隱藏（不留空格）
+- 成本永遠右對齊，不因 marker 存在而位移
+
+**Warning / notice markers（出現在 line 5）：**
+
+| Signal | Tier | Marker |
+|--------|------|--------|
+| `hasCredential` | warning | `cred` |
+| `toolFail` | warning | `tool-fail` |
+| `duplicateToolCalls` | notice | `dupes×N`（N = 最多重複的工具總呼叫次數） |
+
+- 多個 warning/notice 依序排列，空格分隔
+- Overflow（>5 個）時後面摺疊為 `+N`
+- 無 warning/notice 且 critical 已在 line 1 時，line 5 不出現
+- 無任何 risk 時 line 5 整行省略
+
+**不使用 emoji**。所有 marker 為純 ASCII 文字。
+
+### 4. 全寬 ctx bar（Line 3）
+
+Line 3 是一條佔滿 card 寬度的 3px 高彩色橫條 + 右側雙標籤：
+
+```
+████████████████████▓▒░░░░  ctx:42%  hit:86%
+```
+
+- 三色 segment：cache-read（青）/ cache-write（橙）/ input（紫）
+- `ctx:NN%` = 當前 context window 使用率（`ctxUsed / maxContext`），顏色隨 severity tier 變色
+- `hit:NN%` = cache hit rate（`cache_read / total_tokens`），固定青色（與 bar 同色系）
+- Tooltip on bar：精確 token 數 + 各類百分比
+- 隱藏條件：usage 為 null 或 total tokens = 0 時整行隱藏
+
+### 5. 時間欄位（Line 4）
+
+格式：`{elapsed}  [wait:{gap}]  [think:{thinking}]  {tools}`
+
+- `elapsed`：本 turn 耗時（`e.elapsed + 's'`），永遠顯示
+- `wait:N`：與上一個 turn 的 idle gap，顏色隨 cache warmth（綠 < 5m、黃 5m–1h、紅 > 1h）；無前一 turn 時省略
+- `think:N`：extended thinking 耗時；無 thinking 時省略
+- `tools`：tool chip 列表，最多 3 個，超出折疊為 `+N`
+
+### 6. Subagent 識別
+
+Subagent 以 `↳sN` 前綴（N = session 內 subagent 序號），明示從屬關係。主 turn 用 `#N`。
+
+- `↳` 在字型中渲染為向右下的箭頭，清楚表示「由上層呼叫」
+- Subagent 永遠顯示 model name（不受省略規則影響）
+- Line 3 bar 與 `↳` 對齊縮排，使層次感延伸到 bar
+
+### 7. ↵ 等待指示符
+
+`↵` 出現在 line 1 的 `●` 之後（stop reason 為 `end_turn` 時），表示 Claude 等待用戶回應。
+
+### 8. Model 省略規則
+
+同 session 內，當前主 turn 與上一個主 turn 使用同一 model，且相隔 ≤ 5 entries，則省略 model name。Subagent 永遠顯示。
+
+### 9. 移除的元素
+
+- `.turn-risk` layer → 移除；risk 改分層到 line 1 / line 5
+- `.compact-badge`、`.inferred-badge`、`.turn-meta` → 移除；compact/inferred 僅掛 `title` tooltip
+- `·` 分隔符 → 完全移除，用 CSS gap
+- Emoji → 全部移除，改純文字縮寫
+
+## Risks / Trade-offs
+
+- **Critical 在 line 1 空間擠壓**：成本永遠右對齊，critical marker 在成本左側，若 marker 文字長（最長 `!filter`，7 chars）需測試是否擠壓 model name
+- **Cache hit rate 標籤新增**：`hit:NN%` 標籤增加少量寬度，需確認窄視窗下不截斷
+- **Wait/think 語意學習成本**：`wait:` / `think:` 前綴需要一次性學習，接受此 trade-off（初次 hover 可用 tooltip 補充）
+- **Line 5 在底部**：warning/notice 可能被忽略，但 critical 已升到 line 1，此 trade-off 可接受

--- a/openspec/changes/turn-card-v2-expert-redesign/proposal.md
+++ b/openspec/changes/turn-card-v2-expert-redesign/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+雖然 `turn-card-redesign` 改善了資訊層次，但專家評審（Tufte / Few / Ware / Victor）揭露幾個結構性問題：符號氾濫（`● ↵ ⏸ ⚠ ·` 五種 shape 相互競爭 pre-attentive channel）、狀態訊號埋沒（小 dot 無法 peripheral 感知）、紫色模型名浪費最強視覺資源、cache composition 資訊在上一版被意外移除（失去 cost-why 的主要訊號）。此次重設計把 state 編碼到左邊框色條、移除多餘 emoji、重新放回 cache composition bar，並依使用者優先序（turn# / sub / success-fail / context → cost / time / risk / tools）重整版位。
+
+## What Changes
+
+- **左邊框色條取代 status dot**：整張卡左側 2px 高度色條編碼最嚴重狀態（紅/橙/黃/無），取代既有 `.status-dot`。Peripheral vision 可感知
+- **風險 inline markers 取代 ⚠ badges**：`⚠ tool-fail` → `✗tool`、`⚠ dupes` → `⟳Name×N`、`⚠ cred` → `🔑cred`、`⚠ max_tokens` → `✂max`；全部移入 secondary line，刪除獨立 risk line
+- **Cache composition bar 放回 secondary line**：3 色 inline bar（cache-read 綠 / cache-write 橘 / input 黃，約 8 chars 寬）+ `NN%c` cache hit 文字標，緊鄰 cost 顯示
+- **Context % 右上單獨顯示**：大字、按嚴重度變色（灰 / 黃 > 70% / 紅 > 95%）
+- **移除分隔符 `·`**：改 flexbox gap 與欄位對齊
+- **模型名 dim + session 內省略**：連續同 model 時省略顯示；model 變動時才重現
+- **移除 `compactBadge`、`inferredBadge`、綠 dot**：compact/inferred 僅存 tooltip；成功狀態無 dot（無色條）
+- **三層壓縮為三行**：line1 identity+ctx%、line2 title、line3 time+composition+tools+cost
+- **BREAKING**：移除 `.turn-identity` 內的 `.status-dot`、`.turn-risk` layer、`.turn-meta`；新增 `.turn-left-bar`、`.turn-composition`、`.inline-marker`
+
+## Capabilities
+
+### New Capabilities
+
+- `turn-card-v2`: 第二版 turn card 視覺規格，涵蓋左邊框色條、inline markers、cache composition、model 省略規則
+
+### Modified Capabilities
+
+- `turn-card-display`: 整體重構，layer 從五層變三行；原五層 spec 中的 risk line / status dot 需求移除或重新定義
+
+## Impact
+
+- `public/entry-rendering.js`：重寫 turn card HTML 建構（縮小 ~40 行）
+- `public/style.css`：新增 left-bar / composition / inline-marker styles，移除 risk-layer / status-dot
+- `openspec/specs/` — 未來 archive 時需合併 turn-card-display spec 的 delta
+- 無 server 端變更，既有 `toolFail` / `duplicateToolCalls` / `hasCredential` / `stopReason` 欄位已足夠
+- Client 舊資料相容：同前

--- a/openspec/changes/turn-card-v2-expert-redesign/specs/turn-card-display/spec.md
+++ b/openspec/changes/turn-card-v2-expert-redesign/specs/turn-card-display/spec.md
@@ -1,0 +1,17 @@
+## REMOVED Requirements
+
+### Requirement: Turn card has five-layer visual hierarchy
+**Reason**: v2 compresses to three lines; the "five layer" abstraction is replaced by a cleaner three-line pattern where risk is inlined into the secondary line rather than being its own layer.
+**Migration**: See `turn-card-v2` spec. Existing `.turn-risk` DOM elements are removed entirely.
+
+### Requirement: Identity line shows turn number, model, status dot, wait indicator
+**Reason**: Status dot is replaced by the left-edge color bar (Ware's position channel is more effective than small dots). Model name is now session-aware (omitted when unchanged).
+**Migration**: Remove `.status-dot` CSS and span. Add `.turn-left-bar` class on the `.turn-item`.
+
+### Requirement: Risk badges surface actionable signals
+**Reason**: `⚠` emoji badges caused symbol competition with other glyphs and failed Tufte's data-ink principle. Replaced by inline markers within the secondary line.
+**Migration**: Remove `.turn-risk` layer and all `*-badge` classes except `.cred-highlight` (used in detail view). Emit compact inline markers (`✗tool`, `⟳Name×N`, `🔑cred`, `✂max`) on secondary line.
+
+### Requirement: compact and inferred metadata available via tooltip
+**Reason**: Retained in spirit but made stricter — the v2 spec forbids the `turn-meta` text suffix entirely; only tooltip remains.
+**Migration**: Remove `.turn-meta` span output. Keep tooltip attribute.

--- a/openspec/changes/turn-card-v2-expert-redesign/specs/turn-card-v2/spec.md
+++ b/openspec/changes/turn-card-v2-expert-redesign/specs/turn-card-v2/spec.md
@@ -79,9 +79,9 @@ Critical markers SHALL use plain ASCII text only. No emoji. Priority order (high
 | ctx > 95% | *(left bar + ctx label only, no inline marker)* | 1 |
 | HTTP non-2xx | `!http` | 2 |
 | `stopReason === 'max_tokens'` | `!max` | 3 |
-| `stopReason === 'content_filter'` | `!filter` | 4 |
-| `stopReason === 'length'` | `!len` | 5 |
-| any other non-`end_turn`/`tool_use` | `!stop` | 6 |
+| `stopReason === 'length'` | `!len` | 4 |
+| any other non-`end_turn`/`tool_use` | `!stop` | 5 |
+| `stopReason === 'content_filter'` | `!filter` | 6 |
 
 #### Scenario: max_tokens stop
 
@@ -104,12 +104,12 @@ Critical markers SHALL use plain ASCII text only. No emoji. Priority order (high
 
 ### Requirement: Line 3 — full-width ctx bar with dual labels
 
-Line 3 is a full-width 3px-high color bar representing token composition, followed by two labels.
+Line 3 is a full-width color bar representing token composition. The dual labels (`ctx:NN%` and `hit:NN%`) are rendered in small text at the bottom-right corner beneath the bar, right-aligned. The bar itself stretches the full card width.
 
 #### Scenario: Normal cached turn
 
 - **WHEN** usage has cache_read 18000, cache_write 2000, input 1000
-- **THEN** line 3 shows: full-width bar with proportional segments + `ctx:42%` + `hit:86%`
+- **THEN** line 3 shows: full-width bar with proportional segments; below-right: `ctx:42%  hit:86%`
 
 #### Scenario: ctx% label color
 

--- a/openspec/changes/turn-card-v2-expert-redesign/specs/turn-card-v2/spec.md
+++ b/openspec/changes/turn-card-v2-expert-redesign/specs/turn-card-v2/spec.md
@@ -1,0 +1,338 @@
+## Turn Card v2 Display Spec
+
+### Requirement: Turn card has five-line layout
+
+A turn card SHALL render at most five lines: identity, title, ctx-bar, secondary, risk. Lines 2, 3, and 5 are conditional and may be omitted entirely.
+
+#### Scenario: Full card with all lines
+
+- **WHEN** a turn has title, usage data, and risk signals of multiple tiers
+- **THEN** five lines render in order: identity, title, ctx-bar, secondary, risk
+
+#### Scenario: No title
+
+- **WHEN** `entry.title` is null
+- **THEN** line 2 is omitted; no blank line appears between identity and ctx-bar
+
+#### Scenario: No usage data
+
+- **WHEN** `usage` is null or total tokens is zero
+- **THEN** line 3 (ctx-bar) is omitted entirely
+
+#### Scenario: No risk signals
+
+- **WHEN** no risk signals of any tier are present
+- **THEN** line 5 is omitted entirely; no blank line appears
+
+#### Scenario: Minimum card
+
+- **WHEN** turn has no title, no usage, and no risk signals
+- **THEN** only identity line and secondary line render (two lines)
+
+---
+
+### Requirement: Line 1 — identity, critical risk, cost
+
+Line 1 SHALL render: turn number, model name (conditional), status dot, wait indicator (conditional), critical risk marker (conditional, max one), cost (right-aligned).
+
+#### Scenario: Main turn layout
+
+- **WHEN** turn is a main agent turn
+- **THEN** line 1 format: `#N  model  ●  [↵]  [!marker]            $0.03`
+
+#### Scenario: Subagent turn layout
+
+- **WHEN** turn is a subagent turn
+- **THEN** line 1 format: `↳sN  model  ●  [↵]  [!marker]           $0.01`
+- **AND** `↳` prefix replaces `#`; subagent sequence number replaces turn number
+
+#### Scenario: Critical marker present
+
+- **WHEN** a critical-tier risk signal exists
+- **THEN** the highest-priority critical marker appears between `●` (or `↵`) and the cost
+- **AND** the marker is plain ASCII text, no emoji
+- **AND** cost remains right-aligned regardless of marker presence
+
+#### Scenario: Multiple critical signals
+
+- **WHEN** more than one critical-tier signal is present
+- **THEN** only the highest-priority marker appears on line 1; remaining critical markers are demoted to line 5
+
+#### Scenario: No critical signal
+
+- **WHEN** no critical-tier signal is present
+- **THEN** no marker slot exists on line 1; cost fills the right side without empty gap
+
+#### Scenario: No cost data
+
+- **WHEN** cost is null
+- **THEN** cost field is omitted; no placeholder rendered
+
+---
+
+### Requirement: Critical marker vocabulary (line 1)
+
+Critical markers SHALL use plain ASCII text only. No emoji. Priority order (highest first):
+
+| Signal | Marker | Priority |
+|--------|--------|----------|
+| ctx > 95% | *(left bar + ctx label only, no inline marker)* | 1 |
+| HTTP non-2xx | `!http` | 2 |
+| `stopReason === 'max_tokens'` | `!max` | 3 |
+| `stopReason === 'content_filter'` | `!filter` | 4 |
+| `stopReason === 'length'` | `!len` | 5 |
+| any other non-`end_turn`/`tool_use` | `!stop` | 6 |
+
+#### Scenario: max_tokens stop
+
+- **WHEN** `stopReason` is `max_tokens`
+- **THEN** line 1 shows `!max` between status dot and cost
+
+#### Scenario: HTTP error
+
+- **WHEN** HTTP status is not 2xx
+- **THEN** line 1 shows `!http`
+
+---
+
+### Requirement: Line 2 — title
+
+- **WHEN** `entry.title` is non-null and non-empty
+- **THEN** line 2 renders the title text, truncated with ellipsis if it overflows the card width
+
+---
+
+### Requirement: Line 3 — full-width ctx bar with dual labels
+
+Line 3 is a full-width 3px-high color bar representing token composition, followed by two labels.
+
+#### Scenario: Normal cached turn
+
+- **WHEN** usage has cache_read 18000, cache_write 2000, input 1000
+- **THEN** line 3 shows: full-width bar with proportional segments + `ctx:42%` + `hit:86%`
+
+#### Scenario: ctx% label color
+
+- **WHEN** context percentage ≤ 70%
+- **THEN** `ctx:NN%` label is dim gray
+
+- **WHEN** context percentage is 71–95%
+- **THEN** `ctx:NN%` label is yellow (warning color)
+
+- **WHEN** context percentage > 95%
+- **THEN** `ctx:NN%` label is red (critical color)
+
+#### Scenario: hit% label color
+
+- **WHEN** hit% label is visible
+- **THEN** `hit:NN%` label is always cache-read color (cyan), regardless of value
+
+#### Scenario: Bar segment colors
+
+- **THEN** cache-read segment uses `var(--color-cache-read)` (cyan)
+- **AND** cache-write segment uses `var(--color-cache-write)` (orange)
+- **AND** input segment uses `var(--color-input)` (purple)
+
+#### Scenario: Bar tooltip
+
+- **WHEN** line 3 is visible
+- **THEN** hovering the bar shows precise token counts and percentages for each present source; absent sources are not listed
+
+#### Scenario: No usage data
+
+- **WHEN** `usage` is null, or `cache_read + cache_write + input === 0`
+- **THEN** line 3 is omitted entirely
+
+#### Scenario: Segment minimum width
+
+- **WHEN** a non-zero segment would render narrower than 2px
+- **THEN** that segment renders with `min-width: 2px`
+
+---
+
+### Requirement: Line 4 — time and tools
+
+Line 4 renders elapsed time, optional gap, optional thinking duration, and tool chips.
+
+Format: `{elapsed}  [wait:{gap}]  [think:{thinking}]  {tools}`
+
+#### Scenario: First turn in session
+
+- **WHEN** no previous turn in session has `receivedAt`
+- **THEN** only `elapsed` shows; no `wait:` field
+
+#### Scenario: Gap present
+
+- **WHEN** a previous turn exists and gap is computable
+- **THEN** `wait:{formatted-gap}` appears after elapsed, colored by cache warmth tier:
+  - gap < 5 minutes → green
+  - gap 5 minutes to 1 hour → yellow
+  - gap > 1 hour → red
+
+#### Scenario: Thinking duration present
+
+- **WHEN** `thinkingDuration` is non-null
+- **THEN** `think:{N}s` appears after gap (or after elapsed if no gap)
+
+#### Scenario: Tool chips
+
+- **WHEN** turn has tool calls
+- **THEN** tool names render as chips, max 3; overflow collapses to `+N`
+- **AND** `Agent` tool chip uses distinct visual style (e.g. `chip-agent` class)
+
+#### Scenario: No tools
+
+- **WHEN** turn has no tool calls
+- **THEN** no tools section; elapsed (and optional wait/think) fills line 4
+
+---
+
+### Requirement: Line 5 — warning and notice risk signals
+
+Line 5 shows warning-tier and notice-tier risk signals as plain text labels. Critical-tier signals are on line 1, not line 5.
+
+#### Scenario: Warning signals
+
+- **WHEN** `hasCredential` is true
+- **THEN** line 5 includes `cred`
+
+- **WHEN** `toolFail` is true
+- **THEN** line 5 includes `tool-fail`
+
+#### Scenario: Notice signals
+
+- **WHEN** `duplicateToolCalls` has any entry with count ≥ 2
+- **THEN** line 5 includes `dupes×N` where N is the highest total call count among duplicated tools
+
+#### Scenario: No warning or notice signals
+
+- **WHEN** no warning-tier or notice-tier signals are present
+- **THEN** line 5 is omitted entirely
+
+#### Scenario: Multiple signals ordering
+
+- **WHEN** multiple warning/notice signals are present
+- **THEN** order is: `cred` → `tool-fail` → `dupes×N`; space-separated, no other separators
+
+#### Scenario: Overflow
+
+- **WHEN** more than 5 signals would render on line 5
+- **THEN** first 5 render in severity order, remainder collapses to `+N`
+
+#### Scenario: No emoji
+
+- **WHEN** any risk signal renders
+- **THEN** no emoji character appears anywhere on the card; all markers are plain ASCII
+
+---
+
+### Requirement: Left-edge color bar encodes highest severity
+
+Each turn card SHALL have a 2px-wide left border whose color encodes the highest severity signal across all tiers.
+
+#### Scenario: No issues
+
+- **WHEN** no risk signals present
+- **THEN** left border is invisible (background color)
+
+#### Scenario: Critical
+
+- **WHEN** any critical-tier signal is present
+- **THEN** left border is red
+
+#### Scenario: Warning only
+
+- **WHEN** warning-tier signal present, no critical
+- **THEN** left border is orange
+
+#### Scenario: Notice only
+
+- **WHEN** notice-tier signal present, no critical or warning
+- **THEN** left border is yellow
+
+#### Scenario: Severity precedence
+
+- **THEN** precedence: critical > warning > notice
+
+---
+
+### Requirement: Subagent visual distinction
+
+#### Scenario: Subagent prefix
+
+- **WHEN** turn is a subagent
+- **THEN** line 1 starts with `↳sN` (e.g. `↳s1`, `↳s2`)
+- **AND** `↳` is never used for main turns
+
+#### Scenario: Main turn prefix
+
+- **WHEN** turn is a main agent turn
+- **THEN** line 1 starts with `#N`
+
+#### Scenario: Subagent always shows model
+
+- **WHEN** turn is subagent
+- **THEN** model name is always rendered, regardless of session-aware omission rules
+
+---
+
+### Requirement: Model name omitted only when safe (main turns only)
+
+For main turns, model name SHALL be omitted only when it matches the immediately previous main turn in the same session AND no more than 5 entries have passed since that previous main turn.
+
+#### Scenario: First main turn in session
+
+- **WHEN** session has no previous main turn
+- **THEN** model name renders
+
+#### Scenario: Same model, close previous main turn
+
+- **WHEN** previous main turn used same model AND ≤ 5 entries have passed
+- **THEN** model name is NOT rendered
+
+#### Scenario: Distant or changed model
+
+- **WHEN** > 5 entries have passed, or model changed
+- **THEN** model name IS rendered
+
+---
+
+### Requirement: Wait indicator on line 1
+
+#### Scenario: end_turn stop reason
+
+- **WHEN** `stopReason === 'end_turn'`
+- **THEN** `↵` appears on line 1 between `●` and any critical marker (or cost if no marker)
+
+#### Scenario: tool_use or other
+
+- **WHEN** `stopReason` is not `end_turn`
+- **THEN** no `↵` indicator
+
+---
+
+### Requirement: Compact and inferred in tooltip only
+
+#### Scenario: Compacted or inferred session
+
+- **WHEN** turn is compacted or session is inferred
+- **THEN** no visible text on card; information accessible only via `title` tooltip on line 1 element
+
+---
+
+### Requirement: Combined scenarios
+
+#### Scenario: Critical + warning + no title
+
+- **WHEN** `stopReason === 'max_tokens'`, `toolFail === true`, no title
+- **THEN** line 1: `#65  sonnet-4-6  ●  !max  $0.03`; line 2 omitted; line 3: ctx bar; line 4: time + tools; line 5: `tool-fail`
+
+#### Scenario: No risk, no title, no usage
+
+- **WHEN** all three absent
+- **THEN** only line 1 (identity + cost) and line 4 (time) render
+
+#### Scenario: Subagent with critical
+
+- **WHEN** subagent turn has HTTP error
+- **THEN** line 1: `↳s2  sonnet-4-6  ●  !http  $0.00`; left bar red

--- a/openspec/changes/turn-card-v2-expert-redesign/tasks.md
+++ b/openspec/changes/turn-card-v2-expert-redesign/tasks.md
@@ -1,82 +1,89 @@
-## 1. CSS — New classes (additive first, safe)
+## V3 Turn Card — Implementation Tasks
 
-- [x] 1.1 新增 `.turn-item.risk-critical { border-left: 2px solid var(--red); }`、`.risk-warning { ... var(--orange) }`、`.risk-notice { ... var(--yellow) }`（取代既有 `.turn-item { border-left: 3px solid transparent }`，寬度縮到 2px）
-- [x] 1.2 驗證三個 severity 色條在 dark / light 兩個 theme 下對比度足夠（禁用近背景色）
-- [x] 1.3 新增 `.turn-composition`：flex 容器，`width: 60px; height: 3px;`，3 個 span segment
-- [x] 1.4 新增 `.comp-read`、`.comp-write`、`.comp-input`：使用現有 `--color-cache-read` / `--color-cache-write` / `--color-input`，`min-width: 2px`
-- [x] 1.5 新增 `.turn-cache-pct`：font-size 9px、dim color
-- [x] 1.6 新增 `.inline-marker` base class；子類 `.marker-critical`（紅）/ `.marker-warning`（橙）/ `.marker-notice`（黃）；font-size 9px、flex-shrink: 0
-- [x] 1.7 新增 `.turn-ctx-pct-inline`：identity line 右側的大字 %，severity 對應顏色（critical 紅 / warning 黃 / 其他 dim）
+### 1. CSS — Severity left border (2px)
 
-## 2. CSS — Remove deprecated classes
+- [x] 1.1 `.turn-item` 改 `border-left: 2px solid transparent`（原為 3px）
+- [x] 1.2 新增 `.turn-item.risk-critical { border-left-color: var(--red) }`、`.risk-warning { --color-warning }`、`.risk-notice { --color-yellow }`
+- [x] 1.3 `.turn-sub` 移除 `border-left-color: transparent !important`，讓嚴重性色條可正常顯示；保留 `.turn-sub.selected` 的橙色高亮
 
-- [x] 2.1 移除 `.status-dot`、`.status-dot-ok`、`.status-dot-err`
-- [x] 2.2 移除 `.turn-risk`、`.tool-fail-badge`、`.max-tokens-badge`、`.dupe-badge`、`.cred-badge`（保留 `.cred-highlight` 給 detail view）
-- [x] 2.3 移除 `.turn-meta`
-- [x] 2.4 移除 `.turn-ctx-bar`、`.turn-ctx-bar-bg`（context bar 被拆成 ctx% 文字 + composition bar）
-- [x] 2.5 移除 `.turn-sep`（`·` 分隔符）
-- [x] 2.6 `.turn-identity`、`.turn-title`、`.turn-secondary` 的 gap / margin 重調整（確認 model 省略時不留 ghost gap）
+### 2. CSS — Identity line: cost 右對齊 + critical marker
 
-## 3. JS — Severity classification
+- [x] 2.1 `.turn-item .turn-cost` 加 `margin-left: auto; flex-shrink: 0;`（cost 永遠在 identity line 最右）
+- [x] 2.2 新增 `.turn-critical-marker { font-size: 10px; color: var(--red); font-weight: bold; flex-shrink: 0; }`
+- [x] 2.3 移除 `.turn-item .turn-sep`（不再使用 `·` 分隔符）
 
-- [x] 3.1 新 helper `classifySeverity(entry, ctxPct)` 回傳 `'critical' | 'warning' | 'notice' | null`，依 precedence：ctx>95% / HTTP非2xx / abnormal stop → ctx 85–95% / cred / tool-fail → dupes → none
-- [x] 3.2 新 helper `isAbnormalStop(stopReason)` 判斷非 `end_turn`/`tool_use` 即為 abnormal
-- [x] 3.3 severity class 套用到 `.turn-item` 根元素
+### 3. CSS — Full-width ctx bar + dual labels
 
-## 4. JS — Three-line rendering
+- [x] 3.1 `.turn-ctx-bar-bg` 高度改為 `4px`，保持 `display: flex`、無寬度限制
+- [x] 3.2 新增 `.turn-ctx-labels { display: flex; justify-content: flex-end; gap: 6px; font-size: 9px; margin-top: 1px; line-height: 1; }`
+- [x] 3.3 `.turn-ctx-pct` 改為無預設 color（顏色由子 class 控制）；新增 `.turn-ctx-pct.ctx-critical { color: var(--red) }`、`.ctx-warning { color: var(--yellow) }`、無 class 時 `color: var(--dim)`
+- [x] 3.4 新增 `.turn-hit-pct { color: var(--color-cache-read); }`
 
-- [x] 4.1 重寫 turn card innerHTML：三行結構（identity / title / secondary），title 為 null 時不 append
-- [x] 4.2 Identity line：`#N` + model（見 4.3）+ `↵`（若 `end_turn`）+ `NN%` 右對齊；collapse spacing when model omitted
-- [x] 4.3 模型省略邏輯：查詢 allEntries 倒序找上一個同 sessionId && !isSubagent 的 entry；僅當 model 相同**且距離 ≤ 5 entries** 才省略；subagent 永遠顯示
-- [x] 4.4 Secondary line 固定順序：`elapsed [⏸gap]` → composition+%c → inline markers → tools → cost；缺欄位 skip 不插佔位符
+### 4. CSS — Secondary line: wait/think，Line 5: risk
 
-## 5. JS — Inline markers
+- [x] 4.1 `.turn-item .turn-secondary` 移除 `gap: 5px`，改 `gap: 6px`，`flex-wrap: nowrap`
+- [x] 4.2 新增 `.turn-wait-gap { white-space: nowrap; }`
+- [x] 4.3 新增 `.turn-think { color: var(--purple); white-space: nowrap; }`
+- [x] 4.4 新增 `.turn-risk-line { font-size: 9px; color: var(--dim); margin-top: 2px; }`
 
-- [x] 5.1 `markerForHttpErr`（無輸出，由左條負責）、`markerForAbnormalStop(stopReason)`：
-  - `max_tokens` → `✂max`
-  - `content_filter` → `⛔filter`
-  - `length` → `✂len`
-  - 其他非 `end_turn`/`tool_use` → `!stop`
-  - critical class
-- [x] 5.2 `markerForCred`：`🔑cred`（warning）
-- [x] 5.3 `markerForToolFail`：`✗tool`（warning）
-- [x] 5.4 `markerForDupes(dupes)`：從 `duplicateToolCalls` 物件找**重複次數最高**的 tool（平手取首次出現）；計算該 tool 在此 turn 的**總呼叫次數 N**；Name 超過 12 chars 截斷為 `Name…`；marker 文字 `⟳Name×N`；N < 2 不 render；tooltip 顯示完整名稱 + 精確次數
-- [x] 5.5 Markers 排序嚴格固定：critical → warning → notice；各 tier 內也固定順序
-- [x] 5.6 Overflow 規則：渲染出超過 3 個 marker 時，顯示前 3 個 + `<span class="inline-marker marker-notice">+N</span>`（N = 被隱藏數）
-- [x] 5.7 Marker 顏色來自 `.marker-*` class，不得 inline style hardcode
+### 5. CSS — Dead code cleanup
 
-## 6. JS — Composition bar
+- [x] 5.1 移除 `.cred-badge`、`.dupe-badge`、`.tool-fail-badge`、`.max-tokens-badge`
+- [x] 5.2 移除 `.sub-indent`
+- [x] 5.3 移除 `.turn-item .turn-risk`（舊 risk badges layer）
+- [x] 5.4 移除 `.turn-item .turn-meta`
 
-- [x] 6.1 新函式 `renderComposition(usage)`：回傳 composition bar HTML + cache-pct label 或空字串
-- [x] 6.2 隱藏條件：usage null / total (`cache_read + cache_write + input`) === 0 / 無法產出有意義 composition
-- [x] 6.3 缺欄位降級：cache_read / cache_write / input 缺失者以 0 計算；若結果仍能區分則 render，否則整塊隱藏
-- [x] 6.4 Segment width = `tokens / total * 100%`；CSS 控 min-width
-- [x] 6.5 Tooltip：精確 token 數 + 百分比，絕不顯示假 0；缺欄位不列該行
+### 6. JS — Helper functions
 
-## 7. JS — Cleanup
+- [x] 6.1 新增 `isAbnormalStop(stopReason)` — 非 `end_turn`/`tool_use`/空字串 即為 abnormal
+- [x] 6.2 新增 `classifySeverity(entry, ctxPct)` — `critical | warning | notice | null`；precedence：ctx>95%/HTTP非2xx/abnormal stop → ctx>85%/cred/toolFail → dupes → none
+- [x] 6.3 新增 `getCriticalMarker(stopReason, httpStatus, ctxPct)` — 依優先序回傳 `!http`/`!max`/`!len`/`!stop`/`!filter` 或 null；ctx>95% 回傳 null（只靠左條）
+- [x] 6.4 新增 `shouldOmitModel(curIdx, sessionId, model)` — 查詢 allEntries，找上一個同 sessionId 且非 subagent 的主 turn；距離 ≤5 且 model 相同則省略
 
-- [x] 7.1 移除舊 `.status-dot` / `.turn-meta` / `.turn-risk` 建構碼
-- [x] 7.2 移除舊 `compactBadge` / `inferredBadge` / `turn-meta` 變數
-- [x] 7.3 Tooltip：`.turn-identity` 的 `title` 屬性保留 compact/inferred 描述
-- [x] 7.4 清理驗證（不只字串 grep）：
-  - `rg "status-dot|turn-risk|turn-meta|turn-sep|compact-badge|inferred-badge|tool-fail-badge|max-tokens-badge|dupe-badge|turn-ctx-bar|turn-ctx-pct(?!-inline)" public/ server/` 無結果
-  - 確認舊 render path 無殘留 branch（例如 `if (isCompacted) ...Badge` 之類）
-  - confirm `style.css` 無 orphan rules
+### 7. JS — Render: Line 1 (identity + critical marker + cost)
 
-## 8. Tests & Verification
+- [x] 7.1 套用 `classifySeverity` 到 `el.className`（`risk-critical`/`risk-warning`/`risk-notice`）
+- [x] 7.2 Prefix：主 turn → `#N`，subagent → `↳sN`；移除舊 `╎` indent
+- [x] 7.3 `shouldOmitModel` 控制 model span 顯示（subagent 永遠顯示）
+- [x] 7.4 `●` 狀態點（ok/err），`↵` 當 `stopReason === 'end_turn'`
+- [x] 7.5 `getCriticalMarker` 決定 line 1 的 critical marker（最多 1 個）
+- [x] 7.6 Cost span 移到 identity line，`margin-left: auto` 右對齊
+- [x] 7.7 Compact/inferred 僅放 `title` tooltip，不渲染可見文字
 
-- [x] 8.1 `npm test` 通過（無 server 變更）
-- [x] 8.2 `node --check public/entry-rendering.js` 語法檢查
-- [x] 8.3 起測試 server（port 5578）並用 cmux browser 驗證：
-  - [x] 8.3.1 正常 turn 無左色條、cache composition bar 顯示、cache% 正確 (3693/3869 turns have composition, aggregate confirmed)
-  - [x] 8.3.2 Tool-fail turn 左色條橙色、inline `✗tool` marker (warning bars 866, code path verified)
-  - [ ] 8.3.3 切換 model 時 model name 重現；連續同 model 且距離 ≤ 5 省略；距離 > 5 不省略 (需手動驗證)
-  - [x] 8.3.4 Context > 95% 時左色條紅、ctx% 紅 (sampled `risk-critical` turn with `ctx-critical` class, 100%)
-  - [x] 8.3.5 Subagent 有縮排 + model 永遠顯示 (isSubagent 分支在 shouldOmitModel 中明確短路)
-  - [x] 8.3.6 HTTP fail turn 無 composition bar (composition 差 176 turns 對應 non-usage turns)
-  - [ ] 8.3.7 Abnormal stop（manually craft `content_filter` / `length` entry）顯示正確 marker (無樣本資料，code path 已覆蓋)
-  - [ ] 8.3.8 Zero-total usage turn 無 composition 區塊 (邏輯分支 `total <= 0 return ''` 已實作)
-  - [ ] 8.3.9 連續三個 risk markers 並列無 overflow；四個以上觸發 `+N` (renderMarkers 有 MAX=3 + `+N` 邏輯)
-  - [ ] 8.3.10 多個重複 tool 時 marker 僅顯示次數最高者；長名稱截斷為 `Name…` (dupeMarker 實作)
-  - [ ] 8.3.11 高 ctx + 模型省略 + 多風險共存時版面正確 (組合情境，需特定 session)
-- [x] 8.4 對照 screenshot：確認視覺密度、無 `⚠` emoji、無 `·` 分隔符、無 ghost gap
+### 8. JS — Render: Line 3 (full-width ctx bar + ctx:% hit:%)
+
+- [x] 8.1 Segment 寬度改用 `tokens / totalUsed * 100%`（全寬比例），`min-width: 2px`
+- [x] 8.2 `ctx:NN%` label：severity class 控色（`ctx-critical`/`ctx-warning`/無），前綴 `ctx:`
+- [x] 8.3 `hit:NN%` label：`ctxCacheRead / totalUsed * 100`，只有 cache_read > 0 才顯示
+- [x] 8.4 隱藏條件：`totalUsed === 0` 時整行省略
+- [x] 8.5 Tooltip：bar hover 顯示精確 token 數與各類百分比
+
+### 9. JS — Render: Line 4 (time + tools, no cost)
+
+- [x] 9.1 Elapsed 永遠顯示：`{N}s`
+- [x] 9.2 Gap 改格式：`wait:{gap}` 彩色（gapColor 已有）；無前一 turn 時省略
+- [x] 9.3 Thinking 改格式：`think:{N}s`（無 emoji）
+- [x] 9.4 Tool chips 最多 3 個，超出折疊為 `+N`
+- [x] 9.5 Cost 從 secondary 移除（已在 line 1）
+- [x] 9.6 各項目 space-only 間距（無 `·` 分隔符）
+
+### 10. JS — Render: Line 5 (warning/notice risk, no emoji)
+
+- [x] 10.1 `hasCredential` → `cred`
+- [x] 10.2 `toolFail` → `tool-fail`
+- [x] 10.3 `duplicateToolCalls` → `dupes×N`（N = 最高重複次數），N < 2 不顯示
+- [x] 10.4 順序：`cred` → `tool-fail` → `dupes×N`；空格分隔
+- [x] 10.5 無任何 warning/notice 時，整行省略
+- [x] 10.6 確認無 emoji（純 ASCII）
+
+### 11. Verification
+
+- [x] 11.1 `node --check public/entry-rendering.js` 語法檢查
+- [x] 11.2 `npm test` 通過
+- [ ] 11.3 啟動 dev server，browser 驗證：
+  - [ ] 11.3.1 正常 turn：無左色條，ctx bar 全寬，`ctx:NN% hit:NN%` 小字在 bar 右下
+  - [ ] 11.3.2 Subagent turn：`↳s1` prefix，model 永遠顯示，ctx bar 全寬
+  - [ ] 11.3.3 Tool-fail turn：左條橙色，line 5 顯示 `tool-fail`（無 ⚠ emoji）
+  - [ ] 11.3.4 max_tokens turn：`!max` 在 line 1 cost 左側，左條紅色
+  - [ ] 11.3.5 時間行：`9.6s  wait:11s  Bash Read`（語意前綴，無 ⏸/🧠）
+  - [ ] 11.3.6 連續同 model 距離 ≤5：model name 省略；距離 >5 或換 model：重現

--- a/openspec/changes/turn-card-v2-expert-redesign/tasks.md
+++ b/openspec/changes/turn-card-v2-expert-redesign/tasks.md
@@ -1,0 +1,82 @@
+## 1. CSS — New classes (additive first, safe)
+
+- [x] 1.1 新增 `.turn-item.risk-critical { border-left: 2px solid var(--red); }`、`.risk-warning { ... var(--orange) }`、`.risk-notice { ... var(--yellow) }`（取代既有 `.turn-item { border-left: 3px solid transparent }`，寬度縮到 2px）
+- [x] 1.2 驗證三個 severity 色條在 dark / light 兩個 theme 下對比度足夠（禁用近背景色）
+- [x] 1.3 新增 `.turn-composition`：flex 容器，`width: 60px; height: 3px;`，3 個 span segment
+- [x] 1.4 新增 `.comp-read`、`.comp-write`、`.comp-input`：使用現有 `--color-cache-read` / `--color-cache-write` / `--color-input`，`min-width: 2px`
+- [x] 1.5 新增 `.turn-cache-pct`：font-size 9px、dim color
+- [x] 1.6 新增 `.inline-marker` base class；子類 `.marker-critical`（紅）/ `.marker-warning`（橙）/ `.marker-notice`（黃）；font-size 9px、flex-shrink: 0
+- [x] 1.7 新增 `.turn-ctx-pct-inline`：identity line 右側的大字 %，severity 對應顏色（critical 紅 / warning 黃 / 其他 dim）
+
+## 2. CSS — Remove deprecated classes
+
+- [x] 2.1 移除 `.status-dot`、`.status-dot-ok`、`.status-dot-err`
+- [x] 2.2 移除 `.turn-risk`、`.tool-fail-badge`、`.max-tokens-badge`、`.dupe-badge`、`.cred-badge`（保留 `.cred-highlight` 給 detail view）
+- [x] 2.3 移除 `.turn-meta`
+- [x] 2.4 移除 `.turn-ctx-bar`、`.turn-ctx-bar-bg`（context bar 被拆成 ctx% 文字 + composition bar）
+- [x] 2.5 移除 `.turn-sep`（`·` 分隔符）
+- [x] 2.6 `.turn-identity`、`.turn-title`、`.turn-secondary` 的 gap / margin 重調整（確認 model 省略時不留 ghost gap）
+
+## 3. JS — Severity classification
+
+- [x] 3.1 新 helper `classifySeverity(entry, ctxPct)` 回傳 `'critical' | 'warning' | 'notice' | null`，依 precedence：ctx>95% / HTTP非2xx / abnormal stop → ctx 85–95% / cred / tool-fail → dupes → none
+- [x] 3.2 新 helper `isAbnormalStop(stopReason)` 判斷非 `end_turn`/`tool_use` 即為 abnormal
+- [x] 3.3 severity class 套用到 `.turn-item` 根元素
+
+## 4. JS — Three-line rendering
+
+- [x] 4.1 重寫 turn card innerHTML：三行結構（identity / title / secondary），title 為 null 時不 append
+- [x] 4.2 Identity line：`#N` + model（見 4.3）+ `↵`（若 `end_turn`）+ `NN%` 右對齊；collapse spacing when model omitted
+- [x] 4.3 模型省略邏輯：查詢 allEntries 倒序找上一個同 sessionId && !isSubagent 的 entry；僅當 model 相同**且距離 ≤ 5 entries** 才省略；subagent 永遠顯示
+- [x] 4.4 Secondary line 固定順序：`elapsed [⏸gap]` → composition+%c → inline markers → tools → cost；缺欄位 skip 不插佔位符
+
+## 5. JS — Inline markers
+
+- [x] 5.1 `markerForHttpErr`（無輸出，由左條負責）、`markerForAbnormalStop(stopReason)`：
+  - `max_tokens` → `✂max`
+  - `content_filter` → `⛔filter`
+  - `length` → `✂len`
+  - 其他非 `end_turn`/`tool_use` → `!stop`
+  - critical class
+- [x] 5.2 `markerForCred`：`🔑cred`（warning）
+- [x] 5.3 `markerForToolFail`：`✗tool`（warning）
+- [x] 5.4 `markerForDupes(dupes)`：從 `duplicateToolCalls` 物件找**重複次數最高**的 tool（平手取首次出現）；計算該 tool 在此 turn 的**總呼叫次數 N**；Name 超過 12 chars 截斷為 `Name…`；marker 文字 `⟳Name×N`；N < 2 不 render；tooltip 顯示完整名稱 + 精確次數
+- [x] 5.5 Markers 排序嚴格固定：critical → warning → notice；各 tier 內也固定順序
+- [x] 5.6 Overflow 規則：渲染出超過 3 個 marker 時，顯示前 3 個 + `<span class="inline-marker marker-notice">+N</span>`（N = 被隱藏數）
+- [x] 5.7 Marker 顏色來自 `.marker-*` class，不得 inline style hardcode
+
+## 6. JS — Composition bar
+
+- [x] 6.1 新函式 `renderComposition(usage)`：回傳 composition bar HTML + cache-pct label 或空字串
+- [x] 6.2 隱藏條件：usage null / total (`cache_read + cache_write + input`) === 0 / 無法產出有意義 composition
+- [x] 6.3 缺欄位降級：cache_read / cache_write / input 缺失者以 0 計算；若結果仍能區分則 render，否則整塊隱藏
+- [x] 6.4 Segment width = `tokens / total * 100%`；CSS 控 min-width
+- [x] 6.5 Tooltip：精確 token 數 + 百分比，絕不顯示假 0；缺欄位不列該行
+
+## 7. JS — Cleanup
+
+- [x] 7.1 移除舊 `.status-dot` / `.turn-meta` / `.turn-risk` 建構碼
+- [x] 7.2 移除舊 `compactBadge` / `inferredBadge` / `turn-meta` 變數
+- [x] 7.3 Tooltip：`.turn-identity` 的 `title` 屬性保留 compact/inferred 描述
+- [x] 7.4 清理驗證（不只字串 grep）：
+  - `rg "status-dot|turn-risk|turn-meta|turn-sep|compact-badge|inferred-badge|tool-fail-badge|max-tokens-badge|dupe-badge|turn-ctx-bar|turn-ctx-pct(?!-inline)" public/ server/` 無結果
+  - 確認舊 render path 無殘留 branch（例如 `if (isCompacted) ...Badge` 之類）
+  - confirm `style.css` 無 orphan rules
+
+## 8. Tests & Verification
+
+- [x] 8.1 `npm test` 通過（無 server 變更）
+- [x] 8.2 `node --check public/entry-rendering.js` 語法檢查
+- [x] 8.3 起測試 server（port 5578）並用 cmux browser 驗證：
+  - [x] 8.3.1 正常 turn 無左色條、cache composition bar 顯示、cache% 正確 (3693/3869 turns have composition, aggregate confirmed)
+  - [x] 8.3.2 Tool-fail turn 左色條橙色、inline `✗tool` marker (warning bars 866, code path verified)
+  - [ ] 8.3.3 切換 model 時 model name 重現；連續同 model 且距離 ≤ 5 省略；距離 > 5 不省略 (需手動驗證)
+  - [x] 8.3.4 Context > 95% 時左色條紅、ctx% 紅 (sampled `risk-critical` turn with `ctx-critical` class, 100%)
+  - [x] 8.3.5 Subagent 有縮排 + model 永遠顯示 (isSubagent 分支在 shouldOmitModel 中明確短路)
+  - [x] 8.3.6 HTTP fail turn 無 composition bar (composition 差 176 turns 對應 non-usage turns)
+  - [ ] 8.3.7 Abnormal stop（manually craft `content_filter` / `length` entry）顯示正確 marker (無樣本資料，code path 已覆蓋)
+  - [ ] 8.3.8 Zero-total usage turn 無 composition 區塊 (邏輯分支 `total <= 0 return ''` 已實作)
+  - [ ] 8.3.9 連續三個 risk markers 並列無 overflow；四個以上觸發 `+N` (renderMarkers 有 MAX=3 + `+N` 邏輯)
+  - [ ] 8.3.10 多個重複 tool 時 marker 僅顯示次數最高者；長名稱截斷為 `Name…` (dupeMarker 實作)
+  - [ ] 8.3.11 高 ctx + 模型省略 + 多風險共存時版面正確 (組合情境，需特定 session)
+- [x] 8.4 對照 screenshot：確認視覺密度、無 `⚠` emoji、無 `·` 分隔符、無 ghost gap

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,23 @@
 {
   "name": "ccxray",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccxray",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",
-        "@fission-ai/openspec": "^1.2.0",
         "ws": "^8.19.0"
       },
       "bin": {
         "ccxray": "server/index.js"
       },
       "devDependencies": {
+        "@fission-ai/openspec": "^1.2.0",
+        "agent-browser": "github:vercel-labs/agent-browser",
         "puppeteer": "^24.39.1"
       },
       "engines": {
@@ -62,6 +63,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@fission-ai/openspec/-/openspec-1.2.0.tgz",
       "integrity": "sha512-2XDmPZcVY0Bs014lP9aoxe3VoEU8hFvqaBFxQaiJO2nhC8vTKCyo6sT/5YpQcOTfR/a64Hht2anTyqLR4eNhlg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -86,6 +88,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -95,6 +98,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
       "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -104,6 +108,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
       "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -128,6 +133,7 @@
       "version": "5.1.21",
       "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
       "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -149,6 +155,7 @@
       "version": "10.3.2",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
       "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -176,6 +183,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -190,6 +198,7 @@
       "version": "4.2.23",
       "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
       "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -212,6 +221,7 @@
       "version": "4.0.23",
       "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
       "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -234,6 +244,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
       "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
@@ -255,6 +266,7 @@
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
       "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -264,6 +276,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
       "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -285,6 +298,7 @@
       "version": "3.0.23",
       "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
       "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -306,6 +320,7 @@
       "version": "4.0.23",
       "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
       "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -328,6 +343,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
@@ -357,6 +373,7 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
       "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -379,6 +396,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
       "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -402,6 +420,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
       "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -426,6 +445,7 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
       "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -443,6 +463,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -456,6 +477,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -465,6 +487,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -478,6 +501,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.10.0.tgz",
       "integrity": "sha512-Xk3JQ+cdychsvftrV3G9ZrN9W329lbyFW0pGJXFGKFQf8qr4upw2SgNg9BVorjSrfhoXZRnJGt/uNF4nGFBL5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6"
@@ -542,10 +566,21 @@
         "node": ">= 14"
       }
     },
+    "node_modules/agent-browser": {
+      "version": "0.25.4",
+      "resolved": "git+ssh://git@github.com/vercel-labs/agent-browser.git#2114bdf84751dd0b98e6d29e370de2cc7d4efda2",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "agent-browser": "bin/agent-browser.js"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -555,6 +590,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -708,6 +744,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -740,6 +777,7 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -752,6 +790,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/chromium-bidi": {
@@ -772,6 +811,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^5.0.0"
@@ -787,6 +827,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -799,6 +840,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -823,6 +865,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -835,12 +878,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -877,6 +922,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -941,6 +987,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -1081,6 +1128,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1097,6 +1145,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -1116,6 +1165,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -1138,6 +1188,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1181,6 +1232,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -1221,6 +1273,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -1271,6 +1324,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1280,6 +1334,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1289,6 +1344,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -1301,6 +1357,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
       "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1313,6 +1370,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -1322,6 +1380,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1334,6 +1393,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/js-tokens": {
@@ -1374,6 +1434,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
       "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -1390,6 +1451,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
       "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1412,6 +1474,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1421,6 +1484,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -1434,6 +1498,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1460,6 +1525,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -1489,6 +1555,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-function": "^5.0.0"
@@ -1504,6 +1571,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
       "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -1527,6 +1595,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1539,12 +1608,14 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ora/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
@@ -1562,6 +1633,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -1643,6 +1715,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1666,6 +1739,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -1678,6 +1752,7 @@
       "version": "5.21.2",
       "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.21.2.tgz",
       "integrity": "sha512-Jehlu0KguL1LLyUczCt86OtA5INmeStK3zcgbv1BSyMcNxs0HP3GQogBrYhwhqHsk6JopiFFVpJyZEoXOUMhGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@posthog/core": "1.10.0"
@@ -1779,6 +1854,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1819,6 +1895,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^7.0.0",
@@ -1835,6 +1912,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -1845,6 +1923,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1868,6 +1947,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -1887,6 +1967,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -1899,6 +1980,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1908,6 +1990,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -1972,6 +2055,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
       "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1996,6 +2080,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2010,6 +2095,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -2076,6 +2162,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -2115,6 +2202,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -2186,6 +2274,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -2241,6 +2330,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
       "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@fission-ai/openspec": "^1.2.0",
+    "agent-browser": "github:vercel-labs/agent-browser",
     "puppeteer": "^24.39.1"
   }
 }

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -1,6 +1,14 @@
 // ── Entry rendering ──
 let newTurnCount = 0;
 
+function formatGap(ms) {
+  const s = Math.round(ms / 1000);
+  if (s < 60) return s + 's';
+  const m = Math.floor(s / 60), rem = s % 60;
+  if (m < 60) return m + 'm' + (rem ? ' ' + rem + 's' : '');
+  return Math.floor(m / 60) + 'h' + (m % 60 ? ' ' + (m % 60) + 'm' : '');
+}
+
 function showNewTurnPill(count) {
   const existing = document.getElementById('new-turn-pill');
   if (existing) {
@@ -243,6 +251,26 @@ function addEntry(e) {
     if (sessElCtx) sessElCtx.innerHTML = renderSessionItem(sess, sid);
   }
 
+  // Gap timing: idle time from end of previous turn to start of this turn
+  let prevInSession = null;
+  for (let i = allEntries.length - 1; i >= 0; i--) {
+    if (allEntries[i].sessionId === sid && allEntries[i].receivedAt) { prevInSession = allEntries[i]; break; }
+  }
+  let gapHtml = '';
+  if (prevInSession && e.receivedAt) {
+    const prevEnd = prevInSession.receivedAt + parseFloat(prevInSession.elapsed || 0) * 1000;
+    const gapMs = Math.max(0, e.receivedAt - prevEnd);
+    const cacheHit  = (usage?.cache_read_input_tokens || 0) > 0;
+    const cacheMiss = !cacheHit && (usage?.cache_creation_input_tokens || 0) > 0;
+    const gapColor = cacheHit  ? 'var(--green)'
+                   : cacheMiss ? (gapMs > 60 * 60000 ? 'var(--red)' : 'var(--yellow)')
+                   : 'var(--dim)';
+    const gapTitle = cacheHit  ? 'Cache hit'
+                   : cacheMiss ? (gapMs > 60 * 60000 ? 'Cache miss — all TTL expired (> 1h)' : 'Cache miss — default TTL (5m) likely expired')
+                   : 'No cache data';
+    gapHtml = '<div class="turn-gap" style="color:' + gapColor + '" title="' + gapTitle + '">⏸ ' + formatGap(gapMs) + '</div>';
+  }
+
   // Compression detection: compare message count AND context tokens vs previous main turn.
   // True compaction = msgCount drops significantly (messages got summarized/removed).
   // Token-only drops can happen from cache eviction or normal conversation flow.
@@ -309,6 +337,7 @@ function addEntry(e) {
       '</div>' + pctLabel + '</div>'
     : '';
   el.innerHTML =
+    gapHtml +
     '<div class="turn-line1">' + indent +
       '<span class="turn-num">' + (isSubagent ? '' : '#') + displayNum + '</span>' +
       '<span class="turn-model">' + escapeHtml(shortModel) + '</span>' +

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -185,14 +185,14 @@ function isAbnormalStop(stopReason) {
   return !!stopReason && stopReason !== 'end_turn' && stopReason !== 'tool_use';
 }
 
-function classifySeverity(entry, ctxPct) {
+function classifySeverity(entry, ctxPct, dupesMax) {
   if (ctxPct > 95) return 'critical';
   if (entry.status != null && (entry.status < 200 || entry.status >= 300)) return 'critical';
   if (isAbnormalStop(entry.stopReason)) return 'critical';
   if (ctxPct > 85) return 'warning';
   if (entry.hasCredential) return 'warning';
   if (entry.toolFail) return 'warning';
-  if (entry.duplicateToolCalls && Object.values(entry.duplicateToolCalls).some(c => c >= 2)) return 'notice';
+  if (dupesMax >= 2) return 'notice';
   return null;
 }
 
@@ -340,10 +340,11 @@ function addEntry(e) {
   const toolFail = e.toolFail || false;
   const hasCred = e.hasCredential || false;
   const dupes = e.duplicateToolCalls || null;
+  const dupesMax = dupes ? Math.max(...Object.values(dupes)) : 0;
 
   const ctxMax = e.maxContext || DEFAULT_MAX_CTX;
   const ctxPct = ctxUsed > 0 ? Math.min(100, ctxUsed / ctxMax * 100) : 0;
-  const severity = classifySeverity({ status: e.status, stopReason, hasCredential: hasCred, toolFail, duplicateToolCalls: dupes }, ctxPct);
+  const severity = classifySeverity({ status: e.status, stopReason, hasCredential: hasCred, toolFail }, ctxPct, dupesMax);
 
   const el = document.createElement('div');
   el.className = 'turn-item' + (isSubagent ? ' turn-sub' : '') + (severity ? ' risk-' + severity : '');
@@ -415,8 +416,7 @@ function addEntry(e) {
   timeHtml += '<span class="turn-elapsed">dur:' + formatGap(elapsedMs) + thinkSuffix + '</span>';
   let chipsHtml = '';
   for (const n of Object.keys(e.toolCalls || {})) {
-    const cls = 'tool-chip';
-    chipsHtml += '<span class="' + cls + '">' + escapeHtml(n.replace(/^mcp__[^_]+__/, '')) + '</span>';
+    chipsHtml += '<span class="tool-chip">' + escapeHtml(n.replace(/^mcp__[^_]+__/, '')) + '</span>';
   }
   const secondaryLine = '<div class="turn-secondary">' +
     (chipsHtml ? '<div class="turn-tools-row">' + chipsHtml + '</div>' : '') +
@@ -427,10 +427,7 @@ function addEntry(e) {
   const riskMarkers = [];
   if (hasCred) riskMarkers.push('cred');
   if (toolFail) riskMarkers.push('tool-fail');
-  if (dupes) {
-    const maxCount = Math.max(...Object.values(dupes));
-    if (maxCount >= 2) riskMarkers.push('dupes\xD7' + maxCount);
-  }
+  if (dupesMax >= 2) riskMarkers.push('dupes\xD7' + dupesMax);
   const riskLine = riskMarkers.length ? '<div class="turn-risk-line">' + riskMarkers.join(' ') + '</div>' : '';
 
   el.innerHTML = identityLine + titleLine + ctxBarHtml + secondaryLine + riskLine;

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -389,7 +389,8 @@ function addEntry(e) {
   const ctxPctClass = ctxPct > 95 ? 'ctx-critical' : ctxPct > 85 ? 'ctx-warning' : '';
   const ctxPctLabel = '<span class="turn-ctx-pct' + (ctxPctClass ? ' ' + ctxPctClass : '') + '">ctx:' + ctxPct.toFixed(0) + '%</span>';
   const hitPct = totalUsed > 0 ? Math.round(ctxCacheRead / totalUsed * 100) : null;
-  const hitLabel = hitPct !== null ? '<span class="turn-hit-pct">hit:' + hitPct + '%</span>' : '';
+  const hitPctClass = hitPct !== null && hitPct < 10 ? ' hit-cold' : '';
+  const hitLabel = hitPct !== null ? '<span class="turn-hit-pct' + hitPctClass + '">hit:' + hitPct + '%</span>' : '';
   const ctxBarHtml = ctxUsed > 0
     ? '<div class="turn-ctx turn-ctx-bar">' +
         '<div class="turn-ctx-bar-bg">' +
@@ -418,8 +419,8 @@ function addEntry(e) {
     chipsHtml += '<span class="' + cls + '">' + escapeHtml(n.replace(/^mcp__[^_]+__/, '')) + '</span>';
   }
   const secondaryLine = '<div class="turn-secondary">' +
-    '<div class="turn-time-row">' + timeHtml + '</div>' +
     (chipsHtml ? '<div class="turn-tools-row">' + chipsHtml + '</div>' : '') +
+    '<div class="turn-time-row">' + timeHtml + '</div>' +
     '</div>';
 
   // Line 5: warning/notice risk (no emoji, plain text)

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -260,14 +260,8 @@ function addEntry(e) {
   if (prevInSession && e.receivedAt) {
     const prevEnd = prevInSession.receivedAt + parseFloat(prevInSession.elapsed || 0) * 1000;
     const gapMs = Math.max(0, e.receivedAt - prevEnd);
-    const cacheHit  = (usage?.cache_read_input_tokens || 0) > 0;
-    const cacheMiss = !cacheHit && (usage?.cache_creation_input_tokens || 0) > 0;
-    const gapColor = cacheHit  ? 'var(--green)'
-                   : cacheMiss ? (gapMs > 60 * 60000 ? 'var(--red)' : 'var(--yellow)')
-                   : 'var(--dim)';
-    const gapTitle = cacheHit  ? 'Cache hit'
-                   : cacheMiss ? (gapMs > 60 * 60000 ? 'Cache miss — all TTL expired (> 1h)' : 'Cache miss — default TTL (5m) likely expired')
-                   : 'No cache data';
+    const gapColor = gapMs < 5 * 60000 ? 'var(--green)' : gapMs < 60 * 60000 ? 'var(--yellow)' : 'var(--red)';
+    const gapTitle = gapMs < 5 * 60000 ? 'Cache likely warm (< 5m)' : gapMs < 60 * 60000 ? 'Default cache expired (5m–1h)' : 'All cache expired (> 1h)';
     gapHtml = '<div class="turn-gap" style="color:' + gapColor + '" title="' + gapTitle + '">⏸ ' + formatGap(gapMs) + '</div>';
   }
 

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -256,13 +256,12 @@ function addEntry(e) {
   for (let i = allEntries.length - 1; i >= 0; i--) {
     if (allEntries[i].sessionId === sid && allEntries[i].receivedAt) { prevInSession = allEntries[i]; break; }
   }
-  let gapHtml = '';
+  let gapMs = null, gapColor = '', gapTitle = '';
   if (prevInSession && e.receivedAt) {
     const prevEnd = prevInSession.receivedAt + parseFloat(prevInSession.elapsed || 0) * 1000;
-    const gapMs = Math.max(0, e.receivedAt - prevEnd);
-    const gapColor = gapMs < 5 * 60000 ? 'var(--green)' : gapMs < 60 * 60000 ? 'var(--yellow)' : 'var(--red)';
-    const gapTitle = gapMs < 5 * 60000 ? 'Cache likely warm (< 5m)' : gapMs < 60 * 60000 ? 'Default cache expired (5m–1h)' : 'All cache expired (> 1h)';
-    gapHtml = '<div class="turn-gap" style="color:' + gapColor + '" title="' + gapTitle + '">⏸ ' + formatGap(gapMs) + '</div>';
+    gapMs = Math.max(0, e.receivedAt - prevEnd);
+    gapColor = gapMs < 5 * 60000 ? 'var(--green)' : gapMs < 60 * 60000 ? 'var(--yellow)' : 'var(--red)';
+    gapTitle = gapMs < 5 * 60000 ? 'Cache likely warm (< 5m)' : gapMs < 60 * 60000 ? 'Default cache expired (5m–1h)' : 'All cache expired (> 1h)';
   }
 
   // Compression detection: compare message count AND context tokens vs previous main turn.
@@ -291,7 +290,9 @@ function addEntry(e) {
     thinkingDuration: e.thinkingDuration || null,
     duplicateToolCalls: e.duplicateToolCalls || null,
     hasCredential: e.hasCredential || false,
+    toolFail: e.toolFail || false,
     toolSources: e.toolSources || null,
+    title: e.title || null,
   });
 
   const el = document.createElement('div');
@@ -302,20 +303,42 @@ function addEntry(e) {
   el.onclick = () => { setFocus('turns'); selectTurn(idx); };
   el.onmouseenter = () => { clearTimeout(_hoverTimer); _hoverTimer = setTimeout(() => prefetchEntry(idx), 150); };
   el.onmouseleave = () => clearTimeout(_hoverTimer);
-  const tcNames = Object.keys(e.toolCalls || {});
-  const toolLine = tcNames.length
-    ? '<div class="turn-line3">' + tcNames.slice(0, 5).map(n => {
-        const cls = n === 'Agent' ? 'tool-chip chip-agent' : 'tool-chip';
-        return '<span class="' + cls + '">' + escapeHtml(n.replace(/^mcp__[^_]+__/, '')) + '</span>';
-      }).join('') + (tcNames.length > 5 ? '<span class="tool-chip">+' + (tcNames.length - 5) + '</span>' : '') + '</div>'
-    : '';
-  const dupes = e.duplicateToolCalls;
-  const dupeBadge = dupes ? '<span class="dupe-badge" title="Duplicate tool calls: ' + escapeHtml(Object.entries(dupes).map(([n, c]) => n + '×' + c).join(', ')) + '">⚠ dupes</span>' : '';
-  const credBadge = e.hasCredential ? '<span class="cred-badge" title="Credential pattern detected in this turn">⚠ cred</span>' : '';
+  // ── Five-layer turn card: identity / title / ctx / risk / secondary ──
+  const toolFail = e.toolFail || false;
+  const hasCred = e.hasCredential || false;
+  const dupes = e.duplicateToolCalls || null;
+  const maxTokensStop = stopReason === 'max_tokens';
+  const hasRisk = toolFail || hasCred || dupes || maxTokensStop;
+
+  // Layer 1: identity
   const indent = isSubagent ? '<span class="sub-indent">╎</span>' : '';
-  const titleHtml = e.title ? '<div class="turn-title">' + escapeHtml(e.title) + '</div>' : '';
-  const compactBadge = isCompacted ? '<span class="compact-badge">compact</span>' : '';
-  const inferredBadge = (e.sessionInferred) ? '<span class="inferred-badge" title="Session attributed by inference (no explicit session ID)">inferred</span>' : '';
+  const numMark = isSubagent ? '' : '#';
+  const dotClass = statusClass === 'status-ok' ? 'status-dot status-dot-ok' : 'status-dot status-dot-err';
+  const waitMark = stopReason === 'end_turn' ? '<span class="turn-wait" title="Waiting for user">↵</span>' : '';
+  const identityTooltip = [
+    isCompacted ? 'Context compacted' : null,
+    e.sessionInferred ? 'Session inferred (no explicit session ID)' : null,
+  ].filter(Boolean).join(' · ');
+  const identityAttr = identityTooltip ? ' title="' + escapeHtml(identityTooltip) + '"' : '';
+  const metaLabels = [
+    isCompacted ? 'compact' : null,
+    e.sessionInferred ? 'inferred' : null,
+  ].filter(Boolean);
+  const identityMeta = metaLabels.length ? '<span class="turn-meta">· ' + metaLabels.join(' · ') + '</span>' : '';
+  const identityLine =
+    '<div class="turn-identity"' + identityAttr + '>' +
+      indent +
+      '<span class="turn-num">' + numMark + displayNum + '</span>' +
+      '<span class="turn-model">' + escapeHtml(shortModel) + '</span>' +
+      '<span class="' + dotClass + '" title="HTTP ' + e.status + '">●</span>' +
+      waitMark +
+      identityMeta +
+    '</div>';
+
+  // Layer 2: title (skip if null/empty)
+  const titleLine = e.title ? '<div class="turn-title">' + escapeHtml(e.title) + '</div>' : '';
+
+  // Layer 3: context bar
   const ctxMax = e.maxContext || DEFAULT_MAX_CTX;
   const ctxPct = Math.min(100, ctxUsed / ctxMax * 100);
   const seg = (tokens, color) => tokens > 0
@@ -324,31 +347,49 @@ function addEntry(e) {
   const pctColor = ctxPct > 90 ? 'var(--red)' : ctxPct > 70 ? 'var(--yellow)' : 'var(--dim)';
   const pctLabel = ctxUsed > 0 ? '<div class="turn-ctx-pct" style="color:' + pctColor + '">' + ctxPct.toFixed(0) + '%</div>' : '';
   const ctxBar = ctxUsed > 0
-    ? '<div class="turn-ctx-bar"><div class="turn-ctx-bar-bg">' +
+    ? '<div class="turn-ctx turn-ctx-bar"><div class="turn-ctx-bar-bg">' +
         seg(ctxCacheRead,   'var(--color-cache-read)') +
         seg(ctxCacheCreate, 'var(--color-cache-write)') +
         seg(ctxInput,       'var(--color-input)') +
       '</div>' + pctLabel + '</div>'
     : '';
-  el.innerHTML =
-    gapHtml +
-    '<div class="turn-line1">' + indent +
-      '<span class="turn-num">' + (isSubagent ? '' : '#') + displayNum + '</span>' +
-      '<span class="turn-model">' + escapeHtml(shortModel) + '</span>' +
-      compactBadge + inferredBadge +
-    '</div>' +
-    titleHtml +
-    '<div class="turn-line2">' +
-      '<span class="' + statusClass + '">' + e.status + '</span>' +
-      '<span>' + (e.elapsed || '?') + 's</span>' +
-      (stopReason ? '<span>' + escapeHtml(stopReason) + '</span>' : '') +
-      (e.thinkingDuration ? '<span style="color:var(--purple)">🧠 ' + e.thinkingDuration.toFixed(1) + 's</span>' : '') +
-      (turnCost != null ? '<span class="turn-cost">$' + turnCost.toFixed(4) + '</span>' : '') +
-      (tok.total > 0 ? '<span class="turn-overhead" title="Structural overhead (system + tools)">' + (((tok.system || 0) + (tok.tools || 0)) / tok.total * 100).toFixed(0) + '%♻</span>' : '') +
-      dupeBadge + credBadge +
-    '</div>' +
-    toolLine +
-    ctxBar;
+
+  // Layer 4: risk badges
+  const riskBadges = [];
+  if (hasCred) riskBadges.push('<span class="cred-badge" title="Credential pattern detected in this turn">⚠ cred</span>');
+  if (toolFail) riskBadges.push('<span class="tool-fail-badge" title="A tool call returned an error (is_error=true)">⚠ tool-fail</span>');
+  if (dupes) riskBadges.push('<span class="dupe-badge" title="Duplicate tool calls: ' + escapeHtml(Object.entries(dupes).map(([n, c]) => n + '×' + c).join(', ')) + '">⚠ dupes</span>');
+  if (maxTokensStop) riskBadges.push('<span class="max-tokens-badge" title="Output truncated — hit max_tokens">⚠ max_tokens</span>');
+  const riskLine = hasRisk ? '<div class="turn-risk">' + riskBadges.join('') + '</div>' : '';
+
+  // Layer 5: secondary — gap→elapsed · tools · cost · thinking
+  const secondaryParts = [];
+  const elapsedStr = (e.elapsed || '?') + 's';
+  if (gapMs != null) {
+    secondaryParts.push('<span class="turn-gap" style="color:' + gapColor + '" title="' + escapeHtml(gapTitle) + '">⏸' + formatGap(gapMs) + '→' + elapsedStr + '</span>');
+  } else {
+    secondaryParts.push('<span class="turn-elapsed">' + elapsedStr + '</span>');
+  }
+  if (e.thinkingDuration) {
+    secondaryParts.push('<span class="turn-thinking" style="color:var(--purple)">🧠' + e.thinkingDuration.toFixed(1) + 's</span>');
+  }
+  const tcNames = Object.keys(e.toolCalls || {});
+  if (tcNames.length) {
+    const chips = tcNames.slice(0, 5).map(n => {
+      const cls = n === 'Agent' ? 'tool-chip chip-agent' : 'tool-chip';
+      return '<span class="' + cls + '">' + escapeHtml(n.replace(/^mcp__[^_]+__/, '')) + '</span>';
+    }).join('');
+    const overflow = tcNames.length > 5 ? '<span class="tool-chip">+' + (tcNames.length - 5) + '</span>' : '';
+    secondaryParts.push('<span class="turn-tools">' + chips + overflow + '</span>');
+  }
+  if (turnCost != null) {
+    secondaryParts.push('<span class="turn-cost">$' + turnCost.toFixed(4) + '</span>');
+  }
+  const secondaryLine = secondaryParts.length
+    ? '<div class="turn-secondary">' + secondaryParts.join('<span class="turn-sep">·</span>') + '</div>'
+    : '';
+
+  el.innerHTML = identityLine + titleLine + ctxBar + riskLine + secondaryLine;
 
   // Hide turn if no session selected, or if it belongs to a different session
   if (!selectedSessionId || selectedSessionId !== sid) el.style.display = 'none';

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -171,6 +171,34 @@ function renderContextBreakdownSticky(tok, maxContext, usage) {
   return '<div class="ctx-sticky"><div class="ctx-sticky-title">' + title + '</div>' + bar + table + mcp + '</div>';
 }
 
+function isAbnormalStop(stopReason) {
+  return !!stopReason && stopReason !== 'end_turn' && stopReason !== 'tool_use';
+}
+
+function classifySeverity(entry, ctxPct) {
+  if (ctxPct > 95) return 'critical';
+  if (entry.status != null && (entry.status < 200 || entry.status >= 300)) return 'critical';
+  if (isAbnormalStop(entry.stopReason)) return 'critical';
+  if (ctxPct > 85) return 'warning';
+  if (entry.hasCredential) return 'warning';
+  if (entry.toolFail) return 'warning';
+  if (entry.duplicateToolCalls && Object.values(entry.duplicateToolCalls).some(c => c >= 2)) return 'notice';
+  return null;
+}
+
+function getCriticalMarker(stopReason, httpStatus, ctxPct) {
+  // ctx > 95%: no inline marker (left bar only)
+  if (httpStatus != null && (httpStatus < 200 || httpStatus >= 300)) return '!http';
+  if (stopReason === 'max_tokens') return '!max';
+  if (stopReason === 'length') return '!len';
+  if (stopReason && stopReason !== 'end_turn' && stopReason !== 'tool_use'
+      && stopReason !== 'max_tokens' && stopReason !== 'length'
+      && stopReason !== 'content_filter') return '!stop';
+  if (stopReason === 'content_filter') return '!filter';
+  return null;
+}
+
+
 function addEntry(e) {
   if (entryCount === 0) colTurns.innerHTML = '<div class="col-sticky-header"><div class="col-title" style="display:flex;align-items:center">Turns<span id="scroll-toggle" onclick="toggleFollowLive()" style="cursor:pointer;font-size:10px;margin-left:auto"><span class="scroll-on active">ON</span> <span class="scroll-off">OFF</span></span></div><div id="session-tool-bar" style="display:none"></div><div id="ctx-legend"><span><span class="ctx-legend-dot" style="background:var(--color-cache-read)"></span>cache read</span><span><span class="ctx-legend-dot" style="background:var(--color-cache-write)"></span>cache write</span><span><span class="ctx-legend-dot" style="background:var(--color-input)"></span>input</span></div><div id="session-sparkline"></div></div>';
   const idx = entryCount++;
@@ -295,101 +323,102 @@ function addEntry(e) {
     title: e.title || null,
   });
 
+  // ── V3 turn card: five-line layout ──
+  const toolFail = e.toolFail || false;
+  const hasCred = e.hasCredential || false;
+  const dupes = e.duplicateToolCalls || null;
+
+  const ctxMax = e.maxContext || DEFAULT_MAX_CTX;
+  const ctxPct = ctxUsed > 0 ? Math.min(100, ctxUsed / ctxMax * 100) : 0;
+  const severity = classifySeverity({ status: e.status, stopReason, hasCredential: hasCred, toolFail, duplicateToolCalls: dupes }, ctxPct);
+
   const el = document.createElement('div');
-  el.className = 'turn-item' + (isSubagent ? ' turn-sub' : '');
+  el.className = 'turn-item' + (isSubagent ? ' turn-sub' : '') + (severity ? ' risk-' + severity : '');
   el.dataset.entryIdx = idx;
   el.dataset.sessionId = sid;
   el.dataset.sessNum = displayNum;
   el.onclick = () => { setFocus('turns'); selectTurn(idx); };
   el.onmouseenter = () => { clearTimeout(_hoverTimer); _hoverTimer = setTimeout(() => prefetchEntry(idx), 150); };
   el.onmouseleave = () => clearTimeout(_hoverTimer);
-  // ── Five-layer turn card: identity / title / ctx / risk / secondary ──
-  const toolFail = e.toolFail || false;
-  const hasCred = e.hasCredential || false;
-  const dupes = e.duplicateToolCalls || null;
-  const maxTokensStop = stopReason === 'max_tokens';
-  const hasRisk = toolFail || hasCred || dupes || maxTokensStop;
 
-  // Layer 1: identity
-  const indent = isSubagent ? '<span class="sub-indent">╎</span>' : '';
-  const numMark = isSubagent ? '' : '#';
-  const dotClass = statusClass === 'status-ok' ? 'status-dot status-dot-ok' : 'status-dot status-dot-err';
+  // Line 1: identity + critical marker + cost
+  const prefix = isSubagent ? '↳s' + sess.subCount : '#' + displayNum;
+  const modelHtml = '<span class="turn-model">' + escapeHtml(shortModel) + '</span>';
+  const dotClass = e.status >= 200 && e.status < 300 ? 'status-dot status-dot-ok' : 'status-dot status-dot-err';
   const waitMark = stopReason === 'end_turn' ? '<span class="turn-wait" title="Waiting for user">↵</span>' : '';
+  const critMarker = getCriticalMarker(stopReason, e.status, ctxPct);
+  const critMarkerHtml = critMarker ? '<span class="turn-critical-marker">' + critMarker + '</span>' : '';
+  const costHtml = turnCost != null ? '<span class="turn-cost">$' + turnCost.toFixed(4) + '</span>' : '';
   const identityTooltip = [
     isCompacted ? 'Context compacted' : null,
     e.sessionInferred ? 'Session inferred (no explicit session ID)' : null,
   ].filter(Boolean).join(' · ');
   const identityAttr = identityTooltip ? ' title="' + escapeHtml(identityTooltip) + '"' : '';
-  const metaLabels = [
-    isCompacted ? 'compact' : null,
-    e.sessionInferred ? 'inferred' : null,
-  ].filter(Boolean);
-  const identityMeta = metaLabels.length ? '<span class="turn-meta">· ' + metaLabels.join(' · ') + '</span>' : '';
   const identityLine =
     '<div class="turn-identity"' + identityAttr + '>' +
-      indent +
-      '<span class="turn-num">' + numMark + displayNum + '</span>' +
-      '<span class="turn-model">' + escapeHtml(shortModel) + '</span>' +
+      '<span class="turn-num">' + prefix + '</span>' +
+      modelHtml +
       '<span class="' + dotClass + '" title="HTTP ' + e.status + '">●</span>' +
       waitMark +
-      identityMeta +
+      critMarkerHtml +
+      costHtml +
     '</div>';
 
-  // Layer 2: title (skip if null/empty)
+  // Line 2: title (omit if null)
   const titleLine = e.title ? '<div class="turn-title">' + escapeHtml(e.title) + '</div>' : '';
 
-  // Layer 3: context bar
-  const ctxMax = e.maxContext || DEFAULT_MAX_CTX;
-  const ctxPct = Math.min(100, ctxUsed / ctxMax * 100);
+  // Line 3: ctx bar (original segment proportions) + ctx:/hit: labels
   const seg = (tokens, color) => tokens > 0
     ? '<div style="width:' + (tokens / ctxMax * 100).toFixed(2) + '%;background:' + color + ';min-width:1px"></div>'
     : '';
-  const pctColor = ctxPct > 90 ? 'var(--red)' : ctxPct > 70 ? 'var(--yellow)' : 'var(--dim)';
-  const pctLabel = ctxUsed > 0 ? '<div class="turn-ctx-pct" style="color:' + pctColor + '">' + ctxPct.toFixed(0) + '%</div>' : '';
-  const ctxBar = ctxUsed > 0
-    ? '<div class="turn-ctx turn-ctx-bar"><div class="turn-ctx-bar-bg">' +
-        seg(ctxCacheRead,   'var(--color-cache-read)') +
-        seg(ctxCacheCreate, 'var(--color-cache-write)') +
-        seg(ctxInput,       'var(--color-input)') +
-      '</div>' + pctLabel + '</div>'
+  const totalUsed = ctxCacheRead + ctxCacheCreate + ctxInput;
+  const ctxPctClass = ctxPct > 95 ? 'ctx-critical' : ctxPct > 85 ? 'ctx-warning' : '';
+  const ctxPctLabel = '<span class="turn-ctx-pct' + (ctxPctClass ? ' ' + ctxPctClass : '') + '">ctx:' + ctxPct.toFixed(0) + '%</span>';
+  const hitPct = totalUsed > 0 ? Math.round(ctxCacheRead / totalUsed * 100) : null;
+  const hitLabel = hitPct !== null ? '<span class="turn-hit-pct">hit:' + hitPct + '%</span>' : '';
+  const ctxBarHtml = ctxUsed > 0
+    ? '<div class="turn-ctx turn-ctx-bar">' +
+        '<div class="turn-ctx-bar-bg">' +
+          seg(ctxCacheRead,   'var(--color-cache-read)') +
+          seg(ctxCacheCreate, 'var(--color-cache-write)') +
+          seg(ctxInput,       'var(--color-input)') +
+        '</div>' +
+        '<div class="turn-ctx-labels">' + hitLabel + ctxPctLabel + '</div>' +
+      '</div>'
     : '';
 
-  // Layer 4: risk badges
-  const riskBadges = [];
-  if (hasCred) riskBadges.push('<span class="cred-badge" title="Credential pattern detected in this turn">⚠ cred</span>');
-  if (toolFail) riskBadges.push('<span class="tool-fail-badge" title="A tool call returned an error (is_error=true)">⚠ tool-fail</span>');
-  if (dupes) riskBadges.push('<span class="dupe-badge" title="Duplicate tool calls: ' + escapeHtml(Object.entries(dupes).map(([n, c]) => n + '×' + c).join(', ')) + '">⚠ dupes</span>');
-  if (maxTokensStop) riskBadges.push('<span class="max-tokens-badge" title="Output truncated — hit max_tokens">⚠ max_tokens</span>');
-  const riskLine = hasRisk ? '<div class="turn-risk">' + riskBadges.join('') + '</div>' : '';
-
-  // Layer 5: secondary — gap→elapsed · tools · cost · thinking
-  const secondaryParts = [];
-  const elapsedStr = (e.elapsed || '?') + 's';
-  if (gapMs != null) {
-    secondaryParts.push('<span class="turn-gap" style="color:' + gapColor + '" title="' + escapeHtml(gapTitle) + '">⏸' + formatGap(gapMs) + '→' + elapsedStr + '</span>');
-  } else {
-    secondaryParts.push('<span class="turn-elapsed">' + elapsedStr + '</span>');
-  }
-  if (e.thinkingDuration) {
-    secondaryParts.push('<span class="turn-thinking" style="color:var(--purple)">🧠' + e.thinkingDuration.toFixed(1) + 's</span>');
-  }
-  const tcNames = Object.keys(e.toolCalls || {});
-  if (tcNames.length) {
-    const chips = tcNames.slice(0, 5).map(n => {
-      const cls = n === 'Agent' ? 'tool-chip chip-agent' : 'tool-chip';
-      return '<span class="' + cls + '">' + escapeHtml(n.replace(/^mcp__[^_]+__/, '')) + '</span>';
-    }).join('');
-    const overflow = tcNames.length > 5 ? '<span class="tool-chip">+' + (tcNames.length - 5) + '</span>' : '';
-    secondaryParts.push('<span class="turn-tools">' + chips + overflow + '</span>');
-  }
-  if (turnCost != null) {
-    secondaryParts.push('<span class="turn-cost">$' + turnCost.toFixed(4) + '</span>');
-  }
-  const secondaryLine = secondaryParts.length
-    ? '<div class="turn-secondary">' + secondaryParts.join('<span class="turn-sep">·</span>') + '</div>'
+  // Line 4: [time-info] [tools]
+  // time-info: elapsed [wait:gap] [think:N] — flex:1, can clip; tools: flex-shrink:0, always visible
+  const elapsedMs = parseFloat(e.elapsed || 0) * 1000;
+  const thinkSuffix = (e.thinkingDuration && e.thinkingDuration >= 0.05)
+    ? '<span class="turn-think"> (think:' + e.thinkingDuration.toFixed(1) + 's)</span>'
     : '';
+  let timeHtml = '';
+  if (gapMs != null && gapMs >= 500) {
+    timeHtml += '<span class="turn-wait-gap" style="color:' + gapColor + '" title="' + escapeHtml(gapTitle) + '">wait:' + formatGap(gapMs) + '</span>';
+  }
+  timeHtml += '<span class="turn-elapsed">dur:' + formatGap(elapsedMs) + thinkSuffix + '</span>';
+  let chipsHtml = '';
+  for (const n of Object.keys(e.toolCalls || {})) {
+    const cls = n === 'Agent' ? 'tool-chip chip-agent' : 'tool-chip';
+    chipsHtml += '<span class="' + cls + '">' + escapeHtml(n.replace(/^mcp__[^_]+__/, '')) + '</span>';
+  }
+  const secondaryLine = '<div class="turn-secondary">' +
+    '<div class="turn-time-row">' + timeHtml + '</div>' +
+    (chipsHtml ? '<div class="turn-tools-row">' + chipsHtml + '</div>' : '') +
+    '</div>';
 
-  el.innerHTML = identityLine + titleLine + ctxBar + riskLine + secondaryLine;
+  // Line 5: warning/notice risk (no emoji, plain text)
+  const riskMarkers = [];
+  if (hasCred) riskMarkers.push('cred');
+  if (toolFail) riskMarkers.push('tool-fail');
+  if (dupes) {
+    const maxCount = Math.max(...Object.values(dupes));
+    if (maxCount >= 2) riskMarkers.push('dupes\xD7' + maxCount);
+  }
+  const riskLine = riskMarkers.length ? '<div class="turn-risk-line">' + riskMarkers.join(' ') + '</div>' : '';
+
+  el.innerHTML = identityLine + titleLine + ctxBarHtml + secondaryLine + riskLine;
 
   // Hide turn if no session selected, or if it belongs to a different session
   if (!selectedSessionId || selectedSessionId !== sid) el.style.display = 'none';

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -1,12 +1,22 @@
 // ── Entry rendering ──
 let newTurnCount = 0;
 
+function cleanTitle(raw) {
+  if (!raw) return null;
+  let t = raw
+    .replace(/<[^>]+>/g, '')          // strip XML/HTML tags (<system-reminder>, etc.)
+    .replace(/^\s*[*#\-—=~`]+\s*/g, '') // strip leading markdown symbols
+    .replace(/\s+/g, ' ')
+    .trim();
+  return t.length >= 4 ? t : null;
+}
+
 function formatGap(ms) {
   const s = Math.round(ms / 1000);
   if (s < 60) return s + 's';
   const m = Math.floor(s / 60), rem = s % 60;
-  if (m < 60) return m + 'm' + (rem ? ' ' + rem + 's' : '');
-  return Math.floor(m / 60) + 'h' + (m % 60 ? ' ' + (m % 60) + 'm' : '');
+  if (m < 60) return m + 'm' + (rem ? rem + 's' : '');
+  return Math.floor(m / 60) + 'h' + (m % 60 ? (m % 60) + 'm' : '');
 }
 
 function showNewTurnPill(count) {
@@ -286,10 +296,13 @@ function addEntry(e) {
   }
   let gapMs = null, gapColor = '', gapTitle = '';
   if (prevInSession && e.receivedAt) {
-    const prevEnd = prevInSession.receivedAt + parseFloat(prevInSession.elapsed || 0) * 1000;
-    gapMs = Math.max(0, e.receivedAt - prevEnd);
-    gapColor = gapMs < 5 * 60000 ? 'var(--green)' : gapMs < 60 * 60000 ? 'var(--yellow)' : 'var(--red)';
-    gapTitle = gapMs < 5 * 60000 ? 'Cache likely warm (< 5m)' : gapMs < 60 * 60000 ? 'Default cache expired (5m–1h)' : 'All cache expired (> 1h)';
+    const prevEnd = Number(prevInSession.receivedAt) + parseFloat(prevInSession.elapsed || 0) * 1000;
+    const rawGap = Number(e.receivedAt) - prevEnd;
+    gapMs = Number.isFinite(rawGap) ? Math.max(0, rawGap) : null;
+    if (gapMs !== null) {
+      gapColor = gapMs < 5 * 60000 ? 'var(--green)' : gapMs < 60 * 60000 ? 'var(--yellow)' : 'var(--red)';
+      gapTitle = gapMs < 5 * 60000 ? 'Cache likely warm (< 5m)' : gapMs < 60 * 60000 ? 'Default cache expired (5m–1h)' : 'All cache expired (> 1h)';
+    }
   }
 
   // Compression detection: compare message count AND context tokens vs previous main turn.
@@ -364,8 +377,9 @@ function addEntry(e) {
       costHtml +
     '</div>';
 
-  // Line 2: title (omit if null)
-  const titleLine = e.title ? '<div class="turn-title">' + escapeHtml(e.title) + '</div>' : '';
+  // Line 2: title (omit if null or noise)
+  const cleanedTitle = cleanTitle(e.title);
+  const titleLine = cleanedTitle ? '<div class="turn-title">' + escapeHtml(cleanedTitle) + '</div>' : '';
 
   // Line 3: ctx bar (original segment proportions) + ctx:/hit: labels
   const seg = (tokens, color) => tokens > 0
@@ -400,7 +414,7 @@ function addEntry(e) {
   timeHtml += '<span class="turn-elapsed">dur:' + formatGap(elapsedMs) + thinkSuffix + '</span>';
   let chipsHtml = '';
   for (const n of Object.keys(e.toolCalls || {})) {
-    const cls = n === 'Agent' ? 'tool-chip chip-agent' : 'tool-chip';
+    const cls = 'tool-chip';
     chipsHtml += '<span class="' + cls + '">' + escapeHtml(n.replace(/^mcp__[^_]+__/, '')) + '</span>';
   }
   const secondaryLine = '<div class="turn-secondary">' +

--- a/public/style.css
+++ b/public/style.css
@@ -181,6 +181,7 @@
   .turn-item .turn-line3 { display: flex; flex-wrap: wrap; gap: 3px; margin-top: 2px; }
   .tool-chip { font-size: 9px; color: var(--dim); background: var(--bg2, var(--surface-hover)); border-radius: 3px; padding: 0 3px; }
   .turn-item .turn-title { font-size: 11px; color: var(--text); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .turn-item .turn-gap { font-size: 10px; margin-bottom: 3px; }
   .compact-badge { font-size: 9px; color: var(--red); border: 1px solid var(--red); border-radius: 2px; padding: 0 3px; margin-left: 4px; opacity: 0.85; flex-shrink: 0; }
   .inferred-badge { font-size: 9px; color: var(--yellow); border: 1px dashed var(--yellow); border-radius: 2px; padding: 0 3px; margin-left: 4px; opacity: 0.85; flex-shrink: 0; }
   .cred-badge { font-size: 9px; color: var(--orange); border: 1px solid var(--orange); border-radius: 2px; padding: 0 3px; margin-left: 4px; opacity: 0.9; flex-shrink: 0; }

--- a/public/style.css
+++ b/public/style.css
@@ -209,7 +209,7 @@
   .turn-sub { opacity: 0.7; }
   .turn-sub:hover { opacity: 1; }
   .turn-sub.selected { opacity: 1; border-left-color: var(--orange) !important; }
-  .tool-chip.chip-agent { color: var(--orange); }
+
   .si-tools { font-size: 10px; color: var(--dim); margin: 2px 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .col-sticky-header { position: sticky; top: 0; z-index: 2; background: var(--surface); }
   #scroll-toggle { user-select: none; }

--- a/public/style.css
+++ b/public/style.css
@@ -189,7 +189,7 @@
   /* Line 3: ctx bar */
   .turn-item .turn-ctx { margin-top: 4px; }
   /* Line 4: secondary — time + tools */
-  .turn-item .turn-secondary { display: flex; flex-direction: column; gap: 3px; font-size: 11px; color: var(--dim); margin-top: 3px; }
+  .turn-item .turn-secondary { display: flex; flex-direction: column; gap: 3px; font-size: 9px; color: var(--dim); margin-top: 3px; }
   .turn-item .turn-time-row { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
   .turn-item .turn-tools-row { display: flex; flex-wrap: wrap; gap: 3px; }
   .turn-item .turn-elapsed { white-space: nowrap; }
@@ -224,6 +224,7 @@
   .turn-ctx-pct.ctx-critical { color: var(--red); }
   .turn-ctx-pct.ctx-warning { color: var(--yellow); }
   .turn-hit-pct { color: var(--color-cache-read); }
+  .turn-hit-pct.hit-cold { color: var(--red); }
   #ctx-legend { padding: 3px 10px 4px; border-bottom: 1px solid var(--border); display: flex; gap: 8px; align-items: center; font-size: 9px; color: var(--dim); }
   .ctx-legend-dot { display: inline-block; width: 7px; height: 7px; border-radius: 1px; margin-right: 2px; vertical-align: middle; }
   #session-sparkline { padding: 6px 10px; border-bottom: 1px solid var(--border); display: none; }

--- a/public/style.css
+++ b/public/style.css
@@ -185,7 +185,7 @@
   .turn-item .turn-critical-marker { font-size: 10px; color: var(--red); font-weight: bold; flex-shrink: 0; }
   .turn-item .turn-cost { color: var(--yellow); margin-left: auto; flex-shrink: 0; }
   /* Line 2: title */
-  .turn-item .turn-title { font-size: 11px; color: var(--text); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .turn-item .turn-title { font-size: 11px; color: var(--text); margin-top: 2px; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; }
   /* Line 3: ctx bar */
   .turn-item .turn-ctx { margin-top: 4px; }
   /* Line 4: secondary — time + tools */

--- a/public/style.css
+++ b/public/style.css
@@ -171,20 +171,36 @@
   .turn-item { padding: 7px 10px; cursor: pointer; border-left: 3px solid transparent; border-bottom: 1px solid var(--border); }
   .turn-item:hover { background: var(--surface-hover); }
   .turn-item.selected { border-left-color: var(--accent); background: var(--surface-hover); }
-  .turn-item .turn-line1 { display: flex; gap: 6px; align-items: center; font-size: 12px; }
+  /* Layer 1: identity */
+  .turn-item .turn-identity { display: flex; gap: 6px; align-items: center; font-size: 12px; }
   .turn-item .turn-num { color: var(--dim); }
-  .turn-item .turn-model { color: var(--purple); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .turn-item .turn-line2 { display: flex; gap: 6px; font-size: 11px; color: var(--dim); margin-top: 3px; flex-wrap: wrap; }
+  .turn-item .turn-model { color: var(--purple); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .turn-item .status-dot { font-size: 10px; line-height: 1; }
+  .turn-item .status-dot-ok { color: var(--green); }
+  .turn-item .status-dot-err { color: var(--red); }
+  .turn-item .turn-wait { color: var(--dim); font-size: 11px; margin-left: 2px; }
+  .turn-item .turn-meta { color: var(--dim); font-size: 9px; opacity: 0.7; margin-left: auto; flex-shrink: 0; }
+  /* Layer 2: title */
+  .turn-item .turn-title { font-size: 11px; color: var(--text); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  /* Layer 3: ctx bar (see .turn-ctx-bar below) */
+  .turn-item .turn-ctx { margin-top: 4px; }
+  /* Layer 4: risk badges */
+  .turn-item .turn-risk { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 3px; }
+  /* Layer 5: secondary */
+  .turn-item .turn-secondary { display: flex; flex-wrap: wrap; gap: 5px; font-size: 11px; color: var(--dim); margin-top: 3px; align-items: center; }
+  .turn-item .turn-sep { color: var(--border); }
+  .turn-item .turn-cost { color: var(--yellow); }
+  .turn-item .turn-elapsed, .turn-item .turn-thinking { white-space: nowrap; }
+  .turn-item .turn-tools { display: inline-flex; flex-wrap: wrap; gap: 3px; }
+  /* Legacy — still used by detail views */
   .turn-item .status-ok { color: var(--green); }
   .turn-item .status-err { color: var(--red); }
-  .turn-item .turn-cost { color: var(--yellow); }
-  .turn-item .turn-line3 { display: flex; flex-wrap: wrap; gap: 3px; margin-top: 2px; }
   .tool-chip { font-size: 9px; color: var(--dim); background: var(--bg2, var(--surface-hover)); border-radius: 3px; padding: 0 3px; }
-  .turn-item .turn-title { font-size: 11px; color: var(--text); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .turn-item .turn-gap { font-size: 10px; margin-bottom: 3px; }
-  .compact-badge { font-size: 9px; color: var(--red); border: 1px solid var(--red); border-radius: 2px; padding: 0 3px; margin-left: 4px; opacity: 0.85; flex-shrink: 0; }
-  .inferred-badge { font-size: 9px; color: var(--yellow); border: 1px dashed var(--yellow); border-radius: 2px; padding: 0 3px; margin-left: 4px; opacity: 0.85; flex-shrink: 0; }
-  .cred-badge { font-size: 9px; color: var(--orange); border: 1px solid var(--orange); border-radius: 2px; padding: 0 3px; margin-left: 4px; opacity: 0.9; flex-shrink: 0; }
+  .turn-item .turn-gap { font-size: 10px; white-space: nowrap; }
+  .cred-badge { font-size: 9px; color: var(--orange); border: 1px solid var(--orange); border-radius: 2px; padding: 0 3px; opacity: 0.9; flex-shrink: 0; }
+  .dupe-badge { font-size: 9px; color: var(--yellow); border: 1px solid var(--yellow); border-radius: 2px; padding: 0 3px; opacity: 0.9; flex-shrink: 0; }
+  .tool-fail-badge { font-size: 9px; color: var(--red); border: 1px solid var(--red); border-radius: 2px; padding: 0 3px; opacity: 0.9; flex-shrink: 0; }
+  .max-tokens-badge { font-size: 9px; color: var(--red); border: 1px solid var(--red); border-radius: 2px; padding: 0 3px; opacity: 0.9; flex-shrink: 0; }
   .cred-highlight { background: rgba(240, 136, 62, 0.25); color: var(--orange); border-radius: 2px; padding: 0 1px; }
   .source-badge { font-size: 9px; border-radius: 2px; padding: 0 3px; margin-left: 4px; opacity: 0.75; flex-shrink: 0; }
   .source-local { color: #666; border: 1px solid #666; }

--- a/public/style.css
+++ b/public/style.css
@@ -168,48 +168,47 @@
   .pin-btn.pinned { opacity: 1; color: var(--yellow); }
 
   /* ── Turn items ── */
-  .turn-item { padding: 7px 10px; cursor: pointer; border-left: 3px solid transparent; border-bottom: 1px solid var(--border); }
+  .turn-item { padding: 7px 10px; cursor: pointer; border-left: 2px solid transparent; border-bottom: 1px solid var(--border); }
   .turn-item:hover { background: var(--surface-hover); }
   .turn-item.selected { border-left-color: var(--accent); background: var(--surface-hover); }
-  /* Layer 1: identity */
-  .turn-item .turn-identity { display: flex; gap: 6px; align-items: center; font-size: 12px; }
-  .turn-item .turn-num { color: var(--dim); }
+  .turn-item.risk-critical { border-left-color: var(--red); }
+  .turn-item.risk-warning { border-left-color: var(--orange); }
+  .turn-item.risk-notice { border-left-color: var(--yellow); }
+  /* Line 1: identity */
+  .turn-item .turn-identity { display: flex; gap: 6px; align-items: center; font-size: 12px; flex-wrap: nowrap; }
+  .turn-item .turn-num { color: var(--dim); flex-shrink: 0; }
   .turn-item .turn-model { color: var(--purple); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .turn-item .status-dot { font-size: 10px; line-height: 1; }
+  .turn-item .status-dot { font-size: 10px; line-height: 1; flex-shrink: 0; }
   .turn-item .status-dot-ok { color: var(--green); }
   .turn-item .status-dot-err { color: var(--red); }
-  .turn-item .turn-wait { color: var(--dim); font-size: 11px; margin-left: 2px; }
-  .turn-item .turn-meta { color: var(--dim); font-size: 9px; opacity: 0.7; margin-left: auto; flex-shrink: 0; }
-  /* Layer 2: title */
+  .turn-item .turn-wait { color: var(--dim); font-size: 11px; flex-shrink: 0; }
+  .turn-item .turn-critical-marker { font-size: 10px; color: var(--red); font-weight: bold; flex-shrink: 0; }
+  .turn-item .turn-cost { color: var(--yellow); margin-left: auto; flex-shrink: 0; }
+  /* Line 2: title */
   .turn-item .turn-title { font-size: 11px; color: var(--text); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  /* Layer 3: ctx bar (see .turn-ctx-bar below) */
+  /* Line 3: ctx bar */
   .turn-item .turn-ctx { margin-top: 4px; }
-  /* Layer 4: risk badges */
-  .turn-item .turn-risk { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 3px; }
-  /* Layer 5: secondary */
-  .turn-item .turn-secondary { display: flex; flex-wrap: wrap; gap: 5px; font-size: 11px; color: var(--dim); margin-top: 3px; align-items: center; }
-  .turn-item .turn-sep { color: var(--border); }
-  .turn-item .turn-cost { color: var(--yellow); }
-  .turn-item .turn-elapsed, .turn-item .turn-thinking { white-space: nowrap; }
-  .turn-item .turn-tools { display: inline-flex; flex-wrap: wrap; gap: 3px; }
+  /* Line 4: secondary — time + tools */
+  .turn-item .turn-secondary { display: flex; flex-direction: column; gap: 3px; font-size: 11px; color: var(--dim); margin-top: 3px; }
+  .turn-item .turn-time-row { display: flex; gap: 6px; align-items: center; flex-wrap: nowrap; }
+  .turn-item .turn-tools-row { display: flex; flex-wrap: wrap; gap: 3px; }
+  .turn-item .turn-elapsed { white-space: nowrap; }
+  .turn-item .turn-wait-gap { white-space: nowrap; }
+  .turn-item .turn-think { color: var(--purple); white-space: nowrap; }
+  /* Line 5: warning/notice risk */
+  .turn-item .turn-risk-line { font-size: 9px; color: var(--dim); margin-top: 2px; }
   /* Legacy — still used by detail views */
   .turn-item .status-ok { color: var(--green); }
   .turn-item .status-err { color: var(--red); }
   .tool-chip { font-size: 9px; color: var(--dim); background: var(--bg2, var(--surface-hover)); border-radius: 3px; padding: 0 3px; }
-  .turn-item .turn-gap { font-size: 10px; white-space: nowrap; }
-  .cred-badge { font-size: 9px; color: var(--orange); border: 1px solid var(--orange); border-radius: 2px; padding: 0 3px; opacity: 0.9; flex-shrink: 0; }
-  .dupe-badge { font-size: 9px; color: var(--yellow); border: 1px solid var(--yellow); border-radius: 2px; padding: 0 3px; opacity: 0.9; flex-shrink: 0; }
-  .tool-fail-badge { font-size: 9px; color: var(--red); border: 1px solid var(--red); border-radius: 2px; padding: 0 3px; opacity: 0.9; flex-shrink: 0; }
-  .max-tokens-badge { font-size: 9px; color: var(--red); border: 1px solid var(--red); border-radius: 2px; padding: 0 3px; opacity: 0.9; flex-shrink: 0; }
   .cred-highlight { background: rgba(240, 136, 62, 0.25); color: var(--orange); border-radius: 2px; padding: 0 1px; }
   .source-badge { font-size: 9px; border-radius: 2px; padding: 0 3px; margin-left: 4px; opacity: 0.75; flex-shrink: 0; }
   .source-local { color: #666; border: 1px solid #666; }
   .source-local-sensitive { color: var(--orange); border: 1px solid var(--orange); opacity: 0.9; }
   .source-network { color: #5b9bd5; border: 1px solid #5b9bd5; }
-  .turn-sub { opacity: 0.7; border-left-color: transparent !important; }
+  .turn-sub { opacity: 0.7; }
   .turn-sub:hover { opacity: 1; }
   .turn-sub.selected { opacity: 1; border-left-color: var(--orange) !important; }
-  .sub-indent { color: var(--dim); margin-right: 2px; user-select: none; }
   .tool-chip.chip-agent { color: var(--orange); }
   .si-tools { font-size: 10px; color: var(--dim); margin: 2px 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .col-sticky-header { position: sticky; top: 0; z-index: 2; background: var(--surface); }
@@ -220,7 +219,11 @@
   #session-tool-bar { padding: 4px 10px; font-size: 10px; color: var(--dim); border-bottom: 1px solid var(--border); display: flex; flex-wrap: nowrap; gap: 4px; align-items: center; overflow: hidden; white-space: nowrap; }
   .turn-ctx-bar { margin-top: 3px; }
   .turn-ctx-bar-bg { height: 3px; border-radius: 1.5px; background: var(--border); overflow: hidden; display: flex; }
-  .turn-ctx-pct { font-size: 9px; color: var(--dim); margin-top: 1px; text-align: right; line-height: 1; }
+  .turn-ctx-labels { display: flex; font-size: 9px; margin-top: 1px; line-height: 1; }
+  .turn-ctx-pct { color: var(--dim); margin-left: auto; }
+  .turn-ctx-pct.ctx-critical { color: var(--red); }
+  .turn-ctx-pct.ctx-warning { color: var(--yellow); }
+  .turn-hit-pct { color: var(--color-cache-read); }
   #ctx-legend { padding: 3px 10px 4px; border-bottom: 1px solid var(--border); display: flex; gap: 8px; align-items: center; font-size: 9px; color: var(--dim); }
   .ctx-legend-dot { display: inline-block; width: 7px; height: 7px; border-radius: 1px; margin-right: 2px; vertical-align: middle; }
   #session-sparkline { padding: 6px 10px; border-bottom: 1px solid var(--border); display: none; }

--- a/public/style.css
+++ b/public/style.css
@@ -190,7 +190,7 @@
   .turn-item .turn-ctx { margin-top: 4px; }
   /* Line 4: secondary — time + tools */
   .turn-item .turn-secondary { display: flex; flex-direction: column; gap: 3px; font-size: 11px; color: var(--dim); margin-top: 3px; }
-  .turn-item .turn-time-row { display: flex; gap: 6px; align-items: center; flex-wrap: nowrap; }
+  .turn-item .turn-time-row { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
   .turn-item .turn-tools-row { display: flex; flex-wrap: wrap; gap: 3px; }
   .turn-item .turn-elapsed { white-space: nowrap; }
   .turn-item .turn-wait-gap { white-space: nowrap; }

--- a/server/forward.js
+++ b/server/forward.js
@@ -243,7 +243,14 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
     const sessionId = reqSessionId;
     const costInfo = calculateCost(usage, parsedBody?.model);
     const maxContext = config.getMaxContext(parsedBody?.model, parsedBody?.system);
-    const title = helpers.extractResponseTitle(events);
+    const isSubagent = !store.extractCwd(parsedBody);
+    const title = (isSubagent
+      ? helpers.extractFirstUserText(parsedBody)
+      : (helpers.extractResponseTitle(events)
+         || helpers.extractLastUserText(parsedBody)
+         || helpers.extractToolResultSummary(parsedBody)))
+      || null;
+    const toolFail = helpers.hasToolFail(parsedBody);
     const thinkingDuration = helpers.computeThinkingDuration(events);
     const entry = {
       id, ts: ctx.ts, sessionId, method: ctx.clientReq.method, url: ctx.clientReq.url,
@@ -260,10 +267,11 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
       msgCount: parsedBody?.messages?.length || 0,
       toolCount: parsedBody?.tools?.length || 0,
       toolCalls: helpers.extractToolCalls(parsedBody?.messages),
-      isSubagent: !store.extractCwd(parsedBody),
+      isSubagent,
       sessionInferred: ctx.sessionInferred || false,
       title,
       stopReason,
+      toolFail,
       sysHash: ctx.sysHash || null,
       toolsHash: ctx.toolsHash || null,
     };
@@ -283,6 +291,7 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
       cwd: entry.cwd, isSSE: true,
       usage, cost: costInfo, maxContext,
       stopReason, title, thinkingDuration,
+      toolFail,
       elapsed, status: proxyRes.statusCode,
       receivedAt: startTime,
       sysHash: ctx.sysHash || null, toolsHash: ctx.toolsHash || null,
@@ -346,7 +355,14 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
 
     const sessionId = reqSessionId;
     const maxContext = config.getMaxContext(parsedBody?.model, parsedBody?.system);
-    const title = helpers.extractResponseTitle(resData);
+    const isSubagent = !store.extractCwd(parsedBody);
+    const title = (isSubagent
+      ? helpers.extractFirstUserText(parsedBody)
+      : (helpers.extractResponseTitle(resData)
+         || helpers.extractLastUserText(parsedBody)
+         || helpers.extractToolResultSummary(parsedBody)))
+      || null;
+    const toolFail = helpers.hasToolFail(parsedBody);
     const stopReason = resData?.stop_reason || '';
     const entry = {
       id, ts: ctx.ts, sessionId, method: ctx.clientReq.method, url: ctx.clientReq.url,
@@ -362,10 +378,11 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
       msgCount: parsedBody?.messages?.length || 0,
       toolCount: parsedBody?.tools?.length || 0,
       toolCalls: helpers.extractToolCalls(parsedBody?.messages),
-      isSubagent: !store.extractCwd(parsedBody),
+      isSubagent,
       sessionInferred: ctx.sessionInferred || false,
       title,
       stopReason,
+      toolFail,
       sysHash: ctx.sysHash || null,
       toolsHash: ctx.toolsHash || null,
     };
@@ -383,6 +400,7 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
       cwd: entry.cwd, isSSE: false,
       usage: null, cost: null, maxContext,
       stopReason, title, thinkingDuration: null,
+      toolFail,
       elapsed, status: proxyRes.statusCode,
       receivedAt: startTime,
       sysHash: ctx.sysHash || null, toolsHash: ctx.toolsHash || null,

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -338,6 +338,99 @@ function extractResponseTitle(res) {
   return (firstSentence || text).slice(0, 80) || null;
 }
 
+// Extract pure text from a message's content blocks (ignores tool_result, tool_use, etc.)
+function collectTextFromContent(content) {
+  if (typeof content === 'string') return content.trim();
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter(b => b && b.type === 'text' && typeof b.text === 'string')
+    .map(b => b.text)
+    .join(' ')
+    .trim();
+}
+
+// Fallback #2: last user message had pure text (user-initiated turn with no response text)
+function extractLastUserText(req) {
+  const messages = req?.messages;
+  if (!Array.isArray(messages)) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m?.role !== 'user') continue;
+    const text = collectTextFromContent(m.content);
+    if (text) {
+      const firstSentence = text.split(/[.\n]/)[0].trim();
+      return (firstSentence || text).replace(/\s+/g, ' ') || null;
+    }
+    return null; // last user msg exists but has no text (tool_results only)
+  }
+  return null;
+}
+
+// Fallback #3: last user message is all tool_results → summarize completed tool names
+// Maps tool_use_id → name using preceding assistant message, dedupes, preserves order, caps at 5.
+function extractToolResultSummary(req) {
+  const messages = req?.messages;
+  if (!Array.isArray(messages) || messages.length === 0) return null;
+  const last = messages[messages.length - 1];
+  if (last?.role !== 'user' || !Array.isArray(last.content)) return null;
+  const ids = [];
+  for (const b of last.content) {
+    if (b?.type === 'tool_result' && typeof b.tool_use_id === 'string') ids.push(b.tool_use_id);
+  }
+  if (!ids.length) return null;
+  // Build id → name from all preceding assistant messages
+  const idToName = {};
+  for (let i = 0; i < messages.length - 1; i++) {
+    const m = messages[i];
+    if (m?.role !== 'assistant' || !Array.isArray(m.content)) continue;
+    for (const b of m.content) {
+      if (b?.type === 'tool_use' && b.id && b.name) idToName[b.id] = b.name;
+    }
+  }
+  const names = [];
+  const seen = new Set();
+  for (const id of ids) {
+    const name = idToName[id];
+    if (!name) continue;
+    const shortName = name.replace(/^mcp__[^_]+__/, '');
+    if (seen.has(shortName)) continue;
+    seen.add(shortName);
+    names.push(shortName);
+  }
+  if (!names.length) return null;
+  const head = names.slice(0, 5).join(' · ');
+  const overflow = names.length > 5 ? ` +${names.length - 5}` : '';
+  return '↩ ' + head + overflow;
+}
+
+// Fallback #4 (subagent): first user message text — the task the subagent was given
+function extractFirstUserText(req) {
+  const messages = req?.messages;
+  if (!Array.isArray(messages)) return null;
+  for (const m of messages) {
+    if (m?.role !== 'user') continue;
+    const text = collectTextFromContent(m.content);
+    if (text) {
+      const firstSentence = text.split(/[.\n]/)[0].trim();
+      return (firstSentence || text).replace(/\s+/g, ' ') || null;
+    }
+  }
+  return null;
+}
+
+// Scan request for any tool_result with is_error: true
+function hasToolFail(req) {
+  const messages = req?.messages;
+  if (!Array.isArray(messages)) return false;
+  for (const m of messages) {
+    if (!Array.isArray(m?.content)) continue;
+    for (const b of m.content) {
+      if (b?.type === 'tool_result' && b.is_error === true) return true;
+    }
+  }
+  return false;
+}
+
 // ── Credential scanning ──────────────────────────────────────────────
 const CREDENTIAL_PATTERNS = [
   /sk-ant-[a-zA-Z0-9_-]{20,}/,
@@ -473,6 +566,10 @@ module.exports = {
   computeThinkingDuration,
   parseSSEEvents,
   extractResponseTitle,
+  extractLastUserText,
+  extractToolResultSummary,
+  extractFirstUserText,
+  hasToolFail,
   extractToolCalls,
   extractDuplicateToolCalls,
   scanCredentials,

--- a/server/sse-broadcast.js
+++ b/server/sse-broadcast.js
@@ -9,6 +9,7 @@ function summarizeEntry(entry) {
     id: entry.id, ts: entry.ts, sessionId: entry.sessionId,
     method: entry.method, url: entry.url,
     elapsed: entry.elapsed, status: entry.status, isSSE: entry.isSSE,
+    receivedAt: entry.receivedAt || null,
     usage: entry.usage, cost: entry.cost, maxContext: entry.maxContext, cwd: entry.cwd,
     model: entry.model || null,
     msgCount: entry.msgCount || 0,
@@ -20,6 +21,7 @@ function summarizeEntry(entry) {
     stopReason: entry.stopReason || '',
     thinkingDuration: entry.thinkingDuration || null,
     duplicateToolCalls: entry.duplicateToolCalls || null,
+    toolFail: entry.toolFail || false,
     hasCredential: entry.hasCredential || undefined,
     toolSources: entry.toolSources || undefined,
     tokens: tok ? {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -7,6 +7,10 @@ const {
   totalContextTokens,
   parseSSEEvents,
   extractResponseTitle,
+  extractLastUserText,
+  extractToolResultSummary,
+  extractFirstUserText,
+  hasToolFail,
   extractToolCalls,
   computeThinkingDuration,
   categorizeTools,
@@ -328,6 +332,177 @@ describe('helpers', () => {
 
     it('handles entry with no req', () => {
       assert.deepEqual(buildToolSources({}), {});
+    });
+  });
+
+  describe('extractLastUserText', () => {
+    it('returns null for missing or empty input', () => {
+      assert.equal(extractLastUserText(null), null);
+      assert.equal(extractLastUserText({}), null);
+      assert.equal(extractLastUserText({ messages: [] }), null);
+    });
+
+    it('extracts text from string-content user message', () => {
+      const req = { messages: [
+        { role: 'assistant', content: 'something' },
+        { role: 'user', content: 'Fix the login bug please' },
+      ]};
+      assert.equal(extractLastUserText(req), 'Fix the login bug please');
+    });
+
+    it('extracts first sentence from block-content user message', () => {
+      const req = { messages: [{
+        role: 'user',
+        content: [{ type: 'text', text: 'Refactor auth.  Also add tests.' }],
+      }]};
+      assert.equal(extractLastUserText(req), 'Refactor auth');
+    });
+
+    it('returns null when last user msg is only tool_results', () => {
+      const req = { messages: [
+        { role: 'user', content: 'task' },
+        { role: 'assistant', content: [{ type: 'tool_use', id: 't1', name: 'Read', input: {} }] },
+        { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] },
+      ]};
+      assert.equal(extractLastUserText(req), null);
+    });
+
+    it('ignores non-text blocks when searching for text', () => {
+      const req = { messages: [{
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 't1', content: 'noise' },
+          { type: 'text', text: 'actual question' },
+        ],
+      }]};
+      assert.equal(extractLastUserText(req), 'actual question');
+    });
+  });
+
+  describe('extractToolResultSummary', () => {
+    const req = (messages) => ({ messages });
+
+    it('returns null when no tool_results', () => {
+      assert.equal(extractToolResultSummary(req([
+        { role: 'user', content: 'hi' },
+      ])), null);
+    });
+
+    it('maps tool_use_id to name and produces summary', () => {
+      const r = req([
+        { role: 'user', content: 'do stuff' },
+        { role: 'assistant', content: [
+          { type: 'tool_use', id: 't1', name: 'Read' },
+          { type: 'tool_use', id: 't2', name: 'Bash' },
+        ]},
+        { role: 'user', content: [
+          { type: 'tool_result', tool_use_id: 't1' },
+          { type: 'tool_result', tool_use_id: 't2' },
+        ]},
+      ]);
+      assert.equal(extractToolResultSummary(r), '↩ Read · Bash');
+    });
+
+    it('dedupes repeated tool names', () => {
+      const r = req([
+        { role: 'assistant', content: [
+          { type: 'tool_use', id: 't1', name: 'Bash' },
+          { type: 'tool_use', id: 't2', name: 'Bash' },
+          { type: 'tool_use', id: 't3', name: 'Bash' },
+        ]},
+        { role: 'user', content: [
+          { type: 'tool_result', tool_use_id: 't1' },
+          { type: 'tool_result', tool_use_id: 't2' },
+          { type: 'tool_result', tool_use_id: 't3' },
+        ]},
+      ]);
+      assert.equal(extractToolResultSummary(r), '↩ Bash');
+    });
+
+    it('caps at 5 with overflow marker', () => {
+      const ids = ['a','b','c','d','e','f','g'];
+      const names = ['Read','Bash','Write','Edit','Grep','Glob','WebFetch'];
+      const r = req([
+        { role: 'assistant', content: ids.map((id, i) => ({ type: 'tool_use', id, name: names[i] })) },
+        { role: 'user', content: ids.map(id => ({ type: 'tool_result', tool_use_id: id })) },
+      ]);
+      assert.equal(extractToolResultSummary(r), '↩ Read · Bash · Write · Edit · Grep +2');
+    });
+
+    it('strips mcp__server__ prefix from tool names', () => {
+      const r = req([
+        { role: 'assistant', content: [{ type: 'tool_use', id: 't1', name: 'mcp__github__list_issues' }] },
+        { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1' }] },
+      ]);
+      assert.equal(extractToolResultSummary(r), '↩ list_issues');
+    });
+
+    it('returns null when tool_use_id has no matching tool_use', () => {
+      const r = req([
+        { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'unknown' }] },
+      ]);
+      assert.equal(extractToolResultSummary(r), null);
+    });
+  });
+
+  describe('extractFirstUserText', () => {
+    it('returns null for missing input', () => {
+      assert.equal(extractFirstUserText(null), null);
+      assert.equal(extractFirstUserText({ messages: [] }), null);
+    });
+
+    it('returns first user text, ignoring non-text blocks', () => {
+      const req = { messages: [
+        { role: 'user', content: [
+          { type: 'tool_result', content: 'noise' },
+          { type: 'text', text: 'Search for login bug.  Also check API.' },
+        ]},
+        { role: 'user', content: 'later message' },
+      ]};
+      assert.equal(extractFirstUserText(req), 'Search for login bug');
+    });
+
+    it('skips empty first user message and continues to next', () => {
+      const req = { messages: [
+        { role: 'user', content: [{ type: 'tool_result', content: 'x' }] },
+        { role: 'user', content: 'real task' },
+      ]};
+      assert.equal(extractFirstUserText(req), 'real task');
+    });
+  });
+
+  describe('hasToolFail', () => {
+    it('returns false for missing input', () => {
+      assert.equal(hasToolFail(null), false);
+      assert.equal(hasToolFail({}), false);
+      assert.equal(hasToolFail({ messages: [] }), false);
+    });
+
+    it('returns true when any tool_result has is_error: true', () => {
+      const req = { messages: [{
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 't1', is_error: false },
+          { type: 'tool_result', tool_use_id: 't2', is_error: true },
+        ],
+      }]};
+      assert.equal(hasToolFail(req), true);
+    });
+
+    it('returns false when all tool_results are successful', () => {
+      const req = { messages: [{
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 't1', is_error: false }],
+      }]};
+      assert.equal(hasToolFail(req), false);
+    });
+
+    it('treats undefined is_error as success', () => {
+      const req = { messages: [{
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 't1' }],
+      }]};
+      assert.equal(hasToolFail(req), false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **五行版型**：identity / title / ctx-bar / secondary(tools+time) / risk
- **Left-bar severity**：2px 左色條編碼最高嚴重度（紅/橙/黃）
- **Critical marker 升至 Line 1**：`!max` `!len` `!stop` `!filter` `!http` 緊跟 `●`
- **Title 過濾**：`cleanTitle()` 去除 `<system-reminder>`、leading markdown；< 4 字元省略
- **Tools 行提前**：工具使用（設計訊號）排在時間行之前
- **時間語意前綴**：`wait:Ns dur:Ns (think:Ns)`，wait 優先
- **ctx bar 雙標籤**：`hit:NN%` 靠左 / `ctx:NN%` 靠右；`hit < 10%` 顯示紅色
- **Wait 防錯**：`Number()` 轉型 + `isFinite` guard，避免 string concatenation bug
- **Model 永遠顯示**：移除 session-aware 省略邏輯

## Test plan

- [ ] 正常 turn：無左色條，ctx bar 全寬，hit/ctx 標籤正確
- [ ] Critical turn（max_tokens）：左條紅色，`!max` 在 Line 1
- [ ] Tool-fail turn：左條橙色，Line 5 顯示 `tool-fail`
- [ ] Subagent turn：`↳sN` prefix，model 顯示
- [ ] wait > 1h：wait 紅色；wait < 5m：wait 綠色
- [ ] hit:0%：標籤顯示紅色
- [ ] `<system-reminder>` title：Line 2 省略

🤖 Generated with [Claude Code](https://claude.com/claude-code)