### PR TITLE
feat(forward): CCXRAY_MODEL_PREFIX for upstream model name rewriting

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -57,6 +57,7 @@ const { host: ANTHROPIC_HOST, port: ANTHROPIC_PORT, protocol: ANTHROPIC_PROTOCOL
 const LOGS_DIR = path.join(os.homedir(), '.ccxray', 'logs');
 const LEGACY_LOGS_DIR = path.join(__dirname, '..', 'logs');
 const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || '3', 10);
+const REWRITE_MODEL_PREFIX = process.env.CCXRAY_MODEL_PREFIX || '';
 
 // Storage adapter (local by default, S3 via STORAGE_BACKEND=s3)
 const storage = createStorage();
@@ -134,6 +135,7 @@ module.exports = {
   ANTHROPIC_BASE_URL_SOURCE,
   LOGS_DIR,
   RESTORE_DAYS,
+  REWRITE_MODEL_PREFIX,
   storage,
   MODEL_CONTEXT_FALLBACK,
   DEFAULT_CONTEXT,

--- a/server/config.js
+++ b/server/config.js
@@ -18,7 +18,8 @@ function parseBaseUrl(rawUrl) {
     const protocol = u.protocol.replace(/:$/, ''); // 'https:' → 'https'
     const hostname = u.hostname;
     const port = u.port ? parseInt(u.port, 10) : (protocol === 'https' ? 443 : 80);
-    return { protocol, hostname, port };
+    const basePath = u.pathname !== '/' ? u.pathname.replace(/\/$/, '') : '';
+    return { protocol, hostname, port, basePath };
   } catch {
     console.warn(`[ccxray] Warning: ANTHROPIC_BASE_URL is not a valid URL ("${rawUrl}"); falling back to api.anthropic.com`);
     return null;
@@ -36,22 +37,22 @@ function resolveUpstream(env, proxyPort) {
     if (missing.length > 0 && missing.length < 3) {
       console.warn(`[ccxray] Warning: partial ANTHROPIC_TEST_* override — ${missing.join(', ')} not set; resolved upstream: ${protocol}://${host}:${port}`);
     }
-    return { host, port, protocol, source: 'test-override' };
+    return { host, port, protocol, basePath: '', source: 'test-override' };
   }
 
   const parsed = parseBaseUrl(env.ANTHROPIC_BASE_URL);
   if (parsed) {
-    const { hostname: host, port, protocol } = parsed;
+    const { hostname: host, port, protocol, basePath } = parsed;
     if (new Set(['localhost', '127.0.0.1', '::1']).has(host) && port === proxyPort) {
       console.warn(`[ccxray] Warning: upstream ${protocol}://${host}:${port} points back at the proxy itself — requests will loop`);
     }
-    return { host, port, protocol, source: 'ANTHROPIC_BASE_URL' };
+    return { host, port, protocol, basePath, source: 'ANTHROPIC_BASE_URL' };
   }
 
-  return { host: 'api.anthropic.com', port: 443, protocol: 'https', source: 'default' };
+  return { host: 'api.anthropic.com', port: 443, protocol: 'https', basePath: '', source: 'default' };
 }
 
-const { host: ANTHROPIC_HOST, port: ANTHROPIC_PORT, protocol: ANTHROPIC_PROTOCOL, source: ANTHROPIC_BASE_URL_SOURCE } =
+const { host: ANTHROPIC_HOST, port: ANTHROPIC_PORT, protocol: ANTHROPIC_PROTOCOL, basePath: ANTHROPIC_BASE_PATH, source: ANTHROPIC_BASE_URL_SOURCE } =
   resolveUpstream(process.env, PORT);
 const LOGS_DIR = path.join(os.homedir(), '.ccxray', 'logs');
 const LEGACY_LOGS_DIR = path.join(__dirname, '..', 'logs');
@@ -129,6 +130,7 @@ module.exports = {
   ANTHROPIC_HOST,
   ANTHROPIC_PORT,
   ANTHROPIC_PROTOCOL,
+  ANTHROPIC_BASE_PATH,
   ANTHROPIC_BASE_URL_SOURCE,
   LOGS_DIR,
   RESTORE_DAYS,

--- a/server/forward.js
+++ b/server/forward.js
@@ -53,6 +53,13 @@ function resolveProxyAgent(protocol, env) {
   return createTunnelAgent(proxyUrl);
 }
 
+// ── Model name prefix rewriting ──────────────────────────────────────
+function applyModelPrefix(parsedBody, prefix) {
+  if (!prefix || !parsedBody?.model || parsedBody.model.startsWith(prefix)) return false;
+  parsedBody.model = prefix + parsedBody.model;
+  return true;
+}
+
 // ── Strip injected proxy stats from conversation history ─────────────
 const STATS_PATTERN = /\n\n---\n📊 Context: .+$/s;
 
@@ -80,7 +87,8 @@ function forwardRequest(ctx) {
 
   // Remove previously injected stats so they don't accumulate in conversation
   const statsStripped = stripInjectedStats(parsedBody);
-  const bodyToSend = (ctx.bodyModified || statsStripped) ? Buffer.from(JSON.stringify(parsedBody)) : rawBody;
+  const modelPrefixed = applyModelPrefix(parsedBody, config.REWRITE_MODEL_PREFIX);
+  const bodyToSend = (ctx.bodyModified || statsStripped || modelPrefixed) ? Buffer.from(JSON.stringify(parsedBody)) : rawBody;
 
   const transport = config.ANTHROPIC_PROTOCOL === 'http' ? http : https;
   const tunnelAgent = resolveProxyAgent(config.ANTHROPIC_PROTOCOL, process.env);
@@ -467,4 +475,4 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
   });
 }
 
-module.exports = { forwardRequest, resolveProxyAgent };
+module.exports = { forwardRequest, resolveProxyAgent, applyModelPrefix };

--- a/server/forward.js
+++ b/server/forward.js
@@ -2,11 +2,56 @@
 
 const https = require('https');
 const http = require('http');
+const tls = require('tls');
 const config = require('./config');
 const store = require('./store');
 const { calculateCost } = require('./pricing');
 const helpers = require('./helpers');
 const { broadcast, broadcastSessionStatus } = require('./sse-broadcast');
+
+// ── HTTPS CONNECT tunnel agent for corporate proxies ─────────────────
+
+function createTunnelAgent(proxyUrl) {
+  const proxy = new URL(proxyUrl);
+  const proxyHost = proxy.hostname;
+  const proxyPort = parseInt(proxy.port) || 3128;
+
+  const agent = new https.Agent({ keepAlive: false });
+
+  agent.createConnection = function(options, callback) {
+    const connectReq = http.request({
+      host: proxyHost,
+      port: proxyPort,
+      method: 'CONNECT',
+      path: `${options.host}:${options.port || 443}`,
+      headers: { Host: `${options.host}:${options.port || 443}` },
+    });
+
+    connectReq.on('connect', (res, socket) => {
+      if (res.statusCode !== 200) {
+        socket.destroy();
+        return callback(new Error(`Proxy CONNECT failed: ${res.statusCode} ${res.statusMessage}`));
+      }
+      const tlsOpts = { socket, servername: options.servername || options.host };
+      if (options.rejectUnauthorized !== undefined) tlsOpts.rejectUnauthorized = options.rejectUnauthorized;
+      const tlsSocket = tls.connect(tlsOpts, () => callback(null, tlsSocket));
+      tlsSocket.on('error', callback);
+    });
+
+    connectReq.on('error', callback);
+    connectReq.end();
+  };
+
+  agent._proxyUrl = proxyUrl;
+  return agent;
+}
+
+function resolveProxyAgent(protocol, env) {
+  if (protocol !== 'https') return null;
+  const proxyUrl = env.HTTPS_PROXY || env.https_proxy;
+  if (!proxyUrl) return null;
+  return createTunnelAgent(proxyUrl);
+}
 
 // ── Strip injected proxy stats from conversation history ─────────────
 const STATS_PATTERN = /\n\n---\n📊 Context: .+$/s;
@@ -38,10 +83,12 @@ function forwardRequest(ctx) {
   const bodyToSend = (ctx.bodyModified || statsStripped) ? Buffer.from(JSON.stringify(parsedBody)) : rawBody;
 
   const transport = config.ANTHROPIC_PROTOCOL === 'http' ? http : https;
+  const tunnelAgent = resolveProxyAgent(config.ANTHROPIC_PROTOCOL, process.env);
   const proxyReq = transport.request({
     hostname: config.ANTHROPIC_HOST, port: config.ANTHROPIC_PORT,
-    path: clientReq.url, method: clientReq.method,
+    path: config.ANTHROPIC_BASE_PATH + clientReq.url, method: clientReq.method,
     headers: { ...fwdHeaders, 'content-length': bodyToSend.length },
+    ...(tunnelAgent ? { agent: tunnelAgent } : {}),
   }, (proxyRes) => {
     const isSSE = (proxyRes.headers['content-type'] || '').includes('text/event-stream');
 
@@ -420,4 +467,4 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
   });
 }
 
-module.exports = { forwardRequest };
+module.exports = { forwardRequest, resolveProxyAgent };

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -63,27 +63,37 @@ describe('parseBaseUrl()', () => {
 
   it('parses valid HTTPS URL with explicit port', () => {
     const result = parseBaseUrl('https://proxy.corp.example.com:8443');
-    assert.deepEqual(result, { protocol: 'https', hostname: 'proxy.corp.example.com', port: 8443 });
+    assert.deepEqual(result, { protocol: 'https', hostname: 'proxy.corp.example.com', port: 8443, basePath: '' });
   });
 
   it('infers port 443 for HTTPS URL without explicit port', () => {
     const result = parseBaseUrl('https://proxy.corp.example.com');
-    assert.deepEqual(result, { protocol: 'https', hostname: 'proxy.corp.example.com', port: 443 });
+    assert.deepEqual(result, { protocol: 'https', hostname: 'proxy.corp.example.com', port: 443, basePath: '' });
   });
 
   it('parses valid HTTP URL and infers port 80', () => {
     const result = parseBaseUrl('http://internal-gateway.corp:9090');
-    assert.deepEqual(result, { protocol: 'http', hostname: 'internal-gateway.corp', port: 9090 });
+    assert.deepEqual(result, { protocol: 'http', hostname: 'internal-gateway.corp', port: 9090, basePath: '' });
   });
 
   it('infers port 80 for HTTP URL without explicit port', () => {
     const result = parseBaseUrl('http://internal-gateway.corp');
-    assert.deepEqual(result, { protocol: 'http', hostname: 'internal-gateway.corp', port: 80 });
+    assert.deepEqual(result, { protocol: 'http', hostname: 'internal-gateway.corp', port: 80, basePath: '' });
   });
 
   it('handles trailing slash correctly (common user mistake)', () => {
     const result = parseBaseUrl('https://proxy.example.com/');
-    assert.deepEqual(result, { protocol: 'https', hostname: 'proxy.example.com', port: 443 });
+    assert.deepEqual(result, { protocol: 'https', hostname: 'proxy.example.com', port: 443, basePath: '' });
+  });
+
+  it('captures path from URL with base path', () => {
+    const result = parseBaseUrl('https://adb-1033261988689278.18.azuredatabricks.net/serving-endpoints/anthropic');
+    assert.deepEqual(result, { protocol: 'https', hostname: 'adb-1033261988689278.18.azuredatabricks.net', port: 443, basePath: '/serving-endpoints/anthropic' });
+  });
+
+  it('strips trailing slash from base path', () => {
+    const result = parseBaseUrl('https://gateway.example.com/api/v1/');
+    assert.deepEqual(result, { protocol: 'https', hostname: 'gateway.example.com', port: 443, basePath: '/api/v1' });
   });
 
   it('returns null for malformed URL', () => {
@@ -112,6 +122,7 @@ describe('upstream priority chain', () => {
       port: c.ANTHROPIC_PORT,
       protocol: c.ANTHROPIC_PROTOCOL,
       source: c.ANTHROPIC_BASE_URL_SOURCE,
+      basePath: c.ANTHROPIC_BASE_PATH,
     }));
   `;
 
@@ -159,6 +170,25 @@ describe('upstream priority chain', () => {
     const result = JSON.parse(stdout);
     assert.equal(result.host, 'api.anthropic.com');
     assert.equal(result.source, 'default');
+  });
+
+  it('exposes base path from ANTHROPIC_BASE_URL with path component', async () => {
+    const { stdout } = await runSnippet(snippet, {
+      ANTHROPIC_BASE_URL: 'https://adb-xxx.azuredatabricks.net/serving-endpoints/anthropic',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    const result = JSON.parse(stdout);
+    assert.equal(result.host, 'adb-xxx.azuredatabricks.net');
+    assert.equal(result.basePath, '/serving-endpoints/anthropic');
+  });
+
+  it('exposes empty base path when ANTHROPIC_BASE_URL has no path', async () => {
+    const { stdout } = await runSnippet(snippet, {
+      ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    const result = JSON.parse(stdout);
+    assert.equal(result.basePath, '');
   });
 });
 

--- a/test/forward-proxy.test.js
+++ b/test/forward-proxy.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { resolveProxyAgent } = require('../server/forward');
+
+describe('resolveProxyAgent', () => {
+  it('returns null when no proxy env vars are set', () => {
+    assert.equal(resolveProxyAgent('https', {}), null);
+  });
+
+  it('returns null when protocol is http', () => {
+    assert.equal(resolveProxyAgent('http', { HTTPS_PROXY: 'http://proxy:3128' }), null);
+  });
+
+  it('returns an agent when HTTPS_PROXY is set (uppercase)', () => {
+    const agent = resolveProxyAgent('https', { HTTPS_PROXY: 'http://proxy.example.com:3128' });
+    assert.ok(agent != null);
+    assert.equal(agent._proxyUrl, 'http://proxy.example.com:3128');
+  });
+
+  it('returns an agent when https_proxy is set (lowercase)', () => {
+    const agent = resolveProxyAgent('https', { https_proxy: 'http://proxy.example.com:3128' });
+    assert.ok(agent != null);
+    assert.equal(agent._proxyUrl, 'http://proxy.example.com:3128');
+  });
+
+  it('HTTPS_PROXY takes precedence over https_proxy', () => {
+    const agent = resolveProxyAgent('https', {
+      HTTPS_PROXY: 'http://upper.proxy:3128',
+      https_proxy: 'http://lower.proxy:3128',
+    });
+    assert.equal(agent._proxyUrl, 'http://upper.proxy:3128');
+  });
+});

--- a/test/forward-proxy.test.js
+++ b/test/forward-proxy.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { resolveProxyAgent } = require('../server/forward');
+const { resolveProxyAgent, applyModelPrefix } = require('../server/forward');
 
 describe('resolveProxyAgent', () => {
   it('returns null when no proxy env vars are set', () => {
@@ -31,5 +31,28 @@ describe('resolveProxyAgent', () => {
       https_proxy: 'http://lower.proxy:3128',
     });
     assert.equal(agent._proxyUrl, 'http://upper.proxy:3128');
+  });
+});
+
+describe('applyModelPrefix', () => {
+  it('returns false when prefix is empty', () => {
+    const body = { model: 'claude-sonnet-4-6' };
+    assert.equal(applyModelPrefix(body, ''), false);
+    assert.equal(body.model, 'claude-sonnet-4-6');
+  });
+
+  it('returns false when model already starts with prefix', () => {
+    const body = { model: 'databricks-claude-sonnet-4-6' };
+    assert.equal(applyModelPrefix(body, 'databricks-'), false);
+  });
+
+  it('prepends prefix and returns true', () => {
+    const body = { model: 'claude-sonnet-4-6' };
+    assert.equal(applyModelPrefix(body, 'databricks-'), true);
+    assert.equal(body.model, 'databricks-claude-sonnet-4-6');
+  });
+
+  it('returns false when parsedBody has no model', () => {
+    assert.equal(applyModelPrefix({}, 'databricks-'), false);
   });
 });


### PR DESCRIPTION
Claude Code validates model names client-side and rejects provider-prefixed
names (e.g. databricks-claude-sonnet-4-6) when ANTHROPIC_BASE_URL points
to localhost. CCXRAY_MODEL_PREFIX lets the proxy transparently prepend a
prefix to the model field before forwarding, so the client can use a
standard model name that passes validation.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
