### PR TITLE
fix(windows): hide console window when spawning cost worker

### DIFF
--- a/server/cost-budget.js
+++ b/server/cost-budget.js
@@ -41,7 +41,7 @@ const FAILURE_BACKOFF_MS = 60_000;
 
 function streamUsageEntries() {
   return new Promise((resolve, reject) => {
-    const worker = fork(path.join(__dirname, 'cost-worker.js'), [], { silent: true });
+    const worker = fork(path.join(__dirname, 'cost-worker.js'), [], { silent: true, windowsHide: true });
     const chunks = [];
     let stderrBuf = '';
     const timeout = setTimeout(() => {


### PR DESCRIPTION
## Summary
Adds `windowsHide: true` to the child process fork options to suppress the console window popup on Windows systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)