### PR TITLE
fix(docker): add missing shared/ directory to Dockerfile COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN npm ci --omit=dev
 # Copy application code
 COPY server/ server/
 COPY public/ public/
+COPY shared/ shared/
 
 # Default port
 ENV PROXY_PORT=5577


### PR DESCRIPTION
## Problem

Running `docker build -t ccxray . && docker run -p 5577:5577 ccxray` causes the container to crash immediately on startup with:

```
Error: Cannot find module '../shared/injected-tags'
```

## Root cause

`server/helpers.js` requires `../shared/injected-tags` at load time, but the Dockerfile only copies `server/` and `public/` — the `shared/` directory is never included in the image.

## Fix

Add `COPY shared/ shared/` to the Dockerfile.

```diff
 # Copy application code
 COPY server/ server/
 COPY public/ public/
+COPY shared/ shared/
```

## Test

```bash
docker build -t ccxray .
docker run -p 5577:5577 ccxray
# Dashboard now accessible at http://localhost:5577
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)