### PR TITLE
feat(ux): toggle to disable context stats injection into Claude responses

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-TW">
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -32,6 +32,7 @@
       <div id="status-cluster">
         <span id="topbar-status"></span>
       </div>
+      <span id="stats-toggle" onclick="toggleStatusLine()" style="cursor:pointer;font-size:10px" title="Inject context stats into Claude responses">Inject stats <span class="stats-on">ON</span><span class="stats-off"> OFF</span></span>
       <button id="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark mode">☀️</button>
     </div>
     <div id="topbar-row2">

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -291,6 +291,26 @@ function scrollTurnsToBottom() {
   if (followLiveTurn) colTurns.scrollTop = colTurns.scrollHeight;
 }
 
+// ── Status line injection state ──
+let statusLineEnabled = window.__PROXY_CONFIG__?.statusLine !== false;
+
+function toggleStatusLine() {
+  statusLineEnabled = !statusLineEnabled;
+  _applyStatsToggleUI();
+  fetch('/_api/settings', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ statusLine: statusLineEnabled }),
+  });
+}
+
+function _applyStatsToggleUI() {
+  const btn = document.getElementById('stats-toggle');
+  if (!btn) return;
+  btn.querySelector('.stats-on').classList.toggle('active', statusLineEnabled);
+  btn.querySelector('.stats-off').classList.toggle('active', !statusLineEnabled);
+}
+
 let selectedProjectName = null; // null = (all)
 let selectedSessionId = null;
 let selectedTurnIdx = -1;
@@ -799,11 +819,12 @@ function hideScorecard() {
   }
 }
 
-// Initialize scorecard hover when DOM is ready
+// Initialize scorecard hover and stats toggle when DOM is ready
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initScorecardHover);
+  document.addEventListener('DOMContentLoaded', () => { initScorecardHover(); _applyStatsToggleUI(); });
 } else {
   initScorecardHover();
+  _applyStatsToggleUI();
 }
 
 function renderStackedAreaChart(el, turns) {

--- a/public/style.css
+++ b/public/style.css
@@ -59,6 +59,8 @@
   #status-cluster { margin-left: auto; display: flex; align-items: center; gap: 8px; font-size: 11px; color: var(--dim); flex-shrink: 0; }
   #topbar-row1 #theme-toggle { background: none; border: 1px solid var(--border); color: var(--dim); padding: 3px 8px; font-size: 11px; border-radius: 3px; cursor: pointer; flex-shrink: 0; }
   #topbar-row1 #theme-toggle:hover { background: var(--surface-hover); }
+  #topbar-row1 #stats-toggle { font-size: 10px; letter-spacing: 0.05em; flex-shrink: 0; user-select: none; }
+  #topbar-row1 #stats-toggle:hover { opacity: 0.8; }
   #topbar-row2 { display: flex; align-items: center; padding: 3px 16px 5px; font-size: 12px; border-top: 1px solid var(--border); min-height: 26px; }
   #row2-dashboard, #row2-usage, #row2-sysprompt { display: flex; align-items: center; gap: 8px; width: 100%; }
   #breadcrumb { color: var(--dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 120px; flex: 1; }
@@ -302,6 +304,10 @@
   #scroll-toggle .scroll-on, #scroll-toggle .scroll-off { padding: 1px 4px; border-radius: 3px; color: var(--dim); }
   #scroll-toggle .scroll-on.active { color: var(--green); background: rgba(63,185,80,0.15); }
   #scroll-toggle .scroll-off.active { color: var(--red); background: rgba(248,81,73,0.15); }
+  #stats-toggle { user-select: none; }
+  #stats-toggle .stats-on, #stats-toggle .stats-off { padding: 1px 4px; border-radius: 3px; color: var(--dim); }
+  #stats-toggle .stats-on.active { color: var(--green); background: rgba(63,185,80,0.15); }
+  #stats-toggle .stats-off.active { color: var(--red); background: rgba(248,81,73,0.15); }
   #session-tool-bar { padding: 4px 10px; font-size: 10px; color: var(--dim); border-bottom: 1px solid var(--border); display: flex; flex-wrap: nowrap; gap: 4px; align-items: center; overflow: hidden; white-space: nowrap; }
   .turn-ctx-bar { margin-top: 5px; margin-bottom: 4px; }
   .turn-ctx-bar-bg { height: 3px; border-radius: 1.5px; background: var(--border); overflow: visible; display: flex; position: relative; }

--- a/server/forward.js
+++ b/server/forward.js
@@ -26,6 +26,11 @@ function resolveTitleGenTitle(parsedBody, resPayload, receivedAt) {
   return clean;
 }
 
+// ── Status line injection flag ────────────────────────────────────────
+let statusLineEnabled = true;
+function setStatusLineEnabled(val) { statusLineEnabled = !!val; }
+function getStatusLineEnabled() { return statusLineEnabled; }
+
 // ── HTTPS CONNECT tunnel agent for corporate proxies ─────────────────
 
 function createTunnelAgent(proxyUrl) {
@@ -241,7 +246,7 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
       return r;
     }, '');
     const totalCtx = helpers.totalContextTokens(usage);
-    if (usage && totalCtx && stopReason !== 'tool_use') {
+    if (usage && totalCtx && stopReason !== 'tool_use' && statusLineEnabled) {
       const maxCtx = config.getMaxContext(parsedBody?.model, parsedBody?.system);
       const pct = (totalCtx / maxCtx * 100).toFixed(1);
       const newIdx = maxBlockIndex + 1;
@@ -497,4 +502,4 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
   });
 }
 
-module.exports = { forwardRequest, resolveProxyAgent, applyModelPrefix };
+module.exports = { forwardRequest, resolveProxyAgent, applyModelPrefix, stripInjectedStats, setStatusLineEnabled, getStatusLineEnabled };

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,8 @@ const helpers = require('./helpers');
 const { fetchPricing } = require('./pricing');
 const { restoreFromLogs } = require('./restore');
 const { warmUp: warmUpCosts } = require('./cost-budget');
-const { forwardRequest } = require('./forward');
+const { forwardRequest, setStatusLineEnabled, getStatusLineEnabled } = require('./forward');
+const { readSettings } = require('./settings');
 const { broadcastSessionStatus, broadcastPendingRequest } = require('./sse-broadcast');
 const { authMiddleware } = require('./auth');
 const { extractAgentType, splitB2IntoBlocks } = require('./system-prompt');
@@ -50,22 +51,24 @@ const hub = require('./hub');
 const PUBLIC_DIR = path.join(__dirname, '..', 'public');
 const MIME_TYPES = { '.html': 'text/html', '.css': 'text/css', '.js': 'application/javascript' };
 
-// index.html with config injection (port may shift, so rebuilt after listen)
+// Load persisted settings and apply immediately
+const settings = readSettings();
+setStatusLineEnabled(settings.statusLine);
+
+// index.html with config injection — built fresh per request so dynamic values (statusLine) stay current
 let rawIndexHTML = '';
 try { rawIndexHTML = fs.readFileSync(path.join(PUBLIC_DIR, 'index.html'), 'utf8'); } catch {}
-let indexHTML = rawIndexHTML || '<html><body>Error loading dashboard</body></html>';
+let serverPort = 0;
 
-function rebuildIndexHTML(port) {
-  if (!rawIndexHTML) return;
-  const script = `<script>window.__PROXY_CONFIG__=${JSON.stringify({ DEFAULT_CONTEXT: config.DEFAULT_CONTEXT, PORT: port })}</script>`;
-  indexHTML = rawIndexHTML.replace('<!--__PROXY_CONFIG__-->', script);
-}
+function rebuildIndexHTML(port) { serverPort = port; }
 
 function serveStatic(url, clientRes) {
   const pathname = url.split('?')[0];
   if (pathname === '/' || pathname === '/index.html') {
+    const script = `<script>window.__PROXY_CONFIG__=${JSON.stringify({ DEFAULT_CONTEXT: config.DEFAULT_CONTEXT, PORT: serverPort, statusLine: getStatusLineEnabled() })}</script>`;
+    const html = rawIndexHTML ? rawIndexHTML.replace('<!--__PROXY_CONFIG__-->', script) : '<html><body>Error loading dashboard</body></html>';
     clientRes.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-    clientRes.end(indexHTML);
+    clientRes.end(html);
     return true;
   }
   const ext = path.extname(pathname);

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -8,6 +8,8 @@ const { tokenizeRequest } = require('../helpers');
 const { computeBlockDiff } = require('../system-prompt');
 const { getPlanConfig } = require('../plans');
 const { getEffectivePlan } = require('../plan-detector');
+const forward = require('../forward');
+const { readSettings, writeSettings } = require('../settings');
 
 const AUTO_COMPACT_PCT = 0.835;
 
@@ -142,6 +144,35 @@ function handleApiRoutes(clientReq, clientRes) {
     })().catch(e => {
       if (!clientRes.headersSent) clientRes.writeHead(500);
       clientRes.end(JSON.stringify({ error: e.message }));
+    });
+    return true;
+  }
+
+  if (clientReq.method === 'POST' && clientReq.url === '/_api/settings')
+  {
+    let body = '';
+    clientReq.on('data', c => { body += c; });
+    clientReq.on('end', () =>
+    {
+      try
+      {
+        const patch = JSON.parse(body);
+        const current = readSettings();
+        const updated = { ...current };
+        if (typeof patch.statusLine === 'boolean')
+        {
+          updated.statusLine = patch.statusLine;
+          forward.setStatusLineEnabled(patch.statusLine);
+        }
+        writeSettings(updated);
+        clientRes.writeHead(200, { 'Content-Type': 'application/json' });
+        clientRes.end(JSON.stringify(updated));
+      }
+      catch
+      {
+        clientRes.writeHead(400);
+        clientRes.end();
+      }
     });
     return true;
   }

--- a/server/settings.js
+++ b/server/settings.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const SETTINGS_DIR = process.env.CCXRAY_HOME || path.join(os.homedir(), '.ccxray');
+const SETTINGS_PATH = path.join(SETTINGS_DIR, 'settings.json');
+
+const DEFAULTS = { statusLine: true };
+
+function readSettings()
+{
+  try
+  {
+    return { ...DEFAULTS, ...JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8')) };
+  }
+  catch
+  {
+    return { ...DEFAULTS };
+  }
+}
+
+function writeSettings(data)
+{
+  if (!fs.existsSync(SETTINGS_DIR)) fs.mkdirSync(SETTINGS_DIR, { recursive: true });
+  fs.writeFileSync(SETTINGS_PATH, JSON.stringify(data, null, 2));
+}
+
+module.exports = { readSettings, writeSettings };

--- a/test/forward-proxy.test.js
+++ b/test/forward-proxy.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const { describe, it } = require('node:test');
+const { describe, it, beforeEach } = require('node:test');
 const assert = require('node:assert/strict');
-const { resolveProxyAgent, applyModelPrefix } = require('../server/forward');
+const { resolveProxyAgent, applyModelPrefix, stripInjectedStats, setStatusLineEnabled, getStatusLineEnabled } = require('../server/forward');
 
 describe('resolveProxyAgent', () => {
   it('returns null when no proxy env vars are set', () => {
@@ -54,5 +54,75 @@ describe('applyModelPrefix', () => {
 
   it('returns false when parsedBody has no model', () => {
     assert.equal(applyModelPrefix({}, 'databricks-'), false);
+  });
+});
+
+describe('stripInjectedStats', () => {
+  it('removes the status line from the last assistant text block', () => {
+    const body = {
+      messages: [{
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello world\n\n---\n📊 Context: 10.0% (20,000 / 200,000) | 20,000 in + 5 out' }],
+      }],
+    };
+    assert.equal(stripInjectedStats(body), true);
+    assert.equal(body.messages[0].content[0].text, 'Hello world');
+  });
+
+  it('removes the block entirely when only the status line remains', () => {
+    const body = {
+      messages: [{
+        role: 'assistant',
+        content: [{ type: 'text', text: '\n\n---\n📊 Context: 10.0% (20,000 / 200,000) | 20,000 in + 5 out' }],
+      }],
+    };
+    assert.equal(stripInjectedStats(body), true);
+    assert.equal(body.messages[0].content.length, 0);
+  });
+
+  it('leaves messages without a status line untouched', () => {
+    const body = {
+      messages: [{
+        role: 'assistant',
+        content: [{ type: 'text', text: 'No stats here' }],
+      }],
+    };
+    assert.equal(stripInjectedStats(body), false);
+    assert.equal(body.messages[0].content[0].text, 'No stats here');
+  });
+
+  it('ignores non-assistant messages', () => {
+    const body = {
+      messages: [{
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello\n\n---\n📊 Context: 10.0% (20,000 / 200,000) | 20,000 in + 5 out' }],
+      }],
+    };
+    assert.equal(stripInjectedStats(body), false);
+    assert.ok(body.messages[0].content[0].text.includes('📊'));
+  });
+
+  it('returns false when messages is absent', () => {
+    assert.equal(stripInjectedStats({}), false);
+    assert.equal(stripInjectedStats(null), false);
+  });
+});
+
+describe('statusLineEnabled flag', () => {
+  beforeEach(() => setStatusLineEnabled(true));
+
+  it('defaults to true', () => {
+    assert.equal(getStatusLineEnabled(), true);
+  });
+
+  it('setStatusLineEnabled(false) disables the flag', () => {
+    setStatusLineEnabled(false);
+    assert.equal(getStatusLineEnabled(), false);
+  });
+
+  it('setStatusLineEnabled(true) re-enables the flag', () => {
+    setStatusLineEnabled(false);
+    setStatusLineEnabled(true);
+    assert.equal(getStatusLineEnabled(), true);
   });
 });


### PR DESCRIPTION

Adds an "Inject stats ON/OFF" toggle in the topbar (persisted in ~/.ccxray/settings.json) that controls whether the 📊 Context stats block is appended to Claude responses. Fixes sub-agent workflows where the injected block was truncating the Agent tool result visible to the parent Claude.

Also fixes the HTML lang attribute from zh-TW to en.