### PR TITLE
fix(ui): copy 'claude --resume <uuid>' so it actually resumes the session

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -407,8 +407,7 @@ function formatEntryDateShort(id) {
 
 
 function copySessionContinue(sid, btn) {
-  const shortSid = sid === 'direct-api' ? sid : sid.slice(0, 8);
-  navigator.clipboard.writeText('claude --continue ' + shortSid).then(() => {
+  navigator.clipboard.writeText('claude --resume ' + sid).then(() => {
     const orig = btn.textContent;
     btn.textContent = '✓ copied!';
     btn.style.color = 'var(--green)';
@@ -510,7 +509,7 @@ function renderSessionItem(sess, sid) {
   const titleRow = sess.title
     ? '<div class="si-title">' + escapeHtml(sess.title) + '</div>'
     : '';
-  const copyBtn = '<button class="launch-btn" onclick="event.stopPropagation();copySessionContinue(&quot;' + escapeHtml(sid) + '&quot;,this)" title="Copy: claude --continue ' + escapeHtml(shortSid) + '">&#10697;</button>';
+  const copyBtn = '<button class="launch-btn" onclick="event.stopPropagation();copySessionContinue(&quot;' + escapeHtml(sid) + '&quot;,this)" title="Copy: claude --resume ' + escapeHtml(shortSid) + '">&#10697;</button>';
   return '<div class="si-row1">' +
     '<button class="' + sdotClasses + '"' + (sdotTitle ? ' title="' + sdotTitle + '"' : '') + (sdotOnclick ? ' onclick="' + sdotOnclick + '"' : '') + ' tabindex="-1"></button>' +
     '<span class="sid" title="' + escapeHtml(tooltip) + '">' + escapeHtml(shortSid) + '</span>' +


### PR DESCRIPTION
## Summary

The Sessions-column ⊙ copy button on a session card was writing
`claude --continue <8-char-prefix>` to the clipboard. That command does
not resume the intended session — paste it and you get either a
silently-wrong session or a stray prompt sent to the model. This PR
makes the button copy `claude --resume <full-uuid>` so the pasted
command actually resumes the correct session.

- `public/miller-columns.js` — clipboard payload uses the full UUID and `--resume`
- Tooltip updated from `Copy: claude --continue …` to `Copy: claude --resume …`
- The 8-char short ID rendered in the session card is **unchanged** — only the clipboard content changes

## Why the original was broken

`claude --help` (verified on a current Claude Code install):

| Flag | Help text | Accepts a session id? |
|---|---|---|
| `-c, --continue` | "Continue the most recent conversation in the current directory" | **No** |
| `-r, --resume [value]` | "Resume a conversation by session ID, or open interactive picker with optional search term" | **Yes** |

So the original `claude --continue <8-char>` failed on two axes at once:

1. **Wrong subcommand.** `--continue` always picks "most recent
   conversation in cwd" and ignores anything that follows as a session
   selector. But Claude Code's CLI accepts a positional `prompt` arg —
   so the 8-char string was being parsed as the *first user message*
   sent to the model. Net effect of pasting the old output: resume
   whatever the most recent session in cwd happens to be (frequently
   not the one shown in the dashboard), then say "8f3a1c2e…" to it.

2. **Truncated UUID.** Even if a flag accepted a session-id argument,
   `slice(0, 8)` is not a resumable identifier — `--resume` matches
   on the full UUID. The full UUID is already extracted server-side
   (`server/store.js` `extractSessionId()` parses
   `metadata.user_id`'s `{"session_id":"<uuid>"}`) and is what the
   front-end has in `sid`. We were just truncating it on the way to
   the clipboard for no functional reason.

The dashboard display can keep the 8-char prefix as a visual label;
that part of the UX is fine and untouched. The fix is purely on what
hits the clipboard.

## Note

`server/store.js` `printSessionBanner()` has the same conceptual bug
in the terminal banner (`claude --continue ${sessionId}`). It uses the
full UUID, so the impact is milder, but the command is still wrong for
the same reason. Out of scope for this PR; happy to follow up
separately if desired.

## Test plan

- [ ] `npm run dev`, open dashboard, click ⊙ on a non-`direct-api` session card
- [ ] Verify clipboard contains `claude --resume <36-char UUID>`
- [ ] Paste in a terminal; Claude Code resumes the matching session
- [ ] Hover the button — tooltip reads `Copy: claude --resume <8-char>`
- [ ] Session card still shows the 8-char short ID in the row (visual unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)