### PR TITLE
feat(ux): Miller column keyboard UX — cmd-bar + initial cascade + nav fixes

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -39,6 +39,7 @@ function switchTab(tab, forceDiff) {
 
   // Sync URL
   syncViewParam();
+  if (typeof renderCmdBar === 'function') renderCmdBar();
 }
 
 function syncViewParam() {

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -624,20 +624,10 @@ fetch('/_api/entries').then(r => r.json()).then(data => {
   if (_hasDeepLink) {
     applyDeepLink();
   } else if (sessionsMap.size) {
-    // Auto-select the first project (top of sorted list)
-    const firstProj = [...projectsMap.values()].sort((a, b) => {
-      const pa = pinnedProjects.has(a.name) ? 0 : 1;
-      const pb = pinnedProjects.has(b.name) ? 0 : 1;
-      if (pa !== pb) return pa - pb;
-      const sa = getStatusPriority(getProjectStatusClass(a));
-      const sb = getStatusPriority(getProjectStatusClass(b));
-      if (sa !== sb) return sa - sb;
-      return (b.lastId || '').localeCompare(a.lastId || '');
-    })[0];
-    selectProject(firstProj ? firstProj.name : null);
+    initAutoSelect();
   }
   applySessionFilter();
-  setFocus(_hasDeepLink ? focusedCol : 'projects');
+  setFocus(focusedCol);
   // Restore tab from URL param after deep-link resolution
   if (typeof restoreTabFromUrl === 'function') restoreTabFromUrl();
 });

--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,7 @@
       <div id="status-cluster">
         <span id="topbar-status"></span>
       </div>
+      <button id="hotkeys-btn" onclick="toggleKbdOverlay()" title="Keyboard shortcuts (?)">hotkeys</button>
       <button id="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark mode">☀️</button>
     </div>
     <div id="topbar-row2">
@@ -85,11 +86,39 @@
   </div>
   <div id="columns">
     <div id="col-projects" class="col"><div class="col-title">Projects</div></div>
-    <div id="col-sessions" class="col"><div class="col-title" style="display:flex;align-items:center;gap:6px">Sessions <select id="sess-filter-select" onchange="setSessionFilter(this.value)" style="background:var(--surface);color:var(--dim);border:1px solid var(--border);border-radius:3px;font-size:10px;padding:1px 4px;cursor:pointer"><option value="active">Active</option><option value="active+idle" selected>Active+Idle</option><option value="all">All</option></select></div></div>
-    <div id="col-turns" class="col"><div class="col-sticky-header"><div class="col-title" style="display:flex;align-items:center">Turns<span id="scroll-toggle" onclick="toggleFollowLive()" style="cursor:pointer;font-size:10px;margin-left:auto"><span class="scroll-on active">ON</span> <span class="scroll-off">OFF</span></span></div><div id="session-tool-bar" style="display:none"></div><div id="ctx-legend"><span><span class="ctx-legend-dot" style="background:var(--color-cache-read)"></span>cache read</span><span><span class="ctx-legend-dot" style="background:var(--color-cache-write)"></span>cache write</span><span><span class="ctx-legend-dot" style="background:var(--color-input)"></span>input</span></div><div id="session-sparkline"></div></div></div>
+    <div id="col-sessions" class="col"><div class="col-title" style="display:flex;align-items:center;gap:6px">Sessions <select id="sess-filter-select" onchange="setSessionFilter(this.value)" style="background:var(--surface);color:var(--dim);border:1px solid var(--border);border-radius:3px;font-size:10px;padding:1px 4px;cursor:pointer"><option value="active">Active</option><option value="active+idle" selected>Active+Idle</option><option value="all">All</option></select><span class="col-hint" id="hint-sessions">↑↓ · ← · →</span></div></div>
+    <div id="col-turns" class="col"><div class="col-sticky-header"><div class="col-title" style="display:flex;align-items:center">Turns<span id="scroll-toggle" onclick="toggleFollowLive()" style="cursor:pointer;font-size:10px;margin-left:auto"><span class="scroll-on active">ON</span> <span class="scroll-off">OFF</span></span><span class="col-hint" id="hint-turns">↑↓ · ← · →</span></div><div id="session-tool-bar" style="display:none"></div><div id="ctx-legend"><span><span class="ctx-legend-dot" style="background:var(--color-cache-read)"></span>cache read</span><span><span class="ctx-legend-dot" style="background:var(--color-cache-write)"></span>cache write</span><span><span class="ctx-legend-dot" style="background:var(--color-input)"></span>input</span></div><div id="session-sparkline"></div></div></div>
     <div id="col-sections" class="col"><div class="col-empty">←</div></div>
     <div id="col-detail" class="col"><div class="col-empty">←</div></div>
   </div>
+  <div id="kbd-overlay" style="display:none;position:fixed;inset:0;z-index:1000;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);align-items:center;justify-content:center" onclick="toggleKbdOverlay()">
+    <div style="background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:20px 28px;min-width:340px;max-width:480px" onclick="event.stopPropagation()">
+      <div style="font-size:11px;font-weight:700;color:var(--text);letter-spacing:0.06em;text-transform:uppercase;margin-bottom:14px">Keyboard Shortcuts</div>
+      <div style="font-size:10px;font-weight:600;color:var(--accent);letter-spacing:0.05em;text-transform:uppercase;margin-bottom:6px">Navigation</div>
+      <table style="width:100%;border-collapse:collapse;margin-bottom:12px;font-size:12px">
+        <tr><td style="color:var(--dim);padding:2px 0;width:110px"><kbd>↑ ↓</kbd></td><td style="color:var(--text)">select item</td></tr>
+        <tr><td style="color:var(--dim);padding:2px 0"><kbd>← →</kbd></td><td style="color:var(--text)">move between columns</td></tr>
+        <tr><td style="color:var(--dim);padding:2px 0"><kbd>Esc</kbd></td><td style="color:var(--text)">go left one column</td></tr>
+        <tr><td style="color:var(--dim);padding:2px 0"><kbd>1</kbd> <kbd>2</kbd> <kbd>3</kbd></td><td style="color:var(--text)">switch tab — Dashboard / Usage / System Prompt</td></tr>
+      </table>
+      <div style="font-size:10px;font-weight:600;color:var(--accent);letter-spacing:0.05em;text-transform:uppercase;margin-bottom:6px">Focused Mode</div>
+      <table style="width:100%;border-collapse:collapse;margin-bottom:12px;font-size:12px">
+        <tr><td style="color:var(--dim);padding:2px 0;width:110px"><kbd>Enter</kbd></td><td style="color:var(--text)">enter focused mode</td></tr>
+        <tr><td style="color:var(--dim);padding:2px 0"><kbd>Esc</kbd></td><td style="color:var(--text)">exit focused mode</td></tr>
+        <tr><td style="color:var(--dim);padding:2px 0"><kbd>↑ ↓</kbd></td><td style="color:var(--text)">switch section</td></tr>
+      </table>
+      <div style="font-size:10px;font-weight:600;color:var(--accent);letter-spacing:0.05em;text-transform:uppercase;margin-bottom:6px">Timeline</div>
+      <table style="width:100%;border-collapse:collapse;margin-bottom:4px;font-size:12px">
+        <tr><td style="color:var(--dim);padding:2px 0;width:110px"><kbd>/</kbd></td><td style="color:var(--text)">filter steps</td></tr>
+        <tr><td style="color:var(--dim);padding:2px 0"><kbd>e</kbd> <kbd>E</kbd></td><td style="color:var(--text)">jump to next / prev error step</td></tr>
+        <tr><td style="color:var(--dim);padding:2px 0"><kbd>t</kbd></td><td style="color:var(--text)">jump to thinking step</td></tr>
+        <tr><td style="color:var(--dim);padding:2px 0"><kbd>h</kbd></td><td style="color:var(--text)">jump to human message</td></tr>
+        <tr><td style="color:var(--dim);padding:2px 0"><kbd>]</kbd></td><td style="color:var(--text)">jump to text step</td></tr>
+      </table>
+      <div style="margin-top:12px;font-size:10px;color:var(--dim);text-align:right">press <kbd>?</kbd> or <kbd>Esc</kbd> to close</div>
+    </div>
+  </div>
+
   <div id="diff-overlay" class="fullscreen-page">
     <div class="fp-header">
       <button class="fp-back" onclick="spHandleBack()">←</button>

--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,6 @@
       <div id="status-cluster">
         <span id="topbar-status"></span>
       </div>
-      <button id="hotkeys-btn" onclick="toggleKbdOverlay()" title="Keyboard shortcuts (?)">hotkeys</button>
       <button id="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark mode">☀️</button>
     </div>
     <div id="topbar-row2">
@@ -86,12 +85,16 @@
   </div>
   <div id="columns">
     <div id="col-projects" class="col"><div class="col-title">Projects</div></div>
-    <div id="col-sessions" class="col"><div class="col-title" style="display:flex;align-items:center;gap:6px">Sessions <select id="sess-filter-select" onchange="setSessionFilter(this.value)" style="background:var(--surface);color:var(--dim);border:1px solid var(--border);border-radius:3px;font-size:10px;padding:1px 4px;cursor:pointer"><option value="active">Active</option><option value="active+idle" selected>Active+Idle</option><option value="all">All</option></select><span class="col-hint" id="hint-sessions">↑↓ · ← · →</span></div></div>
-    <div id="col-turns" class="col"><div class="col-sticky-header"><div class="col-title" style="display:flex;align-items:center">Turns<span id="scroll-toggle" onclick="toggleFollowLive()" style="cursor:pointer;font-size:10px;margin-left:auto"><span class="scroll-on active">ON</span> <span class="scroll-off">OFF</span></span><span class="col-hint" id="hint-turns">↑↓ · ← · →</span></div><div id="session-tool-bar" style="display:none"></div><div id="ctx-legend"><span><span class="ctx-legend-dot" style="background:var(--color-cache-read)"></span>cache read</span><span><span class="ctx-legend-dot" style="background:var(--color-cache-write)"></span>cache write</span><span><span class="ctx-legend-dot" style="background:var(--color-input)"></span>input</span></div><div id="session-sparkline"></div></div></div>
+    <div id="col-sessions" class="col"><div class="col-title" style="display:flex;align-items:center;gap:6px">Sessions <select id="sess-filter-select" onchange="setSessionFilter(this.value)" style="background:var(--surface);color:var(--dim);border:1px solid var(--border);border-radius:3px;font-size:10px;padding:1px 4px;cursor:pointer"><option value="active">Active</option><option value="active+idle" selected>Active+Idle</option><option value="all">All</option></select></div></div>
+    <div id="col-turns" class="col"><div class="col-sticky-header"><div class="col-title" style="display:flex;align-items:center">Turns<span id="scroll-toggle" onclick="toggleFollowLive()" style="cursor:pointer;font-size:10px;margin-left:auto"><span class="scroll-on active">ON</span> <span class="scroll-off">OFF</span></span></div><div id="session-tool-bar" style="display:none"></div><div id="ctx-legend"><span><span class="ctx-legend-dot" style="background:var(--color-cache-read)"></span>cache read</span><span><span class="ctx-legend-dot" style="background:var(--color-cache-write)"></span>cache write</span><span><span class="ctx-legend-dot" style="background:var(--color-input)"></span>input</span></div><div id="session-sparkline"></div></div></div>
     <div id="col-sections" class="col"><div class="col-empty">←</div></div>
     <div id="col-detail" class="col"><div class="col-empty">←</div></div>
   </div>
-  <div id="kbd-overlay" style="display:none;position:fixed;inset:0;z-index:1000;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);align-items:center;justify-content:center" onclick="toggleKbdOverlay()">
+  <div id="cmd-bar" class="hidden">
+    <div id="cmd-bar-row1"></div>
+    <div id="cmd-bar-row2"></div>
+  </div>
+  <div id="kbd-overlay" data-hides-cmdbar style="display:none;position:fixed;inset:0;z-index:1000;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);align-items:center;justify-content:center" onclick="toggleKbdOverlay()">
     <div style="background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:20px 28px;min-width:340px;max-width:480px" onclick="event.stopPropagation()">
       <div style="font-size:11px;font-weight:700;color:var(--text);letter-spacing:0.06em;text-transform:uppercase;margin-bottom:14px">Keyboard Shortcuts</div>
       <div style="font-size:10px;font-weight:600;color:var(--accent);letter-spacing:0.05em;text-transform:uppercase;margin-bottom:6px">Navigation</div>
@@ -119,7 +122,7 @@
     </div>
   </div>
 
-  <div id="diff-overlay" class="fullscreen-page">
+  <div id="diff-overlay" data-hides-cmdbar class="fullscreen-page">
     <div class="fp-header">
       <button class="fp-back" onclick="spHandleBack()">←</button>
       <span class="fp-title">System Prompt</span>

--- a/public/keyboard-nav.js
+++ b/public/keyboard-nav.js
@@ -235,14 +235,15 @@ document.addEventListener('keydown', (e) => {
   if (focusedCol === 'projects') {
     if (key === 'ArrowRight') { setFocus('sessions'); return; }
     if (key === 'ArrowUp' || key === 'ArrowDown') {
-      // Build list from visible DOM items to respect active filter and sort order
-      const projItems = [null, ...[...colProjects.querySelectorAll('.project-item')].map(el => {
+      const projItems = [...colProjects.querySelectorAll('.project-item')].map(el => {
         const m = el.getAttribute('onclick')?.match(/selectProject\((.+)\)/);
         if (m) try { return JSON.parse(m[1].replace(/&quot;/g, '"')); } catch(e) {}
         return null;
-      }).filter(n => n !== null)];
+      }).filter(n => n !== null);
+      if (!projItems.length) return;
       const cur = projItems.indexOf(selectedProjectName);
-      const next = Math.max(0, Math.min(projItems.length - 1, cur + (key === 'ArrowDown' ? 1 : -1)));
+      const effectiveCur = cur === -1 ? (key === 'ArrowDown' ? -1 : 0) : cur;
+      const next = Math.max(0, Math.min(projItems.length - 1, effectiveCur + (key === 'ArrowDown' ? 1 : -1)));
       if (next === cur) return;
       selectProject(projItems[next]);
     }

--- a/public/keyboard-nav.js
+++ b/public/keyboard-nav.js
@@ -1,8 +1,147 @@
+// ── Command Bar ──────────────────────────────────────────────────────────────
+let _timelineExpanded = localStorage.getItem('kbar-timeline-expanded') !== 'false';
+
+function isEnabled(keyId) {
+  switch (keyId) {
+    case '→-projects':     return projectsMap.size > 0;
+    case '→-sessions':     return selectedSessionId != null || colSessions.querySelectorAll('.session-item').length > 0;
+    case '→-turns':        return selectedTurnIdx >= 0;
+    case '→-sections':     return selectedSection != null;
+    case 'enter-sections': return selectedSection != null;
+    default:               return true;
+  }
+}
+
+function getCmdBarState() {
+  if (_loading) return null;
+  if (typeof activeTab !== 'undefined' && activeTab !== 'dashboard') return null;
+
+  if (isFocusedMode) {
+    if (tlFilterActive) {
+      return { row1: [{ key: 'Esc', label: 'close filter' }], row2: null, row2Visible: false };
+    }
+    if (selectedSection === 'timeline') {
+      const smallScreen = window.innerHeight <= 900;
+      return {
+        row1: [
+          { key: '↑↓', label: 'steps' },
+          { key: '/', label: 'filter' },
+          { key: 'Esc/←', label: 'exit' },
+          { type: 'toggle' },
+        ],
+        row2: [
+          { key: 'e', label: 'next error' },
+          { key: 'E', label: 'prev error' },
+          { key: 't', label: 'thinking' },
+          { key: 'h', label: 'human' },
+          { key: ']', label: 'text' },
+        ],
+        row2Visible: !smallScreen && _timelineExpanded,
+      };
+    }
+    return {
+      row1: [
+        { key: '↑↓', label: 'switch section' },
+        { key: 'Esc/←', label: 'exit' },
+      ],
+      row2: null,
+      row2Visible: false,
+    };
+  }
+
+  const tabKeys = [
+    { key: '1', label: 'Dashboard' },
+    { key: '2', label: 'Usage' },
+    { key: '3', label: 'Sys Prompt' },
+  ];
+
+  if (focusedCol === 'projects') {
+    return {
+      row1: [
+        { key: '↑↓', label: 'select', id: '↑↓-projects' },
+        { key: '→', label: 'open', id: '→-projects' },
+        ...tabKeys,
+      ],
+      row2: null, row2Visible: false,
+    };
+  }
+  if (focusedCol === 'sessions') {
+    return {
+      row1: [
+        { key: '↑↓', label: 'select' },
+        { key: '←', label: 'back' },
+        { key: '→', label: 'open', id: '→-sessions' },
+        ...tabKeys,
+      ],
+      row2: null, row2Visible: false,
+    };
+  }
+  if (focusedCol === 'turns') {
+    return {
+      row1: [
+        { key: '↑↓', label: 'select' },
+        { key: '←', label: 'back' },
+        { key: '→', label: 'sections', id: '→-turns' },
+        { key: 'Enter', label: 'focus' },
+        ...tabKeys,
+      ],
+      row2: null, row2Visible: false,
+    };
+  }
+  if (focusedCol === 'sections') {
+    return {
+      row1: [
+        { key: '↑↓', label: 'select' },
+        { key: '←', label: 'back' },
+        { key: 'Enter', label: 'focus detail', id: 'enter-sections' },
+        ...tabKeys,
+      ],
+      row2: null, row2Visible: false,
+    };
+  }
+  return null;
+}
+
+function renderCmdBar() {
+  const bar = document.getElementById('cmd-bar');
+  const row1 = document.getElementById('cmd-bar-row1');
+  const row2 = document.getElementById('cmd-bar-row2');
+  if (!bar || !row1 || !row2) return;
+
+  const state = getCmdBarState();
+  if (!state) { bar.className = 'hidden'; return; }
+
+  // Overlay check (use getComputedStyle to catch both inline and class-based display)
+  const overlayActive = [...document.querySelectorAll('[data-hides-cmdbar]')].some(el =>
+    window.getComputedStyle(el).display !== 'none'
+  );
+  bar.className = overlayActive ? 'overlay-active' : '';
+
+  function buildRow(items) {
+    if (!items) return '';
+    return items.map(item => {
+      if (item.type === 'toggle') {
+        const label = _timelineExpanded ? 'less ∧' : 'more ∨';
+        const ariaLabel = _timelineExpanded ? 'collapse timeline shortcuts' : 'expand timeline shortcuts';
+        return `<button class="cmd-toggle" tabindex="-1" aria-label="${ariaLabel}" aria-expanded="${_timelineExpanded}" onclick="(function(){_timelineExpanded=!_timelineExpanded;localStorage.setItem('kbar-timeline-expanded',_timelineExpanded);renderCmdBar();})()">${label}</button>`;
+      }
+      const enabled = item.id ? isEnabled(item.id) : true;
+      const cls = enabled ? 'cmd-key' : 'cmd-key disabled';
+      return `<span class="${cls}"><kbd>${item.key}</kbd> ${item.label}</span>`;
+    }).join('<span class="cmd-sep">·</span>');
+  }
+
+  row1.innerHTML = buildRow(state.row1);
+  row2.innerHTML = buildRow(state.row2);
+  row2.classList.toggle('visible', !!state.row2Visible);
+}
+
 // ── Keyboard shortcuts overlay ──
 function toggleKbdOverlay() {
   const el = document.getElementById('kbd-overlay');
   if (!el) return;
   el.style.display = el.style.display === 'none' ? 'flex' : 'none';
+  renderCmdBar();
 }
 
 // ── Keyboard navigation ──
@@ -137,6 +276,7 @@ document.addEventListener('keydown', (e) => {
       selectSection(sectionNames[next]);
     }
   }
+  renderCmdBar();
 });
 
 // ── T11: Timeline Filter Bar ──────────────────────────────────────────────────
@@ -168,6 +308,7 @@ function openTlFilter() {
     ev.stopPropagation();
   };
   applyTlFilter();
+  renderCmdBar();
 }
 
 function closeTlFilter() {
@@ -176,6 +317,7 @@ function closeTlFilter() {
   const bar = document.getElementById('tl-filter-bar');
   if (bar) bar.style.display = 'none';
   applyTlFilter();
+  renderCmdBar();
 }
 
 function applyTlFilter() {

--- a/public/keyboard-nav.js
+++ b/public/keyboard-nav.js
@@ -1,7 +1,22 @@
+// ── Keyboard shortcuts overlay ──
+function toggleKbdOverlay() {
+  const el = document.getElementById('kbd-overlay');
+  if (!el) return;
+  el.style.display = el.style.display === 'none' ? 'flex' : 'none';
+}
+
 // ── Keyboard navigation ──
 document.addEventListener('keydown', (e) => {
   if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
   const key = e.key;
+
+  // kbd overlay: ? to open, Escape to close (highest priority after input guard)
+  const kbdOverlay = document.getElementById('kbd-overlay');
+  if (kbdOverlay && kbdOverlay.style.display !== 'none') {
+    if (key === 'Escape' || key === '?') { toggleKbdOverlay(); e.preventDefault(); return; }
+    return; // swallow all keys while overlay is open
+  }
+  if (key === '?') { toggleKbdOverlay(); e.preventDefault(); return; }
 
   // Tab switching: 1=Dashboard, 2=Usage, 3=System Prompt
   const tabMap = { '1': 'dashboard', '2': 'usage', '3': 'sysprompt' };
@@ -69,6 +84,12 @@ document.addEventListener('keydown', (e) => {
   if (key === 'Enter' && focusedCol === 'sections' && selectedSection) { enterFocusedMode(); e.preventDefault(); return; }
   // T11: open filter in non-focused timeline view
   if (key === '/' && selectedSection === 'timeline') { openTlFilter(); e.preventDefault(); return; }
+  // Escape in main mode → move left one column
+  if (key === 'Escape') {
+    const leftOf = { sessions: 'projects', turns: 'sessions', sections: 'turns' };
+    if (leftOf[focusedCol]) { setFocus(leftOf[focusedCol]); e.preventDefault(); }
+    return;
+  }
   if (!['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(key)) return;
   e.preventDefault();
 

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -233,7 +233,7 @@ function applySessionFilter() {
     if (!placeholder) {
       placeholder = document.createElement('div');
       placeholder.className = 'sessions-empty col-empty';
-      placeholder.textContent = '此專案尚無記錄';
+      placeholder.textContent = 'No sessions yet';
       colSessions.appendChild(placeholder);
     }
     placeholder.style.display = '';
@@ -304,6 +304,7 @@ function enterFocusedMode() {
   isFocusedMode = true;
   document.getElementById('columns').classList.add('focused');
   renderDetailCol();
+  if (typeof renderCmdBar === 'function') renderCmdBar();
 }
 
 function exitFocusedMode() {
@@ -312,6 +313,7 @@ function exitFocusedMode() {
   document.getElementById('columns').classList.remove('focused');
   setFocus('sections');
   renderDetailCol();
+  if (typeof renderCmdBar === 'function') renderCmdBar();
 }
 const colProjects = document.getElementById('col-projects');
 const colSessions = document.getElementById('col-sessions');
@@ -448,7 +450,7 @@ function renderProjectsCol() {
     '<select id="proj-filter-select" onchange="setProjectFilter(this.value)" style="background:var(--surface);color:var(--dim);border:1px solid var(--border);border-radius:3px;font-size:10px;padding:1px 4px;cursor:pointer">' +
     '<option value="active"' + (projectFilterMode === 'active' ? ' selected' : '') + '>Active</option>' +
     '<option value="all"' + (projectFilterMode === 'all' ? ' selected' : '') + '>All</option>' +
-    '</select><span class="col-hint' + (focusedCol === 'projects' ? ' col-hint-active' : '') + '" id="hint-projects">↑↓ select · →</span></div>';
+    '</select></div>';
 
   const sorted = [...projectsMap.values()].sort((a, b) => {
     // Sort by: pinned first, then status (streaming > idle > off), then last activity
@@ -578,16 +580,7 @@ function setFocus(col) {
   colSessions.classList.toggle('col-focused', col === 'sessions');
   colTurns.classList.toggle('col-focused', col === 'turns');
   colSections.classList.toggle('col-focused', col === 'sections');
-  updateColHints(col);
-}
-
-function updateColHints(col) {
-  const hintIds = ['hint-projects', 'hint-sessions', 'hint-turns', 'hint-sections'];
-  const cols = ['projects', 'sessions', 'turns', 'sections'];
-  hintIds.forEach((id, i) => {
-    const el = document.getElementById(id);
-    if (el) el.classList.toggle('col-hint-active', cols[i] === col);
-  });
+  if (typeof renderCmdBar === 'function') renderCmdBar();
 }
 
 function getVisibleTurnIndices() {
@@ -1101,6 +1094,7 @@ function selectSection(name) {
   });
   renderDetailCol();
   renderBreadcrumb();
+  if (typeof renderCmdBar === 'function') renderCmdBar();
 }
 
 function renderSectionsCol(idx) {

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -205,24 +205,41 @@ function setSessionFilter(mode) {
 }
 
 function applySessionFilter() {
+  let anyVisible = false;
   colSessions.querySelectorAll('.session-item').forEach(el => {
     const sid = el.dataset.sessionId;
     // Pinned sessions are always visible
-    if (pinnedSessions.has(sid)) { el.style.display = ''; return; }
+    if (pinnedSessions.has(sid)) { el.style.display = ''; anyVisible = true; return; }
     // Project filter still applies
     if (selectedProjectName) {
       const sess = sessionsMap.get(sid);
       const projName = getProjectName(sess ? sess.cwd : null);
       if (projName !== selectedProjectName) { el.style.display = 'none'; return; }
     }
-    if (sessionFilterMode === 'all') { el.style.display = ''; return; }
+    if (sessionFilterMode === 'all') { el.style.display = ''; anyVisible = true; return; }
     const status = getStatusClass(sid);
     if (sessionFilterMode === 'active') {
       el.style.display = status === 'sdot-stream' ? '' : 'none';
+      if (status === 'sdot-stream') anyVisible = true;
     } else { // active+idle
       el.style.display = status !== 'sdot-off' ? '' : 'none';
+      if (status !== 'sdot-off') anyVisible = true;
     }
   });
+
+  // Placeholder when a project is selected but no sessions are visible
+  let placeholder = colSessions.querySelector('.sessions-empty');
+  if (!anyVisible && selectedProjectName) {
+    if (!placeholder) {
+      placeholder = document.createElement('div');
+      placeholder.className = 'sessions-empty col-empty';
+      placeholder.textContent = '此專案尚無記錄';
+      colSessions.appendChild(placeholder);
+    }
+    placeholder.style.display = '';
+  } else if (placeholder) {
+    placeholder.style.display = 'none';
+  }
 }
 
 function getStatusClass(sid) {
@@ -431,7 +448,7 @@ function renderProjectsCol() {
     '<select id="proj-filter-select" onchange="setProjectFilter(this.value)" style="background:var(--surface);color:var(--dim);border:1px solid var(--border);border-radius:3px;font-size:10px;padding:1px 4px;cursor:pointer">' +
     '<option value="active"' + (projectFilterMode === 'active' ? ' selected' : '') + '>Active</option>' +
     '<option value="all"' + (projectFilterMode === 'all' ? ' selected' : '') + '>All</option>' +
-    '</select></div>';
+    '</select><span class="col-hint' + (focusedCol === 'projects' ? ' col-hint-active' : '') + '" id="hint-projects">↑↓ select · →</span></div>';
 
   const sorted = [...projectsMap.values()].sort((a, b) => {
     // Sort by: pinned first, then status (streaming > idle > off), then last activity
@@ -464,6 +481,67 @@ function renderProjectsCol() {
       '</div>';
   }
   colProjects.innerHTML = html;
+}
+
+// Returns the first project in sorted order (pinned → streaming → active → lastId)
+function getFirstProject() {
+  return [...projectsMap.values()].sort((a, b) => {
+    const pa = pinnedProjects.has(a.name) ? 0 : 1;
+    const pb = pinnedProjects.has(b.name) ? 0 : 1;
+    if (pa !== pb) return pa - pb;
+    const sa = getStatusPriority(getProjectStatusClass(a));
+    const sb = getStatusPriority(getProjectStatusClass(b));
+    if (sa !== sb) return sa - sb;
+    return (b.lastId || '').localeCompare(a.lastId || '');
+  })[0] || null;
+}
+
+// Returns sessions for a project that are visible under the current session filter
+function getVisibleSessions(projectName) {
+  const proj = projectsMap.get(projectName);
+  if (!proj) return [];
+  return [...proj.sessionIds]
+    .map(sid => ({ sid, ...sessionsMap.get(sid) }))
+    .filter(sess => {
+      if (pinnedSessions.has(sess.sid)) return true;
+      if (sessionFilterMode === 'all') return true;
+      const status = getStatusClass(sess.sid);
+      if (sessionFilterMode === 'active') return status === 'sdot-stream';
+      return status !== 'sdot-off'; // active+idle
+    });
+}
+
+// Auto-select logic on initial load: cascade based on session count / streaming state
+function initAutoSelect() {
+  const firstProj = getFirstProject();
+  if (!firstProj) return;
+  selectProject(firstProj.name);
+
+  const sessions = getVisibleSessions(firstProj.name);
+
+  // Priority 1: streaming session
+  const streaming = sessions.find(s => getStatusClass(s.sid) === 'sdot-stream');
+  if (streaming) {
+    selectSessionAndLatestTurn(streaming.sid);
+    setFocus('turns');
+    return;
+  }
+
+  // Priority 2: exactly one visible session
+  if (sessions.length === 1) {
+    selectSessionAndLatestTurn(sessions[0].sid);
+    setFocus('turns');
+    return;
+  }
+
+  // Priority 3: multiple sessions → stop at sessions column
+  if (sessions.length > 1) {
+    setFocus('sessions');
+    return;
+  }
+
+  // Priority 4: no sessions → stay at projects
+  // (selectProject already set focus to 'projects')
 }
 
 function selectProject(name) {
@@ -500,6 +578,16 @@ function setFocus(col) {
   colSessions.classList.toggle('col-focused', col === 'sessions');
   colTurns.classList.toggle('col-focused', col === 'turns');
   colSections.classList.toggle('col-focused', col === 'sections');
+  updateColHints(col);
+}
+
+function updateColHints(col) {
+  const hintIds = ['hint-projects', 'hint-sessions', 'hint-turns', 'hint-sections'];
+  const cols = ['projects', 'sessions', 'turns', 'sections'];
+  hintIds.forEach((id, i) => {
+    const el = document.getElementById(id);
+    if (el) el.classList.toggle('col-hint-active', cols[i] === col);
+  });
 }
 
 function getVisibleTurnIndices() {

--- a/public/style.css
+++ b/public/style.css
@@ -56,8 +56,6 @@
   #status-cluster { margin-left: auto; display: flex; align-items: center; gap: 8px; font-size: 11px; color: var(--dim); flex-shrink: 0; }
   #topbar-row1 #theme-toggle { background: none; border: 1px solid var(--border); color: var(--dim); padding: 3px 8px; font-size: 11px; border-radius: 3px; cursor: pointer; flex-shrink: 0; }
   #topbar-row1 #theme-toggle:hover { background: var(--surface-hover); }
-  #topbar-row1 #hotkeys-btn { background: none; border: 1px solid var(--border); color: var(--dim); padding: 3px 8px; font-size: 11px; border-radius: 3px; cursor: pointer; flex-shrink: 0; letter-spacing: 0.02em; }
-  #topbar-row1 #hotkeys-btn:hover { background: var(--surface-hover); color: var(--text); }
   #topbar-row2 { display: flex; align-items: center; padding: 3px 16px 5px; font-size: 12px; border-top: 1px solid var(--border); min-height: 26px; }
   #row2-dashboard, #row2-usage, #row2-sysprompt { display: flex; align-items: center; gap: 8px; width: 100%; }
   #breadcrumb { color: var(--dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 120px; flex: 1; }
@@ -76,7 +74,7 @@
   #qt-chip { font-size: 10px; color: var(--dim); }
   #row2-usage span, #row2-sysprompt span { font-size: 11px; color: var(--dim); }
 
-  #columns { display: flex; flex: 1; overflow: hidden; }
+  #columns { display: flex; flex: 1; min-height: 0; overflow: hidden; }
   .col { overflow-y: auto; overflow-x: hidden; border-right: 1px solid var(--border); flex-shrink: 0; min-width: 0; border-top: 2px solid transparent; transition: border-top-color 0.15s; scrollbar-width: thin; scrollbar-color: var(--border) transparent; }
   .col::-webkit-scrollbar { width: 4px; }
   .col::-webkit-scrollbar-track { background: transparent; }
@@ -141,8 +139,17 @@
 
   .col-empty { color: var(--dim); text-align: center; padding: 40px 12px; font-size: 12px; }
   .col-title { padding: 10px 12px; font-size: 10px; font-weight: 600; color: var(--dim); letter-spacing: 0.08em; text-transform: uppercase; border-bottom: 2px solid var(--border); position: sticky; top: 0; background: var(--surface); z-index: 1; }
-  .col-hint { margin-left: auto; font-size: 9px; font-weight: 400; letter-spacing: 0; text-transform: none; color: var(--dim); opacity: 0.6; transition: opacity 0.15s, color 0.15s; user-select: none; }
-  .col-hint.col-hint-active { opacity: 1; color: var(--text); }
+  #cmd-bar { flex-shrink: 0; border-top: 1px solid var(--border); background: var(--surface); user-select: none; transition: opacity 0.15s; }
+  #cmd-bar.hidden { display: none; }
+  #cmd-bar.overlay-active { opacity: 0; pointer-events: none; }
+  #cmd-bar-row1 { height: 28px; display: flex; align-items: center; gap: 10px; padding: 0 12px; font-size: 11px; color: var(--dim); }
+  #cmd-bar-row2 { max-height: 0; overflow: hidden; transition: max-height 0.2s ease; display: flex; align-items: center; gap: 10px; padding: 0 12px; font-size: 11px; color: var(--dim); }
+  #cmd-bar-row2.visible { max-height: 24px; }
+  .cmd-key { display: inline-flex; align-items: center; gap: 3px; white-space: nowrap; }
+  .cmd-key.disabled { opacity: 0.3; }
+  .cmd-sep { color: var(--border); margin: 0 1px; }
+  .cmd-toggle { background: none; border: none; color: var(--dim); cursor: pointer; font-size: 10px; min-width: 44px; height: 100%; padding: 0 4px; font-family: inherit; line-height: 1; }
+  .cmd-toggle:hover { color: var(--text); }
   kbd { display: inline-block; padding: 1px 5px; border: 1px solid var(--border); border-radius: 3px; font-size: 10px; font-family: monospace; background: var(--bg); color: var(--text); }
 
   /* ── Status dots ── */

--- a/public/style.css
+++ b/public/style.css
@@ -56,6 +56,8 @@
   #status-cluster { margin-left: auto; display: flex; align-items: center; gap: 8px; font-size: 11px; color: var(--dim); flex-shrink: 0; }
   #topbar-row1 #theme-toggle { background: none; border: 1px solid var(--border); color: var(--dim); padding: 3px 8px; font-size: 11px; border-radius: 3px; cursor: pointer; flex-shrink: 0; }
   #topbar-row1 #theme-toggle:hover { background: var(--surface-hover); }
+  #topbar-row1 #hotkeys-btn { background: none; border: 1px solid var(--border); color: var(--dim); padding: 3px 8px; font-size: 11px; border-radius: 3px; cursor: pointer; flex-shrink: 0; letter-spacing: 0.02em; }
+  #topbar-row1 #hotkeys-btn:hover { background: var(--surface-hover); color: var(--text); }
   #topbar-row2 { display: flex; align-items: center; padding: 3px 16px 5px; font-size: 12px; border-top: 1px solid var(--border); min-height: 26px; }
   #row2-dashboard, #row2-usage, #row2-sysprompt { display: flex; align-items: center; gap: 8px; width: 100%; }
   #breadcrumb { color: var(--dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 120px; flex: 1; }
@@ -139,6 +141,9 @@
 
   .col-empty { color: var(--dim); text-align: center; padding: 40px 12px; font-size: 12px; }
   .col-title { padding: 10px 12px; font-size: 10px; font-weight: 600; color: var(--dim); letter-spacing: 0.08em; text-transform: uppercase; border-bottom: 2px solid var(--border); position: sticky; top: 0; background: var(--surface); z-index: 1; }
+  .col-hint { margin-left: auto; font-size: 9px; font-weight: 400; letter-spacing: 0; text-transform: none; color: var(--dim); opacity: 0.6; transition: opacity 0.15s, color 0.15s; user-select: none; }
+  .col-hint.col-hint-active { opacity: 1; color: var(--text); }
+  kbd { display: inline-block; padding: 1px 5px; border: 1px solid var(--border); border-radius: 3px; font-size: 10px; font-family: monospace; background: var(--bg); color: var(--text); }
 
   /* ── Status dots ── */
   .sdot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin-right: 5px; flex-shrink: 0; vertical-align: middle; border: none; background: none; padding: 0; outline: none; cursor: default; }


### PR DESCRIPTION
## Summary

- 頁面載入後條件式級聯初始選取（streaming → 單一 session → 多個 → 無）
- 底部 contextual cmd-bar 取代 col-hint spans 與 topbar hotkeys 按鈕，依焦點欄即時更新；timeline 模式下第二排可展開（localStorage 記憶偏好）
- `?` 快捷鍵 overlay（全英文），開啟時 cmd-bar 淡出
- `Escape` 主模式下往左退一欄
- fix: projects 欄 ArrowUp 邊界 bug — null sentinel 導致 toggle-deselect 並重新 auto-select

## Test plan

- [ ] 頁面載入：streaming session → 自動選到 turns 欄
- [ ] 頁面載入：單一 session → 自動選到 turns 欄
- [ ] 頁面載入：多個 sessions → 停在 sessions 欄
- [ ] `↑↓` 在 projects / sessions / turns / sections 各欄正常移動，邊界不越界
- [ ] `←→` 切換欄位
- [ ] `Escape` 從 turns → sessions → projects 退欄
- [ ] `?` 開啟 overlay，`Escape` 或 `?` 關閉
- [ ] cmd-bar 隨焦點欄更新內容；overlay 開啟時淡出
- [ ] timeline focused mode：row2 展開/收合，偏好跨 session 記憶

🤖 Generated with [Claude Code](https://claude.com/claude-code)