### PR TITLE
security: harden network surface, filesystem, and hub IPC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "ccxray",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccxray",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",
-        "@fission-ai/openspec": "^1.2.0",
         "ws": "^8.19.0"
       },
       "bin": {
         "ccxray": "server/index.js"
       },
       "devDependencies": {
+        "@fission-ai/openspec": "^1.2.0",
         "puppeteer": "^24.39.1"
       },
       "engines": {
@@ -62,6 +62,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@fission-ai/openspec/-/openspec-1.2.0.tgz",
       "integrity": "sha512-2XDmPZcVY0Bs014lP9aoxe3VoEU8hFvqaBFxQaiJO2nhC8vTKCyo6sT/5YpQcOTfR/a64Hht2anTyqLR4eNhlg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -86,6 +87,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -95,6 +97,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
       "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -104,6 +107,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
       "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -128,6 +132,7 @@
       "version": "5.1.21",
       "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
       "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -149,6 +154,7 @@
       "version": "10.3.2",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
       "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -176,6 +182,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -190,6 +197,7 @@
       "version": "4.2.23",
       "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
       "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -212,6 +220,7 @@
       "version": "4.0.23",
       "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
       "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -234,6 +243,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
       "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
@@ -255,6 +265,7 @@
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
       "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -264,6 +275,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
       "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -285,6 +297,7 @@
       "version": "3.0.23",
       "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
       "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -306,6 +319,7 @@
       "version": "4.0.23",
       "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
       "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -328,6 +342,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
@@ -357,6 +372,7 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
       "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -379,6 +395,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
       "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -402,6 +419,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
       "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -426,6 +444,7 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
       "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -443,6 +462,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -456,6 +476,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -465,6 +486,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -478,6 +500,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.10.0.tgz",
       "integrity": "sha512-Xk3JQ+cdychsvftrV3G9ZrN9W329lbyFW0pGJXFGKFQf8qr4upw2SgNg9BVorjSrfhoXZRnJGt/uNF4nGFBL5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6"
@@ -546,6 +569,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -555,6 +579,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -695,9 +720,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -708,6 +733,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -740,6 +766,7 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -752,6 +779,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/chromium-bidi": {
@@ -772,6 +800,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^5.0.0"
@@ -787,6 +816,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -799,6 +829,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -823,6 +854,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -835,12 +867,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -877,6 +911,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -941,6 +976,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -1081,6 +1117,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1097,6 +1134,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -1116,6 +1154,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -1138,6 +1177,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1181,6 +1221,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -1221,6 +1262,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -1271,6 +1313,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1280,6 +1323,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1289,6 +1333,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -1301,6 +1346,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
       "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1313,6 +1359,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -1322,6 +1369,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1334,6 +1382,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/js-tokens": {
@@ -1374,6 +1423,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
       "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -1390,6 +1440,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
       "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1412,6 +1463,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1421,6 +1473,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -1434,6 +1487,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1460,6 +1514,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -1489,6 +1544,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-function": "^5.0.0"
@@ -1504,6 +1560,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
       "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -1527,6 +1584,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1539,12 +1597,14 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ora/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
@@ -1562,6 +1622,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -1643,6 +1704,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1666,6 +1728,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -1678,6 +1741,7 @@
       "version": "5.21.2",
       "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.21.2.tgz",
       "integrity": "sha512-Jehlu0KguL1LLyUczCt86OtA5INmeStK3zcgbv1BSyMcNxs0HP3GQogBrYhwhqHsk6JopiFFVpJyZEoXOUMhGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@posthog/core": "1.10.0"
@@ -1779,6 +1843,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1819,6 +1884,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^7.0.0",
@@ -1835,6 +1901,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -1845,6 +1912,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1868,6 +1936,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -1887,6 +1956,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -1899,6 +1969,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1908,6 +1979,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -1972,6 +2044,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
       "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1996,6 +2069,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2010,6 +2084,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -2076,6 +2151,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -2115,6 +2191,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -2186,6 +2263,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -2241,6 +2319,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
       "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/server/config.js
+++ b/server/config.js
@@ -1,61 +1,111 @@
-'use strict';
+"use strict";
 
-const path = require('path');
-const fs = require('fs');
-const os = require('os');
-const { createStorage } = require('./storage');
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const { createStorage } = require("./storage");
 
 // ── Config ──────────────────────────────────────────────────────────
-const PORT = parseInt(process.env.PROXY_PORT || '5577', 10);
+const PORT = parseInt(process.env.PROXY_PORT || "5577", 10);
+const HOST = process.env.HOST || "127.0.0.1";
+const MAX_BODY_BYTES =
+	Math.max(1, parseInt(process.env.CCXRAY_MAX_BODY_MB || "50", 10)) *
+	1024 *
+	1024;
+const SSE_MAX_PER_IP = Math.max(
+	1,
+	parseInt(process.env.CCXRAY_SSE_MAX_PER_IP || "8", 10),
+);
+const HEADERS_TIMEOUT_MS = parseInt(
+	process.env.CCXRAY_HEADERS_TIMEOUT_MS || "60000",
+	10,
+);
+const REQUEST_TIMEOUT_MS = parseInt(
+	process.env.CCXRAY_REQUEST_TIMEOUT_MS || "120000",
+	10,
+);
+const KEEPALIVE_TIMEOUT_MS = parseInt(
+	process.env.CCXRAY_KEEPALIVE_TIMEOUT_MS || "5000",
+	10,
+);
 
 /**
  * @internal – exported for testability only
  */
 function parseBaseUrl(rawUrl) {
-  if (!rawUrl) return null;
-  try {
-    const u = new URL(rawUrl);
-    const protocol = u.protocol.replace(/:$/, ''); // 'https:' → 'https'
-    const hostname = u.hostname;
-    const port = u.port ? parseInt(u.port, 10) : (protocol === 'https' ? 443 : 80);
-    return { protocol, hostname, port };
-  } catch {
-    console.warn(`[ccxray] Warning: ANTHROPIC_BASE_URL is not a valid URL ("${rawUrl}"); falling back to api.anthropic.com`);
-    return null;
-  }
+	if (!rawUrl) return null;
+	try {
+		const u = new URL(rawUrl);
+		const protocol = u.protocol.replace(/:$/, ""); // 'https:' → 'https'
+		const hostname = u.hostname;
+		const port = u.port
+			? parseInt(u.port, 10)
+			: protocol === "https"
+				? 443
+				: 80;
+		return { protocol, hostname, port };
+	} catch {
+		console.warn(
+			`[ccxray] Warning: ANTHROPIC_BASE_URL is not a valid URL ("${rawUrl}"); falling back to api.anthropic.com`,
+		);
+		return null;
+	}
 }
 
 // Priority: ANTHROPIC_TEST_* (test/CI overrides) > ANTHROPIC_BASE_URL > built-in defaults
 function resolveUpstream(env, proxyPort) {
-  if (env.ANTHROPIC_TEST_HOST || env.ANTHROPIC_TEST_PORT || env.ANTHROPIC_TEST_PROTOCOL) {
-    const host = env.ANTHROPIC_TEST_HOST || 'api.anthropic.com';
-    const port = parseInt(env.ANTHROPIC_TEST_PORT || '443', 10);
-    const protocol = env.ANTHROPIC_TEST_PROTOCOL || 'https';
-    const missing = ['ANTHROPIC_TEST_HOST', 'ANTHROPIC_TEST_PORT', 'ANTHROPIC_TEST_PROTOCOL']
-      .filter(k => !env[k]);
-    if (missing.length > 0 && missing.length < 3) {
-      console.warn(`[ccxray] Warning: partial ANTHROPIC_TEST_* override — ${missing.join(', ')} not set; resolved upstream: ${protocol}://${host}:${port}`);
-    }
-    return { host, port, protocol, source: 'test-override' };
-  }
+	if (
+		env.ANTHROPIC_TEST_HOST ||
+		env.ANTHROPIC_TEST_PORT ||
+		env.ANTHROPIC_TEST_PROTOCOL
+	) {
+		const host = env.ANTHROPIC_TEST_HOST || "api.anthropic.com";
+		const port = parseInt(env.ANTHROPIC_TEST_PORT || "443", 10);
+		const protocol = env.ANTHROPIC_TEST_PROTOCOL || "https";
+		const missing = [
+			"ANTHROPIC_TEST_HOST",
+			"ANTHROPIC_TEST_PORT",
+			"ANTHROPIC_TEST_PROTOCOL",
+		].filter((k) => !env[k]);
+		if (missing.length > 0 && missing.length < 3) {
+			console.warn(
+				`[ccxray] Warning: partial ANTHROPIC_TEST_* override — ${missing.join(", ")} not set; resolved upstream: ${protocol}://${host}:${port}`,
+			);
+		}
+		return { host, port, protocol, source: "test-override" };
+	}
 
-  const parsed = parseBaseUrl(env.ANTHROPIC_BASE_URL);
-  if (parsed) {
-    const { hostname: host, port, protocol } = parsed;
-    if (new Set(['localhost', '127.0.0.1', '::1']).has(host) && port === proxyPort) {
-      console.warn(`[ccxray] Warning: upstream ${protocol}://${host}:${port} points back at the proxy itself — requests will loop`);
-    }
-    return { host, port, protocol, source: 'ANTHROPIC_BASE_URL' };
-  }
+	const parsed = parseBaseUrl(env.ANTHROPIC_BASE_URL);
+	if (parsed) {
+		const { hostname: host, port, protocol } = parsed;
+		if (
+			new Set(["localhost", "127.0.0.1", "::1"]).has(host) &&
+			port === proxyPort
+		) {
+			console.warn(
+				`[ccxray] Warning: upstream ${protocol}://${host}:${port} points back at the proxy itself — requests will loop`,
+			);
+		}
+		return { host, port, protocol, source: "ANTHROPIC_BASE_URL" };
+	}
 
-  return { host: 'api.anthropic.com', port: 443, protocol: 'https', source: 'default' };
+	return {
+		host: "api.anthropic.com",
+		port: 443,
+		protocol: "https",
+		source: "default",
+	};
 }
 
-const { host: ANTHROPIC_HOST, port: ANTHROPIC_PORT, protocol: ANTHROPIC_PROTOCOL, source: ANTHROPIC_BASE_URL_SOURCE } =
-  resolveUpstream(process.env, PORT);
-const LOGS_DIR = path.join(os.homedir(), '.ccxray', 'logs');
-const LEGACY_LOGS_DIR = path.join(__dirname, '..', 'logs');
-const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || '3', 10);
+const {
+	host: ANTHROPIC_HOST,
+	port: ANTHROPIC_PORT,
+	protocol: ANTHROPIC_PROTOCOL,
+	source: ANTHROPIC_BASE_URL_SOURCE,
+} = resolveUpstream(process.env, PORT);
+const LOGS_DIR = path.join(os.homedir(), ".ccxray", "logs");
+const LEGACY_LOGS_DIR = path.join(__dirname, "..", "logs");
+const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || "3", 10);
 
 // Storage adapter (local by default, S3 via STORAGE_BACKEND=s3)
 const storage = createStorage();
@@ -63,14 +113,14 @@ const storage = createStorage();
 // Model → context window fallback mapping (used when LiteLLM data unavailable)
 // https://docs.anthropic.com/en/docs/about-claude/models
 const MODEL_CONTEXT_FALLBACK = {
-  'claude-opus-4':     200_000,
-  'claude-sonnet-4':   200_000,
-  'claude-haiku-4':    200_000,
-  'claude-3-5-sonnet': 200_000,
-  'claude-3-5-haiku':  200_000,
-  'claude-3-opus':     200_000,
-  'claude-3-sonnet':   200_000,
-  'claude-3-haiku':    200_000,
+	"claude-opus-4": 200_000,
+	"claude-sonnet-4": 200_000,
+	"claude-haiku-4": 200_000,
+	"claude-3-5-sonnet": 200_000,
+	"claude-3-5-haiku": 200_000,
+	"claude-3-opus": 200_000,
+	"claude-3-sonnet": 200_000,
+	"claude-3-haiku": 200_000,
 };
 const DEFAULT_CONTEXT = 200_000;
 
@@ -78,63 +128,71 @@ const DEFAULT_CONTEXT = 200_000;
 // API request model field never includes [1m], but system prompt does:
 //   "The exact model ID is claude-opus-4-6[1m]."
 function extractModelFromSystem(system) {
-  if (!Array.isArray(system)) return null;
-  for (const block of system) {
-    const text = typeof block === 'string' ? block : (block?.text || '');
-    const m = text.match(/exact model ID is (claude-[^\s.]+)/);
-    if (m) return m[1];
-  }
-  return null;
+	if (!Array.isArray(system)) return null;
+	for (const block of system) {
+		const text = typeof block === "string" ? block : block?.text || "";
+		const m = text.match(/exact model ID is (claude-[^\s.]+)/);
+		if (m) return m[1];
+	}
+	return null;
 }
 
 function getMaxContext(model, system) {
-  // Prefer model ID from system prompt (has [1m] suffix when applicable)
-  const effective = extractModelFromSystem(system) || model;
-  if (!effective) return DEFAULT_CONTEXT;
-  // 1) Explicit suffix: "claude-opus-4-6[1m]" → 1M
-  if (/\[1m\]/i.test(effective)) return 1_000_000;
-  // 2) Known Claude Code defaults (200K standard plan)
-  const stripped = effective.replace(/\[.*\]/, '');
-  const keys = Object.keys(MODEL_CONTEXT_FALLBACK).sort((a, b) => b.length - a.length);
-  for (const key of keys) {
-    if (stripped.startsWith(key)) return MODEL_CONTEXT_FALLBACK[key];
-  }
-  // 3) LiteLLM dynamic data — only for unknown models not in fallback table
-  const { getModelContext } = require('./pricing');
-  const dynamic = getModelContext(stripped);
-  if (dynamic) return dynamic;
-  return DEFAULT_CONTEXT;
+	// Prefer model ID from system prompt (has [1m] suffix when applicable)
+	const effective = extractModelFromSystem(system) || model;
+	if (!effective) return DEFAULT_CONTEXT;
+	// 1) Explicit suffix: "claude-opus-4-6[1m]" → 1M
+	if (/\[1m\]/i.test(effective)) return 1_000_000;
+	// 2) Known Claude Code defaults (200K standard plan)
+	const stripped = effective.replace(/\[.*\]/, "");
+	const keys = Object.keys(MODEL_CONTEXT_FALLBACK).sort(
+		(a, b) => b.length - a.length,
+	);
+	for (const key of keys) {
+		if (stripped.startsWith(key)) return MODEL_CONTEXT_FALLBACK[key];
+	}
+	// 3) LiteLLM dynamic data — only for unknown models not in fallback table
+	const { getModelContext } = require("./pricing");
+	const dynamic = getModelContext(stripped);
+	if (dynamic) return dynamic;
+	return DEFAULT_CONTEXT;
 }
 
 // Ensure logs dir exists; migrate from legacy location if needed
 if (!fs.existsSync(LOGS_DIR)) {
-  fs.mkdirSync(LOGS_DIR, { recursive: true });
-  // One-time migration from old package-relative logs/
-  const legacyIndex = path.join(LEGACY_LOGS_DIR, 'index.ndjson');
-  if (fs.existsSync(legacyIndex)) {
-    try {
-      const files = fs.readdirSync(LEGACY_LOGS_DIR);
-      for (const f of files) {
-        fs.renameSync(path.join(LEGACY_LOGS_DIR, f), path.join(LOGS_DIR, f));
-      }
-      console.log(`Migrated logs from ${LEGACY_LOGS_DIR} → ${LOGS_DIR}`);
-    } catch (e) {
-      console.error(`Log migration failed: ${e.message}`);
-    }
-  }
+	fs.mkdirSync(LOGS_DIR, { recursive: true });
+	// One-time migration from old package-relative logs/
+	const legacyIndex = path.join(LEGACY_LOGS_DIR, "index.ndjson");
+	if (fs.existsSync(legacyIndex)) {
+		try {
+			const files = fs.readdirSync(LEGACY_LOGS_DIR);
+			for (const f of files) {
+				fs.renameSync(path.join(LEGACY_LOGS_DIR, f), path.join(LOGS_DIR, f));
+			}
+			console.log(`Migrated logs from ${LEGACY_LOGS_DIR} → ${LOGS_DIR}`);
+		} catch (e) {
+			console.error(`Log migration failed: ${e.message}`);
+		}
+	}
 }
 
 module.exports = {
-  PORT,
-  ANTHROPIC_HOST,
-  ANTHROPIC_PORT,
-  ANTHROPIC_PROTOCOL,
-  ANTHROPIC_BASE_URL_SOURCE,
-  LOGS_DIR,
-  RESTORE_DAYS,
-  storage,
-  MODEL_CONTEXT_FALLBACK,
-  DEFAULT_CONTEXT,
-  getMaxContext,
-  parseBaseUrl,
+	PORT,
+	HOST,
+	MAX_BODY_BYTES,
+	SSE_MAX_PER_IP,
+	HEADERS_TIMEOUT_MS,
+	REQUEST_TIMEOUT_MS,
+	KEEPALIVE_TIMEOUT_MS,
+	ANTHROPIC_HOST,
+	ANTHROPIC_PORT,
+	ANTHROPIC_PROTOCOL,
+	ANTHROPIC_BASE_URL_SOURCE,
+	LOGS_DIR,
+	RESTORE_DAYS,
+	storage,
+	MODEL_CONTEXT_FALLBACK,
+	DEFAULT_CONTEXT,
+	getMaxContext,
+	parseBaseUrl,
 };

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1,482 +1,673 @@
-'use strict';
+"use strict";
 
-const { countTokens } = require('@anthropic-ai/tokenizer');
+const { countTokens } = require("@anthropic-ai/tokenizer");
 
 // ── Helpers ─────────────────────────────────────────────────────────
+function sanitizeForLog(s) {
+	return String(s)
+		.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "")
+		.replace(/[\x00-\x09\x0b-\x1f\x7f]/g, "?");
+}
+
+function readBodyCapped(req, maxBytes) {
+	return new Promise((resolve, reject) => {
+		const chunks = [];
+		let size = 0;
+		let aborted = false;
+		req.on("data", (chunk) => {
+			if (aborted) return;
+			size += chunk.length;
+			if (size > maxBytes) {
+				aborted = true;
+				const err = new Error("payload_too_large");
+				err.code = "E_PAYLOAD_TOO_LARGE";
+				err.limit = maxBytes;
+				req.destroy();
+				reject(err);
+				return;
+			}
+			chunks.push(chunk);
+		});
+		req.on("end", () => {
+			if (!aborted) resolve(Buffer.concat(chunks));
+		});
+		req.on("error", (err) => {
+			if (!aborted) reject(err);
+		});
+	});
+}
+
 function timestamp() {
-  const d = new Date();
-  const parts = d.toLocaleString('sv-SE', { timeZone: 'Asia/Taipei' }).replace(' ', 'T');
-  const ms = String(d.getMilliseconds()).padStart(3, '0');
-  return (parts + '-' + ms).replace(/[:.]/g, '-');
+	const d = new Date();
+	const parts = d
+		.toLocaleString("sv-SE", { timeZone: "Asia/Taipei" })
+		.replace(" ", "T");
+	const ms = String(d.getMilliseconds()).padStart(3, "0");
+	return (parts + "-" + ms).replace(/[:.]/g, "-");
 }
 
 function taipeiTime() {
-  return new Date().toLocaleTimeString('zh-TW', { timeZone: 'Asia/Taipei', hour12: false });
+	return new Date().toLocaleTimeString("zh-TW", {
+		timeZone: "Asia/Taipei",
+		hour12: false,
+	});
 }
 
 function printSeparator() {
-  console.log('\x1b[33m' + '═'.repeat(60) + '\x1b[0m');
+	console.log("\x1b[33m" + "═".repeat(60) + "\x1b[0m");
 }
 
 function safeCountTokens(text) {
-  if (!text) return 0;
-  try { return countTokens(text); } catch { return 0; }
+	if (!text) return 0;
+	try {
+		return countTokens(text);
+	} catch {
+		return 0;
+	}
 }
 
 // ── Context Breakdown Analysis ───────────────────────────────────────
 const TOOL_CATEGORIES = {
-  core:  ['Bash','Read','Write','Edit','Glob','Grep','WebFetch','WebSearch','NotebookEdit','ToolSearch'],
-  agent: ['Agent','Skill','TaskOutput','TaskStop','AskUserQuestion','EnterPlanMode','ExitPlanMode'],
-  task:  ['TaskCreate','TaskGet','TaskUpdate','TaskList'],
-  team:  ['EnterWorktree','TeamCreate','TeamDelete','SendMessage'],
-  cron:  ['CronCreate','CronDelete','CronList'],
+	core: [
+		"Bash",
+		"Read",
+		"Write",
+		"Edit",
+		"Glob",
+		"Grep",
+		"WebFetch",
+		"WebSearch",
+		"NotebookEdit",
+		"ToolSearch",
+	],
+	agent: [
+		"Agent",
+		"Skill",
+		"TaskOutput",
+		"TaskStop",
+		"AskUserQuestion",
+		"EnterPlanMode",
+		"ExitPlanMode",
+	],
+	task: ["TaskCreate", "TaskGet", "TaskUpdate", "TaskList"],
+	team: ["EnterWorktree", "TeamCreate", "TeamDelete", "SendMessage"],
+	cron: ["CronCreate", "CronDelete", "CronList"],
 };
 
 function parseSystemBlocks(system) {
-  const result = {
-    billingHeader: 0, coreIdentity: 0, coreInstructions: 0,
-    customSkills: 0, customAgents: 0, pluginSkills: 0,
-    mcpServersList: 0, settingsJson: 0, envAndGit: 0, autoMemory: 0,
-  };
-  if (!system || !Array.isArray(system)) return result;
+	const result = {
+		billingHeader: 0,
+		coreIdentity: 0,
+		coreInstructions: 0,
+		customSkills: 0,
+		customAgents: 0,
+		pluginSkills: 0,
+		mcpServersList: 0,
+		settingsJson: 0,
+		envAndGit: 0,
+		autoMemory: 0,
+	};
+	if (!system || !Array.isArray(system)) return result;
 
-  if (system[0]) result.billingHeader = safeCountTokens(system[0].text || '');
-  if (system[1]) result.coreIdentity = safeCountTokens(system[1].text || '');
+	if (system[0]) result.billingHeader = safeCountTokens(system[0].text || "");
+	if (system[1]) result.coreIdentity = safeCountTokens(system[1].text || "");
 
-  const mainText = system.slice(2).map(b => b.text || '').join('\n');
-  if (!mainText) return result;
+	const mainText = system
+		.slice(2)
+		.map((b) => b.text || "")
+		.join("\n");
+	if (!mainText) return result;
 
-  const markerDefs = [
-    { key: 'autoMemory',     pattern: /# auto memory\n|You have a persistent, file-based memory/ },
-    { key: 'customSkills',   pattern: /# User'?s Current Configuration/ },
-    { key: 'customAgents',   pattern: /\*\*Available custom agents/ },
-    { key: 'mcpServersList', pattern: /\*\*Configured MCP servers/ },
-    { key: 'pluginSkills',   pattern: /\*\*Available plugin skills/ },
-    { key: 'settingsJson',   pattern: /\*\*User's settings\.json/ },
-    { key: 'envAndGit',      pattern: /# Environment\n|<env>/ },
-  ];
-  const positions = [];
-  for (const m of markerDefs) {
-    const match = m.pattern.exec(mainText);
-    if (match) positions.push({ key: m.key, index: match.index });
-  }
-  positions.sort((a, b) => a.index - b.index);
+	const markerDefs = [
+		{
+			key: "autoMemory",
+			pattern: /# auto memory\n|You have a persistent, file-based memory/,
+		},
+		{ key: "customSkills", pattern: /# User'?s Current Configuration/ },
+		{ key: "customAgents", pattern: /\*\*Available custom agents/ },
+		{ key: "mcpServersList", pattern: /\*\*Configured MCP servers/ },
+		{ key: "pluginSkills", pattern: /\*\*Available plugin skills/ },
+		{ key: "settingsJson", pattern: /\*\*User's settings\.json/ },
+		{ key: "envAndGit", pattern: /# Environment\n|<env>/ },
+	];
+	const positions = [];
+	for (const m of markerDefs) {
+		const match = m.pattern.exec(mainText);
+		if (match) positions.push({ key: m.key, index: match.index });
+	}
+	positions.sort((a, b) => a.index - b.index);
 
-  const firstPos = positions.length > 0 ? positions[0].index : mainText.length;
-  result.coreInstructions = safeCountTokens(mainText.slice(0, firstPos));
-  for (let i = 0; i < positions.length; i++) {
-    const start = positions[i].index;
-    const end = i + 1 < positions.length ? positions[i + 1].index : mainText.length;
-    result[positions[i].key] = safeCountTokens(mainText.slice(start, end));
-  }
-  return result;
+	const firstPos = positions.length > 0 ? positions[0].index : mainText.length;
+	result.coreInstructions = safeCountTokens(mainText.slice(0, firstPos));
+	for (let i = 0; i < positions.length; i++) {
+		const start = positions[i].index;
+		const end =
+			i + 1 < positions.length ? positions[i + 1].index : mainText.length;
+		result[positions[i].key] = safeCountTokens(mainText.slice(start, end));
+	}
+	return result;
 }
 
 function parseClaudeMdFromMessages(messages) {
-  const result = { globalClaudeMd: 0, projectClaudeMd: 0 };
-  if (!messages || !messages.length) return result;
+	const result = { globalClaudeMd: 0, projectClaudeMd: 0 };
+	if (!messages || !messages.length) return result;
 
-  const firstUser = messages.find(m => m.role === 'user');
-  if (!firstUser) return result;
-  const text = typeof firstUser.content === 'string' ? firstUser.content : JSON.stringify(firstUser.content);
+	const firstUser = messages.find((m) => m.role === "user");
+	if (!firstUser) return result;
+	const text =
+		typeof firstUser.content === "string"
+			? firstUser.content
+			: JSON.stringify(firstUser.content);
 
-  const re = /Contents of ([^\n]+CLAUDE\.md)[^\n]*:\n([\s\S]*?)(?=Contents of [^\n]+CLAUDE\.md|$)/g;
-  let match;
-  while ((match = re.exec(text)) !== null) {
-    const filePath = match[1];
-    const content = match[2];
-    if (filePath.includes('/.claude/CLAUDE.md') || /~\/\.claude/.test(filePath)) {
-      result.globalClaudeMd += safeCountTokens(content);
-    } else {
-      result.projectClaudeMd += safeCountTokens(content);
-    }
-  }
-  return result;
+	const re =
+		/Contents of ([^\n]+CLAUDE\.md)[^\n]*:\n([\s\S]*?)(?=Contents of [^\n]+CLAUDE\.md|$)/g;
+	let match;
+	while ((match = re.exec(text)) !== null) {
+		const filePath = match[1];
+		const content = match[2];
+		if (
+			filePath.includes("/.claude/CLAUDE.md") ||
+			/~\/\.claude/.test(filePath)
+		) {
+			result.globalClaudeMd += safeCountTokens(content);
+		} else {
+			result.projectClaudeMd += safeCountTokens(content);
+		}
+	}
+	return result;
 }
 
 function categorizeTools(tools) {
-  if (!tools || !tools.length) return { byCategory: {}, mcpPlugins: [], counts: {} };
+	if (!tools || !tools.length)
+		return { byCategory: {}, mcpPlugins: [], counts: {} };
 
-  const byCategory = { core: [], agent: [], task: [], team: [], cron: [], mcp: [], other: [] };
-  const mcpPluginsMap = {};
+	const byCategory = {
+		core: [],
+		agent: [],
+		task: [],
+		team: [],
+		cron: [],
+		mcp: [],
+		other: [],
+	};
+	const mcpPluginsMap = {};
 
-  for (const tool of tools) {
-    const name = tool.name || '';
-    if (name.startsWith('mcp__')) {
-      byCategory.mcp.push(tool);
-      const plugin = name.split('__')[1] || 'unknown';
-      if (!mcpPluginsMap[plugin]) mcpPluginsMap[plugin] = [];
-      mcpPluginsMap[plugin].push(tool);
-    } else {
-      let placed = false;
-      for (const [cat, names] of Object.entries(TOOL_CATEGORIES)) {
-        if (names.includes(name)) { byCategory[cat].push(tool); placed = true; break; }
-      }
-      if (!placed) byCategory.other.push(tool);
-    }
-  }
+	for (const tool of tools) {
+		const name = tool.name || "";
+		if (name.startsWith("mcp__")) {
+			byCategory.mcp.push(tool);
+			const plugin = name.split("__")[1] || "unknown";
+			if (!mcpPluginsMap[plugin]) mcpPluginsMap[plugin] = [];
+			mcpPluginsMap[plugin].push(tool);
+		} else {
+			let placed = false;
+			for (const [cat, names] of Object.entries(TOOL_CATEGORIES)) {
+				if (names.includes(name)) {
+					byCategory[cat].push(tool);
+					placed = true;
+					break;
+				}
+			}
+			if (!placed) byCategory.other.push(tool);
+		}
+	}
 
-  const mcpPlugins = Object.entries(mcpPluginsMap).map(([plugin, pluginTools]) => ({
-    plugin, count: pluginTools.length,
-    tokens: safeCountTokens(JSON.stringify(pluginTools)),
-  }));
-  const counts = Object.fromEntries(Object.entries(byCategory).map(([k, v]) => [k, v.length]));
-  return { byCategory, mcpPlugins, counts };
+	const mcpPlugins = Object.entries(mcpPluginsMap).map(
+		([plugin, pluginTools]) => ({
+			plugin,
+			count: pluginTools.length,
+			tokens: safeCountTokens(JSON.stringify(pluginTools)),
+		}),
+	);
+	const counts = Object.fromEntries(
+		Object.entries(byCategory).map(([k, v]) => [k, v.length]),
+	);
+	return { byCategory, mcpPlugins, counts };
 }
 
 function parseSkillsFromMessages(messages) {
-  if (!messages) return [];
-  // Skills are injected via system-reminder in user messages:
-  // "The following skills are available for use with the Skill tool:\n- name: desc\n..."
-  for (const m of messages) {
-    if (m.role !== 'user') continue;
-    const blocks = Array.isArray(m.content) ? m.content : [{ type: 'text', text: m.content || '' }];
-    for (const block of blocks) {
-      const txt = block.type === 'text' ? (block.text || '') : '';
-      const idx = txt.indexOf('The following skills are available for use with the Skill tool:');
-      if (idx < 0) continue;
-      const section = txt.slice(idx);
-      const end = section.indexOf('</system-reminder>');
-      const body = end >= 0 ? section.slice(0, end) : section;
-      const seen = new Set();
-      for (const line of body.split('\n')) {
-        // Support both "- skill-name: description" and "- skill-name" (no description)
-        // Skill names may contain ":" (e.g. "sourceatlas:flow"), so split on ": " (colon-space)
-        const m2 = line.match(/^- (.+?)(?:: .+)?$/);
-        if (m2) { const n = m2[1].trim(); if (n) seen.add(n); }
-      }
-      if (seen.size > 0) return [...seen];
-    }
-  }
-  return [];
+	if (!messages) return [];
+	// Skills are injected via system-reminder in user messages:
+	// "The following skills are available for use with the Skill tool:\n- name: desc\n..."
+	for (const m of messages) {
+		if (m.role !== "user") continue;
+		const blocks = Array.isArray(m.content)
+			? m.content
+			: [{ type: "text", text: m.content || "" }];
+		for (const block of blocks) {
+			const txt = block.type === "text" ? block.text || "" : "";
+			const idx = txt.indexOf(
+				"The following skills are available for use with the Skill tool:",
+			);
+			if (idx < 0) continue;
+			const section = txt.slice(idx);
+			const end = section.indexOf("</system-reminder>");
+			const body = end >= 0 ? section.slice(0, end) : section;
+			const seen = new Set();
+			for (const line of body.split("\n")) {
+				// Support both "- skill-name: description" and "- skill-name" (no description)
+				// Skill names may contain ":" (e.g. "sourceatlas:flow"), so split on ": " (colon-space)
+				const m2 = line.match(/^- (.+?)(?:: .+)?$/);
+				if (m2) {
+					const n = m2[1].trim();
+					if (n) seen.add(n);
+				}
+			}
+			if (seen.size > 0) return [...seen];
+		}
+	}
+	return [];
 }
 
 function analyzeContext(body) {
-  if (!body) return null;
-  const systemBreakdown = parseSystemBlocks(body.system);
-  const claudeMd = parseClaudeMdFromMessages(body.messages);
-  const loadedSkills = parseSkillsFromMessages(body.messages);
-  const toolsCat = categorizeTools(body.tools);
-  const toolTokens = {};
-  for (const [cat, arr] of Object.entries(toolsCat.byCategory)) {
-    toolTokens[cat] = arr.length > 0 ? safeCountTokens(JSON.stringify(arr)) : 0;
-  }
-  let messageTokens = 0;
-  if (body.messages) {
-    for (const m of body.messages) {
-      if (typeof m.content === 'string') {
-        messageTokens += safeCountTokens(m.content);
-      } else if (Array.isArray(m.content)) {
-        for (const block of m.content) {
-          if (block.type === 'text') messageTokens += safeCountTokens(block.text || '');
-          else if (block.type === 'tool_use') messageTokens += safeCountTokens(JSON.stringify(block.input || {}));
-          else if (block.type === 'tool_result') {
-            const c = block.content;
-            if (typeof c === 'string') messageTokens += safeCountTokens(c);
-            else if (Array.isArray(c)) messageTokens += c.reduce((s, b) => s + safeCountTokens(b.text || ''), 0);
-          }
-        }
-      }
-    }
-  }
-  return {
-    systemBreakdown, claudeMd, messageTokens, loadedSkills,
-    toolsBreakdown: { mcpPlugins: toolsCat.mcpPlugins, counts: toolsCat.counts, toolTokens },
-  };
+	if (!body) return null;
+	const systemBreakdown = parseSystemBlocks(body.system);
+	const claudeMd = parseClaudeMdFromMessages(body.messages);
+	const loadedSkills = parseSkillsFromMessages(body.messages);
+	const toolsCat = categorizeTools(body.tools);
+	const toolTokens = {};
+	for (const [cat, arr] of Object.entries(toolsCat.byCategory)) {
+		toolTokens[cat] = arr.length > 0 ? safeCountTokens(JSON.stringify(arr)) : 0;
+	}
+	let messageTokens = 0;
+	if (body.messages) {
+		for (const m of body.messages) {
+			if (typeof m.content === "string") {
+				messageTokens += safeCountTokens(m.content);
+			} else if (Array.isArray(m.content)) {
+				for (const block of m.content) {
+					if (block.type === "text")
+						messageTokens += safeCountTokens(block.text || "");
+					else if (block.type === "tool_use")
+						messageTokens += safeCountTokens(JSON.stringify(block.input || {}));
+					else if (block.type === "tool_result") {
+						const c = block.content;
+						if (typeof c === "string") messageTokens += safeCountTokens(c);
+						else if (Array.isArray(c))
+							messageTokens += c.reduce(
+								(s, b) => s + safeCountTokens(b.text || ""),
+								0,
+							);
+					}
+				}
+			}
+		}
+	}
+	return {
+		systemBreakdown,
+		claudeMd,
+		messageTokens,
+		loadedSkills,
+		toolsBreakdown: {
+			mcpPlugins: toolsCat.mcpPlugins,
+			counts: toolsCat.counts,
+			toolTokens,
+		},
+	};
 }
 
 function tokenizeRequest(body) {
-  if (!body) return null;
-  const breakdown = {};
-  if (body.system) {
-    const text = typeof body.system === 'string' ? body.system : JSON.stringify(body.system);
-    breakdown.system = safeCountTokens(text);
-  }
-  if (body.tools && body.tools.length) {
-    breakdown.tools = safeCountTokens(JSON.stringify(body.tools));
-  }
-  if (body.messages && body.messages.length) {
-    let total = 0;
-    breakdown.perMessage = body.messages.map(m => {
-      let tokens = 0;
-      const blocks = [];
-      if (typeof m.content === 'string') {
-        const t = safeCountTokens(m.content);
-        tokens = t;
-        if (t > 0) blocks.push({ type: 'text', tokens: t });
-      } else if (Array.isArray(m.content)) {
-        for (const block of m.content) {
-          if (block.type === 'text') {
-            const t = safeCountTokens(block.text || '');
-            tokens += t;
-            if (t > 0) blocks.push({ type: 'text', tokens: t });
-          } else if (block.type === 'thinking') {
-            const t = safeCountTokens(block.thinking || '');
-            tokens += t;
-            if (t > 0) blocks.push({ type: 'thinking', tokens: t });
-          } else if (block.type === 'tool_use') {
-            const t = safeCountTokens(JSON.stringify(block.input || {}));
-            tokens += t;
-            if (t > 0) blocks.push({ type: 'tool_use', name: block.name || null, tokens: t });
-          } else if (block.type === 'tool_result') {
-            const c = block.content;
-            let t = 0;
-            if (typeof c === 'string') t = safeCountTokens(c);
-            else if (Array.isArray(c)) t = c.reduce((s, b) => s + safeCountTokens(b.text || ''), 0);
-            tokens += t;
-            if (t > 0) blocks.push({ type: 'tool_result', name: block.name || null, tokens: t });
-          }
-        }
-      }
-      total += tokens;
-      return { role: m.role, tokens, blocks };
-    });
-    breakdown.messages = total;
-  }
-  breakdown.total = (breakdown.system || 0) + (breakdown.tools || 0) + (breakdown.messages || 0);
-  breakdown.contextBreakdown = analyzeContext(body);
-  return breakdown;
+	if (!body) return null;
+	const breakdown = {};
+	if (body.system) {
+		const text =
+			typeof body.system === "string"
+				? body.system
+				: JSON.stringify(body.system);
+		breakdown.system = safeCountTokens(text);
+	}
+	if (body.tools && body.tools.length) {
+		breakdown.tools = safeCountTokens(JSON.stringify(body.tools));
+	}
+	if (body.messages && body.messages.length) {
+		let total = 0;
+		breakdown.perMessage = body.messages.map((m) => {
+			let tokens = 0;
+			const blocks = [];
+			if (typeof m.content === "string") {
+				const t = safeCountTokens(m.content);
+				tokens = t;
+				if (t > 0) blocks.push({ type: "text", tokens: t });
+			} else if (Array.isArray(m.content)) {
+				for (const block of m.content) {
+					if (block.type === "text") {
+						const t = safeCountTokens(block.text || "");
+						tokens += t;
+						if (t > 0) blocks.push({ type: "text", tokens: t });
+					} else if (block.type === "thinking") {
+						const t = safeCountTokens(block.thinking || "");
+						tokens += t;
+						if (t > 0) blocks.push({ type: "thinking", tokens: t });
+					} else if (block.type === "tool_use") {
+						const t = safeCountTokens(JSON.stringify(block.input || {}));
+						tokens += t;
+						if (t > 0)
+							blocks.push({
+								type: "tool_use",
+								name: block.name || null,
+								tokens: t,
+							});
+					} else if (block.type === "tool_result") {
+						const c = block.content;
+						let t = 0;
+						if (typeof c === "string") t = safeCountTokens(c);
+						else if (Array.isArray(c))
+							t = c.reduce((s, b) => s + safeCountTokens(b.text || ""), 0);
+						tokens += t;
+						if (t > 0)
+							blocks.push({
+								type: "tool_result",
+								name: block.name || null,
+								tokens: t,
+							});
+					}
+				}
+			}
+			total += tokens;
+			return { role: m.role, tokens, blocks };
+		});
+		breakdown.messages = total;
+	}
+	breakdown.total =
+		(breakdown.system || 0) +
+		(breakdown.tools || 0) +
+		(breakdown.messages || 0);
+	breakdown.contextBreakdown = analyzeContext(body);
+	return breakdown;
 }
 
 function extractUsage(resData) {
-  if (!Array.isArray(resData)) return null;
-  const msgStart = resData.find(e => e.type === 'message_start');
-  const msgDelta = resData.find(e => e.type === 'message_delta');
-  const u = msgStart?.message?.usage || {};
-  return {
-    input_tokens: u.input_tokens || 0,
-    output_tokens: msgDelta?.usage?.output_tokens || u.output_tokens || 0,
-    cache_creation_input_tokens: u.cache_creation_input_tokens || 0,
-    cache_read_input_tokens: u.cache_read_input_tokens || 0,
-  };
+	if (!Array.isArray(resData)) return null;
+	const msgStart = resData.find((e) => e.type === "message_start");
+	const msgDelta = resData.find((e) => e.type === "message_delta");
+	const u = msgStart?.message?.usage || {};
+	return {
+		input_tokens: u.input_tokens || 0,
+		output_tokens: msgDelta?.usage?.output_tokens || u.output_tokens || 0,
+		cache_creation_input_tokens: u.cache_creation_input_tokens || 0,
+		cache_read_input_tokens: u.cache_read_input_tokens || 0,
+	};
 }
 
 function summarizeRequest(body) {
-  const lines = [];
-  lines.push(`  Model:     ${body.model || '?'}`);
-  if (body.system) {
-    const text = typeof body.system === 'string' ? body.system : JSON.stringify(body.system);
-    lines.push(`  System:    ${safeCountTokens(text).toLocaleString()} tokens`);
-  }
-  if (body.tools && body.tools.length > 0) {
-    const names = body.tools.map(t => t.name);
-    const preview = names.slice(0, 7).join(', ');
-    const suffix = names.length > 7 ? `, … (${names.length} total)` : '';
-    lines.push(`  Tools:     ${names.length} [${preview}${suffix}]`);
-  }
-  if (body.messages && body.messages.length > 0) {
-    const msgs = body.messages;
-    const userCount = msgs.filter(m => m.role === 'user').length;
-    const asstCount = msgs.filter(m => m.role === 'assistant').length;
-    lines.push(`  Messages:  ${msgs.length} (${userCount} user, ${asstCount} assistant)`);
-  }
-  return lines.join('\n');
+	const lines = [];
+	lines.push(`  Model:     ${body.model || "?"}`);
+	if (body.system) {
+		const text =
+			typeof body.system === "string"
+				? body.system
+				: JSON.stringify(body.system);
+		lines.push(`  System:    ${safeCountTokens(text).toLocaleString()} tokens`);
+	}
+	if (body.tools && body.tools.length > 0) {
+		const names = body.tools.map((t) => t.name);
+		const preview = names.slice(0, 7).join(", ");
+		const suffix = names.length > 7 ? `, … (${names.length} total)` : "";
+		lines.push(`  Tools:     ${names.length} [${preview}${suffix}]`);
+	}
+	if (body.messages && body.messages.length > 0) {
+		const msgs = body.messages;
+		const userCount = msgs.filter((m) => m.role === "user").length;
+		const asstCount = msgs.filter((m) => m.role === "assistant").length;
+		lines.push(
+			`  Messages:  ${msgs.length} (${userCount} user, ${asstCount} assistant)`,
+		);
+	}
+	return lines.join("\n");
 }
 
 function totalContextTokens(usage) {
-  if (!usage) return 0;
-  return (usage.input_tokens || 0)
-    + (usage.cache_creation_input_tokens || 0)
-    + (usage.cache_read_input_tokens || 0);
+	if (!usage) return 0;
+	return (
+		(usage.input_tokens || 0) +
+		(usage.cache_creation_input_tokens || 0) +
+		(usage.cache_read_input_tokens || 0)
+	);
 }
 
 function printContextBar(usage, model, system) {
-  const { getMaxContext } = require('./config');
-  if (!usage) return;
-  const maxCtx = getMaxContext(model, system);
-  const used = totalContextTokens(usage);
-  if (!used) return;
-  const pct = Math.min(100, (used / maxCtx) * 100);
-  const barWidth = 40;
-  const filled = Math.round(barWidth * pct / 100);
-  const empty = barWidth - filled;
-  const color = pct > 90 ? '\x1b[31m' : pct > 70 ? '\x1b[33m' : '\x1b[32m';
-  const bar = color + '█'.repeat(filled) + '\x1b[90m' + '░'.repeat(empty) + '\x1b[0m';
-  console.log(`  Context ${bar} ${pct.toFixed(0)}% (${used.toLocaleString()} / ${maxCtx.toLocaleString()})`);
-  const parts = [];
-  if (usage.cache_read_input_tokens) parts.push(`cache:${usage.cache_read_input_tokens.toLocaleString()}↩`);
-  if (usage.cache_creation_input_tokens) parts.push(`${usage.cache_creation_input_tokens.toLocaleString()}↗`);
-  if (parts.length) console.log(`  ${parts.join('  ')}`);
+	const { getMaxContext } = require("./config");
+	if (!usage) return;
+	const maxCtx = getMaxContext(model, system);
+	const used = totalContextTokens(usage);
+	if (!used) return;
+	const pct = Math.min(100, (used / maxCtx) * 100);
+	const barWidth = 40;
+	const filled = Math.round((barWidth * pct) / 100);
+	const empty = barWidth - filled;
+	const color = pct > 90 ? "\x1b[31m" : pct > 70 ? "\x1b[33m" : "\x1b[32m";
+	const bar =
+		color + "█".repeat(filled) + "\x1b[90m" + "░".repeat(empty) + "\x1b[0m";
+	console.log(
+		`  Context ${bar} ${pct.toFixed(0)}% (${used.toLocaleString()} / ${maxCtx.toLocaleString()})`,
+	);
+	const parts = [];
+	if (usage.cache_read_input_tokens)
+		parts.push(`cache:${usage.cache_read_input_tokens.toLocaleString()}↩`);
+	if (usage.cache_creation_input_tokens)
+		parts.push(`${usage.cache_creation_input_tokens.toLocaleString()}↗`);
+	if (parts.length) console.log(`  ${parts.join("  ")}`);
 }
 
 function computeThinkingDuration(events) {
-  let start = null, end = null;
-  for (const ev of events) {
-    if (!ev._ts) continue;
-    if (ev.type === 'content_block_start' && ev.content_block?.type === 'thinking') start = ev._ts;
-    else if (ev.type === 'content_block_stop' && start && !end) end = ev._ts;
-  }
-  return (start && end) ? (end - start) / 1000 : null;
+	let start = null,
+		end = null;
+	for (const ev of events) {
+		if (!ev._ts) continue;
+		if (
+			ev.type === "content_block_start" &&
+			ev.content_block?.type === "thinking"
+		)
+			start = ev._ts;
+		else if (ev.type === "content_block_stop" && start && !end) end = ev._ts;
+	}
+	return start && end ? (end - start) / 1000 : null;
 }
 
 function parseSSEEvents(raw) {
-  const events = [];
-  for (const line of raw.split('\n')) {
-    if (line.startsWith('data: ')) {
-      const data = line.slice(6).trim();
-      if (data === '[DONE]') continue;
-      try { events.push(JSON.parse(data)); } catch {}
-    }
-  }
-  return events;
+	const events = [];
+	for (const line of raw.split("\n")) {
+		if (line.startsWith("data: ")) {
+			const data = line.slice(6).trim();
+			if (data === "[DONE]") continue;
+			try {
+				events.push(JSON.parse(data));
+			} catch {}
+		}
+	}
+	return events;
 }
 
 // ── Turn title extraction ─────────────────────────────────────────
 function extractResponseTitle(res) {
-  if (!res) return null;
-  let text = '';
-  if (Array.isArray(res)) {
-    text = res
-      .filter(ev => ev.type === 'content_block_delta' && ev.delta?.type === 'text_delta')
-      .map(ev => ev.delta.text).join('');
-  } else if (res.content) {
-    text = (res.content || []).filter(b => b.type === 'text').map(b => b.text).join('');
-  }
-  text = text.trim().replace(/\s+/g, ' ');
-  if (!text) return null;
-  const firstSentence = text.split(/[.\n]/)[0].trim();
-  return (firstSentence || text).slice(0, 80) || null;
+	if (!res) return null;
+	let text = "";
+	if (Array.isArray(res)) {
+		text = res
+			.filter(
+				(ev) =>
+					ev.type === "content_block_delta" && ev.delta?.type === "text_delta",
+			)
+			.map((ev) => ev.delta.text)
+			.join("");
+	} else if (res.content) {
+		text = (res.content || [])
+			.filter((b) => b.type === "text")
+			.map((b) => b.text)
+			.join("");
+	}
+	text = text.trim().replace(/\s+/g, " ");
+	if (!text) return null;
+	const firstSentence = text.split(/[.\n]/)[0].trim();
+	return (firstSentence || text).slice(0, 80) || null;
 }
 
 // ── Credential scanning ──────────────────────────────────────────────
 const CREDENTIAL_PATTERNS = [
-  /sk-ant-[a-zA-Z0-9_-]{20,}/,
-  /sk-[a-zA-Z0-9]{20,}/,
-  /ghp_[a-zA-Z0-9]{36}/,
-  /AKIA[0-9A-Z]{16}/,
-  /-----BEGIN (?:RSA|EC|OPENSSH) PRIVATE KEY-----/,
+	/sk-ant-[a-zA-Z0-9_-]{20,}/,
+	/sk-[a-zA-Z0-9]{20,}/,
+	/ghp_[a-zA-Z0-9]{36}/,
+	/AKIA[0-9A-Z]{16}/,
+	/-----BEGIN (?:RSA|EC|OPENSSH) PRIVATE KEY-----/,
 ];
 
 function scanCredentials(text) {
-  if (!text) return false;
-  if (CREDENTIAL_PATTERNS.some(p => p.test(text))) return true;
-  try {
-    const decoded = decodeURIComponent(text);
-    if (decoded !== text) return CREDENTIAL_PATTERNS.some(p => p.test(decoded));
-  } catch (_) {}
-  return false;
+	if (!text) return false;
+	if (CREDENTIAL_PATTERNS.some((p) => p.test(text))) return true;
+	try {
+		const decoded = decodeURIComponent(text);
+		if (decoded !== text)
+			return CREDENTIAL_PATTERNS.some((p) => p.test(decoded));
+	} catch (_) {}
+	return false;
 }
 
 function entryHasCredential(entry) {
-  // Scan current response (assistant text deltas)
-  if (Array.isArray(entry.res)) {
-    for (const ev of entry.res) {
-      if (ev.type === 'content_block_delta' && ev.delta?.type === 'text_delta') {
-        if (scanCredentials(ev.delta.text)) return true;
-      }
-    }
-  }
-  // Scan messages history: assistant text blocks + tool_result content
-  const messages = entry.req?.messages;
-  if (!Array.isArray(messages)) return false;
-  for (const msg of messages) {
-    if (!Array.isArray(msg.content)) continue;
-    for (const block of msg.content) {
-      if (msg.role === 'assistant' && block.type === 'text') {
-        if (scanCredentials(block.text)) return true;
-      } else if (msg.role === 'assistant' && block.type === 'tool_use' && block.input) {
-        if (scanCredentials(JSON.stringify(block.input))) return true;
-      } else if (block.type === 'tool_result') {
-        const c = block.content;
-        if (typeof c === 'string' && scanCredentials(c)) return true;
-        if (Array.isArray(c)) {
-          for (const b of c) {
-            if (b.type === 'text' && scanCredentials(b.text)) return true;
-          }
-        }
-      }
-    }
-  }
-  return false;
+	// Scan current response (assistant text deltas)
+	if (Array.isArray(entry.res)) {
+		for (const ev of entry.res) {
+			if (
+				ev.type === "content_block_delta" &&
+				ev.delta?.type === "text_delta"
+			) {
+				if (scanCredentials(ev.delta.text)) return true;
+			}
+		}
+	}
+	// Scan messages history: assistant text blocks + tool_result content
+	const messages = entry.req?.messages;
+	if (!Array.isArray(messages)) return false;
+	for (const msg of messages) {
+		if (!Array.isArray(msg.content)) continue;
+		for (const block of msg.content) {
+			if (msg.role === "assistant" && block.type === "text") {
+				if (scanCredentials(block.text)) return true;
+			} else if (
+				msg.role === "assistant" &&
+				block.type === "tool_use" &&
+				block.input
+			) {
+				if (scanCredentials(JSON.stringify(block.input))) return true;
+			} else if (block.type === "tool_result") {
+				const c = block.content;
+				if (typeof c === "string" && scanCredentials(c)) return true;
+				if (Array.isArray(c)) {
+					for (const b of c) {
+						if (b.type === "text" && scanCredentials(b.text)) return true;
+					}
+				}
+			}
+		}
+	}
+	return false;
 }
 
 // ── Taint / source classification ───────────────────────────────────
 const SENSITIVE_PATH_PATTERNS = [
-  '~/.ssh/', 'id_rsa', 'id_ed25519', 'id_ecdsa', 'authorized_keys', 'known_hosts',
-  '.env', '/.env',
-  '/etc/passwd', '/etc/shadow', '/etc/sudoers',
+	"~/.ssh/",
+	"id_rsa",
+	"id_ed25519",
+	"id_ecdsa",
+	"authorized_keys",
+	"known_hosts",
+	".env",
+	"/.env",
+	"/etc/passwd",
+	"/etc/shadow",
+	"/etc/sudoers",
 ];
 
-const NETWORK_TOOL_NAMES = new Set(['WebFetch', 'WebSearch']);
-const NETWORK_TOOL_SUFFIXES = ['_fetch', '_search', '_browse', '_crawl'];
+const NETWORK_TOOL_NAMES = new Set(["WebFetch", "WebSearch"]);
+const NETWORK_TOOL_SUFFIXES = ["_fetch", "_search", "_browse", "_crawl"];
 
 function classifyToolSource(toolName, toolInput) {
-  if (NETWORK_TOOL_NAMES.has(toolName)) return 'network';
-  if (toolName.startsWith('mcp__') && NETWORK_TOOL_SUFFIXES.some(s => toolName.endsWith(s))) return 'network';
-  const inputStr = toolInput ? JSON.stringify(toolInput).toLowerCase() : '';
-  if (SENSITIVE_PATH_PATTERNS.some(p => inputStr.includes(p.toLowerCase()))) return 'local:sensitive';
-  return 'local';
+	if (NETWORK_TOOL_NAMES.has(toolName)) return "network";
+	if (
+		toolName.startsWith("mcp__") &&
+		NETWORK_TOOL_SUFFIXES.some((s) => toolName.endsWith(s))
+	)
+		return "network";
+	const inputStr = toolInput ? JSON.stringify(toolInput).toLowerCase() : "";
+	if (SENSITIVE_PATH_PATTERNS.some((p) => inputStr.includes(p.toLowerCase())))
+		return "local:sensitive";
+	return "local";
 }
 
 function buildToolSources(entry) {
-  const sources = {};
-  const messages = entry.req?.messages;
-  if (!Array.isArray(messages)) return sources;
-  for (const msg of messages) {
-    if (msg.role !== 'assistant' || !Array.isArray(msg.content)) continue;
-    for (const block of msg.content) {
-      if (block.type === 'tool_use' && block.id) {
-        sources[block.id] = classifyToolSource(block.name, block.input);
-      }
-    }
-  }
-  return sources;
+	const sources = {};
+	const messages = entry.req?.messages;
+	if (!Array.isArray(messages)) return sources;
+	for (const msg of messages) {
+		if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+		for (const block of msg.content) {
+			if (block.type === "tool_use" && block.id) {
+				sources[block.id] = classifyToolSource(block.name, block.input);
+			}
+		}
+	}
+	return sources;
 }
 
 // ── Tool usage extraction ────────────────────────────────────────────
 function extractToolCalls(messages) {
-  const counts = {};
-  (messages || []).forEach(m => {
-    if (!Array.isArray(m.content)) return;
-    m.content.forEach(b => {
-      if (b.type === 'tool_use' && b.name) counts[b.name] = (counts[b.name] || 0) + 1;
-    });
-  });
-  return counts;
+	const counts = {};
+	(messages || []).forEach((m) => {
+		if (!Array.isArray(m.content)) return;
+		m.content.forEach((b) => {
+			if (b.type === "tool_use" && b.name)
+				counts[b.name] = (counts[b.name] || 0) + 1;
+		});
+	});
+	return counts;
 }
 
 function extractDuplicateToolCalls(messages) {
-  const seen = {};  // key → { name, count }
-  (messages || []).forEach(m => {
-    if (!Array.isArray(m.content)) return;
-    m.content.forEach(b => {
-      if (b.type !== 'tool_use' || !b.name) return;
-      const inputStr = JSON.stringify(b.input || {});
-      // Large inputs (>10KB): truncated key (may over-count, acceptable tradeoff)
-      const key = b.name + '\0' + (inputStr.length > 10240 ? inputStr.slice(0, 200) : inputStr);
-      if (!seen[key]) seen[key] = { name: b.name, count: 0 };
-      seen[key].count++;
-    });
-  });
-  const dupes = {};
-  for (const { name, count } of Object.values(seen)) {
-    if (count > 1) dupes[name] = (dupes[name] || 0) + (count - 1);
-  }
-  return Object.keys(dupes).length > 0 ? dupes : null;
+	const seen = {}; // key → { name, count }
+	(messages || []).forEach((m) => {
+		if (!Array.isArray(m.content)) return;
+		m.content.forEach((b) => {
+			if (b.type !== "tool_use" || !b.name) return;
+			const inputStr = JSON.stringify(b.input || {});
+			// Large inputs (>10KB): truncated key (may over-count, acceptable tradeoff)
+			const key =
+				b.name +
+				"\0" +
+				(inputStr.length > 10240 ? inputStr.slice(0, 200) : inputStr);
+			if (!seen[key]) seen[key] = { name: b.name, count: 0 };
+			seen[key].count++;
+		});
+	});
+	const dupes = {};
+	for (const { name, count } of Object.values(seen)) {
+		if (count > 1) dupes[name] = (dupes[name] || 0) + (count - 1);
+	}
+	return Object.keys(dupes).length > 0 ? dupes : null;
 }
 
 module.exports = {
-  timestamp,
-  taipeiTime,
-  printSeparator,
-  safeCountTokens,
-  TOOL_CATEGORIES,
-  parseSystemBlocks,
-  parseClaudeMdFromMessages,
-  categorizeTools,
-  analyzeContext,
-  tokenizeRequest,
-  extractUsage,
-  summarizeRequest,
-  totalContextTokens,
-  printContextBar,
-  computeThinkingDuration,
-  parseSSEEvents,
-  extractResponseTitle,
-  extractToolCalls,
-  extractDuplicateToolCalls,
-  scanCredentials,
-  entryHasCredential,
-  classifyToolSource,
-  buildToolSources,
+	sanitizeForLog,
+	readBodyCapped,
+	timestamp,
+	taipeiTime,
+	printSeparator,
+	safeCountTokens,
+	TOOL_CATEGORIES,
+	parseSystemBlocks,
+	parseClaudeMdFromMessages,
+	categorizeTools,
+	analyzeContext,
+	tokenizeRequest,
+	extractUsage,
+	summarizeRequest,
+	totalContextTokens,
+	printContextBar,
+	computeThinkingDuration,
+	parseSSEEvents,
+	extractResponseTitle,
+	extractToolCalls,
+	extractDuplicateToolCalls,
+	scanCredentials,
+	entryHasCredential,
+	classifyToolSource,
+	buildToolSources,
 };

--- a/server/hub.js
+++ b/server/hub.js
@@ -1,14 +1,14 @@
-'use strict';
+"use strict";
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const http = require('http');
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const http = require("http");
 
-const HUB_DIR = process.env.CCXRAY_HOME || path.join(os.homedir(), '.ccxray');
-const HUB_LOCK_PATH = path.join(HUB_DIR, 'hub.json');
-const HUB_LOG_PATH = path.join(HUB_DIR, 'hub.log');
-const FORK_LOCK_PATH = path.join(HUB_DIR, 'hub.fork.lock');
+const HUB_DIR = process.env.CCXRAY_HOME || path.join(os.homedir(), ".ccxray");
+const HUB_LOCK_PATH = path.join(HUB_DIR, "hub.json");
+const HUB_LOG_PATH = path.join(HUB_DIR, "hub.log");
+const FORK_LOCK_PATH = path.join(HUB_DIR, "hub.fork.lock");
 const FORK_LOCK_STALE_MS = 15000;
 const IDLE_TIMEOUT_MS = 5000;
 const DEAD_CLIENT_CHECK_MS = 30000;
@@ -16,279 +16,365 @@ const HUB_HEALTH_CHECK_MS = 5000;
 const READINESS_POLL_MS = 200;
 const READINESS_TIMEOUT_MS = 10000;
 const HUB_LOG_MAX_BYTES = 1 * 1024 * 1024; // 1 MB
-const HUB_LOG_KEEP_BYTES = 100 * 1024;     // 100 KB
+const HUB_LOG_KEEP_BYTES = 100 * 1024; // 100 KB
 
 // ── Lockfile operations ─────────────────────────────────────────────
 
 function ensureHubDir() {
-  if (!fs.existsSync(HUB_DIR)) fs.mkdirSync(HUB_DIR, { recursive: true });
+	if (!fs.existsSync(HUB_DIR))
+		fs.mkdirSync(HUB_DIR, { recursive: true, mode: 0o700 });
+	try {
+		fs.chmodSync(HUB_DIR, 0o700);
+	} catch {}
 }
 
 function readHubLock() {
-  try {
-    return JSON.parse(fs.readFileSync(HUB_LOCK_PATH, 'utf8'));
-  } catch {
-    return null;
-  }
+	try {
+		return JSON.parse(fs.readFileSync(HUB_LOCK_PATH, "utf8"));
+	} catch {
+		return null;
+	}
 }
 
 function writeHubLock(port, pid, versionOverride) {
-  ensureHubDir();
-  const version = versionOverride || require('../package.json').version;
-  const data = { port, pid, version, startedAt: new Date().toISOString() };
-  fs.writeFileSync(HUB_LOCK_PATH, JSON.stringify(data));
-  return data;
+	ensureHubDir();
+	const version = versionOverride || require("../package.json").version;
+	const data = { port, pid, version, startedAt: new Date().toISOString() };
+	fs.writeFileSync(HUB_LOCK_PATH, JSON.stringify(data), { mode: 0o600 });
+	return data;
 }
 
 function deleteHubLock() {
-  try { fs.unlinkSync(HUB_LOCK_PATH); } catch {}
+	try {
+		fs.unlinkSync(HUB_LOCK_PATH);
+	} catch {}
 }
 
 // ── PID check ───────────────────────────────────────────────────────
 
 function isPidAlive(pid) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 // ── Health check (HTTP probe) ───────────────────────────────────────
 
 function checkHubHealth(port, timeoutMs = 2000) {
-  return new Promise(resolve => {
-    const req = http.get(`http://localhost:${port}/_api/health`, { timeout: timeoutMs }, res => {
-      let data = '';
-      res.on('data', chunk => { data += chunk; });
-      res.on('end', () => {
-        try {
-          const parsed = JSON.parse(data);
-          resolve(parsed.ok === true);
-        } catch { resolve(false); }
-      });
-    });
-    req.on('error', () => resolve(false));
-    req.on('timeout', () => { req.destroy(); resolve(false); });
-  });
+	return new Promise((resolve) => {
+		const req = http.get(
+			`http://localhost:${port}/_api/health`,
+			{ timeout: timeoutMs },
+			(res) => {
+				let data = "";
+				res.on("data", (chunk) => {
+					data += chunk;
+				});
+				res.on("end", () => {
+					try {
+						const parsed = JSON.parse(data);
+						resolve(parsed.ok === true);
+					} catch {
+						resolve(false);
+					}
+				});
+			},
+		);
+		req.on("error", () => resolve(false));
+		req.on("timeout", () => {
+			req.destroy();
+			resolve(false);
+		});
+	});
 }
 
 // ── Orphan hub probe (port-level fallback when lockfile missing) ────
 
 function probeHubStatus(port, timeoutMs = 2000) {
-  return new Promise(resolve => {
-    const req = http.get(`http://localhost:${port}/_api/hub/status`, { timeout: timeoutMs }, res => {
-      let data = '';
-      res.on('data', chunk => { data += chunk; });
-      res.on('end', () => {
-        try {
-          const parsed = JSON.parse(data);
-          if (parsed.app === 'ccxray' && parsed.pid && parsed.version && parsed.port) resolve(parsed);
-          else resolve(null);
-        } catch { resolve(null); }
-      });
-    });
-    req.on('error', () => resolve(null));
-    req.on('timeout', () => { req.destroy(); resolve(null); });
-  });
+	return new Promise((resolve) => {
+		const req = http.get(
+			`http://localhost:${port}/_api/hub/status`,
+			{ timeout: timeoutMs },
+			(res) => {
+				let data = "";
+				res.on("data", (chunk) => {
+					data += chunk;
+				});
+				res.on("end", () => {
+					try {
+						const parsed = JSON.parse(data);
+						if (
+							parsed.app === "ccxray" &&
+							parsed.pid &&
+							parsed.version &&
+							parsed.port
+						)
+							resolve(parsed);
+						else resolve(null);
+					} catch {
+						resolve(null);
+					}
+				});
+			},
+		);
+		req.on("error", () => resolve(null));
+		req.on("timeout", () => {
+			req.destroy();
+			resolve(null);
+		});
+	});
 }
 
 // ── Hub discovery (dual verification: pid + health) ─────────────────
 
 async function discoverHub(defaultPort) {
-  const lock = readHubLock();
-  if (lock) {
-    if (!isPidAlive(lock.pid)) {
-      deleteHubLock();
-      return null;
-    }
-    const healthy = await checkHubHealth(lock.port);
-    if (!healthy) {
-      deleteHubLock();
-      // Do NOT kill lock.pid here: hub.json may be stale from a crash, and the pid
-      // may have been reused by an unrelated process. Sending SIGTERM to an arbitrary
-      // pid is unsafe. The hub startup retry loop (5 × 1s) handles the shutdown-race
-      // case where the port hasn't been released yet.
-      return null;
-    }
-    return lock;
-  }
+	const lock = readHubLock();
+	if (lock) {
+		if (!isPidAlive(lock.pid)) {
+			deleteHubLock();
+			return null;
+		}
+		const healthy = await checkHubHealth(lock.port);
+		if (!healthy) {
+			deleteHubLock();
+			// Do NOT kill lock.pid here: hub.json may be stale from a crash, and the pid
+			// may have been reused by an unrelated process. Sending SIGTERM to an arbitrary
+			// pid is unsafe. The hub startup retry loop (5 × 1s) handles the shutdown-race
+			// case where the port hasn't been released yet.
+			return null;
+		}
+		return lock;
+	}
 
-  // Lockfile missing — probe default port for orphan hub
-  if (!defaultPort) return null;
-  const status = await probeHubStatus(defaultPort);
-  if (!status) return null;
-  if (status.port !== defaultPort) return null; // reject port mismatch (non-ccxray service)
-  if (!isPidAlive(status.pid)) return null;
+	// Lockfile missing — probe default port for orphan hub
+	if (!defaultPort) return null;
+	const status = await probeHubStatus(defaultPort);
+	if (!status) return null;
+	if (status.port !== defaultPort) return null; // reject port mismatch (non-ccxray service)
+	if (!isPidAlive(status.pid)) return null;
 
-  // Reconstruct lockfile from live hub (use hub's version, not client's)
-  const recovered = writeHubLock(status.port, status.pid, status.version);
-  return recovered;
+	// Reconstruct lockfile from live hub (use hub's version, not client's)
+	const recovered = writeHubLock(status.port, status.pid, status.version);
+	return recovered;
 }
 
 // ── Version compatibility (semver major check) ──────────────────────
 
 function checkVersionCompat(hubVersion) {
-  const clientVersion = require('../package.json').version;
-  if (hubVersion === clientVersion) return { ok: true };
+	const clientVersion = require("../package.json").version;
+	if (hubVersion === clientVersion) return { ok: true };
 
-  const hubMajor = parseInt(hubVersion.split('.')[0], 10);
-  const clientMajor = parseInt(clientVersion.split('.')[0], 10);
+	const hubMajor = parseInt(hubVersion.split(".")[0], 10);
+	const clientMajor = parseInt(clientVersion.split(".")[0], 10);
 
-  if (hubMajor !== clientMajor) {
-    return {
-      ok: false,
-      fatal: true,
-      message: `Hub (v${hubVersion}) is incompatible with this client (v${clientVersion}). Close all ccxray instances and restart.`,
-    };
-  }
+	if (hubMajor !== clientMajor) {
+		return {
+			ok: false,
+			fatal: true,
+			message: `Hub (v${hubVersion}) is incompatible with this client (v${clientVersion}). Close all ccxray instances and restart.`,
+		};
+	}
 
-  const hubMinor = parseInt(hubVersion.split('.')[1], 10);
-  const clientMinor = parseInt(clientVersion.split('.')[1], 10);
-  if (hubMinor !== clientMinor) {
-    return {
-      ok: true,
-      warning: `Hub is v${hubVersion}, client is v${clientVersion} (minor version mismatch)`,
-    };
-  }
+	const hubMinor = parseInt(hubVersion.split(".")[1], 10);
+	const clientMinor = parseInt(clientVersion.split(".")[1], 10);
+	if (hubMinor !== clientMinor) {
+		return {
+			ok: true,
+			warning: `Hub is v${hubVersion}, client is v${clientVersion} (minor version mismatch)`,
+		};
+	}
 
-  return { ok: true };
+	return { ok: true };
 }
 
 // ── Fork lock (prevents multiple clients from forking hubs simultaneously) ──
 
 function tryAcquireForkLock() {
-  ensureHubDir();
-  try {
-    fs.writeFileSync(FORK_LOCK_PATH, JSON.stringify({ pid: process.pid, at: Date.now() }), { flag: 'wx' });
-    return true;
-  } catch (err) {
-    if (err.code === 'EEXIST') {
-      // Check if the existing lock is stale
-      try {
-        const lock = JSON.parse(fs.readFileSync(FORK_LOCK_PATH, 'utf8'));
-        if (Date.now() - lock.at > FORK_LOCK_STALE_MS || !isPidAlive(lock.pid)) {
-          // Atomic rename to avoid TOCTOU: move stale lock aside, then try wx create.
-          // If another client races us, only one rename succeeds (the other gets ENOENT).
-          const staleTarget = FORK_LOCK_PATH + `.stale.${process.pid}`;
-          try {
-            fs.renameSync(FORK_LOCK_PATH, staleTarget);
-            fs.unlinkSync(staleTarget);
-          } catch {}
-          // Now attempt exclusive create — may fail if another client won the race
-          try {
-            fs.writeFileSync(FORK_LOCK_PATH, JSON.stringify({ pid: process.pid, at: Date.now() }), { flag: 'wx' });
-            return true;
-          } catch {
-            return false;
-          }
-        }
-      } catch {}
-      return false;
-    }
-    return false;
-  }
+	ensureHubDir();
+	try {
+		fs.writeFileSync(
+			FORK_LOCK_PATH,
+			JSON.stringify({ pid: process.pid, at: Date.now() }),
+			{ flag: "wx", mode: 0o600 },
+		);
+		return true;
+	} catch (err) {
+		if (err.code === "EEXIST") {
+			// Check if the existing lock is stale
+			try {
+				const lock = JSON.parse(fs.readFileSync(FORK_LOCK_PATH, "utf8"));
+				if (
+					Date.now() - lock.at > FORK_LOCK_STALE_MS ||
+					!isPidAlive(lock.pid)
+				) {
+					// Atomic rename to avoid TOCTOU: move stale lock aside, then try wx create.
+					// If another client races us, only one rename succeeds (the other gets ENOENT).
+					const staleTarget = FORK_LOCK_PATH + `.stale.${process.pid}`;
+					try {
+						fs.renameSync(FORK_LOCK_PATH, staleTarget);
+						fs.unlinkSync(staleTarget);
+					} catch {}
+					// Now attempt exclusive create — may fail if another client won the race
+					try {
+						fs.writeFileSync(
+							FORK_LOCK_PATH,
+							JSON.stringify({ pid: process.pid, at: Date.now() }),
+							{ flag: "wx", mode: 0o600 },
+						);
+						return true;
+					} catch {
+						return false;
+					}
+				}
+			} catch {}
+			return false;
+		}
+		return false;
+	}
 }
 
 function releaseForkLock() {
-  try { fs.unlinkSync(FORK_LOCK_PATH); } catch {}
+	try {
+		fs.unlinkSync(FORK_LOCK_PATH);
+	} catch {}
 }
 
 // ── Fork detached hub process ───────────────────────────────────────
 
 function forkHub(port) {
-  const { spawn } = require('child_process');
-  ensureHubDir();
-  truncateHubLog();
+	const { spawn } = require("child_process");
+	ensureHubDir();
+	truncateHubLog();
 
-  const fd = fs.openSync(HUB_LOG_PATH, 'a');
-  const hubScript = path.resolve(__dirname, 'index.js');
-  const args = ['--port', String(port), '--hub-mode'];
+	const fd = fs.openSync(HUB_LOG_PATH, "a", 0o600);
+	try {
+		fs.chmodSync(HUB_LOG_PATH, 0o600);
+	} catch {}
+	const hubScript = path.resolve(__dirname, "index.js");
+	const args = ["--port", String(port), "--hub-mode"];
 
-  const child = spawn(process.execPath, [hubScript, ...args], {
-    detached: true,
-    stdio: ['ignore', fd, fd],
-    env: { ...process.env },
-  });
-  child.unref();
-  fs.closeSync(fd);
-  return child.pid;
+	const child = spawn(process.execPath, [hubScript, ...args], {
+		detached: true,
+		stdio: ["ignore", fd, fd],
+		env: { ...process.env },
+	});
+	child.unref();
+	fs.closeSync(fd);
+	return child.pid;
 }
 
 // ── Wait for hub readiness (poll lockfile) ──────────────────────────
 
 function waitForHubReady(timeoutMs = READINESS_TIMEOUT_MS) {
-  return new Promise((resolve, reject) => {
-    const start = Date.now();
-    const check = () => {
-      const lock = readHubLock();
-      if (lock) return resolve(lock);
-      if (Date.now() - start > timeoutMs) {
-        return reject(new Error(`Hub did not become ready within ${timeoutMs / 1000}s. Check ${HUB_LOG_PATH}`));
-      }
-      setTimeout(check, READINESS_POLL_MS);
-    };
-    check();
-  });
+	return new Promise((resolve, reject) => {
+		const start = Date.now();
+		const check = () => {
+			const lock = readHubLock();
+			if (lock) return resolve(lock);
+			if (Date.now() - start > timeoutMs) {
+				return reject(
+					new Error(
+						`Hub did not become ready within ${timeoutMs / 1000}s. Check ${HUB_LOG_PATH}`,
+					),
+				);
+			}
+			setTimeout(check, READINESS_POLL_MS);
+		};
+		check();
+	});
 }
 
 // ── Client registration (HTTP calls to hub) ─────────────────────────
 
 function registerClient(port, pid, cwd) {
-  return new Promise((resolve, reject) => {
-    const body = JSON.stringify({ pid, cwd });
-    const req = http.request(`http://localhost:${port}/_api/hub/register`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
-      timeout: 3000,
-    }, res => {
-      let data = '';
-      res.on('data', chunk => { data += chunk; });
-      res.on('end', () => {
-        if (res.statusCode !== 200) return resolve(null);
-        try { resolve(JSON.parse(data)); } catch { resolve(null); }
-      });
-    });
-    req.on('error', reject);
-    req.on('timeout', () => { req.destroy(); reject(new Error('register timeout')); });
-    req.end(body);
-  });
+	return new Promise((resolve, reject) => {
+		const body = JSON.stringify({ pid, cwd });
+		const req = http.request(
+			`http://localhost:${port}/_api/hub/register`,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"Content-Length": Buffer.byteLength(body),
+				},
+				timeout: 3000,
+			},
+			(res) => {
+				let data = "";
+				res.on("data", (chunk) => {
+					data += chunk;
+				});
+				res.on("end", () => {
+					if (res.statusCode !== 200) return resolve(null);
+					try {
+						resolve(JSON.parse(data));
+					} catch {
+						resolve(null);
+					}
+				});
+			},
+		);
+		req.on("error", reject);
+		req.on("timeout", () => {
+			req.destroy();
+			reject(new Error("register timeout"));
+		});
+		req.end(body);
+	});
 }
 
 function unregisterClient(port, pid) {
-  return new Promise(resolve => {
-    const body = JSON.stringify({ pid });
-    const req = http.request(`http://localhost:${port}/_api/hub/unregister`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
-      timeout: 3000,
-    }, res => {
-      res.resume();
-      resolve();
-    });
-    req.on('error', () => resolve());
-    req.on('timeout', () => { req.destroy(); resolve(); });
-    req.end(body);
-  });
+	return new Promise((resolve) => {
+		const body = JSON.stringify({ pid });
+		const req = http.request(
+			`http://localhost:${port}/_api/hub/unregister`,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"Content-Length": Buffer.byteLength(body),
+				},
+				timeout: 3000,
+			},
+			(res) => {
+				res.resume();
+				resolve();
+			},
+		);
+		req.on("error", () => resolve());
+		req.on("timeout", () => {
+			req.destroy();
+			resolve();
+		});
+		req.end(body);
+	});
 }
 
 // ── Hub log truncation ──────────────────────────────────────────────
 
 function truncateHubLog() {
-  try {
-    const stat = fs.statSync(HUB_LOG_PATH);
-    if (stat.size > HUB_LOG_MAX_BYTES) {
-      const buf = Buffer.alloc(HUB_LOG_KEEP_BYTES);
-      const fd = fs.openSync(HUB_LOG_PATH, 'r');
-      fs.readSync(fd, buf, 0, HUB_LOG_KEEP_BYTES, stat.size - HUB_LOG_KEEP_BYTES);
-      fs.closeSync(fd);
-      // Find first newline to avoid partial line
-      const nl = buf.indexOf(0x0a);
-      const clean = nl >= 0 ? buf.subarray(nl + 1) : buf;
-      fs.writeFileSync(HUB_LOG_PATH, clean);
-    }
-  } catch {}
+	try {
+		const stat = fs.statSync(HUB_LOG_PATH);
+		if (stat.size > HUB_LOG_MAX_BYTES) {
+			const buf = Buffer.alloc(HUB_LOG_KEEP_BYTES);
+			const fd = fs.openSync(HUB_LOG_PATH, "r");
+			fs.readSync(
+				fd,
+				buf,
+				0,
+				HUB_LOG_KEEP_BYTES,
+				stat.size - HUB_LOG_KEEP_BYTES,
+			);
+			fs.closeSync(fd);
+			// Find first newline to avoid partial line
+			const nl = buf.indexOf(0x0a);
+			const clean = nl >= 0 ? buf.subarray(nl + 1) : buf;
+			fs.writeFileSync(HUB_LOG_PATH, clean, { mode: 0o600 });
+		}
+	} catch {}
 }
 
 // ── Client lifecycle (hub-side state) ───────────────────────────────
@@ -300,197 +386,286 @@ let hubListenPort = null; // set once at startup, survives lockfile deletion
 let onShutdown = null; // injectable shutdown handler (default: process.exit)
 
 function addClient(pid, cwd) {
-  if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
-  clients.set(pid, { cwd, connectedAt: new Date().toISOString() });
+	if (idleTimer) {
+		clearTimeout(idleTimer);
+		idleTimer = null;
+	}
+	clients.set(pid, { cwd, connectedAt: new Date().toISOString() });
 }
 
 function removeClient(pid) {
-  clients.delete(pid);
-  if (clients.size === 0) startIdleTimer();
+	clients.delete(pid);
+	if (clients.size === 0) startIdleTimer();
 }
 
 function startIdleTimer() {
-  if (idleTimer) return;
-  idleTimer = setTimeout(() => {
-    console.log('All clients disconnected. Shutting down hub.');
-    shutdownHub();
-  }, IDLE_TIMEOUT_MS);
+	if (idleTimer) return;
+	idleTimer = setTimeout(() => {
+		console.log("All clients disconnected. Shutting down hub.");
+		shutdownHub();
+	}, IDLE_TIMEOUT_MS);
 }
 
-function setOnShutdown(fn) { onShutdown = fn; }
+function setOnShutdown(fn) {
+	onShutdown = fn;
+}
 
 function shutdownHub() {
-  if (deadCheckInterval) clearInterval(deadCheckInterval);
-  deleteHubLock();
-  if (onShutdown) onShutdown();
-  else process.exit(0);
+	if (deadCheckInterval) clearInterval(deadCheckInterval);
+	deleteHubLock();
+	if (onShutdown) onShutdown();
+	else process.exit(0);
 }
 
 function startDeadClientCheck() {
-  deadCheckInterval = setInterval(() => {
-    for (const [pid] of clients) {
-      if (!isPidAlive(pid)) {
-        console.log(`Dead client detected: pid ${pid}, removing.`);
-        removeClient(pid);
-      }
-    }
-  }, DEAD_CLIENT_CHECK_MS);
-  deadCheckInterval.unref();
+	deadCheckInterval = setInterval(() => {
+		for (const [pid] of clients) {
+			if (!isPidAlive(pid)) {
+				console.log(`Dead client detected: pid ${pid}, removing.`);
+				removeClient(pid);
+			}
+		}
+	}, DEAD_CLIENT_CHECK_MS);
+	deadCheckInterval.unref();
 }
 
-function setHubPort(port) { hubListenPort = port; }
+function setHubPort(port) {
+	hubListenPort = port;
+}
 
 function getHubStatus() {
-  return {
-    app: 'ccxray',
-    port: hubListenPort || readHubLock()?.port,
-    pid: process.pid,
-    version: require('../package.json').version,
-    uptime: Math.floor(process.uptime()),
-    clients: [...clients.entries()].map(([pid, info]) => ({ pid, ...info })),
-  };
+	return {
+		app: "ccxray",
+		port: hubListenPort || readHubLock()?.port,
+		pid: process.pid,
+		version: require("../package.json").version,
+		uptime: Math.floor(process.uptime()),
+		clients: [...clients.entries()].map(([pid, info]) => ({ pid, ...info })),
+	};
 }
 
 // ── Hub route handler (mounted in server) ───────────────────────────
 
+const LOOPBACK_ADDRS = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1"]);
+const HUB_BODY_MAX = 1024;
+const MAX_PID = 1 << 22; // 4_194_304
+const MAX_CWD_LEN = 4096;
+
+function isLoopbackRemote(clientReq) {
+	const addr = clientReq.socket && clientReq.socket.remoteAddress;
+	if (!addr) return false;
+	return LOOPBACK_ADDRS.has(addr);
+}
+
+function validRegisterPayload(obj) {
+	if (!obj || typeof obj !== "object") return false;
+	if (!Number.isInteger(obj.pid) || obj.pid <= 0 || obj.pid > MAX_PID)
+		return false;
+	if (
+		typeof obj.cwd !== "string" ||
+		obj.cwd.length === 0 ||
+		obj.cwd.length > MAX_CWD_LEN
+	)
+		return false;
+	return true;
+}
+
+function validUnregisterPayload(obj) {
+	if (!obj || typeof obj !== "object") return false;
+	if (!Number.isInteger(obj.pid) || obj.pid <= 0 || obj.pid > MAX_PID)
+		return false;
+	return true;
+}
+
+function readHubBody(clientReq, clientRes, onDone) {
+	const chunks = [];
+	let size = 0;
+	let aborted = false;
+	clientReq.on("data", (c) => {
+		if (aborted) return;
+		size += c.length;
+		if (size > HUB_BODY_MAX) {
+			aborted = true;
+			clientRes.writeHead(413, { "Content-Type": "application/json" });
+			clientRes.end(
+				JSON.stringify({
+					error: "payload_too_large",
+					limit_bytes: HUB_BODY_MAX,
+				}),
+			);
+			clientReq.destroy();
+			return;
+		}
+		chunks.push(c);
+	});
+	clientReq.on("end", () => {
+		if (!aborted) onDone(Buffer.concat(chunks).toString());
+	});
+}
+
 function handleHubRoutes(clientReq, clientRes) {
-  if (clientReq.url === '/_api/health' && clientReq.method === 'GET') {
-    clientRes.writeHead(200, { 'Content-Type': 'application/json' });
-    clientRes.end(JSON.stringify({ ok: true }));
-    return true;
-  }
+	if (clientReq.url === "/_api/health" && clientReq.method === "GET") {
+		clientRes.writeHead(200, { "Content-Type": "application/json" });
+		clientRes.end(JSON.stringify({ ok: true }));
+		return true;
+	}
 
-  if (clientReq.url === '/_api/hub/status' && clientReq.method === 'GET') {
-    clientRes.writeHead(200, { 'Content-Type': 'application/json' });
-    clientRes.end(JSON.stringify(getHubStatus()));
-    return true;
-  }
+	// Hub control endpoints: loopback only
+	const isHubCtl =
+		clientReq.url === "/_api/hub/status" ||
+		clientReq.url === "/_api/hub/register" ||
+		clientReq.url === "/_api/hub/unregister";
+	if (isHubCtl && !isLoopbackRemote(clientReq)) {
+		clientRes.writeHead(403, { "Content-Type": "application/json" });
+		clientRes.end(JSON.stringify({ error: "forbidden" }));
+		return true;
+	}
 
-  if (clientReq.url === '/_api/hub/register' && clientReq.method === 'POST') {
-    let body = '';
-    clientReq.on('data', c => { body += c; });
-    clientReq.on('end', () => {
-      try {
-        const { pid, cwd } = JSON.parse(body);
-        const wasEmpty = clients.size === 0;
-        addClient(pid, cwd);
-        clientRes.writeHead(200, { 'Content-Type': 'application/json' });
-        clientRes.end(JSON.stringify({ ok: true, firstClient: wasEmpty }));
-      } catch {
-        clientRes.writeHead(400);
-        clientRes.end('Bad request');
-      }
-    });
-    return true;
-  }
+	if (clientReq.url === "/_api/hub/status" && clientReq.method === "GET") {
+		clientRes.writeHead(200, { "Content-Type": "application/json" });
+		clientRes.end(JSON.stringify(getHubStatus()));
+		return true;
+	}
 
-  if (clientReq.url === '/_api/hub/unregister' && clientReq.method === 'POST') {
-    let body = '';
-    clientReq.on('data', c => { body += c; });
-    clientReq.on('end', () => {
-      try {
-        const { pid } = JSON.parse(body);
-        removeClient(pid);
-        clientRes.writeHead(200, { 'Content-Type': 'application/json' });
-        clientRes.end(JSON.stringify({ ok: true }));
-      } catch {
-        clientRes.writeHead(400);
-        clientRes.end('Bad request');
-      }
-    });
-    return true;
-  }
+	if (clientReq.url === "/_api/hub/register" && clientReq.method === "POST") {
+		readHubBody(clientReq, clientRes, (body) => {
+			try {
+				const parsed = JSON.parse(body);
+				if (!validRegisterPayload(parsed)) {
+					clientRes.writeHead(400, { "Content-Type": "application/json" });
+					clientRes.end(JSON.stringify({ error: "invalid_payload" }));
+					return;
+				}
+				const wasEmpty = clients.size === 0;
+				addClient(parsed.pid, parsed.cwd);
+				clientRes.writeHead(200, { "Content-Type": "application/json" });
+				clientRes.end(JSON.stringify({ ok: true, firstClient: wasEmpty }));
+			} catch {
+				clientRes.writeHead(400);
+				clientRes.end("Bad request");
+			}
+		});
+		return true;
+	}
 
-  return false;
+	if (clientReq.url === "/_api/hub/unregister" && clientReq.method === "POST") {
+		readHubBody(clientReq, clientRes, (body) => {
+			try {
+				const parsed = JSON.parse(body);
+				if (!validUnregisterPayload(parsed)) {
+					clientRes.writeHead(400, { "Content-Type": "application/json" });
+					clientRes.end(JSON.stringify({ error: "invalid_payload" }));
+					return;
+				}
+				removeClient(parsed.pid);
+				clientRes.writeHead(200, { "Content-Type": "application/json" });
+				clientRes.end(JSON.stringify({ ok: true }));
+			} catch {
+				clientRes.writeHead(400);
+				clientRes.end("Bad request");
+			}
+		});
+		return true;
+	}
+
+	return false;
 }
 
 // ── Hub pid monitoring (client-side recovery) ───────────────────────
 
 function startHubMonitor(hubPid, hubPort, onRecovery) {
-  const interval = setInterval(async () => {
-    if (isPidAlive(hubPid)) return;
+	const interval = setInterval(async () => {
+		if (isPidAlive(hubPid)) return;
 
-    clearInterval(interval);
-    console.error('\x1b[33mHub process died. Attempting recovery...\x1b[0m');
-    deleteHubLock();
+		clearInterval(interval);
+		console.error("\x1b[33mHub process died. Attempting recovery...\x1b[0m");
+		deleteHubLock();
 
-    let acquired = false;
-    try {
-      acquired = tryAcquireForkLock();
-      if (acquired) forkHub(hubPort);
-      const lock = await waitForHubReady();
-      if (acquired) releaseForkLock();
-      if (lock.port !== hubPort) {
-        if (acquired) releaseForkLock();
-        console.error(`\x1b[31mHub recovered on port ${lock.port} but Claude is using port ${hubPort}. Cannot recover.\x1b[0m`);
-        try { process.kill(lock.pid, 'SIGTERM'); } catch {}
-        return;
-      }
-      console.error(`\x1b[32mHub recovered (pid ${lock.pid}, port ${lock.port})\x1b[0m`);
-      if (onRecovery) onRecovery(lock);
-      startHubMonitor(lock.pid, lock.port, onRecovery);
-    } catch (err) {
-      if (acquired) releaseForkLock();
-      console.error(`\x1b[31mHub recovery failed: ${err.message}\x1b[0m`);
-    }
-  }, HUB_HEALTH_CHECK_MS);
-  interval.unref();
-  return interval;
+		let acquired = false;
+		try {
+			acquired = tryAcquireForkLock();
+			if (acquired) forkHub(hubPort);
+			const lock = await waitForHubReady();
+			if (acquired) releaseForkLock();
+			if (lock.port !== hubPort) {
+				if (acquired) releaseForkLock();
+				console.error(
+					`\x1b[31mHub recovered on port ${lock.port} but Claude is using port ${hubPort}. Cannot recover.\x1b[0m`,
+				);
+				try {
+					process.kill(lock.pid, "SIGTERM");
+				} catch {}
+				return;
+			}
+			console.error(
+				`\x1b[32mHub recovered (pid ${lock.pid}, port ${lock.port})\x1b[0m`,
+			);
+			if (onRecovery) onRecovery(lock);
+			startHubMonitor(lock.pid, lock.port, onRecovery);
+		} catch (err) {
+			if (acquired) releaseForkLock();
+			console.error(`\x1b[31mHub recovery failed: ${err.message}\x1b[0m`);
+		}
+	}, HUB_HEALTH_CHECK_MS);
+	interval.unref();
+	return interval;
 }
 
 // ── Port scanner (used by hub and Claude-mode startup) ──────────────
 
-function tryListen(srv, port, maxAttempts) {
-  return new Promise((resolve, reject) => {
-    let attempt = 0;
-    function onError(err) {
-      if (err.code === 'EADDRINUSE' && attempt < maxAttempts) {
-        attempt++;
-        srv.listen(port + attempt);
-      } else {
-        srv.removeListener('error', onError);
-        srv.removeListener('listening', onListening);
-        reject(err);
-      }
-    }
-    function onListening() {
-      srv.removeListener('error', onError);
-      resolve(srv.address().port);
-    }
-    srv.on('error', onError);
-    srv.once('listening', onListening);
-    srv.listen(port);
-  });
+function tryListen(srv, port, maxAttempts, host) {
+	return new Promise((resolve, reject) => {
+		let attempt = 0;
+		function onError(err) {
+			if (err.code === "EADDRINUSE" && attempt < maxAttempts) {
+				attempt++;
+				if (host) srv.listen(port + attempt, host);
+				else srv.listen(port + attempt);
+			} else {
+				srv.removeListener("error", onError);
+				srv.removeListener("listening", onListening);
+				reject(err);
+			}
+		}
+		function onListening() {
+			srv.removeListener("error", onError);
+			resolve(srv.address().port);
+		}
+		srv.on("error", onError);
+		srv.once("listening", onListening);
+		if (host) srv.listen(port, host);
+		else srv.listen(port);
+	});
 }
 
 module.exports = {
-  HUB_DIR,
-  HUB_LOCK_PATH,
-  HUB_LOG_PATH,
-  readHubLock,
-  writeHubLock,
-  deleteHubLock,
-  isPidAlive,
-  checkHubHealth,
-  probeHubStatus,
-  discoverHub,
-  checkVersionCompat,
-  tryAcquireForkLock,
-  releaseForkLock,
-  forkHub,
-  waitForHubReady,
-  registerClient,
-  unregisterClient,
-  truncateHubLog,
-  addClient,
-  removeClient,
-  startIdleTimer,
-  setOnShutdown,
-  shutdownHub,
-  startDeadClientCheck,
-  setHubPort,
-  getHubStatus,
-  handleHubRoutes,
-  startHubMonitor,
-  tryListen,
+	HUB_DIR,
+	HUB_LOCK_PATH,
+	HUB_LOG_PATH,
+	readHubLock,
+	writeHubLock,
+	deleteHubLock,
+	isPidAlive,
+	checkHubHealth,
+	probeHubStatus,
+	discoverHub,
+	checkVersionCompat,
+	tryAcquireForkLock,
+	releaseForkLock,
+	forkHub,
+	waitForHubReady,
+	registerClient,
+	unregisterClient,
+	truncateHubLog,
+	addClient,
+	removeClient,
+	startIdleTimer,
+	setOnShutdown,
+	shutdownHub,
+	startDeadClientCheck,
+	setHubPort,
+	getHubStatus,
+	handleHubRoutes,
+	startHubMonitor,
+	tryListen,
 };

--- a/server/index.js
+++ b/server/index.js
@@ -115,8 +115,24 @@ const server = http.createServer((clientReq, clientRes) => {
   const startTime = Date.now();
 
   const reqChunks = [];
-  clientReq.on('data', chunk => reqChunks.push(chunk));
+  let reqSize = 0;
+  let reqAborted = false;
+  clientReq.on('data', chunk => {
+    if (reqAborted) return;
+    reqSize += chunk.length;
+    if (reqSize > config.MAX_BODY_BYTES) {
+      reqAborted = true;
+      if (!clientRes.headersSent) {
+        clientRes.writeHead(413, { 'Content-Type': 'application/json' });
+      }
+      clientRes.end(JSON.stringify({ error: 'payload_too_large', limit_bytes: config.MAX_BODY_BYTES }));
+      clientReq.destroy();
+      return;
+    }
+    reqChunks.push(chunk);
+  });
   clientReq.on('end', () => {
+    if (reqAborted) return;
     const rawBody = Buffer.concat(reqChunks);
     let parsedBody = null;
     try { parsedBody = JSON.parse(rawBody.toString()); } catch {}
@@ -212,7 +228,7 @@ const server = http.createServer((clientReq, clientRes) => {
     // Terminal summary
     if (isNewSession) store.printSessionBanner(reqSessionId);
     helpers.printSeparator();
-    console.log(`\x1b[36m📤 REQUEST  [${ts}]  ${clientReq.method} ${clientReq.url}\x1b[0m`);
+    console.log(`\x1b[36m📤 REQUEST  [${ts}]  ${helpers.sanitizeForLog(clientReq.method)} ${helpers.sanitizeForLog(clientReq.url)}\x1b[0m`);
     if (parsedBody) console.log(helpers.summarizeRequest(parsedBody));
 
     // Build context for forwarding
@@ -248,6 +264,9 @@ const server = http.createServer((clientReq, clientRes) => {
   });
 });
 
+server.headersTimeout = config.HEADERS_TIMEOUT_MS;
+server.requestTimeout = config.REQUEST_TIMEOUT_MS;
+server.keepAliveTimeout = config.KEEPALIVE_TIMEOUT_MS;
 
 // ── Spawn Claude Code with proxy env ──
 function spawnClaude(port, args) {
@@ -410,7 +429,7 @@ async function startServer() {
     const HUB_BIND_DELAY_MS = 1000;
     for (let i = 0; i <= HUB_BIND_RETRIES; i++) {
       try {
-        actualPort = await hub.tryListen(server, config.PORT, 0);
+        actualPort = await hub.tryListen(server, config.PORT, 0, config.HOST);
         break;
       } catch (err) {
         if (err.code !== 'EADDRINUSE' || i === HUB_BIND_RETRIES) {
@@ -425,7 +444,7 @@ async function startServer() {
       }
     }
   } else {
-    actualPort = await hub.tryListen(server, config.PORT, maxAttempts);
+    actualPort = await hub.tryListen(server, config.PORT, maxAttempts, config.HOST);
   }
   rebuildIndexHTML(actualPort);
 
@@ -446,8 +465,9 @@ async function startServer() {
   } else if (claudeMode) {
     _origLog(`\x1b[90mccxray → http://localhost:${actualPort}\x1b[0m`);
   } else {
+    const bindNote = config.HOST === '127.0.0.1' ? '' : ` (bound to ${config.HOST})`;
     console.log();
-    console.log(`\x1b[35m🔌 Claude API Proxy listening on http://localhost:${actualPort}\x1b[0m`);
+    console.log(`\x1b[35m🔌 Claude API Proxy listening on http://localhost:${actualPort}${bindNote}\x1b[0m`);
     console.log(`\x1b[90m   Dashboard → http://localhost:${actualPort}/`);
     const upstreamUrl = `${config.ANTHROPIC_PROTOCOL}://${config.ANTHROPIC_HOST}:${config.ANTHROPIC_PORT}`;
     const upstreamNote = config.ANTHROPIC_BASE_URL_SOURCE === 'ANTHROPIC_BASE_URL' ? ' (from ANTHROPIC_BASE_URL)' : '';

--- a/server/routes/intercept.js
+++ b/server/routes/intercept.js
@@ -1,89 +1,163 @@
-'use strict';
+"use strict";
 
-const store = require('../store');
-const { taipeiTime } = require('../helpers');
-const { broadcastInterceptToggle, broadcastInterceptRemoved, broadcastSessionStatus } = require('../sse-broadcast');
-const { forwardRequest } = require('../forward');
+const store = require("../store");
+const config = require("../config");
+const { taipeiTime } = require("../helpers");
+const {
+	broadcastInterceptToggle,
+	broadcastInterceptRemoved,
+	broadcastSessionStatus,
+} = require("../sse-broadcast");
+const { forwardRequest } = require("../forward");
+
+const SMALL_BODY_LIMIT = 4096;
+
+function accumulateCapped(req, res, maxBytes, onDone) {
+	const chunks = [];
+	let size = 0;
+	let aborted = false;
+	req.on("data", (c) => {
+		if (aborted) return;
+		size += c.length;
+		if (size > maxBytes) {
+			aborted = true;
+			if (!res.headersSent)
+				res.writeHead(413, { "Content-Type": "application/json" });
+			res.end(
+				JSON.stringify({ error: "payload_too_large", limit_bytes: maxBytes }),
+			);
+			req.destroy();
+			return;
+		}
+		chunks.push(c);
+	});
+	req.on("end", () => {
+		if (!aborted) onDone(Buffer.concat(chunks));
+	});
+}
 
 function handleInterceptRoutes(clientReq, clientRes) {
-  if (clientReq.url === '/_api/intercept/toggle' && clientReq.method === 'POST') {
-    const chunks = []; clientReq.on('data', c => chunks.push(c));
-    clientReq.on('end', () => {
-      try {
-        const { sessionId } = JSON.parse(Buffer.concat(chunks).toString());
-        if (!sessionId) { clientRes.writeHead(400); clientRes.end('missing sessionId'); return; }
-        const enabled = !store.interceptSessions.has(sessionId);
-        if (enabled) store.interceptSessions.add(sessionId); else store.interceptSessions.delete(sessionId);
-        broadcastInterceptToggle(sessionId, enabled);
-        console.log(`\x1b[33m${enabled ? '⏸' : '▶'} INTERCEPT ${enabled ? 'ON' : 'OFF'} for session ${sessionId.slice(0, 8)}\x1b[0m`);
-        clientRes.writeHead(200, { 'Content-Type': 'application/json' });
-        clientRes.end(JSON.stringify({ sessionId, enabled }));
-      } catch { clientRes.writeHead(400); clientRes.end('bad json'); }
-    });
-    return true;
-  }
+	if (
+		clientReq.url === "/_api/intercept/toggle" &&
+		clientReq.method === "POST"
+	) {
+		accumulateCapped(clientReq, clientRes, SMALL_BODY_LIMIT, (buf) => {
+			try {
+				const { sessionId } = JSON.parse(buf.toString());
+				if (!sessionId) {
+					clientRes.writeHead(400);
+					clientRes.end("missing sessionId");
+					return;
+				}
+				const enabled = !store.interceptSessions.has(sessionId);
+				if (enabled) store.interceptSessions.add(sessionId);
+				else store.interceptSessions.delete(sessionId);
+				broadcastInterceptToggle(sessionId, enabled);
+				console.log(
+					`\x1b[33m${enabled ? "⏸" : "▶"} INTERCEPT ${enabled ? "ON" : "OFF"} for session ${sessionId.slice(0, 8)}\x1b[0m`,
+				);
+				clientRes.writeHead(200, { "Content-Type": "application/json" });
+				clientRes.end(JSON.stringify({ sessionId, enabled }));
+			} catch {
+				clientRes.writeHead(400);
+				clientRes.end("bad json");
+			}
+		});
+		return true;
+	}
 
-  const approveMatch = clientReq.url.match(/^\/_api\/intercept\/(.+)\/approve$/);
-  if (approveMatch && clientReq.method === 'POST') {
-    const reqId = decodeURIComponent(approveMatch[1]);
-    const pending = store.pendingRequests.get(reqId);
-    if (!pending) { clientRes.writeHead(404); clientRes.end('not found'); return true; }
-    const chunks = []; clientReq.on('data', c => chunks.push(c));
-    clientReq.on('end', () => {
-      clearTimeout(pending.timer);
-      store.pendingRequests.delete(reqId);
-      broadcastInterceptRemoved(reqId);
-      try {
-        const payload = Buffer.concat(chunks).toString();
-        if (payload) {
-          const { body } = JSON.parse(payload);
-          if (body) { pending.parsedBody = body; pending.bodyModified = true; }
-        }
-      } catch {}
-      console.log(`\x1b[32m✓ INTERCEPT APPROVED [${taipeiTime()}] ${reqId}\x1b[0m`);
-      forwardRequest(pending);
-      clientRes.writeHead(200, { 'Content-Type': 'application/json' });
-      clientRes.end(JSON.stringify({ ok: true }));
-    });
-    return true;
-  }
+	const approveMatch = clientReq.url.match(
+		/^\/_api\/intercept\/(.+)\/approve$/,
+	);
+	if (approveMatch && clientReq.method === "POST") {
+		const reqId = decodeURIComponent(approveMatch[1]);
+		const pending = store.pendingRequests.get(reqId);
+		if (!pending) {
+			clientRes.writeHead(404);
+			clientRes.end("not found");
+			return true;
+		}
+		accumulateCapped(clientReq, clientRes, config.MAX_BODY_BYTES, (buf) => {
+			clearTimeout(pending.timer);
+			store.pendingRequests.delete(reqId);
+			broadcastInterceptRemoved(reqId);
+			try {
+				const payload = buf.toString();
+				if (payload) {
+					const { body } = JSON.parse(payload);
+					if (body) {
+						pending.parsedBody = body;
+						pending.bodyModified = true;
+					}
+				}
+			} catch {}
+			console.log(
+				`\x1b[32m✓ INTERCEPT APPROVED [${taipeiTime()}] ${reqId}\x1b[0m`,
+			);
+			forwardRequest(pending);
+			clientRes.writeHead(200, { "Content-Type": "application/json" });
+			clientRes.end(JSON.stringify({ ok: true }));
+		});
+		return true;
+	}
 
-  const rejectMatch = clientReq.url.match(/^\/_api\/intercept\/(.+)\/reject$/);
-  if (rejectMatch && clientReq.method === 'POST') {
-    const reqId = decodeURIComponent(rejectMatch[1]);
-    const pending = store.pendingRequests.get(reqId);
-    if (!pending) { clientRes.writeHead(404); clientRes.end('not found'); return true; }
-    clearTimeout(pending.timer);
-    store.pendingRequests.delete(reqId);
-    broadcastInterceptRemoved(reqId);
-    if (pending.reqSessionId) {
-      store.activeRequests[pending.reqSessionId] = Math.max(0, (store.activeRequests[pending.reqSessionId] || 1) - 1);
-      broadcastSessionStatus(pending.reqSessionId);
-    }
-    console.log(`\x1b[31m✕ INTERCEPT REJECTED [${taipeiTime()}] ${reqId}\x1b[0m`);
-    if (!pending.clientRes.headersSent) {
-      pending.clientRes.writeHead(499, { 'Content-Type': 'application/json' });
-    }
-    pending.clientRes.end(JSON.stringify({ error: 'request_rejected', message: 'Request rejected by dashboard' }));
-    clientRes.writeHead(200, { 'Content-Type': 'application/json' });
-    clientRes.end(JSON.stringify({ ok: true }));
-    return true;
-  }
+	const rejectMatch = clientReq.url.match(/^\/_api\/intercept\/(.+)\/reject$/);
+	if (rejectMatch && clientReq.method === "POST") {
+		const reqId = decodeURIComponent(rejectMatch[1]);
+		const pending = store.pendingRequests.get(reqId);
+		if (!pending) {
+			clientRes.writeHead(404);
+			clientRes.end("not found");
+			return true;
+		}
+		clearTimeout(pending.timer);
+		store.pendingRequests.delete(reqId);
+		broadcastInterceptRemoved(reqId);
+		if (pending.reqSessionId) {
+			store.activeRequests[pending.reqSessionId] = Math.max(
+				0,
+				(store.activeRequests[pending.reqSessionId] || 1) - 1,
+			);
+			broadcastSessionStatus(pending.reqSessionId);
+		}
+		console.log(
+			`\x1b[31m✕ INTERCEPT REJECTED [${taipeiTime()}] ${reqId}\x1b[0m`,
+		);
+		if (!pending.clientRes.headersSent) {
+			pending.clientRes.writeHead(499, { "Content-Type": "application/json" });
+		}
+		pending.clientRes.end(
+			JSON.stringify({
+				error: "request_rejected",
+				message: "Request rejected by dashboard",
+			}),
+		);
+		clientRes.writeHead(200, { "Content-Type": "application/json" });
+		clientRes.end(JSON.stringify({ ok: true }));
+		return true;
+	}
 
-  if (clientReq.url === '/_api/intercept/timeout' && clientReq.method === 'POST') {
-    const chunks = []; clientReq.on('data', c => chunks.push(c));
-    clientReq.on('end', () => {
-      try {
-        const { timeout } = JSON.parse(Buffer.concat(chunks).toString());
-        store.setInterceptTimeout(Math.max(30, Math.min(180, Number(timeout) || 120)));
-        clientRes.writeHead(200, { 'Content-Type': 'application/json' });
-        clientRes.end(JSON.stringify({ timeout: store.getInterceptTimeout() }));
-      } catch { clientRes.writeHead(400); clientRes.end('bad json'); }
-    });
-    return true;
-  }
+	if (
+		clientReq.url === "/_api/intercept/timeout" &&
+		clientReq.method === "POST"
+	) {
+		accumulateCapped(clientReq, clientRes, SMALL_BODY_LIMIT, (buf) => {
+			try {
+				const { timeout } = JSON.parse(buf.toString());
+				store.setInterceptTimeout(
+					Math.max(30, Math.min(180, Number(timeout) || 120)),
+				);
+				clientRes.writeHead(200, { "Content-Type": "application/json" });
+				clientRes.end(JSON.stringify({ timeout: store.getInterceptTimeout() }));
+			} catch {
+				clientRes.writeHead(400);
+				clientRes.end("bad json");
+			}
+		});
+		return true;
+	}
 
-  return false;
+	return false;
 }
 
 module.exports = { handleInterceptRoutes };

--- a/server/routes/sse.js
+++ b/server/routes/sse.js
@@ -1,44 +1,73 @@
-'use strict';
+"use strict";
 
-const store = require('../store');
+const store = require("../store");
+const config = require("../config");
 
 function handleSSERoute(clientReq, clientRes) {
-  if (clientReq.url !== '/_events') return false;
+	if (clientReq.url !== "/_events") return false;
 
-  clientRes.writeHead(200, {
-    'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-cache',
-    'Connection': 'keep-alive',
-  });
-  clientRes.write(':\n\n');
+	const ip = clientReq.socket.remoteAddress || "unknown";
+	const current = store.sseClientsByIp.get(ip) || 0;
+	if (current >= config.SSE_MAX_PER_IP) {
+		clientRes.writeHead(429, { "Content-Type": "application/json" });
+		clientRes.end(
+			JSON.stringify({
+				error: "too_many_sse_connections",
+				limit: config.SSE_MAX_PER_IP,
+			}),
+		);
+		return true;
+	}
+	store.sseClientsByIp.set(ip, current + 1);
 
-  // Send current session statuses
-  for (const [sid, meta] of Object.entries(store.sessionMeta)) {
-    if (meta.lastSeenAt || (store.activeRequests[sid] || 0) > 0) {
-      const active = (store.activeRequests[sid] || 0) > 0;
-      const data = JSON.stringify({ _type: 'session_status', sessionId: sid, active, lastSeenAt: meta.lastSeenAt || null });
-      clientRes.write(`data: ${data}\n\n`);
-    }
-  }
+	clientRes.writeHead(200, {
+		"Content-Type": "text/event-stream",
+		"Cache-Control": "no-cache",
+		Connection: "keep-alive",
+	});
+	clientRes.write(":\n\n");
 
-  // Send intercept state
-  for (const sid of store.interceptSessions) {
-    clientRes.write(`data: ${JSON.stringify({ _type: 'intercept_toggled', sessionId: sid, enabled: true })}\n\n`);
-  }
-  for (const [reqId, pending] of store.pendingRequests) {
-    clientRes.write(`data: ${JSON.stringify({ _type: 'pending_request', requestId: reqId, sessionId: pending.reqSessionId, body: pending.parsedBody })}\n\n`);
-  }
+	// Send current session statuses
+	for (const [sid, meta] of Object.entries(store.sessionMeta)) {
+		if (meta.lastSeenAt || (store.activeRequests[sid] || 0) > 0) {
+			const active = (store.activeRequests[sid] || 0) > 0;
+			const data = JSON.stringify({
+				_type: "session_status",
+				sessionId: sid,
+				active,
+				lastSeenAt: meta.lastSeenAt || null,
+			});
+			clientRes.write(`data: ${data}\n\n`);
+		}
+	}
 
-  // Send current interceptTimeout
-  clientRes.write(`data: ${JSON.stringify({ _type: 'intercept_timeout', timeout: store.getInterceptTimeout() })}\n\n`);
+	// Send intercept state
+	for (const sid of store.interceptSessions) {
+		clientRes.write(
+			`data: ${JSON.stringify({ _type: "intercept_toggled", sessionId: sid, enabled: true })}\n\n`,
+		);
+	}
+	for (const [reqId, pending] of store.pendingRequests) {
+		clientRes.write(
+			`data: ${JSON.stringify({ _type: "pending_request", requestId: reqId, sessionId: pending.reqSessionId, body: pending.parsedBody })}\n\n`,
+		);
+	}
 
-  store.sseClients.push(clientRes);
-  clientReq.on('close', () => {
-    const idx = store.sseClients.indexOf(clientRes);
-    if (idx >= 0) store.sseClients.splice(idx, 1);
-  });
+	// Send current interceptTimeout
+	clientRes.write(
+		`data: ${JSON.stringify({ _type: "intercept_timeout", timeout: store.getInterceptTimeout() })}\n\n`,
+	);
 
-  return true;
+	store.sseClients.push(clientRes);
+	clientReq.on("close", () => {
+		const idx = store.sseClients.indexOf(clientRes);
+		if (idx >= 0) store.sseClients.splice(idx, 1);
+		const count = (store.sseClientsByIp.get(ip) || 1) - 1;
+		if (count <= 0) store.sseClientsByIp.delete(ip);
+		else store.sseClientsByIp.set(ip, count);
+	});
+
+	return true;
 }
 
 module.exports = { handleSSERoute };

--- a/server/storage/local.js
+++ b/server/storage/local.js
@@ -1,8 +1,34 @@
-'use strict';
+"use strict";
 
-const fs = require('fs');
+const fs = require("fs");
 const fsp = fs.promises;
-const path = require('path');
+const path = require("path");
+
+const FILE_MODE = 0o600;
+const DIR_MODE = 0o700;
+
+function safeJoin(baseDir, id, suffix) {
+	const name = String(id) + String(suffix || "");
+	if (
+		!name ||
+		name.includes("\0") ||
+		name.includes("/") ||
+		name.includes("\\") ||
+		name === "." ||
+		name === ".."
+	) {
+		throw new Error(`invalid storage id: ${JSON.stringify(name)}`);
+	}
+	const resolved = path.resolve(baseDir, name);
+	const baseResolved = path.resolve(baseDir);
+	if (
+		resolved !== baseResolved &&
+		!resolved.startsWith(baseResolved + path.sep)
+	) {
+		throw new Error(`path traversal blocked: ${JSON.stringify(name)}`);
+	}
+	return resolved;
+}
 
 /**
  * Local filesystem storage adapter.
@@ -10,76 +36,86 @@ const path = require('path');
  * @returns {import('./interface').StorageAdapter}
  */
 function createLocalStorage(logsDir) {
-  const sharedDir = path.join(logsDir, 'shared');
-  const indexPath = path.join(logsDir, 'index.ndjson');
+	const sharedDir = path.join(logsDir, "shared");
+	const indexPath = path.join(logsDir, "index.ndjson");
 
-  return {
-    async init() {
-      await fsp.mkdir(logsDir, { recursive: true });
-      await fsp.mkdir(sharedDir, { recursive: true });
-    },
+	return {
+		async init() {
+			await fsp.mkdir(logsDir, { recursive: true, mode: DIR_MODE });
+			await fsp.mkdir(sharedDir, { recursive: true, mode: DIR_MODE });
+			try {
+				await fsp.chmod(logsDir, DIR_MODE);
+			} catch {}
+			try {
+				await fsp.chmod(sharedDir, DIR_MODE);
+			} catch {}
+		},
 
-    async write(id, suffix, data) {
-      await fsp.writeFile(path.join(logsDir, id + suffix), data);
-    },
+		async write(id, suffix, data) {
+			await fsp.writeFile(safeJoin(logsDir, id, suffix), data, {
+				mode: FILE_MODE,
+			});
+		},
 
-    async read(id, suffix) {
-      return fsp.readFile(path.join(logsDir, id + suffix), 'utf8');
-    },
+		async read(id, suffix) {
+			return fsp.readFile(safeJoin(logsDir, id, suffix), "utf8");
+		},
 
-    async list() {
-      return fsp.readdir(logsDir);
-    },
+		async list() {
+			return fsp.readdir(logsDir);
+		},
 
-    async stat(id, suffix) {
-      return fsp.stat(path.join(logsDir, id + suffix));
-    },
+		async stat(id, suffix) {
+			return fsp.stat(safeJoin(logsDir, id, suffix));
+		},
 
-    // ── Index (index.ndjson) ──────────────────────────────────────────
+		// ── Index (index.ndjson) ──────────────────────────────────────────
 
-    async appendIndex(line) {
-      await fsp.appendFile(indexPath, line);
-    },
+		async appendIndex(line) {
+			await fsp.appendFile(indexPath, line, { mode: FILE_MODE });
+		},
 
-    async readIndex() {
-      try {
-        return await fsp.readFile(indexPath, 'utf8');
-      } catch (e) {
-        if (e.code === 'ENOENT') return '';
-        throw e;
-      }
-    },
+		async readIndex() {
+			try {
+				return await fsp.readFile(indexPath, "utf8");
+			} catch (e) {
+				if (e.code === "ENOENT") return "";
+				throw e;
+			}
+		},
 
-    // ── Shared content-addressed storage (shared/) ───────────────────
+		// ── Shared content-addressed storage (shared/) ───────────────────
 
-    async writeSharedIfAbsent(filename, data) {
-      const p = path.join(sharedDir, filename);
-      try {
-        await fsp.writeFile(p, data, { flag: 'wx' });
-      } catch (e) {
-        if (e.code !== 'EEXIST') throw e;
-      }
-    },
+		async writeSharedIfAbsent(filename, data) {
+			const p = safeJoin(sharedDir, filename, "");
+			try {
+				await fsp.writeFile(p, data, { flag: "wx", mode: FILE_MODE });
+			} catch (e) {
+				if (e.code !== "EEXIST") throw e;
+			}
+		},
 
-    async readShared(filename) {
-      return fsp.readFile(path.join(sharedDir, filename), 'utf8');
-    },
+		async readShared(filename) {
+			return fsp.readFile(safeJoin(sharedDir, filename, ""), "utf8");
+		},
 
-    async statShared(filename) {
-      try {
-        return await fsp.stat(path.join(sharedDir, filename));
-      } catch { return null; }
-    },
+		async statShared(filename) {
+			try {
+				return await fsp.stat(safeJoin(sharedDir, filename, ""));
+			} catch {
+				return null;
+			}
+		},
 
-    async listShared() {
-      try {
-        return await fsp.readdir(sharedDir);
-      } catch (e) {
-        if (e.code === 'ENOENT') return [];
-        throw e;
-      }
-    },
-  };
+		async listShared() {
+			try {
+				return await fsp.readdir(sharedDir);
+			} catch (e) {
+				if (e.code === "ENOENT") return [];
+				throw e;
+			}
+		},
+	};
 }
 
-module.exports = { createLocalStorage };
+module.exports = { createLocalStorage, safeJoin };

--- a/server/store.js
+++ b/server/store.js
@@ -1,14 +1,15 @@
-'use strict';
+"use strict";
 
 // ── In-memory store & SSE clients ───────────────────────────────────
-const MAX_ENTRIES = parseInt(process.env.CCXRAY_MAX_ENTRIES || '5000', 10);
+const MAX_ENTRIES = parseInt(process.env.CCXRAY_MAX_ENTRIES || "5000", 10);
 const entries = [];
 const sseClients = [];
+const sseClientsByIp = new Map();
 
 function trimEntries() {
-  if (entries.length > MAX_ENTRIES) {
-    entries.splice(0, entries.length - MAX_ENTRIES);
-  }
+	if (entries.length > MAX_ENTRIES) {
+		entries.splice(0, entries.length - MAX_ENTRIES);
+	}
 }
 
 // ── Rate limit state (from Anthropic response headers) ──────────────
@@ -33,134 +34,158 @@ const pendingRequests = new Map();
 let interceptTimeout = 120;
 
 function isQuotaCheck(req) {
-  return req?.max_tokens === 1 && !req?.system &&
-    req?.messages?.length === 1 && req.messages[0]?.content === 'quota';
+	return (
+		req?.max_tokens === 1 &&
+		!req?.system &&
+		req?.messages?.length === 1 &&
+		req.messages[0]?.content === "quota"
+	);
 }
 
 function extractCwd(req) {
-  if (isQuotaCheck(req)) return '(quota-check)';
-  if (!req?.system) return null;
-  const txt = Array.isArray(req.system) ? req.system.map(b => b.text || '').join('\n') : String(req.system);
-  const m = txt.match(/Primary working directory: (.+)/);
-  return m ? m[1].trim() : null;
+	if (isQuotaCheck(req)) return "(quota-check)";
+	if (!req?.system) return null;
+	const txt = Array.isArray(req.system)
+		? req.system.map((b) => b.text || "").join("\n")
+		: String(req.system);
+	const m = txt.match(/Primary working directory: (.+)/);
+	return m ? m[1].trim() : null;
 }
 
 function extractSessionId(req) {
-  const uid = req?.metadata?.user_id || '';
-  // New format: user_id is JSON like {"session_id":"xxx-yyy"}
-  const jsonMatch = uid.match(/"session_id"\s*:\s*"([a-f0-9-]+)"/);
-  if (jsonMatch) return jsonMatch[1];
-  // Legacy format: user_id is "session_xxx-yyy"
-  const m = uid.match(/session_([a-f0-9-]+)/);
-  return m ? m[1] : null;
+	const uid = req?.metadata?.user_id || "";
+	// New format: user_id is JSON like {"session_id":"xxx-yyy"}
+	const jsonMatch = uid.match(/"session_id"\s*:\s*"([a-f0-9-]+)"/);
+	if (jsonMatch) return jsonMatch[1];
+	// Legacy format: user_id is "session_xxx-yyy"
+	const m = uid.match(/session_([a-f0-9-]+)/);
+	return m ? m[1] : null;
 }
 
 // Bare subagent requests: no session_id, no system prompt, no tools, 1-2 messages.
 // These are Claude Code's Agent tool kickoff calls that lack any identifying metadata.
 function isLikelySubagent(req) {
-  if (extractSessionId(req)) return false;      // has explicit session → not orphan
-  if (extractCwd(req)) return false;             // has system prompt with cwd → not bare
-  if (req?.tools?.length) return false;           // has tool definitions → not bare
-  if ((req?.messages?.length || 0) > 2) return false;
-  // Require metadata to be absent or empty (genuine API callers usually set metadata)
-  const meta = req?.metadata;
-  if (meta && Object.keys(meta).length > 0) return false;
-  return true;
+	if (extractSessionId(req)) return false; // has explicit session → not orphan
+	if (extractCwd(req)) return false; // has system prompt with cwd → not bare
+	if (req?.tools?.length) return false; // has tool definitions → not bare
+	if ((req?.messages?.length || 0) > 2) return false;
+	// Require metadata to be absent or empty (genuine API callers usually set metadata)
+	const meta = req?.metadata;
+	if (meta && Object.keys(meta).length > 0) return false;
+	return true;
 }
 
 // Find the best parent session for an orphan subagent request.
 // Scoring: inflight sessions get massive priority boost, then sorted by recency.
 // Only considers sessions active within the last 30s to avoid stale attribution.
 function inferParentSession() {
-  const now = Date.now();
-  const WINDOW_MS = 30000;
-  let best = null, bestScore = -1;
+	const now = Date.now();
+	const WINDOW_MS = 30000;
+	let best = null,
+		bestScore = -1;
 
-  for (const [sid, meta] of Object.entries(sessionMeta)) {
-    if (sid === 'direct-api') continue;
-    const seenAt = meta.lastSeenAt || 0;
-    if (now - seenAt > WINDOW_MS) continue;
+	for (const [sid, meta] of Object.entries(sessionMeta)) {
+		if (sid === "direct-api") continue;
+		const seenAt = meta.lastSeenAt || 0;
+		if (now - seenAt > WINDOW_MS) continue;
 
-    const inflight = (activeRequests[sid] || 0) > 0;
-    // Inflight sessions score 1e13 + recency; idle sessions score just recency
-    const score = (inflight ? 1e13 : 0) + seenAt;
-    if (score > bestScore) {
-      best = sid;
-      bestScore = score;
-    }
-  }
-  return best;
+		const inflight = (activeRequests[sid] || 0) > 0;
+		// Inflight sessions score 1e13 + recency; idle sessions score just recency
+		const score = (inflight ? 1e13 : 0) + seenAt;
+		if (score > bestScore) {
+			best = sid;
+			bestScore = score;
+		}
+	}
+	return best;
 }
 
 function detectSession(req) {
-  const realId = extractSessionId(req);
+	const realId = extractSessionId(req);
 
-  // Explicit session_id → authoritative
-  if (realId) {
-    const isNew = realId !== currentSessionId;
-    if (isNew) {
-      sessionCounter++;
-      currentSessionId = realId;
-    }
-    lastMsgCount = req?.messages?.length || 0;
-    return { sessionId: currentSessionId, isNewSession: isNew };
-  }
+	// Explicit session_id → authoritative
+	if (realId) {
+		const isNew = realId !== currentSessionId;
+		if (isNew) {
+			sessionCounter++;
+			currentSessionId = realId;
+		}
+		lastMsgCount = req?.messages?.length || 0;
+		return { sessionId: currentSessionId, isNewSession: isNew };
+	}
 
-  // Likely subagent → infer parent, never pollute global state
-  if (isLikelySubagent(req)) {
-    const parent = inferParentSession();
-    if (parent) return { sessionId: parent, isNewSession: false, inferred: true };
-    // No recent session → keep as-is, don't create spurious session
-    return { sessionId: currentSessionId || 'direct-api', isNewSession: false, inferred: true };
-  }
+	// Likely subagent → infer parent, never pollute global state
+	if (isLikelySubagent(req)) {
+		const parent = inferParentSession();
+		if (parent)
+			return { sessionId: parent, isNewSession: false, inferred: true };
+		// No recent session → keep as-is, don't create spurious session
+		return {
+			sessionId: currentSessionId || "direct-api",
+			isNewSession: false,
+			inferred: true,
+		};
+	}
 
-  // Non-subagent without session_id: original heuristic
-  const isNew = !currentSessionId || (req?.messages?.length || 0) < lastMsgCount;
-  if (isNew) {
-    sessionCounter++;
-    currentSessionId = 'direct-api';
-  }
-  lastMsgCount = req?.messages?.length || 0;
-  return { sessionId: currentSessionId, isNewSession: isNew };
+	// Non-subagent without session_id: original heuristic
+	const isNew =
+		!currentSessionId || (req?.messages?.length || 0) < lastMsgCount;
+	if (isNew) {
+		sessionCounter++;
+		currentSessionId = "direct-api";
+	}
+	lastMsgCount = req?.messages?.length || 0;
+	return { sessionId: currentSessionId, isNewSession: isNew };
 }
 
 function printSessionBanner(sessionId) {
-  const w = 60;
-  const shortId = sessionId.slice(0, 8);
-  const label = ` NEW SESSION ${shortId} `;
-  const pad = Math.max(0, Math.floor((w - label.length) / 2));
-  const line = '★'.repeat(pad) + label + '★'.repeat(w - pad - label.length);
-  console.log();
-  console.log('\x1b[1;35m' + line + '\x1b[0m');
-  console.log(`\x1b[35m   claude --continue ${sessionId}\x1b[0m`);
-  console.log();
+	const w = 60;
+	const shortId = sessionId.slice(0, 8);
+	const label = ` NEW SESSION ${shortId} `;
+	const pad = Math.max(0, Math.floor((w - label.length) / 2));
+	const line = "★".repeat(pad) + label + "★".repeat(w - pad - label.length);
+	console.log();
+	console.log("\x1b[1;35m" + line + "\x1b[0m");
+	console.log(`\x1b[35m   claude --continue ${sessionId}\x1b[0m`);
+	console.log();
 }
 
-function getRateLimitState() { return rateLimitState; }
-function setRateLimitState(state) { rateLimitState = state; }
-function getInterceptTimeout() { return interceptTimeout; }
-function setInterceptTimeout(val) { interceptTimeout = val; }
-function getCurrentSessionId() { return currentSessionId; }
+function getRateLimitState() {
+	return rateLimitState;
+}
+function setRateLimitState(state) {
+	rateLimitState = state;
+}
+function getInterceptTimeout() {
+	return interceptTimeout;
+}
+function setInterceptTimeout(val) {
+	interceptTimeout = val;
+}
+function getCurrentSessionId() {
+	return currentSessionId;
+}
 
 module.exports = {
-  MAX_ENTRIES,
-  entries,
-  trimEntries,
-  sseClients,
-  getRateLimitState,
-  setRateLimitState,
-  sessionMeta,
-  activeRequests,
-  sessionCosts,
-  versionIndex,
-  interceptSessions,
-  pendingRequests,
-  getInterceptTimeout,
-  setInterceptTimeout,
-  getCurrentSessionId,
-  isQuotaCheck,
-  extractCwd,
-  extractSessionId,
-  detectSession,
-  printSessionBanner,
+	MAX_ENTRIES,
+	entries,
+	trimEntries,
+	sseClients,
+	sseClientsByIp,
+	getRateLimitState,
+	setRateLimitState,
+	sessionMeta,
+	activeRequests,
+	sessionCosts,
+	versionIndex,
+	interceptSessions,
+	pendingRequests,
+	getInterceptTimeout,
+	setInterceptTimeout,
+	getCurrentSessionId,
+	isQuotaCheck,
+	extractCwd,
+	extractSessionId,
+	detectSession,
+	printSessionBanner,
 };

--- a/test/fs-mode.test.js
+++ b/test/fs-mode.test.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { createLocalStorage } = require("../server/storage/local");
+
+const isWindows = process.platform === "win32";
+
+describe("storage fs modes", { skip: isWindows }, () => {
+	const tmpDir = path.join(os.tmpdir(), "ccxray-mode-" + Date.now());
+	let storage;
+
+	before(async () => {
+		storage = createLocalStorage(tmpDir);
+		await storage.init();
+	});
+
+	after(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("logsDir has 0700 permissions", () => {
+		const mode = fs.statSync(tmpDir).mode & 0o777;
+		assert.equal(mode, 0o700);
+	});
+
+	it("sharedDir has 0700 permissions", () => {
+		const mode = fs.statSync(path.join(tmpDir, "shared")).mode & 0o777;
+		assert.equal(mode, 0o700);
+	});
+
+	it("written log file has 0600 permissions", async () => {
+		await storage.write("test-mode", "_req.json", "x");
+		const mode =
+			fs.statSync(path.join(tmpDir, "test-mode_req.json")).mode & 0o777;
+		assert.equal(mode, 0o600);
+	});
+
+	it("written shared file has 0600 permissions", async () => {
+		await storage.writeSharedIfAbsent("hash-abc", "data");
+		const mode =
+			fs.statSync(path.join(tmpDir, "shared", "hash-abc")).mode & 0o777;
+		assert.equal(mode, 0o600);
+	});
+});

--- a/test/hub-loopback.test.js
+++ b/test/hub-loopback.test.js
@@ -1,0 +1,209 @@
+"use strict";
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const http = require("http");
+
+const TEST_HUB_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "ccxray-hub-lb-"));
+process.env.CCXRAY_HOME = TEST_HUB_DIR;
+
+const hub = require("../server/hub");
+hub.setOnShutdown(() => {});
+
+describe("hub loopback + validation", () => {
+	let server;
+	let port;
+
+	before(async () => {
+		server = http.createServer((req, res) => {
+			if (!hub.handleHubRoutes(req, res)) {
+				res.writeHead(404);
+				res.end("not found");
+			}
+		});
+		await new Promise((r) => server.listen(0, "127.0.0.1", r));
+		port = server.address().port;
+		hub.setHubPort(port);
+	});
+
+	after(async () => {
+		await new Promise((r) => server.close(r));
+		fs.rmSync(TEST_HUB_DIR, { recursive: true, force: true });
+	});
+
+	function reqJSON(method, urlPath, body, extraHeaders = {}) {
+		return new Promise((resolve, reject) => {
+			const data = body ? JSON.stringify(body) : "";
+			const r = http.request(
+				{
+					host: "127.0.0.1",
+					port,
+					method,
+					path: urlPath,
+					agent: false,
+					headers: {
+						"Content-Type": "application/json",
+						"Content-Length": Buffer.byteLength(data),
+						...extraHeaders,
+					},
+				},
+				(res) => {
+					let buf = "";
+					res.on("data", (c) => {
+						buf += c;
+					});
+					res.on("end", () => resolve({ status: res.statusCode, body: buf }));
+				},
+			);
+			r.on("error", reject);
+			r.end(data);
+		});
+	}
+
+	it("register with valid payload returns 200", async () => {
+		const { status } = await reqJSON("POST", "/_api/hub/register", {
+			pid: 12345,
+			cwd: "/tmp/foo",
+		});
+		assert.equal(status, 200);
+	});
+
+	it("register rejects negative pid", async () => {
+		const { status } = await reqJSON("POST", "/_api/hub/register", {
+			pid: -1,
+			cwd: "/tmp",
+		});
+		assert.equal(status, 400);
+	});
+
+	it("register rejects non-integer pid", async () => {
+		const { status } = await reqJSON("POST", "/_api/hub/register", {
+			pid: "abc",
+			cwd: "/tmp",
+		});
+		assert.equal(status, 400);
+	});
+
+	it("register rejects pid above cap", async () => {
+		const { status } = await reqJSON("POST", "/_api/hub/register", {
+			pid: (1 << 22) + 1,
+			cwd: "/tmp",
+		});
+		assert.equal(status, 400);
+	});
+
+	it("register rejects empty cwd", async () => {
+		const { status } = await reqJSON("POST", "/_api/hub/register", {
+			pid: 12347,
+			cwd: "",
+		});
+		assert.equal(status, 400);
+	});
+
+	it("register rejects body > 1KB with 413", async () => {
+		const payload = JSON.stringify({ pid: 12348, cwd: "x".repeat(2000) });
+		const { status } = await new Promise((resolve, reject) => {
+			const r = http.request(
+				{
+					host: "127.0.0.1",
+					port,
+					method: "POST",
+					path: "/_api/hub/register",
+					headers: {
+						"Content-Type": "application/json",
+						"Content-Length": Buffer.byteLength(payload),
+					},
+				},
+				(res) => {
+					res.resume();
+					res.on("end", () => resolve({ status: res.statusCode }));
+				},
+			);
+			r.on("error", reject);
+			r.end(payload);
+		});
+		assert.equal(status, 413);
+	});
+
+	it("unregister with valid pid returns 200", async () => {
+		await reqJSON("POST", "/_api/hub/register", { pid: 22222, cwd: "/tmp" });
+		const { status } = await reqJSON("POST", "/_api/hub/unregister", {
+			pid: 22222,
+		});
+		assert.equal(status, 200);
+	});
+
+	it("hub/status accessible from loopback", async () => {
+		const { status } = await reqJSON("GET", "/_api/hub/status");
+		assert.equal(status, 200);
+	});
+
+	it("health endpoint works without loopback check", async () => {
+		const { status } = await reqJSON("GET", "/_api/health");
+		assert.equal(status, 200);
+	});
+});
+
+describe("hub rejects non-loopback remote", () => {
+	it("non-loopback remoteAddress returns 403", () => {
+		// Direct unit test on handleHubRoutes with faked remoteAddress
+		const fakeReq = {
+			url: "/_api/hub/status",
+			method: "GET",
+			socket: { remoteAddress: "192.168.1.42" },
+			on: () => {},
+		};
+		let status = null;
+		const fakeRes = {
+			writeHead: (s) => {
+				status = s;
+				return fakeRes;
+			},
+			end: () => {},
+		};
+		const handled = hub.handleHubRoutes(fakeReq, fakeRes);
+		assert.equal(handled, true);
+		assert.equal(status, 403);
+	});
+
+	it("loopback ::1 is allowed", () => {
+		const fakeReq = {
+			url: "/_api/hub/status",
+			method: "GET",
+			socket: { remoteAddress: "::1" },
+			on: () => {},
+		};
+		let status = null;
+		const fakeRes = {
+			writeHead: (s) => {
+				status = s;
+				return fakeRes;
+			},
+			end: () => {},
+		};
+		hub.handleHubRoutes(fakeReq, fakeRes);
+		assert.equal(status, 200);
+	});
+
+	it("loopback ::ffff:127.0.0.1 is allowed", () => {
+		const fakeReq = {
+			url: "/_api/hub/status",
+			method: "GET",
+			socket: { remoteAddress: "::ffff:127.0.0.1" },
+			on: () => {},
+		};
+		let status = null;
+		const fakeRes = {
+			writeHead: (s) => {
+				status = s;
+				return fakeRes;
+			},
+			end: () => {},
+		};
+		hub.handleHubRoutes(fakeReq, fakeRes);
+		assert.equal(status, 200);
+	});
+});

--- a/test/startup.test.js
+++ b/test/startup.test.js
@@ -1,1299 +1,1666 @@
-'use strict';
+"use strict";
 
-const { describe, it, before, after } = require('node:test');
-const assert = require('node:assert/strict');
-const { spawn } = require('child_process');
-const http = require('http');
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const net = require('net');
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const { spawn } = require("child_process");
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const net = require("net");
 
-const SERVER_SCRIPT = path.resolve(__dirname, '..', 'server', 'index.js');
-const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-startup-test-'));
+const SERVER_SCRIPT = path.resolve(__dirname, "..", "server", "index.js");
+const TEST_HOME = fs.mkdtempSync(
+	path.join(os.tmpdir(), "ccxray-startup-test-"),
+);
 
 after(() => {
-  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+	fs.rmSync(TEST_HOME, { recursive: true, force: true });
 });
 
 // ── Helper: find an available port ─────────────────────────────────
 
 async function findFreePort() {
-  return new Promise((resolve, reject) => {
-    const srv = net.createServer();
-    srv.listen(0, () => {
-      const port = srv.address().port;
-      srv.close(() => resolve(port));
-    });
-    srv.on('error', reject);
-  });
+	return new Promise((resolve, reject) => {
+		const srv = net.createServer();
+		srv.listen(0, () => {
+			const port = srv.address().port;
+			srv.close(() => resolve(port));
+		});
+		srv.on("error", reject);
+	});
 }
 
 // ── Helper: spawn server and wait for ready ────────────────────────
 
 function spawnServer(args, opts = {}) {
-  const env = {
-    ...process.env,
-    CCXRAY_HOME: TEST_HOME,
-    BROWSER: 'none', // never open browser in tests
-    ...opts.env,
-  };
-  const child = spawn(process.execPath, [SERVER_SCRIPT, ...args], {
-    env,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  let stdout = '';
-  let stderr = '';
-  child.stdout.on('data', d => { stdout += d; });
-  child.stderr.on('data', d => { stderr += d; });
-  child.getOutput = () => ({ stdout, stderr });
-  return child;
+	const env = {
+		...process.env,
+		CCXRAY_HOME: TEST_HOME,
+		BROWSER: "none", // never open browser in tests
+		...opts.env,
+	};
+	const child = spawn(process.execPath, [SERVER_SCRIPT, ...args], {
+		env,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	let stdout = "";
+	let stderr = "";
+	child.stdout.on("data", (d) => {
+		stdout += d;
+	});
+	child.stderr.on("data", (d) => {
+		stderr += d;
+	});
+	child.getOutput = () => ({ stdout, stderr });
+	return child;
 }
 
 function waitForPort(port, timeoutMs = 8000) {
-  return new Promise((resolve, reject) => {
-    const start = Date.now();
-    const check = () => {
-      const req = http.get(`http://localhost:${port}/_api/health`, { timeout: 1000 }, res => {
-        let data = '';
-        res.on('data', c => { data += c; });
-        res.on('end', () => {
-          try {
-            if (JSON.parse(data).ok) return resolve();
-          } catch {}
-          if (Date.now() - start > timeoutMs) return reject(new Error('timeout'));
-          setTimeout(check, 200);
-        });
-      });
-      req.on('error', () => {
-        if (Date.now() - start > timeoutMs) return reject(new Error('timeout'));
-        setTimeout(check, 200);
-      });
-      req.on('timeout', () => {
-        req.destroy();
-        if (Date.now() - start > timeoutMs) return reject(new Error('timeout'));
-        setTimeout(check, 200);
-      });
-    };
-    check();
-  });
+	return new Promise((resolve, reject) => {
+		const start = Date.now();
+		const check = () => {
+			const req = http.get(
+				`http://localhost:${port}/_api/health`,
+				{ timeout: 1000 },
+				(res) => {
+					let data = "";
+					res.on("data", (c) => {
+						data += c;
+					});
+					res.on("end", () => {
+						try {
+							if (JSON.parse(data).ok) return resolve();
+						} catch {}
+						if (Date.now() - start > timeoutMs)
+							return reject(new Error("timeout"));
+						setTimeout(check, 200);
+					});
+				},
+			);
+			req.on("error", () => {
+				if (Date.now() - start > timeoutMs) return reject(new Error("timeout"));
+				setTimeout(check, 200);
+			});
+			req.on("timeout", () => {
+				req.destroy();
+				if (Date.now() - start > timeoutMs) return reject(new Error("timeout"));
+				setTimeout(check, 200);
+			});
+		};
+		check();
+	});
 }
 
 function killAndWait(child) {
-  return new Promise(resolve => {
-    if (child.exitCode !== null) return resolve();
-    child.on('exit', resolve);
-    child.kill('SIGTERM');
-    setTimeout(() => {
-      try { child.kill('SIGKILL'); } catch {}
-      resolve();
-    }, 3000);
-  });
+	return new Promise((resolve) => {
+		if (child.exitCode !== null) return resolve();
+		child.on("exit", resolve);
+		child.kill("SIGTERM");
+		setTimeout(() => {
+			try {
+				child.kill("SIGKILL");
+			} catch {}
+			resolve();
+		}, 3000);
+	});
 }
 
 // ── S4: standalone mode (ccxray without claude) ────────────────────
 
-describe('S4: standalone mode', () => {
-  let child;
-  let port;
+describe("S4: standalone mode", () => {
+	let child;
+	let port;
 
-  before(async () => {
-    port = await findFreePort();
-    child = spawnServer(['--port', String(port)]);
-    await waitForPort(port);
-  });
+	before(async () => {
+		port = await findFreePort();
+		child = spawnServer(["--port", String(port)]);
+		await waitForPort(port);
+	});
 
-  after(async () => {
-    await killAndWait(child);
-  });
+	after(async () => {
+		await killAndWait(child);
+	});
 
-  it('serves health endpoint', async () => {
-    const data = await httpGet(port, '/_api/health');
-    assert.deepEqual(data, { ok: true });
-  });
+	it("serves health endpoint", async () => {
+		const data = await httpGet(port, "/_api/health");
+		assert.deepEqual(data, { ok: true });
+	});
 
-  it('serves dashboard HTML at /', async () => {
-    const html = await httpGetRaw(port, '/');
-    assert.ok(html.includes('<!DOCTYPE html') || html.includes('<html'));
-  });
+	it("serves dashboard HTML at /", async () => {
+		const html = await httpGetRaw(port, "/");
+		assert.ok(html.includes("<!DOCTYPE html") || html.includes("<html"));
+	});
 
-  it('serves hub status', async () => {
-    const data = await httpGet(port, '/_api/hub/status');
-    assert.equal(data.app, 'ccxray');
-    assert.ok(data.version);
-  });
+	it("serves hub status", async () => {
+		const data = await httpGet(port, "/_api/hub/status");
+		assert.equal(data.app, "ccxray");
+		assert.ok(data.version);
+	});
 });
 
 // ── S5: status subcommand ──────────────────────────────────────────
 
-describe('S5: status subcommand', () => {
-  it('reports no hub when nothing is running', async () => {
-    // Ensure no lockfile
-    try { fs.unlinkSync(path.join(TEST_HOME, 'hub.json')); } catch {}
+describe("S5: status subcommand", () => {
+	it("reports no hub when nothing is running", async () => {
+		// Ensure no lockfile
+		try {
+			fs.unlinkSync(path.join(TEST_HOME, "hub.json"));
+		} catch {}
 
-    const { stdout, code } = await spawnAndCollect(['status']);
-    assert.ok(stdout.includes('No hub running'));
-    assert.equal(code, 0);
-  });
+		const { stdout, code } = await spawnAndCollect(["status"]);
+		assert.ok(stdout.includes("No hub running"));
+		assert.equal(code, 0);
+	});
 
-  it('reports dead hub and cleans lockfile', async () => {
-    // Write a fake lockfile with dead pid
-    const lockPath = path.join(TEST_HOME, 'hub.json');
-    fs.writeFileSync(lockPath, JSON.stringify({ port: 9999, pid: 999999, version: '1.0.0' }));
+	it("reports dead hub and cleans lockfile", async () => {
+		// Write a fake lockfile with dead pid
+		const lockPath = path.join(TEST_HOME, "hub.json");
+		fs.writeFileSync(
+			lockPath,
+			JSON.stringify({ port: 9999, pid: 999999, version: "1.0.0" }),
+		);
 
-    const { stdout, code } = await spawnAndCollect(['status']);
-    assert.ok(stdout.includes('dead') || stdout.includes('Cleaning'));
-    assert.equal(code, 1);
+		const { stdout, code } = await spawnAndCollect(["status"]);
+		assert.ok(stdout.includes("dead") || stdout.includes("Cleaning"));
+		assert.equal(code, 1);
 
-    // Lockfile should be cleaned up
-    assert.ok(!fs.existsSync(lockPath));
-  });
+		// Lockfile should be cleaned up
+		assert.ok(!fs.existsSync(lockPath));
+	});
 });
 
 // ── S6: hub mode startup ───────────────────────────────────────────
 
-describe('S6: hub mode startup', () => {
-  let child;
-  let port;
+describe("S6: hub mode startup", () => {
+	let child;
+	let port;
 
-  before(async () => {
-    port = await findFreePort();
-    child = spawnServer(['--port', String(port), '--hub-mode']);
-    await waitForPort(port);
-  });
+	before(async () => {
+		port = await findFreePort();
+		child = spawnServer(["--port", String(port), "--hub-mode"]);
+		await waitForPort(port);
+	});
 
-  after(async () => {
-    await killAndWait(child);
-    try { fs.unlinkSync(path.join(TEST_HOME, 'hub.json')); } catch {}
-  });
+	after(async () => {
+		await killAndWait(child);
+		try {
+			fs.unlinkSync(path.join(TEST_HOME, "hub.json"));
+		} catch {}
+	});
 
-  it('writes lockfile after startup', () => {
-    const lockPath = path.join(TEST_HOME, 'hub.json');
-    assert.ok(fs.existsSync(lockPath));
-    const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
-    assert.equal(lock.port, port);
-    assert.ok(lock.pid > 0);
-    assert.ok(lock.version);
-  });
+	it("writes lockfile after startup", () => {
+		const lockPath = path.join(TEST_HOME, "hub.json");
+		assert.ok(fs.existsSync(lockPath));
+		const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+		assert.equal(lock.port, port);
+		assert.ok(lock.pid > 0);
+		assert.ok(lock.version);
+	});
 
-  it('responds to health check', async () => {
-    const data = await httpGet(port, '/_api/health');
-    assert.deepEqual(data, { ok: true });
-  });
+	it("responds to health check", async () => {
+		const data = await httpGet(port, "/_api/health");
+		assert.deepEqual(data, { ok: true });
+	});
 
-  it('accepts client registration', async () => {
-    const data = await httpPost(port, '/_api/hub/register', { pid: 77777, cwd: '/test' });
-    assert.equal(data.ok, true);
-    assert.equal(data.firstClient, true);
+	it("accepts client registration", async () => {
+		const data = await httpPost(port, "/_api/hub/register", {
+			pid: 77777,
+			cwd: "/test",
+		});
+		assert.equal(data.ok, true);
+		assert.equal(data.firstClient, true);
 
-    // Cleanup
-    await httpPost(port, '/_api/hub/unregister', { pid: 77777 });
-  });
+		// Cleanup
+		await httpPost(port, "/_api/hub/unregister", { pid: 77777 });
+	});
 });
 
 // ── E3: --port validation ──────────────────────────────────────────
 
-describe('E3: --port validation', () => {
-  it('rejects port 0', async () => {
-    const { stderr, code } = await spawnAndCollect(['--port', '0']);
-    assert.ok(stderr.includes('--port requires a valid port'));
-    assert.equal(code, 1);
-  });
+describe("E3: --port validation", () => {
+	it("rejects port 0", async () => {
+		const { stderr, code } = await spawnAndCollect(["--port", "0"]);
+		assert.ok(stderr.includes("--port requires a valid port"));
+		assert.equal(code, 1);
+	});
 
-  it('rejects non-numeric port', async () => {
-    const { stderr, code } = await spawnAndCollect(['--port', 'abc']);
-    assert.ok(stderr.includes('--port requires a valid port'));
-    assert.equal(code, 1);
-  });
+	it("rejects non-numeric port", async () => {
+		const { stderr, code } = await spawnAndCollect(["--port", "abc"]);
+		assert.ok(stderr.includes("--port requires a valid port"));
+		assert.equal(code, 1);
+	});
 
-  it('rejects port > 65535', async () => {
-    const { stderr, code } = await spawnAndCollect(['--port', '99999']);
-    assert.ok(stderr.includes('--port requires a valid port'));
-    assert.equal(code, 1);
-  });
+	it("rejects port > 65535", async () => {
+		const { stderr, code } = await spawnAndCollect(["--port", "99999"]);
+		assert.ok(stderr.includes("--port requires a valid port"));
+		assert.equal(code, 1);
+	});
 });
 
 // ── R4: EADDRINUSE handling ────────────────────────────────────────
 
-describe('R4: port conflict', () => {
-  let blocker;
-  let port;
+describe("R4: port conflict", () => {
+	let blocker;
+	let port;
 
-  before(async () => {
-    port = await findFreePort();
-    blocker = net.createServer();
-    await new Promise(r => blocker.listen(port, r));
-  });
+	before(async () => {
+		port = await findFreePort();
+		blocker = net.createServer();
+		await new Promise((r) => blocker.listen(port, "127.0.0.1", r));
+	});
 
-  after(() => {
-    blocker.close();
-  });
+	after(() => {
+		blocker.close();
+	});
 
-  it('standalone mode reports port in use', async () => {
-    const { stderr, code } = await spawnAndCollect(['--port', String(port)]);
-    assert.ok(stderr.includes('already in use') || stderr.includes('EADDRINUSE'));
-    assert.equal(code, 1);
-  });
+	it("standalone mode reports port in use", async () => {
+		const { stderr, code } = await spawnAndCollect(["--port", String(port)]);
+		assert.ok(
+			stderr.includes("already in use") || stderr.includes("EADDRINUSE"),
+		);
+		assert.equal(code, 1);
+	});
 });
 
 // ── R2: hub crash recovery (sequential fork → kill → re-fork) ──────
 
-describe('R2: hub crash recovery', () => {
-  let hubPid1 = null;
-  let hubPid2 = null;
-  let port;
+describe("R2: hub crash recovery", () => {
+	let hubPid1 = null;
+	let hubPid2 = null;
+	let port;
 
-  after(async () => {
-    for (const pid of [hubPid1, hubPid2]) {
-      if (pid) try { process.kill(pid, 'SIGKILL'); } catch {}
-    }
-    try { fs.unlinkSync(path.join(TEST_HOME, 'hub.json')); } catch {}
-  });
+	after(async () => {
+		for (const pid of [hubPid1, hubPid2]) {
+			if (pid)
+				try {
+					process.kill(pid, "SIGKILL");
+				} catch {}
+		}
+		try {
+			fs.unlinkSync(path.join(TEST_HOME, "hub.json"));
+		} catch {}
+	});
 
-  it('re-forks hub after original hub is killed', async () => {
-    port = await findFreePort();
+	it("re-forks hub after original hub is killed", async () => {
+		port = await findFreePort();
 
-    // 1. Fork first hub
-    const child1 = spawnServer(['--port', String(port), '--hub-mode']);
-    await waitForPort(port);
-    const lock1 = JSON.parse(fs.readFileSync(path.join(TEST_HOME, 'hub.json'), 'utf8'));
-    hubPid1 = lock1.pid;
-    assert.ok(hubPid1 > 0);
-    assert.equal(lock1.port, port);
+		// 1. Fork first hub
+		const child1 = spawnServer(["--port", String(port), "--hub-mode"]);
+		await waitForPort(port);
+		const lock1 = JSON.parse(
+			fs.readFileSync(path.join(TEST_HOME, "hub.json"), "utf8"),
+		);
+		hubPid1 = lock1.pid;
+		assert.ok(hubPid1 > 0);
+		assert.equal(lock1.port, port);
 
-    // 2. Kill first hub
-    process.kill(hubPid1, 'SIGKILL');
-    await new Promise(r => child1.on('exit', r));
+		// 2. Kill first hub
+		process.kill(hubPid1, "SIGKILL");
+		await new Promise((r) => child1.on("exit", r));
 
-    // 3. Delete lockfile (simulating what startHubMonitor does)
-    try { fs.unlinkSync(path.join(TEST_HOME, 'hub.json')); } catch {}
+		// 3. Delete lockfile (simulating what startHubMonitor does)
+		try {
+			fs.unlinkSync(path.join(TEST_HOME, "hub.json"));
+		} catch {}
 
-    // 4. Wait for port to be released
-    await new Promise(resolve => {
-      const check = () => {
-        const srv = net.createServer();
-        srv.once('error', () => setTimeout(check, 200));
-        srv.once('listening', () => srv.close(() => resolve()));
-        srv.listen(port);
-      };
-      check();
-    });
+		// 4. Wait for port to be released
+		await new Promise((resolve) => {
+			const check = () => {
+				const srv = net.createServer();
+				srv.once("error", () => setTimeout(check, 200));
+				srv.once("listening", () => srv.close(() => resolve()));
+				srv.listen(port);
+			};
+			check();
+		});
 
-    // 5. Fork second hub on same port
-    const child2 = spawnServer(['--port', String(port), '--hub-mode']);
-    await waitForPort(port);
-    const lock2 = JSON.parse(fs.readFileSync(path.join(TEST_HOME, 'hub.json'), 'utf8'));
-    hubPid2 = lock2.pid;
-    assert.ok(hubPid2 > 0);
-    assert.equal(lock2.port, port);
-    assert.notEqual(hubPid2, hubPid1);
+		// 5. Fork second hub on same port
+		const child2 = spawnServer(["--port", String(port), "--hub-mode"]);
+		await waitForPort(port);
+		const lock2 = JSON.parse(
+			fs.readFileSync(path.join(TEST_HOME, "hub.json"), "utf8"),
+		);
+		hubPid2 = lock2.pid;
+		assert.ok(hubPid2 > 0);
+		assert.equal(lock2.port, port);
+		assert.notEqual(hubPid2, hubPid1);
 
-    // 6. Verify new hub is healthy
-    const health = await httpGet(port, '/_api/health');
-    assert.deepEqual(health, { ok: true });
+		// 6. Verify new hub is healthy
+		const health = await httpGet(port, "/_api/health");
+		assert.deepEqual(health, { ok: true });
 
-    await killAndWait(child2);
-  });
+		await killAndWait(child2);
+	});
 });
 
 // ── E2: claude not found (ENOENT) ──────────────────────────────────
 
-describe('E2: claude not found', () => {
-  it('reports error when claude binary is missing', async () => {
-    const port = await findFreePort();
+describe("E2: claude not found", () => {
+	it("reports error when claude binary is missing", async () => {
+		const port = await findFreePort();
 
-    // Spawn with empty PATH so 'claude' cannot be found.
-    // Keep node in PATH so the process itself can run.
-    const nodeBin = path.dirname(process.execPath);
-    const { stderr, code } = await spawnAndCollect(
-      ['--port', String(port), 'claude'],
-      8000,
-      { PATH: nodeBin }
-    );
+		// Spawn with empty PATH so 'claude' cannot be found.
+		// Keep node in PATH so the process itself can run.
+		const nodeBin = path.dirname(process.execPath);
+		const { stderr, code } = await spawnAndCollect(
+			["--port", String(port), "claude"],
+			8000,
+			{ PATH: nodeBin },
+		);
 
-    assert.ok(
-      stderr.includes('not found') || stderr.includes('ENOENT'),
-      `Expected ENOENT message, got: ${stderr.slice(0, 200)}`
-    );
-  });
+		assert.ok(
+			stderr.includes("not found") || stderr.includes("ENOENT"),
+			`Expected ENOENT message, got: ${stderr.slice(0, 200)}`,
+		);
+	});
 });
 
 // ── P0: Proxy end-to-end (request → forward → response → log) ──────
 
-describe('P0: proxy end-to-end forwarding', () => {
-  let mockUpstream;
-  let mockPort;
-  let proxyChild;
-  let proxyPort;
-  let receivedReq = null;
+describe("P0: proxy end-to-end forwarding", () => {
+	let mockUpstream;
+	let mockPort;
+	let proxyChild;
+	let proxyPort;
+	let receivedReq = null;
 
-  before(async () => {
-    // 1. Start mock "Anthropic API" server
-    mockUpstream = http.createServer((req, res) => {
-      let body = '';
-      req.on('data', c => { body += c; });
-      req.on('end', () => {
-        receivedReq = { method: req.method, url: req.url, headers: req.headers, body };
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({
-          id: 'msg_test123',
-          type: 'message',
-          role: 'assistant',
-          content: [{ type: 'text', text: 'Hello from mock' }],
-          model: 'claude-sonnet-4-20250514',
-          usage: { input_tokens: 10, output_tokens: 5 },
-        }));
-      });
-    });
-    await new Promise(r => mockUpstream.listen(0, r));
-    mockPort = mockUpstream.address().port;
+	before(async () => {
+		// 1. Start mock "Anthropic API" server
+		mockUpstream = http.createServer((req, res) => {
+			let body = "";
+			req.on("data", (c) => {
+				body += c;
+			});
+			req.on("end", () => {
+				receivedReq = {
+					method: req.method,
+					url: req.url,
+					headers: req.headers,
+					body,
+				};
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(
+					JSON.stringify({
+						id: "msg_test123",
+						type: "message",
+						role: "assistant",
+						content: [{ type: "text", text: "Hello from mock" }],
+						model: "claude-sonnet-4-20250514",
+						usage: { input_tokens: 10, output_tokens: 5 },
+					}),
+				);
+			});
+		});
+		await new Promise((r) => mockUpstream.listen(0, r));
+		mockPort = mockUpstream.address().port;
 
-    // 2. Start proxy pointing to mock upstream
-    proxyPort = await findFreePort();
-    proxyChild = spawnServer(['--port', String(proxyPort)], {
-      env: {
-        ANTHROPIC_TEST_HOST: 'localhost',
-        ANTHROPIC_TEST_PORT: String(mockPort),
-        ANTHROPIC_TEST_PROTOCOL: 'http',
-      },
-    });
-    await waitForPort(proxyPort);
-  });
+		// 2. Start proxy pointing to mock upstream
+		proxyPort = await findFreePort();
+		proxyChild = spawnServer(["--port", String(proxyPort)], {
+			env: {
+				ANTHROPIC_TEST_HOST: "localhost",
+				ANTHROPIC_TEST_PORT: String(mockPort),
+				ANTHROPIC_TEST_PROTOCOL: "http",
+			},
+		});
+		await waitForPort(proxyPort);
+	});
 
-  after(async () => {
-    await killAndWait(proxyChild);
-    await new Promise(r => mockUpstream.close(r));
-  });
+	after(async () => {
+		await killAndWait(proxyChild);
+		await new Promise((r) => mockUpstream.close(r));
+	});
 
-  it('forwards request to upstream and returns response', async () => {
-    const requestBody = JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 100,
-      messages: [{ role: 'user', content: 'test' }],
-    });
+	it("forwards request to upstream and returns response", async () => {
+		const requestBody = JSON.stringify({
+			model: "claude-sonnet-4-20250514",
+			max_tokens: 100,
+			messages: [{ role: "user", content: "test" }],
+		});
 
-    const response = await new Promise((resolve, reject) => {
-      const req = http.request(`http://localhost:${proxyPort}/v1/messages`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': Buffer.byteLength(requestBody),
-          'x-api-key': 'test-key',
-          'anthropic-version': '2023-06-01',
-        },
-      }, res => {
-        let data = '';
-        res.on('data', c => { data += c; });
-        res.on('end', () => {
-          try { resolve({ status: res.statusCode, body: JSON.parse(data) }); }
-          catch { resolve({ status: res.statusCode, body: data }); }
-        });
-      });
-      req.on('error', reject);
-      req.end(requestBody);
-    });
+		const response = await new Promise((resolve, reject) => {
+			const req = http.request(
+				`http://localhost:${proxyPort}/v1/messages`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"Content-Length": Buffer.byteLength(requestBody),
+						"x-api-key": "test-key",
+						"anthropic-version": "2023-06-01",
+					},
+				},
+				(res) => {
+					let data = "";
+					res.on("data", (c) => {
+						data += c;
+					});
+					res.on("end", () => {
+						try {
+							resolve({ status: res.statusCode, body: JSON.parse(data) });
+						} catch {
+							resolve({ status: res.statusCode, body: data });
+						}
+					});
+				},
+			);
+			req.on("error", reject);
+			req.end(requestBody);
+		});
 
-    // Verify proxy forwarded to mock upstream
-    assert.ok(receivedReq, 'mock upstream should have received the request');
-    assert.equal(receivedReq.method, 'POST');
-    assert.equal(receivedReq.url, '/v1/messages');
+		// Verify proxy forwarded to mock upstream
+		assert.ok(receivedReq, "mock upstream should have received the request");
+		assert.equal(receivedReq.method, "POST");
+		assert.equal(receivedReq.url, "/v1/messages");
 
-    // Verify proxy returned upstream response to client
-    assert.equal(response.status, 200);
-    assert.equal(response.body.id, 'msg_test123');
-    assert.equal(response.body.content[0].text, 'Hello from mock');
-  });
+		// Verify proxy returned upstream response to client
+		assert.equal(response.status, 200);
+		assert.equal(response.body.id, "msg_test123");
+		assert.equal(response.body.content[0].text, "Hello from mock");
+	});
 
-  it('writes req/res log files', async () => {
-    // Give a moment for async writes
-    await new Promise(r => setTimeout(r, 500));
+	it("writes req/res log files", async () => {
+		// Give a moment for async writes
+		await new Promise((r) => setTimeout(r, 500));
 
-    const logsDir = path.join(TEST_HOME, 'logs');
-    const files = fs.existsSync(logsDir) ? fs.readdirSync(logsDir) : [];
-    const reqFiles = files.filter(f => f.endsWith('_req.json'));
-    const resFiles = files.filter(f => f.endsWith('_res.json'));
+		const logsDir = path.join(TEST_HOME, "logs");
+		const files = fs.existsSync(logsDir) ? fs.readdirSync(logsDir) : [];
+		const reqFiles = files.filter((f) => f.endsWith("_req.json"));
+		const resFiles = files.filter((f) => f.endsWith("_res.json"));
 
-    assert.ok(reqFiles.length > 0, `Expected req log files, found: ${files.join(', ')}`);
-    assert.ok(resFiles.length > 0, `Expected res log files, found: ${files.join(', ')}`);
+		assert.ok(
+			reqFiles.length > 0,
+			`Expected req log files, found: ${files.join(", ")}`,
+		);
+		assert.ok(
+			resFiles.length > 0,
+			`Expected res log files, found: ${files.join(", ")}`,
+		);
 
-    // Verify req log content
-    const reqContent = JSON.parse(fs.readFileSync(path.join(logsDir, reqFiles[0]), 'utf8'));
-    assert.equal(reqContent.model, 'claude-sonnet-4-20250514');
-    assert.ok(reqContent.messages);
-  });
+		// Verify req log content
+		const reqContent = JSON.parse(
+			fs.readFileSync(path.join(logsDir, reqFiles[0]), "utf8"),
+		);
+		assert.equal(reqContent.model, "claude-sonnet-4-20250514");
+		assert.ok(reqContent.messages);
+	});
 });
 
 // ── SSE streaming proxy E2E ─────────────────────────────────────────
 
-describe('SSE streaming proxy', () => {
-  let mockUpstream;
-  let mockPort;
-  let proxyChild;
-  let proxyPort;
+describe("SSE streaming proxy", () => {
+	let mockUpstream;
+	let mockPort;
+	let proxyChild;
+	let proxyPort;
 
-  before(async () => {
-    // Mock upstream that returns SSE event stream (like real Anthropic API)
-    mockUpstream = http.createServer((req, res) => {
-      let body = '';
-      req.on('data', c => { body += c; });
-      req.on('end', () => {
-        res.writeHead(200, {
-          'Content-Type': 'text/event-stream',
-          'Cache-Control': 'no-cache',
-        });
+	before(async () => {
+		// Mock upstream that returns SSE event stream (like real Anthropic API)
+		mockUpstream = http.createServer((req, res) => {
+			let body = "";
+			req.on("data", (c) => {
+				body += c;
+			});
+			req.on("end", () => {
+				res.writeHead(200, {
+					"Content-Type": "text/event-stream",
+					"Cache-Control": "no-cache",
+				});
 
-        // Simulate Anthropic SSE response
-        const events = [
-          { type: 'message_start', message: { id: 'msg_sse_test', type: 'message', role: 'assistant', content: [], model: 'claude-sonnet-4-20250514', usage: { input_tokens: 10, output_tokens: 0 } } },
-          { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
-          { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello ' } },
-          { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'from SSE' } },
-          { type: 'content_block_stop', index: 0 },
-          { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 5 } },
-          { type: 'message_stop' },
-        ];
+				// Simulate Anthropic SSE response
+				const events = [
+					{
+						type: "message_start",
+						message: {
+							id: "msg_sse_test",
+							type: "message",
+							role: "assistant",
+							content: [],
+							model: "claude-sonnet-4-20250514",
+							usage: { input_tokens: 10, output_tokens: 0 },
+						},
+					},
+					{
+						type: "content_block_start",
+						index: 0,
+						content_block: { type: "text", text: "" },
+					},
+					{
+						type: "content_block_delta",
+						index: 0,
+						delta: { type: "text_delta", text: "Hello " },
+					},
+					{
+						type: "content_block_delta",
+						index: 0,
+						delta: { type: "text_delta", text: "from SSE" },
+					},
+					{ type: "content_block_stop", index: 0 },
+					{
+						type: "message_delta",
+						delta: { stop_reason: "end_turn" },
+						usage: { output_tokens: 5 },
+					},
+					{ type: "message_stop" },
+				];
 
-        let i = 0;
-        const sendNext = () => {
-          if (i >= events.length) { res.end(); return; }
-          res.write(`event: ${events[i].type}\ndata: ${JSON.stringify(events[i])}\n\n`);
-          i++;
-          setTimeout(sendNext, 5);
-        };
-        sendNext();
-      });
-    });
-    await new Promise(r => mockUpstream.listen(0, r));
-    mockPort = mockUpstream.address().port;
+				let i = 0;
+				const sendNext = () => {
+					if (i >= events.length) {
+						res.end();
+						return;
+					}
+					res.write(
+						`event: ${events[i].type}\ndata: ${JSON.stringify(events[i])}\n\n`,
+					);
+					i++;
+					setTimeout(sendNext, 5);
+				};
+				sendNext();
+			});
+		});
+		await new Promise((r) => mockUpstream.listen(0, r));
+		mockPort = mockUpstream.address().port;
 
-    proxyPort = await findFreePort();
-    proxyChild = spawnServer(['--port', String(proxyPort)], {
-      env: {
-        ANTHROPIC_TEST_HOST: 'localhost',
-        ANTHROPIC_TEST_PORT: String(mockPort),
-        ANTHROPIC_TEST_PROTOCOL: 'http',
-      },
-    });
-    await waitForPort(proxyPort);
-  });
+		proxyPort = await findFreePort();
+		proxyChild = spawnServer(["--port", String(proxyPort)], {
+			env: {
+				ANTHROPIC_TEST_HOST: "localhost",
+				ANTHROPIC_TEST_PORT: String(mockPort),
+				ANTHROPIC_TEST_PROTOCOL: "http",
+			},
+		});
+		await waitForPort(proxyPort);
+	});
 
-  after(async () => {
-    await killAndWait(proxyChild);
-    await new Promise(r => mockUpstream.close(r));
-  });
+	after(async () => {
+		await killAndWait(proxyChild);
+		await new Promise((r) => mockUpstream.close(r));
+	});
 
-  it('streams SSE chunks from upstream through proxy to client', async () => {
-    const requestBody = JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 100,
-      stream: true,
-      messages: [{ role: 'user', content: 'test sse' }],
-    });
+	it("streams SSE chunks from upstream through proxy to client", async () => {
+		const requestBody = JSON.stringify({
+			model: "claude-sonnet-4-20250514",
+			max_tokens: 100,
+			stream: true,
+			messages: [{ role: "user", content: "test sse" }],
+		});
 
-    const { chunks, headers } = await new Promise((resolve, reject) => {
-      const req = http.request(`http://localhost:${proxyPort}/v1/messages`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': Buffer.byteLength(requestBody),
-          'x-api-key': 'test-key',
-          'anthropic-version': '2023-06-01',
-        },
-      }, res => {
-        const chunks = [];
-        res.on('data', c => { chunks.push(c.toString()); });
-        res.on('end', () => resolve({ chunks, headers: res.headers }));
-      });
-      req.on('error', reject);
-      req.end(requestBody);
-    });
+		const { chunks, headers } = await new Promise((resolve, reject) => {
+			const req = http.request(
+				`http://localhost:${proxyPort}/v1/messages`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"Content-Length": Buffer.byteLength(requestBody),
+						"x-api-key": "test-key",
+						"anthropic-version": "2023-06-01",
+					},
+				},
+				(res) => {
+					const chunks = [];
+					res.on("data", (c) => {
+						chunks.push(c.toString());
+					});
+					res.on("end", () => resolve({ chunks, headers: res.headers }));
+				},
+			);
+			req.on("error", reject);
+			req.end(requestBody);
+		});
 
-    // Verify SSE content-type preserved
-    assert.ok(
-      (headers['content-type'] || '').includes('text/event-stream'),
-      'Response should be text/event-stream'
-    );
+		// Verify SSE content-type preserved
+		assert.ok(
+			(headers["content-type"] || "").includes("text/event-stream"),
+			"Response should be text/event-stream",
+		);
 
-    // Verify SSE events came through
-    const fullResponse = chunks.join('');
-    assert.ok(fullResponse.includes('message_start'), 'Should contain message_start event');
-    assert.ok(fullResponse.includes('content_block_delta'), 'Should contain content_block_delta');
-    assert.ok(fullResponse.includes('Hello '), 'Should contain streamed text "Hello "');
-    assert.ok(fullResponse.includes('from SSE'), 'Should contain streamed text "from SSE"');
-    assert.ok(fullResponse.includes('message_stop'), 'Should contain message_stop');
-  });
+		// Verify SSE events came through
+		const fullResponse = chunks.join("");
+		assert.ok(
+			fullResponse.includes("message_start"),
+			"Should contain message_start event",
+		);
+		assert.ok(
+			fullResponse.includes("content_block_delta"),
+			"Should contain content_block_delta",
+		);
+		assert.ok(
+			fullResponse.includes("Hello "),
+			'Should contain streamed text "Hello "',
+		);
+		assert.ok(
+			fullResponse.includes("from SSE"),
+			'Should contain streamed text "from SSE"',
+		);
+		assert.ok(
+			fullResponse.includes("message_stop"),
+			"Should contain message_stop",
+		);
+	});
 
-  it('writes SSE response to log as parsed events array', async () => {
-    // Wait for async log write
-    await new Promise(r => setTimeout(r, 500));
+	it("writes SSE response to log as parsed events array", async () => {
+		// Wait for async log write
+		await new Promise((r) => setTimeout(r, 500));
 
-    const logsDir = path.join(TEST_HOME, 'logs');
-    const files = fs.existsSync(logsDir) ? fs.readdirSync(logsDir) : [];
-    const resFiles = files.filter(f => f.endsWith('_res.json'));
+		const logsDir = path.join(TEST_HOME, "logs");
+		const files = fs.existsSync(logsDir) ? fs.readdirSync(logsDir) : [];
+		const resFiles = files.filter((f) => f.endsWith("_res.json"));
 
-    // Find the SSE response log (most recent)
-    assert.ok(resFiles.length > 0, 'Should have res log files');
-    const lastResFile = resFiles.sort().pop();
-    const resContent = JSON.parse(fs.readFileSync(path.join(logsDir, lastResFile), 'utf8'));
+		// Find the SSE response log (most recent)
+		assert.ok(resFiles.length > 0, "Should have res log files");
+		const lastResFile = resFiles.sort().pop();
+		const resContent = JSON.parse(
+			fs.readFileSync(path.join(logsDir, lastResFile), "utf8"),
+		);
 
-    // SSE responses are stored as parsed event arrays
-    assert.ok(Array.isArray(resContent), 'SSE res log should be an array of events');
-    assert.ok(resContent.length >= 5, `Expected >= 5 events, got ${resContent.length}`);
+		// SSE responses are stored as parsed event arrays
+		assert.ok(
+			Array.isArray(resContent),
+			"SSE res log should be an array of events",
+		);
+		assert.ok(
+			resContent.length >= 5,
+			`Expected >= 5 events, got ${resContent.length}`,
+		);
 
-    // Verify event types are captured
-    const types = resContent.map(e => e.type);
-    assert.ok(types.includes('message_start'), 'Should log message_start');
-    assert.ok(types.includes('content_block_delta'), 'Should log content_block_delta');
-    assert.ok(types.includes('message_stop'), 'Should log message_stop');
-  });
+		// Verify event types are captured
+		const types = resContent.map((e) => e.type);
+		assert.ok(types.includes("message_start"), "Should log message_start");
+		assert.ok(
+			types.includes("content_block_delta"),
+			"Should log content_block_delta",
+		);
+		assert.ok(types.includes("message_stop"), "Should log message_stop");
+	});
 });
 
 // ── Intercept lifecycle E2E ──────────────────────────────────────────
 
-describe('Intercept lifecycle', () => {
-  let mockUpstream;
-  let mockPort;
-  let proxyChild;
-  let proxyPort;
-  const TEST_SESSION = 'aaaabbbb-cccc-dddd-eeee-ffffffffffff';
-  let mockUpstreamNextResponse = null;
+describe("Intercept lifecycle", () => {
+	let mockUpstream;
+	let mockPort;
+	let proxyChild;
+	let proxyPort;
+	const TEST_SESSION = "aaaabbbb-cccc-dddd-eeee-ffffffffffff";
+	let mockUpstreamNextResponse = null;
 
-  function makeRequestBody(content) {
-    return JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 100,
-      messages: [{ role: 'user', content }],
-      metadata: { user_id: JSON.stringify({ session_id: TEST_SESSION }) },
-    });
-  }
+	function makeRequestBody(content) {
+		return JSON.stringify({
+			model: "claude-sonnet-4-20250514",
+			max_tokens: 100,
+			messages: [{ role: "user", content }],
+			metadata: { user_id: JSON.stringify({ session_id: TEST_SESSION }) },
+		});
+	}
 
-  before(async () => {
-    mockUpstream = http.createServer((req, res) => {
-      let body = '';
-      req.on('data', c => { body += c; });
-      req.on('end', () => {
-        if (mockUpstreamNextResponse) {
-          const r = mockUpstreamNextResponse;
-          res.writeHead(r.status, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify(r.body));
-          return;
-        }
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({
-          id: 'msg_intercept',
-          type: 'message',
-          role: 'assistant',
-          content: [{ type: 'text', text: 'approved response' }],
-          model: 'claude-sonnet-4-20250514',
-          usage: { input_tokens: 10, output_tokens: 5 },
-        }));
-      });
-    });
-    await new Promise(r => mockUpstream.listen(0, r));
-    mockPort = mockUpstream.address().port;
+	before(async () => {
+		mockUpstream = http.createServer((req, res) => {
+			let body = "";
+			req.on("data", (c) => {
+				body += c;
+			});
+			req.on("end", () => {
+				if (mockUpstreamNextResponse) {
+					const r = mockUpstreamNextResponse;
+					res.writeHead(r.status, { "Content-Type": "application/json" });
+					res.end(JSON.stringify(r.body));
+					return;
+				}
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(
+					JSON.stringify({
+						id: "msg_intercept",
+						type: "message",
+						role: "assistant",
+						content: [{ type: "text", text: "approved response" }],
+						model: "claude-sonnet-4-20250514",
+						usage: { input_tokens: 10, output_tokens: 5 },
+					}),
+				);
+			});
+		});
+		await new Promise((r) => mockUpstream.listen(0, r));
+		mockPort = mockUpstream.address().port;
 
-    proxyPort = await findFreePort();
-    proxyChild = spawnServer(['--port', String(proxyPort)], {
-      env: {
-        ANTHROPIC_TEST_HOST: 'localhost',
-        ANTHROPIC_TEST_PORT: String(mockPort),
-        ANTHROPIC_TEST_PROTOCOL: 'http',
-      },
-    });
-    await waitForPort(proxyPort);
+		proxyPort = await findFreePort();
+		proxyChild = spawnServer(["--port", String(proxyPort)], {
+			env: {
+				ANTHROPIC_TEST_HOST: "localhost",
+				ANTHROPIC_TEST_PORT: String(mockPort),
+				ANTHROPIC_TEST_PROTOCOL: "http",
+			},
+		});
+		await waitForPort(proxyPort);
 
-    // Establish session by sending initial request
-    const initBody = makeRequestBody('init session');
-    await new Promise((resolve, reject) => {
-      const req = http.request(`http://localhost:${proxyPort}/v1/messages`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(initBody), 'x-api-key': 'k', 'anthropic-version': '2023-06-01' },
-      }, res => { res.resume(); res.on('end', resolve); });
-      req.on('error', reject);
-      req.end(initBody);
-    });
-  });
+		// Establish session by sending initial request
+		const initBody = makeRequestBody("init session");
+		await new Promise((resolve, reject) => {
+			const req = http.request(
+				`http://localhost:${proxyPort}/v1/messages`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"Content-Length": Buffer.byteLength(initBody),
+						"x-api-key": "k",
+						"anthropic-version": "2023-06-01",
+					},
+				},
+				(res) => {
+					res.resume();
+					res.on("end", resolve);
+				},
+			);
+			req.on("error", reject);
+			req.end(initBody);
+		});
+	});
 
-  after(async () => {
-    await killAndWait(proxyChild);
-    await new Promise(r => mockUpstream.close(r));
-  });
+	after(async () => {
+		await killAndWait(proxyChild);
+		await new Promise((r) => mockUpstream.close(r));
+	});
 
-  it('toggle intercept on/off', async () => {
-    // Enable intercept
-    const on = await httpPost(proxyPort, '/_api/intercept/toggle', { sessionId: TEST_SESSION });
-    assert.equal(on.enabled, true);
-    assert.equal(on.sessionId, TEST_SESSION);
+	it("toggle intercept on/off", async () => {
+		// Enable intercept
+		const on = await httpPost(proxyPort, "/_api/intercept/toggle", {
+			sessionId: TEST_SESSION,
+		});
+		assert.equal(on.enabled, true);
+		assert.equal(on.sessionId, TEST_SESSION);
 
-    // Disable intercept
-    const off = await httpPost(proxyPort, '/_api/intercept/toggle', { sessionId: TEST_SESSION });
-    assert.equal(off.enabled, false);
-  });
+		// Disable intercept
+		const off = await httpPost(proxyPort, "/_api/intercept/toggle", {
+			sessionId: TEST_SESSION,
+		});
+		assert.equal(off.enabled, false);
+	});
 
-  it('intercept → approve → request forwarded', async () => {
-    // Enable intercept
-    await httpPost(proxyPort, '/_api/intercept/toggle', { sessionId: TEST_SESSION });
+	it("intercept → approve → request forwarded", async () => {
+		// Enable intercept
+		await httpPost(proxyPort, "/_api/intercept/toggle", {
+			sessionId: TEST_SESSION,
+		});
 
-    // Connect SSE to catch pending_request event
-    const pendingIdPromise = waitForSSEEvent(proxyPort, 'pending_request');
+		// Connect SSE to catch pending_request event
+		const pendingIdPromise = waitForSSEEvent(proxyPort, "pending_request");
 
-    // Send request — should be held
-    const body = makeRequestBody('intercept me');
-    const responsePromise = sendProxyRequest(proxyPort, body);
+		// Send request — should be held
+		const body = makeRequestBody("intercept me");
+		const responsePromise = sendProxyRequest(proxyPort, body);
 
-    // Wait for SSE to tell us the pending request ID
-    const pendingId = await pendingIdPromise;
-    assert.ok(pendingId, 'Should receive pending_request via SSE');
+		// Wait for SSE to tell us the pending request ID
+		const pendingId = await pendingIdPromise;
+		assert.ok(pendingId, "Should receive pending_request via SSE");
 
-    // Approve the request
-    const approveResult = await httpPost(proxyPort, `/_api/intercept/${encodeURIComponent(pendingId)}/approve`, {});
-    assert.equal(approveResult.ok, true);
+		// Approve the request
+		const approveResult = await httpPost(
+			proxyPort,
+			`/_api/intercept/${encodeURIComponent(pendingId)}/approve`,
+			{},
+		);
+		assert.equal(approveResult.ok, true);
 
-    // Original request should complete
-    const response = await responsePromise;
-    assert.equal(response.status, 200);
-    assert.ok(response.body.includes('approved response'));
+		// Original request should complete
+		const response = await responsePromise;
+		assert.equal(response.status, 200);
+		assert.ok(response.body.includes("approved response"));
 
-    // Disable intercept
-    await httpPost(proxyPort, '/_api/intercept/toggle', { sessionId: TEST_SESSION });
-  });
+		// Disable intercept
+		await httpPost(proxyPort, "/_api/intercept/toggle", {
+			sessionId: TEST_SESSION,
+		});
+	});
 
-  it('intercept → reject → client gets 499', async () => {
-    // Enable intercept
-    await httpPost(proxyPort, '/_api/intercept/toggle', { sessionId: TEST_SESSION });
+	it("intercept → reject → client gets 499", async () => {
+		// Enable intercept
+		await httpPost(proxyPort, "/_api/intercept/toggle", {
+			sessionId: TEST_SESSION,
+		});
 
-    const pendingIdPromise = waitForSSEEvent(proxyPort, 'pending_request');
+		const pendingIdPromise = waitForSSEEvent(proxyPort, "pending_request");
 
-    const body = makeRequestBody('reject me');
-    const responsePromise = sendProxyRequest(proxyPort, body);
+		const body = makeRequestBody("reject me");
+		const responsePromise = sendProxyRequest(proxyPort, body);
 
-    const pendingId = await pendingIdPromise;
-    assert.ok(pendingId, 'Should receive pending_request via SSE');
+		const pendingId = await pendingIdPromise;
+		assert.ok(pendingId, "Should receive pending_request via SSE");
 
-    // Reject the request
-    const rejectResult = await httpPost(proxyPort, `/_api/intercept/${encodeURIComponent(pendingId)}/reject`, {});
-    assert.equal(rejectResult.ok, true);
+		// Reject the request
+		const rejectResult = await httpPost(
+			proxyPort,
+			`/_api/intercept/${encodeURIComponent(pendingId)}/reject`,
+			{},
+		);
+		assert.equal(rejectResult.ok, true);
 
-    // Client should get 499
-    const response = await responsePromise;
-    assert.equal(response.status, 499);
-    assert.ok(response.body.includes('request_rejected'));
+		// Client should get 499
+		const response = await responsePromise;
+		assert.equal(response.status, 499);
+		assert.ok(response.body.includes("request_rejected"));
 
-    // Cleanup
-    await httpPost(proxyPort, '/_api/intercept/toggle', { sessionId: TEST_SESSION });
-  });
+		// Cleanup
+		await httpPost(proxyPort, "/_api/intercept/toggle", {
+			sessionId: TEST_SESSION,
+		});
+	});
 
-  it('intercept → approve → upstream 500 → state recovers', async () => {
-    // Make upstream return 500 for next request
-    mockUpstreamNextResponse = { status: 500, body: { type: 'error', error: { message: 'boom' } } };
+	it("intercept → approve → upstream 500 → state recovers", async () => {
+		// Make upstream return 500 for next request
+		mockUpstreamNextResponse = {
+			status: 500,
+			body: { type: "error", error: { message: "boom" } },
+		};
 
-    // Enable intercept
-    await httpPost(proxyPort, '/_api/intercept/toggle', { sessionId: TEST_SESSION });
+		// Enable intercept
+		await httpPost(proxyPort, "/_api/intercept/toggle", {
+			sessionId: TEST_SESSION,
+		});
 
-    const pendingIdPromise = waitForSSEEvent(proxyPort, 'pending_request');
-    const body = makeRequestBody('intercept then fail');
-    const responsePromise = sendProxyRequest(proxyPort, body);
+		const pendingIdPromise = waitForSSEEvent(proxyPort, "pending_request");
+		const body = makeRequestBody("intercept then fail");
+		const responsePromise = sendProxyRequest(proxyPort, body);
 
-    const pendingId = await pendingIdPromise;
-    assert.ok(pendingId);
+		const pendingId = await pendingIdPromise;
+		assert.ok(pendingId);
 
-    // Approve — proxy forwards to upstream which returns 500
-    await httpPost(proxyPort, `/_api/intercept/${encodeURIComponent(pendingId)}/approve`, {});
+		// Approve — proxy forwards to upstream which returns 500
+		await httpPost(
+			proxyPort,
+			`/_api/intercept/${encodeURIComponent(pendingId)}/approve`,
+			{},
+		);
 
-    const response = await responsePromise;
-    assert.equal(response.status, 500, 'Client should get the 500 from upstream');
+		const response = await responsePromise;
+		assert.equal(
+			response.status,
+			500,
+			"Client should get the 500 from upstream",
+		);
 
-    // Disable intercept
-    await httpPost(proxyPort, '/_api/intercept/toggle', { sessionId: TEST_SESSION });
-    mockUpstreamNextResponse = null;
+		// Disable intercept
+		await httpPost(proxyPort, "/_api/intercept/toggle", {
+			sessionId: TEST_SESSION,
+		});
+		mockUpstreamNextResponse = null;
 
-    // Verify proxy is still healthy
-    const health = await httpGet(proxyPort, '/_api/health');
-    assert.deepEqual(health, { ok: true });
-  });
+		// Verify proxy is still healthy
+		const health = await httpGet(proxyPort, "/_api/health");
+		assert.deepEqual(health, { ok: true });
+	});
 });
 
 // ── Proxy error paths ───────────────────────────────────────────────
 
-describe('Proxy error paths', () => {
-  let proxyChild;
-  let proxyPort;
-  // No mock upstream — proxy points to a port with nothing listening
-  const DEAD_PORT = 1; // privileged, guaranteed no listener
+describe("Proxy error paths", () => {
+	let proxyChild;
+	let proxyPort;
+	// No mock upstream — proxy points to a port with nothing listening
+	const DEAD_PORT = 1; // privileged, guaranteed no listener
 
-  before(async () => {
-    proxyPort = await findFreePort();
-    proxyChild = spawnServer(['--port', String(proxyPort)], {
-      env: {
-        ANTHROPIC_TEST_HOST: '127.0.0.1',
-        ANTHROPIC_TEST_PORT: String(DEAD_PORT),
-        ANTHROPIC_TEST_PROTOCOL: 'http',
-      },
-    });
-    await waitForPort(proxyPort);
-  });
+	before(async () => {
+		proxyPort = await findFreePort();
+		proxyChild = spawnServer(["--port", String(proxyPort)], {
+			env: {
+				ANTHROPIC_TEST_HOST: "127.0.0.1",
+				ANTHROPIC_TEST_PORT: String(DEAD_PORT),
+				ANTHROPIC_TEST_PROTOCOL: "http",
+			},
+		});
+		await waitForPort(proxyPort);
+	});
 
-  after(async () => {
-    await killAndWait(proxyChild);
-  });
+	after(async () => {
+		await killAndWait(proxyChild);
+	});
 
-  it('E1: upstream connection refused → 502 proxy_error', async () => {
-    const response = await sendProxyRequest(proxyPort, JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 100,
-      messages: [{ role: 'user', content: 'test error' }],
-    }));
+	it("E1: upstream connection refused → 502 proxy_error", async () => {
+		const response = await sendProxyRequest(
+			proxyPort,
+			JSON.stringify({
+				model: "claude-sonnet-4-20250514",
+				max_tokens: 100,
+				messages: [{ role: "user", content: "test error" }],
+			}),
+		);
 
-    assert.equal(response.status, 502);
-    const body = JSON.parse(response.body);
-    assert.equal(body.error, 'proxy_error');
-    assert.ok(body.message, 'Should have error message');
-  });
+		assert.equal(response.status, 502);
+		const body = JSON.parse(response.body);
+		assert.equal(body.error, "proxy_error");
+		assert.ok(body.message, "Should have error message");
+	});
 
-  it('E1: proxy survives after upstream error (not crashed)', async () => {
-    // Health check still works after error
-    const health = await httpGet(proxyPort, '/_api/health');
-    assert.deepEqual(health, { ok: true });
-  });
+	it("E1: proxy survives after upstream error (not crashed)", async () => {
+		// Health check still works after error
+		const health = await httpGet(proxyPort, "/_api/health");
+		assert.deepEqual(health, { ok: true });
+	});
 });
 
-describe('Proxy upstream error responses', () => {
-  let mockUpstream;
-  let mockPort;
-  let proxyChild;
-  let proxyPort;
-  let nextResponse = null;
+describe("Proxy upstream error responses", () => {
+	let mockUpstream;
+	let mockPort;
+	let proxyChild;
+	let proxyPort;
+	let nextResponse = null;
 
-  before(async () => {
-    mockUpstream = http.createServer((req, res) => {
-      let body = '';
-      req.on('data', c => { body += c; });
-      req.on('end', () => {
-        if (nextResponse) {
-          const { status, headers, body: resBody, sse, destroyAfter } = nextResponse;
-          res.writeHead(status, headers || { 'Content-Type': 'application/json' });
-          if (sse) {
-            // Send partial SSE then destroy connection
-            for (const chunk of sse) {
-              res.write(chunk);
-            }
-            if (destroyAfter) {
-              setTimeout(() => res.end(), 50);
-            } else if (nextResponse.socketDestroy) {
-              setTimeout(() => res.socket.destroy(), 50);
-            } else {
-              res.end();
-            }
-          } else {
-            res.end(typeof resBody === 'string' ? resBody : JSON.stringify(resBody));
-          }
-        } else {
-          res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ id: 'msg_ok', type: 'message', content: [], usage: { input_tokens: 1, output_tokens: 1 } }));
-        }
-      });
-    });
-    await new Promise(r => mockUpstream.listen(0, r));
-    mockPort = mockUpstream.address().port;
+	before(async () => {
+		mockUpstream = http.createServer((req, res) => {
+			let body = "";
+			req.on("data", (c) => {
+				body += c;
+			});
+			req.on("end", () => {
+				if (nextResponse) {
+					const {
+						status,
+						headers,
+						body: resBody,
+						sse,
+						destroyAfter,
+					} = nextResponse;
+					res.writeHead(
+						status,
+						headers || { "Content-Type": "application/json" },
+					);
+					if (sse) {
+						// Send partial SSE then destroy connection
+						for (const chunk of sse) {
+							res.write(chunk);
+						}
+						if (destroyAfter) {
+							setTimeout(() => res.end(), 50);
+						} else if (nextResponse.socketDestroy) {
+							setTimeout(() => res.socket.destroy(), 50);
+						} else {
+							res.end();
+						}
+					} else {
+						res.end(
+							typeof resBody === "string" ? resBody : JSON.stringify(resBody),
+						);
+					}
+				} else {
+					res.writeHead(200, { "Content-Type": "application/json" });
+					res.end(
+						JSON.stringify({
+							id: "msg_ok",
+							type: "message",
+							content: [],
+							usage: { input_tokens: 1, output_tokens: 1 },
+						}),
+					);
+				}
+			});
+		});
+		await new Promise((r) => mockUpstream.listen(0, r));
+		mockPort = mockUpstream.address().port;
 
-    proxyPort = await findFreePort();
-    proxyChild = spawnServer(['--port', String(proxyPort)], {
-      env: {
-        ANTHROPIC_TEST_HOST: 'localhost',
-        ANTHROPIC_TEST_PORT: String(mockPort),
-        ANTHROPIC_TEST_PROTOCOL: 'http',
-      },
-    });
-    await waitForPort(proxyPort);
-  });
+		proxyPort = await findFreePort();
+		proxyChild = spawnServer(["--port", String(proxyPort)], {
+			env: {
+				ANTHROPIC_TEST_HOST: "localhost",
+				ANTHROPIC_TEST_PORT: String(mockPort),
+				ANTHROPIC_TEST_PROTOCOL: "http",
+			},
+		});
+		await waitForPort(proxyPort);
+	});
 
-  after(async () => {
-    nextResponse = null;
-    await killAndWait(proxyChild);
-    await new Promise(r => mockUpstream.close(r));
-  });
+	after(async () => {
+		nextResponse = null;
+		await killAndWait(proxyChild);
+		await new Promise((r) => mockUpstream.close(r));
+	});
 
-  it('E2: upstream 500 → passthrough to client', async () => {
-    nextResponse = {
-      status: 500,
-      body: { type: 'error', error: { type: 'api_error', message: 'Internal server error' } },
-    };
+	it("E2: upstream 500 → passthrough to client", async () => {
+		nextResponse = {
+			status: 500,
+			body: {
+				type: "error",
+				error: { type: "api_error", message: "Internal server error" },
+			},
+		};
 
-    const response = await sendProxyRequest(proxyPort, JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 100,
-      messages: [{ role: 'user', content: 'test 500' }],
-    }));
+		const response = await sendProxyRequest(
+			proxyPort,
+			JSON.stringify({
+				model: "claude-sonnet-4-20250514",
+				max_tokens: 100,
+				messages: [{ role: "user", content: "test 500" }],
+			}),
+		);
 
-    assert.equal(response.status, 500);
-    const body = JSON.parse(response.body);
-    assert.equal(body.type, 'error');
-    nextResponse = null;
-  });
+		assert.equal(response.status, 500);
+		const body = JSON.parse(response.body);
+		assert.equal(body.type, "error");
+		nextResponse = null;
+	});
 
-  it('E2: upstream 429 rate limit → passthrough to client', async () => {
-    nextResponse = {
-      status: 429,
-      headers: {
-        'Content-Type': 'application/json',
-        'retry-after': '30',
-      },
-      body: { type: 'error', error: { type: 'rate_limit_error', message: 'Rate limited' } },
-    };
+	it("E2: upstream 429 rate limit → passthrough to client", async () => {
+		nextResponse = {
+			status: 429,
+			headers: {
+				"Content-Type": "application/json",
+				"retry-after": "30",
+			},
+			body: {
+				type: "error",
+				error: { type: "rate_limit_error", message: "Rate limited" },
+			},
+		};
 
-    const response = await sendProxyRequest(proxyPort, JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 100,
-      messages: [{ role: 'user', content: 'test 429' }],
-    }));
+		const response = await sendProxyRequest(
+			proxyPort,
+			JSON.stringify({
+				model: "claude-sonnet-4-20250514",
+				max_tokens: 100,
+				messages: [{ role: "user", content: "test 429" }],
+			}),
+		);
 
-    assert.equal(response.status, 429);
-    const body = JSON.parse(response.body);
-    assert.equal(body.error.type, 'rate_limit_error');
-    nextResponse = null;
-  });
+		assert.equal(response.status, 429);
+		const body = JSON.parse(response.body);
+		assert.equal(body.error.type, "rate_limit_error");
+		nextResponse = null;
+	});
 
-  it('E3: SSE stream aborted mid-response → client gets partial data', async () => {
-    nextResponse = {
-      status: 200,
-      headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
-      sse: [
-        'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_partial","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","usage":{"input_tokens":10,"output_tokens":0}}}\n\n',
-        'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
-        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial "}}\n\n',
-      ],
-      destroyAfter: true, // destroy connection after sending partial events
-    };
+	it("E3: SSE stream aborted mid-response → client gets partial data", async () => {
+		nextResponse = {
+			status: 200,
+			headers: {
+				"Content-Type": "text/event-stream",
+				"Cache-Control": "no-cache",
+			},
+			sse: [
+				'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_partial","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","usage":{"input_tokens":10,"output_tokens":0}}}\n\n',
+				'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+				'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial "}}\n\n',
+			],
+			destroyAfter: true, // destroy connection after sending partial events
+		};
 
-    const response = await sendProxyRequest(proxyPort, JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 100,
-      stream: true,
-      messages: [{ role: 'user', content: 'test abort' }],
-    }));
+		const response = await sendProxyRequest(
+			proxyPort,
+			JSON.stringify({
+				model: "claude-sonnet-4-20250514",
+				max_tokens: 100,
+				stream: true,
+				messages: [{ role: "user", content: "test abort" }],
+			}),
+		);
 
-    // Client should receive partial SSE data (whatever was forwarded before disconnect)
-    assert.ok(response.body.includes('message_start'), 'Should have received message_start');
-    assert.ok(response.body.includes('partial '), 'Should have received partial text');
-    // No message_stop — stream was cut
-    nextResponse = null;
-  });
+		// Client should receive partial SSE data (whatever was forwarded before disconnect)
+		assert.ok(
+			response.body.includes("message_start"),
+			"Should have received message_start",
+		);
+		assert.ok(
+			response.body.includes("partial "),
+			"Should have received partial text",
+		);
+		// No message_stop — stream was cut
+		nextResponse = null;
+	});
 
-  it('E3: proxy survives SSE abort (not crashed)', async () => {
-    nextResponse = null;
-    await new Promise(r => setTimeout(r, 200));
-    const health = await httpGet(proxyPort, '/_api/health');
-    assert.deepEqual(health, { ok: true });
-  });
+	it("E3: proxy survives SSE abort (not crashed)", async () => {
+		nextResponse = null;
+		await new Promise((r) => setTimeout(r, 200));
+		const health = await httpGet(proxyPort, "/_api/health");
+		assert.deepEqual(health, { ok: true });
+	});
 
-  it('E3b: upstream socket destroyed mid-SSE → proxy handles ECONNRESET', async () => {
-    nextResponse = {
-      status: 200,
-      headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
-      sse: [
-        'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_reset","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","usage":{"input_tokens":10,"output_tokens":0}}}\n\n',
-        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"before reset"}}\n\n',
-      ],
-      socketDestroy: true,
-    };
+	it("E3b: upstream socket destroyed mid-SSE → proxy handles ECONNRESET", async () => {
+		nextResponse = {
+			status: 200,
+			headers: {
+				"Content-Type": "text/event-stream",
+				"Cache-Control": "no-cache",
+			},
+			sse: [
+				'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_reset","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","usage":{"input_tokens":10,"output_tokens":0}}}\n\n',
+				'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"before reset"}}\n\n',
+			],
+			socketDestroy: true,
+		};
 
-    const response = await sendProxyRequest(proxyPort, JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 100,
-      stream: true,
-      messages: [{ role: 'user', content: 'test reset' }],
-    }));
+		const response = await sendProxyRequest(
+			proxyPort,
+			JSON.stringify({
+				model: "claude-sonnet-4-20250514",
+				max_tokens: 100,
+				stream: true,
+				messages: [{ role: "user", content: "test reset" }],
+			}),
+		);
 
-    // Client response should have ended (not hung)
-    assert.ok(response.status >= 200, 'Should receive a response, not hang');
-    nextResponse = null;
-  });
+		// Client response should have ended (not hung)
+		assert.ok(response.status >= 200, "Should receive a response, not hang");
+		nextResponse = null;
+	});
 
-  it('E3b: proxy survives socket destroy', async () => {
-    await new Promise(r => setTimeout(r, 300));
-    const health = await httpGet(proxyPort, '/_api/health');
-    assert.deepEqual(health, { ok: true });
-  });
+	it("E3b: proxy survives socket destroy", async () => {
+		await new Promise((r) => setTimeout(r, 300));
+		const health = await httpGet(proxyPort, "/_api/health");
+		assert.deepEqual(health, { ok: true });
+	});
 });
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
 // ── State consistency after errors ──────────────────────────────────
 
-describe('Store state consistency after errors', () => {
-  let mockUpstream;
-  let mockPort;
-  let proxyChild;
-  let proxyPort;
-  let nextResponse = null;
-  const SESSION_ID = 'bbbbcccc-dddd-eeee-ffff-000000000000';
+describe("Store state consistency after errors", () => {
+	let mockUpstream;
+	let mockPort;
+	let proxyChild;
+	let proxyPort;
+	let nextResponse = null;
+	const SESSION_ID = "bbbbcccc-dddd-eeee-ffff-000000000000";
 
-  function makeBody(content) {
-    return JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 100,
-      messages: [{ role: 'user', content }],
-      metadata: { user_id: JSON.stringify({ session_id: SESSION_ID }) },
-    });
-  }
+	function makeBody(content) {
+		return JSON.stringify({
+			model: "claude-sonnet-4-20250514",
+			max_tokens: 100,
+			messages: [{ role: "user", content }],
+			metadata: { user_id: JSON.stringify({ session_id: SESSION_ID }) },
+		});
+	}
 
-  before(async () => {
-    mockUpstream = http.createServer((req, res) => {
-      let body = '';
-      req.on('data', c => { body += c; });
-      req.on('end', () => {
-        if (nextResponse) {
-          const { status, headers, body: resBody } = nextResponse;
-          res.writeHead(status, headers || { 'Content-Type': 'application/json' });
-          res.end(typeof resBody === 'string' ? resBody : JSON.stringify(resBody));
-        } else {
-          res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({
-            id: 'msg_ok', type: 'message', role: 'assistant',
-            content: [{ type: 'text', text: 'ok' }],
-            model: 'claude-sonnet-4-20250514',
-            usage: { input_tokens: 10, output_tokens: 5 },
-          }));
-        }
-      });
-    });
-    await new Promise(r => mockUpstream.listen(0, r));
-    mockPort = mockUpstream.address().port;
+	before(async () => {
+		mockUpstream = http.createServer((req, res) => {
+			let body = "";
+			req.on("data", (c) => {
+				body += c;
+			});
+			req.on("end", () => {
+				if (nextResponse) {
+					const { status, headers, body: resBody } = nextResponse;
+					res.writeHead(
+						status,
+						headers || { "Content-Type": "application/json" },
+					);
+					res.end(
+						typeof resBody === "string" ? resBody : JSON.stringify(resBody),
+					);
+				} else {
+					res.writeHead(200, { "Content-Type": "application/json" });
+					res.end(
+						JSON.stringify({
+							id: "msg_ok",
+							type: "message",
+							role: "assistant",
+							content: [{ type: "text", text: "ok" }],
+							model: "claude-sonnet-4-20250514",
+							usage: { input_tokens: 10, output_tokens: 5 },
+						}),
+					);
+				}
+			});
+		});
+		await new Promise((r) => mockUpstream.listen(0, r));
+		mockPort = mockUpstream.address().port;
 
-    proxyPort = await findFreePort();
-    proxyChild = spawnServer(['--port', String(proxyPort)], {
-      env: {
-        ANTHROPIC_TEST_HOST: 'localhost',
-        ANTHROPIC_TEST_PORT: String(mockPort),
-        ANTHROPIC_TEST_PROTOCOL: 'http',
-      },
-    });
-    await waitForPort(proxyPort);
+		proxyPort = await findFreePort();
+		proxyChild = spawnServer(["--port", String(proxyPort)], {
+			env: {
+				ANTHROPIC_TEST_HOST: "localhost",
+				ANTHROPIC_TEST_PORT: String(mockPort),
+				ANTHROPIC_TEST_PROTOCOL: "http",
+			},
+		});
+		await waitForPort(proxyPort);
 
-    // Establish session
-    await sendProxyRequest(proxyPort, makeBody('init'));
-    await new Promise(r => setTimeout(r, 200));
-  });
+		// Establish session
+		await sendProxyRequest(proxyPort, makeBody("init"));
+		await new Promise((r) => setTimeout(r, 200));
+	});
 
-  after(async () => {
-    nextResponse = null;
-    await killAndWait(proxyChild);
-    await new Promise(r => mockUpstream.close(r));
-  });
+	after(async () => {
+		nextResponse = null;
+		await killAndWait(proxyChild);
+		await new Promise((r) => mockUpstream.close(r));
+	});
 
-  it('session becomes inactive after upstream 500', async () => {
-    nextResponse = { status: 500, body: { type: 'error', error: { message: 'fail' } } };
-    await sendProxyRequest(proxyPort, makeBody('trigger 500'));
-    nextResponse = null;
+	it("session becomes inactive after upstream 500", async () => {
+		nextResponse = {
+			status: 500,
+			body: { type: "error", error: { message: "fail" } },
+		};
+		await sendProxyRequest(proxyPort, makeBody("trigger 500"));
+		nextResponse = null;
 
-    // Check session status via SSE — should be inactive
-    await new Promise(r => setTimeout(r, 200));
-    const sseData = await collectSSESnapshot(proxyPort);
-    const sessionStatus = sseData.find(d => d._type === 'session_status' && d.sessionId === SESSION_ID);
-    assert.ok(sessionStatus, 'Should have session_status event');
-    assert.equal(sessionStatus.active, false, 'Session should be inactive after error');
-  });
+		// Check session status via SSE — should be inactive
+		await new Promise((r) => setTimeout(r, 200));
+		const sseData = await collectSSESnapshot(proxyPort);
+		const sessionStatus = sseData.find(
+			(d) => d._type === "session_status" && d.sessionId === SESSION_ID,
+		);
+		assert.ok(sessionStatus, "Should have session_status event");
+		assert.equal(
+			sessionStatus.active,
+			false,
+			"Session should be inactive after error",
+		);
+	});
 
-  it('subsequent request succeeds after previous error', async () => {
-    nextResponse = null; // back to normal
-    const response = await sendProxyRequest(proxyPort, makeBody('after error'));
-    assert.equal(response.status, 200);
-    const body = JSON.parse(response.body);
-    assert.equal(body.content[0].text, 'ok');
-  });
+	it("subsequent request succeeds after previous error", async () => {
+		nextResponse = null; // back to normal
+		const response = await sendProxyRequest(proxyPort, makeBody("after error"));
+		assert.equal(response.status, 200);
+		const body = JSON.parse(response.body);
+		assert.equal(body.content[0].text, "ok");
+	});
 
-  it('entries count is consistent after mixed success/error', async () => {
-    const entries = await httpGet(proxyPort, '/_api/entries');
-    // Should have entries from: init, trigger 500, after error (at least 3)
-    assert.ok(entries.length >= 3, `Expected >= 3 entries, got ${entries.length}`);
-  });
+	it("entries count is consistent after mixed success/error", async () => {
+		const entries = await httpGet(proxyPort, "/_api/entries");
+		// Should have entries from: init, trigger 500, after error (at least 3)
+		assert.ok(
+			entries.length >= 3,
+			`Expected >= 3 entries, got ${entries.length}`,
+		);
+	});
 });
 
 // ── Concurrent requests ─────────────────────────────────────────────
 
-describe('Concurrent proxy requests', () => {
-  let mockUpstream;
-  let mockPort;
-  let proxyChild;
-  let proxyPort;
-  let requestLog = [];
+describe("Concurrent proxy requests", () => {
+	let mockUpstream;
+	let mockPort;
+	let proxyChild;
+	let proxyPort;
+	let requestLog = [];
 
-  before(async () => {
-    // Mock upstream: echo user message back. SSE mode when stream:true.
-    mockUpstream = http.createServer((req, res) => {
-      let body = '';
-      req.on('data', c => { body += c; });
-      req.on('end', () => {
-        const parsed = JSON.parse(body);
-        const userMsg = parsed.messages?.[0]?.content || 'unknown';
-        const delay = Math.floor(Math.random() * 50) + 10;
-        setTimeout(() => {
-          requestLog.push(userMsg);
-          if (parsed.stream) {
-            res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' });
-            res.write(`event: message_start\ndata: ${JSON.stringify({ type: 'message_start', message: { id: `msg_${userMsg}`, type: 'message', role: 'assistant', content: [], model: 'claude-sonnet-4-20250514', usage: { input_tokens: 10, output_tokens: 0 } } })}\n\n`);
-            res.write(`event: content_block_start\ndata: ${JSON.stringify({ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } })}\n\n`);
-            res.write(`event: content_block_delta\ndata: ${JSON.stringify({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: `echo:${userMsg}` } })}\n\n`);
-            res.write(`event: content_block_stop\ndata: ${JSON.stringify({ type: 'content_block_stop', index: 0 })}\n\n`);
-            res.write(`event: message_delta\ndata: ${JSON.stringify({ type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 5 } })}\n\n`);
-            res.write(`event: message_stop\ndata: ${JSON.stringify({ type: 'message_stop' })}\n\n`);
-            res.end();
-          } else {
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({
-              id: `msg_${userMsg}`, type: 'message', role: 'assistant',
-              content: [{ type: 'text', text: `echo:${userMsg}` }],
-              model: 'claude-sonnet-4-20250514',
-              usage: { input_tokens: 10, output_tokens: 5 },
-            }));
-          }
-        }, delay);
-      });
-    });
-    await new Promise(r => mockUpstream.listen(0, r));
-    mockPort = mockUpstream.address().port;
+	before(async () => {
+		// Mock upstream: echo user message back. SSE mode when stream:true.
+		mockUpstream = http.createServer((req, res) => {
+			let body = "";
+			req.on("data", (c) => {
+				body += c;
+			});
+			req.on("end", () => {
+				const parsed = JSON.parse(body);
+				const userMsg = parsed.messages?.[0]?.content || "unknown";
+				const delay = Math.floor(Math.random() * 50) + 10;
+				setTimeout(() => {
+					requestLog.push(userMsg);
+					if (parsed.stream) {
+						res.writeHead(200, {
+							"Content-Type": "text/event-stream",
+							"Cache-Control": "no-cache",
+						});
+						res.write(
+							`event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: `msg_${userMsg}`, type: "message", role: "assistant", content: [], model: "claude-sonnet-4-20250514", usage: { input_tokens: 10, output_tokens: 0 } } })}\n\n`,
+						);
+						res.write(
+							`event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n`,
+						);
+						res.write(
+							`event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: `echo:${userMsg}` } })}\n\n`,
+						);
+						res.write(
+							`event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+						);
+						res.write(
+							`event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } })}\n\n`,
+						);
+						res.write(
+							`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+						);
+						res.end();
+					} else {
+						res.writeHead(200, { "Content-Type": "application/json" });
+						res.end(
+							JSON.stringify({
+								id: `msg_${userMsg}`,
+								type: "message",
+								role: "assistant",
+								content: [{ type: "text", text: `echo:${userMsg}` }],
+								model: "claude-sonnet-4-20250514",
+								usage: { input_tokens: 10, output_tokens: 5 },
+							}),
+						);
+					}
+				}, delay);
+			});
+		});
+		await new Promise((r) => mockUpstream.listen(0, r));
+		mockPort = mockUpstream.address().port;
 
-    proxyPort = await findFreePort();
-    proxyChild = spawnServer(['--port', String(proxyPort)], {
-      env: {
-        ANTHROPIC_TEST_HOST: 'localhost',
-        ANTHROPIC_TEST_PORT: String(mockPort),
-        ANTHROPIC_TEST_PROTOCOL: 'http',
-      },
-    });
-    await waitForPort(proxyPort);
-  });
+		proxyPort = await findFreePort();
+		proxyChild = spawnServer(["--port", String(proxyPort)], {
+			env: {
+				ANTHROPIC_TEST_HOST: "localhost",
+				ANTHROPIC_TEST_PORT: String(mockPort),
+				ANTHROPIC_TEST_PROTOCOL: "http",
+			},
+		});
+		await waitForPort(proxyPort);
+	});
 
-  after(async () => {
-    await killAndWait(proxyChild);
-    await new Promise(r => mockUpstream.close(r));
-  });
+	after(async () => {
+		await killAndWait(proxyChild);
+		await new Promise((r) => mockUpstream.close(r));
+	});
 
-  it('5 concurrent requests each get correct response', async () => {
-    const ids = ['alpha', 'beta', 'gamma', 'delta', 'epsilon'];
+	it("5 concurrent requests each get correct response", async () => {
+		const ids = ["alpha", "beta", "gamma", "delta", "epsilon"];
 
-    const responses = await Promise.all(ids.map(id =>
-      sendProxyRequest(proxyPort, JSON.stringify({
-        model: 'claude-sonnet-4-20250514',
-        max_tokens: 100,
-        messages: [{ role: 'user', content: id }],
-      }))
-    ));
+		const responses = await Promise.all(
+			ids.map((id) =>
+				sendProxyRequest(
+					proxyPort,
+					JSON.stringify({
+						model: "claude-sonnet-4-20250514",
+						max_tokens: 100,
+						messages: [{ role: "user", content: id }],
+					}),
+				),
+			),
+		);
 
-    // Each response should echo back its own request ID
-    for (let i = 0; i < ids.length; i++) {
-      assert.equal(responses[i].status, 200, `Request ${ids[i]} should succeed`);
-      const body = JSON.parse(responses[i].body);
-      assert.equal(body.content[0].text, `echo:${ids[i]}`, `Response for ${ids[i]} should match`);
-    }
-  });
+		// Each response should echo back its own request ID
+		for (let i = 0; i < ids.length; i++) {
+			assert.equal(
+				responses[i].status,
+				200,
+				`Request ${ids[i]} should succeed`,
+			);
+			const body = JSON.parse(responses[i].body);
+			assert.equal(
+				body.content[0].text,
+				`echo:${ids[i]}`,
+				`Response for ${ids[i]} should match`,
+			);
+		}
+	});
 
-  it('3 concurrent SSE streaming requests each get correct events', async () => {
-    const ids = ['stream-a', 'stream-b', 'stream-c'];
+	it("3 concurrent SSE streaming requests each get correct events", async () => {
+		const ids = ["stream-a", "stream-b", "stream-c"];
 
-    const responses = await Promise.all(ids.map(id =>
-      sendProxyRequest(proxyPort, JSON.stringify({
-        model: 'claude-sonnet-4-20250514',
-        max_tokens: 100,
-        stream: true,
-        messages: [{ role: 'user', content: id }],
-      }))
-    ));
+		const responses = await Promise.all(
+			ids.map((id) =>
+				sendProxyRequest(
+					proxyPort,
+					JSON.stringify({
+						model: "claude-sonnet-4-20250514",
+						max_tokens: 100,
+						stream: true,
+						messages: [{ role: "user", content: id }],
+					}),
+				),
+			),
+		);
 
-    for (let i = 0; i < ids.length; i++) {
-      assert.equal(responses[i].status, 200, `SSE request ${ids[i]} should succeed`);
-      assert.ok(responses[i].body.includes(`echo:${ids[i]}`), `SSE response for ${ids[i]} should contain its echo`);
-    }
-  });
+		for (let i = 0; i < ids.length; i++) {
+			assert.equal(
+				responses[i].status,
+				200,
+				`SSE request ${ids[i]} should succeed`,
+			);
+			assert.ok(
+				responses[i].body.includes(`echo:${ids[i]}`),
+				`SSE response for ${ids[i]} should contain its echo`,
+			);
+		}
+	});
 
-  it('all concurrent requests are logged separately', async () => {
-    await new Promise(r => setTimeout(r, 500));
-    const logsDir = path.join(TEST_HOME, 'logs');
-    const files = fs.existsSync(logsDir) ? fs.readdirSync(logsDir) : [];
-    const reqFiles = files.filter(f => f.endsWith('_req.json'));
-    // Should have at least 5 req files from concurrent test
-    assert.ok(reqFiles.length >= 5, `Expected >= 5 req logs, got ${reqFiles.length}`);
-  });
+	it("all concurrent requests are logged separately", async () => {
+		await new Promise((r) => setTimeout(r, 500));
+		const logsDir = path.join(TEST_HOME, "logs");
+		const files = fs.existsSync(logsDir) ? fs.readdirSync(logsDir) : [];
+		const reqFiles = files.filter((f) => f.endsWith("_req.json"));
+		// Should have at least 5 req files from concurrent test
+		assert.ok(
+			reqFiles.length >= 5,
+			`Expected >= 5 req logs, got ${reqFiles.length}`,
+		);
+	});
 
-  it('upstream received all 8 requests (5 non-streaming + 3 streaming)', () => {
-    assert.equal(requestLog.length, 8, 'Mock upstream should have received 8 requests');
-    const sorted = [...requestLog].sort();
-    assert.deepEqual(sorted, ['alpha', 'beta', 'delta', 'epsilon', 'gamma', 'stream-a', 'stream-b', 'stream-c']);
-  });
+	it("upstream received all 8 requests (5 non-streaming + 3 streaming)", () => {
+		assert.equal(
+			requestLog.length,
+			8,
+			"Mock upstream should have received 8 requests",
+		);
+		const sorted = [...requestLog].sort();
+		assert.deepEqual(sorted, [
+			"alpha",
+			"beta",
+			"delta",
+			"epsilon",
+			"gamma",
+			"stream-a",
+			"stream-b",
+			"stream-c",
+		]);
+	});
 });
 
 // ── Hub crash recovery race condition ────────────────────────────────
 
-describe('Hub recovery race: two simultaneous forks', () => {
-  let port;
+describe("Hub recovery race: two simultaneous forks", () => {
+	let port;
 
-  after(() => {
-    // Kill any hub on port
-    try {
-      const lockPath = path.join(TEST_HOME, 'hub.json');
-      if (fs.existsSync(lockPath)) {
-        const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
-        try { process.kill(lock.pid, 'SIGKILL'); } catch {}
-        fs.unlinkSync(lockPath);
-      }
-    } catch {}
-  });
+	after(() => {
+		// Kill any hub on port
+		try {
+			const lockPath = path.join(TEST_HOME, "hub.json");
+			if (fs.existsSync(lockPath)) {
+				const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+				try {
+					process.kill(lock.pid, "SIGKILL");
+				} catch {}
+				fs.unlinkSync(lockPath);
+			}
+		} catch {}
+	});
 
-  it('two concurrent forkHub calls → only one hub survives', async () => {
-    port = await findFreePort();
+	it("two concurrent forkHub calls → only one hub survives", async () => {
+		port = await findFreePort();
 
-    // Fork two hubs simultaneously on the same port
-    const child1 = spawnServer(['--port', String(port), '--hub-mode']);
-    const child2 = spawnServer(['--port', String(port), '--hub-mode']);
+		// Fork two hubs simultaneously on the same port
+		const child1 = spawnServer(["--port", String(port), "--hub-mode"]);
+		const child2 = spawnServer(["--port", String(port), "--hub-mode"]);
 
-    // Wait for one to succeed (write lockfile)
-    await waitForPort(port);
+		// Wait for one to succeed (write lockfile)
+		await waitForPort(port);
 
-    // Only one hub should be listening
-    const health = await httpGet(port, '/_api/health');
-    assert.deepEqual(health, { ok: true });
+		// Only one hub should be listening
+		const health = await httpGet(port, "/_api/health");
+		assert.deepEqual(health, { ok: true });
 
-    // Lockfile should exist with correct port
-    const lockPath = path.join(TEST_HOME, 'hub.json');
-    assert.ok(fs.existsSync(lockPath));
-    const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
-    assert.equal(lock.port, port);
+		// Lockfile should exist with correct port
+		const lockPath = path.join(TEST_HOME, "hub.json");
+		assert.ok(fs.existsSync(lockPath));
+		const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+		assert.equal(lock.port, port);
 
-    // Clean up both children
-    await killAndWait(child1);
-    await killAndWait(child2);
+		// Clean up both children
+		await killAndWait(child1);
+		await killAndWait(child2);
 
-    // Wait for port release
-    await new Promise(resolve => {
-      const check = () => {
-        const srv = net.createServer();
-        srv.once('error', () => setTimeout(check, 200));
-        srv.once('listening', () => srv.close(() => resolve()));
-        srv.listen(port);
-      };
-      check();
-    });
-  });
+		// Wait for port release
+		await new Promise((resolve) => {
+			const check = () => {
+				const srv = net.createServer();
+				srv.once("error", () => setTimeout(check, 200));
+				srv.once("listening", () => srv.close(() => resolve()));
+				srv.listen(port);
+			};
+			check();
+		});
+	});
 });
 
 function collectSSESnapshot(port, timeoutMs = 2000) {
-  return new Promise(resolve => {
-    const events = [];
-    const req = http.get(`http://localhost:${port}/_events`, res => {
-      let buf = '';
-      const timer = setTimeout(() => { req.destroy(); resolve(events); }, timeoutMs);
-      res.on('data', chunk => {
-        buf += chunk.toString();
-        const lines = buf.split('\n');
-        buf = lines.pop();
-        for (const line of lines) {
-          if (!line.startsWith('data: ')) continue;
-          try { events.push(JSON.parse(line.slice(6))); } catch {}
-        }
-      });
-      res.on('end', () => { clearTimeout(timer); resolve(events); });
-    });
-    req.on('error', () => resolve(events));
-  });
+	return new Promise((resolve) => {
+		const events = [];
+		const req = http.get(`http://localhost:${port}/_events`, (res) => {
+			let buf = "";
+			const timer = setTimeout(() => {
+				req.destroy();
+				resolve(events);
+			}, timeoutMs);
+			res.on("data", (chunk) => {
+				buf += chunk.toString();
+				const lines = buf.split("\n");
+				buf = lines.pop();
+				for (const line of lines) {
+					if (!line.startsWith("data: ")) continue;
+					try {
+						events.push(JSON.parse(line.slice(6)));
+					} catch {}
+				}
+			});
+			res.on("end", () => {
+				clearTimeout(timer);
+				resolve(events);
+			});
+		});
+		req.on("error", () => resolve(events));
+	});
 }
 
 function waitForSSEEvent(port, eventType, timeoutMs = 5000) {
-  return new Promise((resolve, reject) => {
-    const req = http.get(`http://localhost:${port}/_events`, res => {
-      let buf = '';
-      const timer = setTimeout(() => { req.destroy(); reject(new Error(`SSE timeout waiting for ${eventType}`)); }, timeoutMs);
-      res.on('data', chunk => {
-        buf += chunk.toString();
-        const lines = buf.split('\n');
-        for (const line of lines) {
-          if (!line.startsWith('data: ')) continue;
-          try {
-            const data = JSON.parse(line.slice(6));
-            if (data._type === eventType) {
-              clearTimeout(timer);
-              req.destroy();
-              resolve(data.requestId || data.id || null);
-              return;
-            }
-          } catch {}
-        }
-      });
-    });
-    req.on('error', () => {}); // ignore destroy errors
-  });
+	return new Promise((resolve, reject) => {
+		const req = http.get(`http://localhost:${port}/_events`, (res) => {
+			let buf = "";
+			const timer = setTimeout(() => {
+				req.destroy();
+				reject(new Error(`SSE timeout waiting for ${eventType}`));
+			}, timeoutMs);
+			res.on("data", (chunk) => {
+				buf += chunk.toString();
+				const lines = buf.split("\n");
+				for (const line of lines) {
+					if (!line.startsWith("data: ")) continue;
+					try {
+						const data = JSON.parse(line.slice(6));
+						if (data._type === eventType) {
+							clearTimeout(timer);
+							req.destroy();
+							resolve(data.requestId || data.id || null);
+							return;
+						}
+					} catch {}
+				}
+			});
+		});
+		req.on("error", () => {}); // ignore destroy errors
+	});
 }
 
 function sendProxyRequest(port, body) {
-  return new Promise((resolve, reject) => {
-    const req = http.request(`http://localhost:${port}/v1/messages`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body), 'x-api-key': 'k', 'anthropic-version': '2023-06-01' },
-    }, res => {
-      let data = '';
-      res.on('data', c => { data += c; });
-      res.on('end', () => resolve({ status: res.statusCode, body: data }));
-    });
-    req.on('error', reject);
-    req.end(body);
-  });
+	return new Promise((resolve, reject) => {
+		const req = http.request(
+			`http://localhost:${port}/v1/messages`,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"Content-Length": Buffer.byteLength(body),
+					"x-api-key": "k",
+					"anthropic-version": "2023-06-01",
+				},
+			},
+			(res) => {
+				let data = "";
+				res.on("data", (c) => {
+					data += c;
+				});
+				res.on("end", () => resolve({ status: res.statusCode, body: data }));
+			},
+		);
+		req.on("error", reject);
+		req.end(body);
+	});
 }
 
 function httpGet(port, urlPath) {
-  return new Promise((resolve, reject) => {
-    http.get(`http://localhost:${port}${urlPath}`, res => {
-      let data = '';
-      res.on('data', c => { data += c; });
-      res.on('end', () => {
-        try { resolve(JSON.parse(data)); }
-        catch { reject(new Error(`Bad JSON: ${data}`)); }
-      });
-    }).on('error', reject);
-  });
+	return new Promise((resolve, reject) => {
+		http
+			.get(`http://localhost:${port}${urlPath}`, (res) => {
+				let data = "";
+				res.on("data", (c) => {
+					data += c;
+				});
+				res.on("end", () => {
+					try {
+						resolve(JSON.parse(data));
+					} catch {
+						reject(new Error(`Bad JSON: ${data}`));
+					}
+				});
+			})
+			.on("error", reject);
+	});
 }
 
 function httpGetRaw(port, urlPath) {
-  return new Promise((resolve, reject) => {
-    http.get(`http://localhost:${port}${urlPath}`, res => {
-      let data = '';
-      res.on('data', c => { data += c; });
-      res.on('end', () => resolve(data));
-    }).on('error', reject);
-  });
+	return new Promise((resolve, reject) => {
+		http
+			.get(`http://localhost:${port}${urlPath}`, (res) => {
+				let data = "";
+				res.on("data", (c) => {
+					data += c;
+				});
+				res.on("end", () => resolve(data));
+			})
+			.on("error", reject);
+	});
 }
 
 function httpPost(port, urlPath, body) {
-  return new Promise((resolve, reject) => {
-    const json = JSON.stringify(body);
-    const req = http.request(`http://localhost:${port}${urlPath}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(json) },
-    }, res => {
-      let data = '';
-      res.on('data', c => { data += c; });
-      res.on('end', () => {
-        try { resolve(JSON.parse(data)); }
-        catch { reject(new Error(`Bad JSON: ${data}`)); }
-      });
-    });
-    req.on('error', reject);
-    req.end(json);
-  });
+	return new Promise((resolve, reject) => {
+		const json = JSON.stringify(body);
+		const req = http.request(
+			`http://localhost:${port}${urlPath}`,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"Content-Length": Buffer.byteLength(json),
+				},
+			},
+			(res) => {
+				let data = "";
+				res.on("data", (c) => {
+					data += c;
+				});
+				res.on("end", () => {
+					try {
+						resolve(JSON.parse(data));
+					} catch {
+						reject(new Error(`Bad JSON: ${data}`));
+					}
+				});
+			},
+		);
+		req.on("error", reject);
+		req.end(json);
+	});
 }
 
 function spawnAndCollect(args, timeoutMs = 10000, envOverrides = {}) {
-  return new Promise(resolve => {
-    const child = spawnServer(args, { env: envOverrides });
-    let done = false;
-    const finish = (code) => {
-      if (done) return;
-      done = true;
-      const { stdout, stderr } = child.getOutput();
-      resolve({ stdout, stderr, code });
-    };
-    child.on('exit', (code) => finish(code));
-    setTimeout(() => {
-      try { child.kill('SIGTERM'); } catch {}
-      finish(null);
-    }, timeoutMs);
-  });
+	return new Promise((resolve) => {
+		const child = spawnServer(args, { env: envOverrides });
+		let done = false;
+		const finish = (code) => {
+			if (done) return;
+			done = true;
+			const { stdout, stderr } = child.getOutput();
+			resolve({ stdout, stderr, code });
+		};
+		child.on("exit", (code) => finish(code));
+		setTimeout(() => {
+			try {
+				child.kill("SIGTERM");
+			} catch {}
+			finish(null);
+		}, timeoutMs);
+	});
 }

--- a/test/storage-path-traversal.test.js
+++ b/test/storage-path-traversal.test.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { createLocalStorage, safeJoin } = require("../server/storage/local");
+
+describe("storage path traversal guard", () => {
+	const tmpDir = path.join(os.tmpdir(), "ccxray-pt-" + Date.now());
+	let storage;
+
+	before(async () => {
+		storage = createLocalStorage(tmpDir);
+		await storage.init();
+	});
+
+	after(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("rejects id containing ..", async () => {
+		await assert.rejects(() =>
+			storage.write("../../etc/passwd", "_req.json", "x"),
+		);
+	});
+
+	it("rejects id containing slash", async () => {
+		await assert.rejects(() => storage.write("foo/bar", "_req.json", "x"));
+	});
+
+	it("rejects id containing backslash", async () => {
+		await assert.rejects(() => storage.write("foo\\bar", "_req.json", "x"));
+	});
+
+	it("rejects id containing null byte", async () => {
+		await assert.rejects(() => storage.write("abc\x00", "_req.json", "x"));
+	});
+
+	it("accepts normal id", async () => {
+		await storage.write("normal-id-123", "_req.json", "ok");
+		const data = await storage.read("normal-id-123", "_req.json");
+		assert.equal(data, "ok");
+	});
+
+	it("safeJoin rejects absolute-like escape", () => {
+		assert.throws(() => safeJoin(tmpDir, "../escape", ""));
+	});
+
+	it("safeJoin accepts simple filename", () => {
+		const p = safeJoin(tmpDir, "file", "_req.json");
+		assert.ok(p.startsWith(tmpDir + path.sep));
+	});
+});


### PR DESCRIPTION
## Summary

Security hardening for network/shared deployment scenarios. Part 1 of 3 PRs from the audit in #7.

### Network surface reduction
- **Bind `127.0.0.1` by default** — previously `0.0.0.0`, exposing proxy + dashboard to the entire network. Add `HOST` env for opt-in LAN access.
- **Request body cap** — 50 MB default (`CCXRAY_MAX_BODY_MB`), returns 413 on exceed. Prevents OOM via large POST.
- **Per-IP SSE limit** — max 8 concurrent connections per IP (`CCXRAY_SSE_MAX_PER_IP`). Prevents connection exhaustion.
- **HTTP timeouts** — `headersTimeout=60s`, `requestTimeout=120s`, `keepAliveTimeout=5s`. Mitigates slowloris.
- **Log injection sanitize** — strip ANSI escapes and control chars from logged request URLs/methods.

### Filesystem hardening
- **File permissions** — log files `0o600`, directories `0o700`. Hub lockfile and log also `0o600`.
- **Path traversal guard** — `safeJoin()` rejects `../`, `/`, `\`, null bytes; verifies resolved path stays within base dir.

### Hub IPC isolation
- **Loopback-only** — `/_api/hub/*` restricted to `127.0.0.1` / `::1` / `::ffff:127.0.0.1`. Non-local requests get 403.
- **Input validation** — `pid` must be positive int ≤ 2²², `cwd` must be string ≤ 4096 chars, body capped at 1 KB.
- `/_api/health` remains open (pure liveness probe, no sensitive info).

### npm audit
- `npm audit fix` — bumps basic-ftp to resolve HIGH CRLF injection in `@aws-sdk` transitive dep.

## Breaking change

Server now binds `127.0.0.1` by default. Users accessing ccxray from other machines on the LAN need to set `HOST=0.0.0.0`.

## Test plan

- [x] 236 tests pass, 0 failures
- [x] New tests: `storage-path-traversal.test.js` (7 cases), `fs-mode.test.js` (4 cases), `hub-loopback.test.js` (12 cases)
- [ ] Manual: `npx ccxray claude` starts and proxies correctly
- [ ] Manual: dashboard loads, entries display, SSE streaming works
- [ ] `npm audit --audit-level=high` → 0 vulnerabilities

Ref: #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)