### PR TITLE
feat: add Codex V0 raw Responses capture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,14 @@ ccxray claude (2nd)  → discover hub via ~/.ccxray/hub.json → connect as clie
 - Crash recovery: clients monitor hub pid every 5s, auto-fork new hub using port as mutex
 - Version check: semver major mismatch → reject, minor → warn, patch → silent
 
+### Agent Launching
+
+- Launchers are registered in `server/providers.js`. Add future providers there with one entry for command name, display name, upstream family, launch args/env, and install hint; avoid adding new `if provider` branches in `server/index.js`.
+- Claude mode sets `ANTHROPIC_BASE_URL=http://localhost:<port>` in the spawned Claude process.
+- Codex mode spawns `codex -c 'openai_base_url="http://localhost:<port>/v1"' ...args` and logs raw OpenAI Responses request/response JSON.
+- Extra user args pass through unchanged after ccxray's injected launcher config.
+- `--no-browser` only suppresses browser auto-open. The dashboard remains available on the proxy port.
+
 ### Data Flow
 
 ```

--- a/README.md
+++ b/README.md
@@ -23,15 +23,20 @@ ccxray makes it a glass box.
 
 ```bash
 npx ccxray claude
+# or
+npx ccxray codex
 ```
 
-That's it. Proxy starts, Claude Code launches through it, and the dashboard opens automatically in your browser. Run it in multiple terminals — they automatically share one dashboard.
+That's it. Proxy starts, the selected CLI launches through it, and the dashboard opens automatically in your browser. Run it in multiple terminals — they automatically share one dashboard.
+
+The launcher argument is provider-backed. Today `claude` and `codex` are supported; unknown provider commands fail fast instead of silently starting an unconfigured proxy.
 
 ### Other ways to run
 
 ```bash
 ccxray                           # Proxy + dashboard only
 ccxray claude --continue         # All claude args pass through
+ccxray codex exec "hello"        # All codex args pass through
 ccxray --port 8080 claude        # Custom port (independent, no hub sharing)
 ccxray claude --no-browser       # Skip auto-open browser
 ccxray status                    # Show hub info and connected clients

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -23,15 +23,20 @@ ccxray 讓它變成透明的。
 
 ```bash
 npx ccxray claude
+# 或
+npx ccxray codex
 ```
 
-就這樣。代理啟動、Claude Code 透過代理連線、儀表板自動在瀏覽器中開啟。在多個終端機執行時會自動共用同一個 dashboard。
+就這樣。代理啟動、選定的 CLI 透過代理連線、儀表板自動在瀏覽器中開啟。在多個終端機執行時會自動共用同一個 dashboard。
+
+launcher 參數由 provider registry 管理。目前支援 `claude` 與 `codex`；未知的 provider command 會直接失敗，避免靜默啟動未設定的 proxy。
 
 ### 其他執行方式
 
 ```bash
 ccxray                           # 只啟動代理 + 儀表板
 ccxray claude --continue         # 所有 claude 參數直接穿透
+ccxray codex exec "hello"        # 所有 codex 參數直接穿透
 ccxray --port 8080 claude        # 自訂 port（獨立模式，不共用 hub）
 ccxray claude --no-browser       # 不自動開啟瀏覽器
 ccxray status                    # 顯示 hub 資訊及已連線的 client

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -182,12 +182,12 @@ function renderContextBreakdownSticky(tok, maxContext, usage) {
 }
 
 function isAbnormalStop(stopReason) {
-  return !!stopReason && stopReason !== 'end_turn' && stopReason !== 'tool_use';
+  return !!stopReason && !['end_turn', 'tool_use', 'completed'].includes(stopReason);
 }
 
 function classifySeverity(entry, ctxPct, dupesMax) {
   if (ctxPct > 95) return 'critical';
-  if (entry.status != null && (entry.status < 200 || entry.status >= 300)) return 'critical';
+  if (entry.status != null && !isHttpStatusOk(entry.status)) return 'critical';
   if (isAbnormalStop(entry.stopReason)) return 'critical';
   if (ctxPct > 85) return 'warning';
   if (entry.hasCredential) return 'warning';
@@ -198,10 +198,11 @@ function classifySeverity(entry, ctxPct, dupesMax) {
 
 function getCriticalMarker(stopReason, httpStatus, ctxPct) {
   // ctx > 95%: no inline marker (left bar only)
-  if (httpStatus != null && (httpStatus < 200 || httpStatus >= 300)) return '!http';
+  if (httpStatus != null && !isHttpStatusOk(httpStatus)) return '!http';
   if (stopReason === 'max_tokens') return '!max';
   if (stopReason === 'length') return '!len';
   if (stopReason && stopReason !== 'end_turn' && stopReason !== 'tool_use'
+      && stopReason !== 'completed'
       && stopReason !== 'max_tokens' && stopReason !== 'length'
       && stopReason !== 'content_filter') return '!stop';
   if (stopReason === 'content_filter') return '!filter';
@@ -279,7 +280,7 @@ function addEntry(e) {
   if (turnCost != null) proj.totalCost += turnCost;
   renderProjectsCol();
 
-  const statusClass = e.status >= 200 && e.status < 300 ? 'status-ok' : 'status-err';
+  const statusClass = isHttpStatusOk(e.status) ? 'status-ok' : 'status-err';
   const shortModel = model.replace('claude-', '').replace(/-[0-9]{8}$/, '');
 
   const ctxCacheCreate = usage ? (usage.cache_creation_input_tokens || 0) : 0;
@@ -365,7 +366,7 @@ function addEntry(e) {
   // Line 1: identity + critical marker + cost
   const prefix = isSubagent ? '↳s' + sess.subCount : '#' + displayNum;
   const modelHtml = '<span class="turn-model">' + escapeHtml(shortModel) + '</span>';
-  const dotClass = e.status >= 200 && e.status < 300 ? 'status-dot status-dot-ok' : 'status-dot status-dot-err';
+  const dotClass = isHttpStatusOk(e.status) ? 'status-dot status-dot-ok' : 'status-dot status-dot-err';
   const waitMark = stopReason === 'end_turn' ? '<span class="turn-wait" title="Waiting for user">↵</span>' : '';
   const critMarker = getCriticalMarker(stopReason, e.status, ctxPct);
   const critMarkerHtml = critMarker ? '<span class="turn-critical-marker">' + critMarker + '</span>' : '';

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -446,8 +446,8 @@ function clearAll() { // kept for console use if needed
 }
 
 function renderSessionItem(sess, sid) {
-  const shortSid = sid === 'direct-api' ? 'direct API' : sid.slice(0, 8);
-  const tooltip = sid === 'direct-api' ? 'direct API' : sid;
+  const shortSid = formatSessionIdLabel(sid);
+  const tooltip = formatSessionTooltip(null, sid);
   const shortModel = (sess.model || '?').replace('claude-', '').replace(/-[0-9]{8}$/, '');
   const costStr = sess.totalCost > 0 ? '$' + sess.totalCost.toFixed(2) : '—';
   const dateStr = sess.lastId ? formatRelativeTime(sess.lastId) : (sess.firstId ? formatEntryDate(sess.firstId) : escapeHtml(sess.firstTs || ''));
@@ -1032,7 +1032,7 @@ function syncUrlFromState() {
   if (typeof activeTab !== 'undefined' && activeTab !== 'dashboard') params.set('view', activeTab);
   const projName = selectedProjectName || (selectedSessionId && sessionsMap.get(selectedSessionId) && getProjectName(sessionsMap.get(selectedSessionId).cwd));
   if (projName) params.set('p', projName);
-  if (selectedSessionId) params.set('s', selectedSessionId.slice(0, 8));
+  if (selectedSessionId) params.set('s', formatSessionUrlToken(selectedSessionId));
   if (selectedTurnIdx >= 0) {
     const e = allEntries[selectedTurnIdx];
     const turnEl = e ? colTurns.querySelector('.turn-item[data-entry-idx="' + selectedTurnIdx + '"]') : null;

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -5,6 +5,10 @@ const sessionsMap = new Map(); // sid → { id, firstTs, firstId, count, model, 
 const projectsMap = new Map(); // projectName → { name, totalCost, sessionIds, firstId, lastId }
 const sessionStatusMap = new Map(); // sid → { active: bool, lastSeenAt: number|null }
 
+function isHttpStatusOk(status) {
+  return status === 101 || (status >= 200 && status < 300);
+}
+
 // ── Toast notifications ──
 function showToast(message, duration) {
   duration = duration || 5000;
@@ -1165,7 +1169,7 @@ function renderSectionsCol(idx) {
   const usage = e.usage || {};
   const inTok = usage.input_tokens || '?';
   const outTok = usage.output_tokens || '?';
-  const statusClass = e.status >= 200 && e.status < 300 ? 'status-ok' : 'status-err';
+  const statusClass = isHttpStatusOk(e.status) ? 'status-ok' : 'status-err';
   const resEvents = Array.isArray(e.res) ? e.res : [];
   const stopReason = e.stopReason || (Array.isArray(resEvents) ? (resEvents.find(ev => ev.type === 'message_delta')?.delta?.stop_reason || '') : '');
   const turnCost = e.cost;

--- a/public/session-label.js
+++ b/public/session-label.js
@@ -1,23 +1,40 @@
 'use strict';
 
-// Returns the visible label for a session card / breadcrumb / intercept overlay.
-// Prefers the Claude Code title-generator output when present; otherwise falls
-// back to the 8-character short id, preserving the old synthetic label for
-// direct-api traffic.
-function formatSessionLabel(sess, sid) {
-  if (sess && sess.title) return sess.title;
-  if (sid === 'direct-api') return 'direct API';
+const NAMED_SESSION_LABELS = Object.freeze({
+  'direct-api': 'direct API',
+  'codex-raw': 'Codex Raw',
+});
+
+function formatSessionIdLabel(sid) {
   if (!sid) return '?';
+  if (NAMED_SESSION_LABELS[sid]) return NAMED_SESSION_LABELS[sid];
   return sid.slice(0, 8);
 }
 
+function formatSessionUrlToken(sid) {
+  if (!sid) return '';
+  if (NAMED_SESSION_LABELS[sid]) return sid;
+  return sid.slice(0, 8);
+}
+
+// Returns the visible label for a session card / breadcrumb / intercept overlay.
+// Prefers the Claude Code title-generator output when present; otherwise falls
+// back to the short id or a friendly label for synthetic named sessions.
+function formatSessionLabel(sess, sid) {
+  if (sess && sess.title) return sess.title;
+  return formatSessionIdLabel(sid);
+}
+
 function formatSessionTooltip(sess, sid) {
-  const shortSid = sid === 'direct-api' ? 'direct API' : (sid || '').slice(0, 8);
+  const shortSid = formatSessionIdLabel(sid);
   if (sess && sess.title) return sess.title + ' · ' + shortSid;
-  return shortSid;
+  if (NAMED_SESSION_LABELS[sid]) return shortSid + ' · ' + sid;
+  return sid || shortSid;
 }
 
 if (typeof window !== 'undefined') {
+  window.formatSessionIdLabel = formatSessionIdLabel;
   window.formatSessionLabel = formatSessionLabel;
   window.formatSessionTooltip = formatSessionTooltip;
+  window.formatSessionUrlToken = formatSessionUrlToken;
 }

--- a/server/config.js
+++ b/server/config.js
@@ -21,39 +21,151 @@ function parseBaseUrl(rawUrl) {
     const basePath = u.pathname !== '/' ? u.pathname.replace(/\/$/, '') : '';
     return { protocol, hostname, port, basePath };
   } catch {
-    console.warn(`[ccxray] Warning: ANTHROPIC_BASE_URL is not a valid URL ("${rawUrl}"); falling back to api.anthropic.com`);
     return null;
   }
 }
 
-// Priority: ANTHROPIC_TEST_* (test/CI overrides) > ANTHROPIC_BASE_URL > built-in defaults
-function resolveUpstream(env, proxyPort) {
-  if (env.ANTHROPIC_TEST_HOST || env.ANTHROPIC_TEST_PORT || env.ANTHROPIC_TEST_PROTOCOL) {
-    const host = env.ANTHROPIC_TEST_HOST || 'api.anthropic.com';
-    const port = parseInt(env.ANTHROPIC_TEST_PORT || '443', 10);
-    const protocol = env.ANTHROPIC_TEST_PROTOCOL || 'https';
-    const missing = ['ANTHROPIC_TEST_HOST', 'ANTHROPIC_TEST_PORT', 'ANTHROPIC_TEST_PROTOCOL']
-      .filter(k => !env[k]);
-    if (missing.length > 0 && missing.length < 3) {
-      console.warn(`[ccxray] Warning: partial ANTHROPIC_TEST_* override — ${missing.join(', ')} not set; resolved upstream: ${protocol}://${host}:${port}`);
-    }
-    return { host, port, protocol, basePath: '', source: 'test-override' };
-  }
-
-  const parsed = parseBaseUrl(env.ANTHROPIC_BASE_URL);
-  if (parsed) {
-    const { hostname: host, port, protocol, basePath } = parsed;
-    if (new Set(['localhost', '127.0.0.1', '::1']).has(host) && port === proxyPort) {
-      console.warn(`[ccxray] Warning: upstream ${protocol}://${host}:${port} points back at the proxy itself — requests will loop`);
-    }
-    return { host, port, protocol, basePath, source: 'ANTHROPIC_BASE_URL' };
-  }
-
-  return { host: 'api.anthropic.com', port: 443, protocol: 'https', basePath: '', source: 'default' };
+function isLoopbackHost(host) {
+  return new Set(['localhost', '127.0.0.1', '::1']).has(host);
 }
 
+function warnInvalidBaseUrl(envName, rawUrl, fallbackHost) {
+  console.warn(`[ccxray] Warning: ${envName} is not a valid URL ("${rawUrl}"); falling back to ${fallbackHost}`);
+}
+
+function warnSelfLoop(provider, protocol, host, port) {
+  console.warn(`[ccxray] Warning: ${provider} upstream ${protocol}://${host}:${port} points back at the proxy itself — requests will loop`);
+}
+
+function resolveChatGPTUpstream(env, proxyPort) {
+  const raw = env.CHATGPT_BASE_URL || env.CODEX_CHATGPT_BASE_URL;
+  const parsed = parseBaseUrl(raw);
+  if (parsed) {
+    const { hostname: host, port, protocol, basePath } = parsed;
+    if (isLoopbackHost(host) && port === proxyPort) {
+      warnSelfLoop('chatgpt', protocol, host, port);
+    }
+    return {
+      provider: 'openai',
+      host,
+      port,
+      protocol,
+      basePath,
+      stripPathPrefix: '/v1',
+      source: env.CHATGPT_BASE_URL ? 'CHATGPT_BASE_URL' : 'CODEX_CHATGPT_BASE_URL',
+    };
+  }
+  if (raw) warnInvalidBaseUrl(env.CHATGPT_BASE_URL ? 'CHATGPT_BASE_URL' : 'CODEX_CHATGPT_BASE_URL', raw, 'chatgpt.com');
+
+  return {
+    provider: 'openai',
+    host: 'chatgpt.com',
+    port: 443,
+    protocol: 'https',
+    basePath: '/backend-api/codex',
+    stripPathPrefix: '/v1',
+    source: 'chatgpt-default',
+  };
+}
+
+// Priority: PROVIDER_TEST_* (test/CI overrides) > PROVIDER_BASE_URL > built-in defaults
+function resolveProviderUpstream(provider, env, proxyPort, opts) {
+  const upper = provider.toUpperCase();
+  const testHostKey = `${upper}_TEST_HOST`;
+  const testPortKey = `${upper}_TEST_PORT`;
+  const testProtocolKey = `${upper}_TEST_PROTOCOL`;
+  const baseUrlKey = `${upper}_BASE_URL`;
+
+  if (env[testHostKey] || env[testPortKey] || env[testProtocolKey]) {
+    const host = env[testHostKey] || opts.defaultHost;
+    const port = parseInt(env[testPortKey] || String(opts.defaultPort), 10);
+    const protocol = env[testProtocolKey] || opts.defaultProtocol;
+    const missing = [testHostKey, testPortKey, testProtocolKey]
+      .filter(k => !env[k]);
+    if (missing.length > 0 && missing.length < 3) {
+      console.warn(`[ccxray] Warning: partial ${upper}_TEST_* override — ${missing.join(', ')} not set; resolved upstream: ${protocol}://${host}:${port}`);
+    }
+    return { provider, host, port, protocol, basePath: '', source: 'test-override' };
+  }
+
+  const parsed = parseBaseUrl(env[baseUrlKey]);
+  if (parsed) {
+    const { hostname: host, port, protocol, basePath } = parsed;
+    if (isLoopbackHost(host) && port === proxyPort) {
+      warnSelfLoop(provider, protocol, host, port);
+    }
+    return { provider, host, port, protocol, basePath, source: baseUrlKey };
+  }
+
+  if (env[baseUrlKey]) warnInvalidBaseUrl(baseUrlKey, env[baseUrlKey], opts.defaultHost);
+
+  return {
+    provider,
+    host: opts.defaultHost,
+    port: opts.defaultPort,
+    protocol: opts.defaultProtocol,
+    basePath: opts.defaultBasePath || '',
+    source: 'default',
+  };
+}
+
+const UPSTREAMS = {
+  anthropic: resolveProviderUpstream('anthropic', process.env, PORT, {
+    defaultHost: 'api.anthropic.com',
+    defaultPort: 443,
+    defaultProtocol: 'https',
+    defaultBasePath: '',
+  }),
+  openai: resolveProviderUpstream('openai', process.env, PORT, {
+    defaultHost: 'api.openai.com',
+    defaultPort: 443,
+    defaultProtocol: 'https',
+    defaultBasePath: '/v1',
+  }),
+  openaiChatGPT: resolveChatGPTUpstream(process.env, PORT),
+};
+
 const { host: ANTHROPIC_HOST, port: ANTHROPIC_PORT, protocol: ANTHROPIC_PROTOCOL, basePath: ANTHROPIC_BASE_PATH, source: ANTHROPIC_BASE_URL_SOURCE } =
-  resolveUpstream(process.env, PORT);
+  UPSTREAMS.anthropic;
+const { host: OPENAI_HOST, port: OPENAI_PORT, protocol: OPENAI_PROTOCOL, basePath: OPENAI_BASE_PATH, source: OPENAI_BASE_URL_SOURCE } =
+  UPSTREAMS.openai;
+
+function getUpstream(provider) {
+  return UPSTREAMS[provider] || UPSTREAMS.anthropic;
+}
+
+function getProviderForRequest(urlPath) {
+  const pathname = (urlPath || '').split('?')[0];
+  if (pathname === '/v1/responses' || pathname.startsWith('/v1/responses/')) return 'openai';
+  if (pathname === '/v1/models' || pathname.startsWith('/v1/models/')) return 'openai';
+  return 'anthropic';
+}
+
+function getUpstreamForRequest(urlPath) {
+  return getUpstream(getProviderForRequest(urlPath));
+}
+
+function getUpstreamForRequestAndHeaders(urlPath, headers = {}) {
+  const upstream = getUpstreamForRequest(urlPath);
+  if (upstream.provider === 'openai' && headers['chatgpt-account-id']) {
+    return UPSTREAMS.openaiChatGPT;
+  }
+  return upstream;
+}
+
+function joinUpstreamPath(upstream, requestUrl) {
+  const basePath = upstream?.basePath || '';
+  let urlPath = requestUrl || '/';
+  const stripPrefix = upstream?.stripPathPrefix;
+  if (stripPrefix && (urlPath === stripPrefix || urlPath.startsWith(`${stripPrefix}/`) || urlPath.startsWith(`${stripPrefix}?`))) {
+    urlPath = urlPath.slice(stripPrefix.length) || '/';
+  }
+  if (!basePath) return urlPath;
+  if (urlPath === basePath || urlPath.startsWith(`${basePath}/`) || urlPath.startsWith(`${basePath}?`)) {
+    return urlPath;
+  }
+  return basePath + (urlPath.startsWith('/') ? urlPath : `/${urlPath}`);
+}
 const LOGS_DIR = path.join(os.homedir(), '.ccxray', 'logs');
 const LEGACY_LOGS_DIR = path.join(__dirname, '..', 'logs');
 const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || '3', 10);
@@ -76,6 +188,21 @@ const MODEL_CONTEXT_FALLBACK = {
   'claude-3-opus':     200_000,
   'claude-3-sonnet':   200_000,
   'claude-3-haiku':    200_000,
+  'gpt-5.2-codex':       400_000,
+  'gpt-5.1-codex-max':   400_000,
+  'gpt-5.1-codex-mini':  400_000,
+  'gpt-5.1-codex':       400_000,
+  'gpt-5-codex':         400_000,
+  'gpt-5.2-chat-latest': 400_000,
+  'gpt-5.1-chat-latest': 400_000,
+  'gpt-5-chat-latest':   400_000,
+  'gpt-5.2':             400_000,
+  'gpt-5.1':             400_000,
+  'gpt-5-mini':          400_000,
+  'gpt-5-nano':          400_000,
+  'gpt-5':               400_000,
+  'gpt-4.1':             1_000_000,
+  'gpt-4o':              128_000,
 };
 const DEFAULT_CONTEXT = 200_000;
 
@@ -136,6 +263,12 @@ module.exports = {
   ANTHROPIC_PROTOCOL,
   ANTHROPIC_BASE_PATH,
   ANTHROPIC_BASE_URL_SOURCE,
+  OPENAI_HOST,
+  OPENAI_PORT,
+  OPENAI_PROTOCOL,
+  OPENAI_BASE_PATH,
+  OPENAI_BASE_URL_SOURCE,
+  UPSTREAMS,
   LOGS_DIR,
   RESTORE_DAYS,
   LOG_RETENTION_DAYS,
@@ -146,4 +279,10 @@ module.exports = {
   DEFAULT_CONTEXT,
   getMaxContext,
   parseBaseUrl,
+  resolveProviderUpstream,
+  getProviderForRequest,
+  getUpstream,
+  getUpstreamForRequest,
+  getUpstreamForRequestAndHeaders,
+  joinUpstreamPath,
 };

--- a/server/forward.js
+++ b/server/forward.js
@@ -150,14 +150,89 @@ function parseSSEFrame(rawFrame, receivedAt) {
   return frame;
 }
 
+function parseSSEText(raw, receivedAt) {
+  const text = String(raw || '').replace(/\r\n/g, '\n');
+  if (!/^\s*(event|data):/m.test(text)) return null;
+  const events = [];
+  for (const part of text.split('\n\n')) {
+    if (!part.trim()) continue;
+    events.push(parseSSEFrame(part, receivedAt));
+  }
+  return events.length ? events : null;
+}
+
+function isOpenAIResponseObject(data) {
+  return !!data && typeof data === 'object' && !Array.isArray(data)
+    && (data.object === 'response' || data.id || data.model || data.status || data.usage || data.output);
+}
+
+function extractOpenAIResponse(data) {
+  if (!data || typeof data !== 'object') return null;
+  if (isOpenAIResponseObject(data.response)) return data.response;
+  return isOpenAIResponseObject(data) ? data : null;
+}
+
+function getOpenAIResponseFromEvents(events) {
+  if (!Array.isArray(events)) return null;
+  for (let i = events.length - 1; i >= 0; i--) {
+    const response = extractOpenAIResponse(events[i]?.data);
+    if (response) return response;
+  }
+  return null;
+}
+
+function getOpenAIOutputSummary(response) {
+  const output = Array.isArray(response?.output) ? response.output : [];
+  for (let i = output.length - 1; i >= 0; i--) {
+    const content = output[i]?.content;
+    if (!Array.isArray(content)) continue;
+    const text = content.map(part => part?.text || '').filter(Boolean).join(' ').replace(/\s+/g, ' ').trim();
+    if (text) return text.slice(0, 80);
+  }
+  return null;
+}
+
+function normalizeOpenAIResponseSummary(meta, resData) {
+  const events = Array.isArray(resData)
+    ? resData
+    : (typeof resData === 'string' ? parseSSEText(resData) : null);
+  const response = events ? getOpenAIResponseFromEvents(events) : extractOpenAIResponse(resData);
+  if (!response) return { summary: meta, resData };
+
+  const responseMetadata = {
+    ...(meta.responseMetadata || {}),
+    provider: 'openai',
+    id: response.id || meta.responseMetadata?.id || null,
+    object: response.object || meta.responseMetadata?.object || null,
+    model: response.model || meta.responseMetadata?.model || null,
+    status: meta.status ?? meta.responseMetadata?.status ?? null,
+    responseStatus: response.status || meta.responseMetadata?.responseStatus || null,
+  };
+
+  return {
+    summary: {
+      ...meta,
+      isSSE: events ? true : meta.isSSE,
+      model: meta.model || response.model || null,
+      usage: meta.usage || response.usage || null,
+      stopReason: meta.stopReason || response.status || '',
+      title: meta.title || getOpenAIOutputSummary(response),
+      responseMetadata,
+    },
+    resData: events || resData,
+  };
+}
+
 function buildResponseMetadata(provider, resData, proxyRes) {
   if (provider === 'openai') {
+    const response = extractOpenAIResponse(resData);
     return {
       provider: 'openai',
-      id: resData && typeof resData === 'object' ? resData.id || null : null,
-      object: resData && typeof resData === 'object' ? resData.object || null : null,
-      model: resData && typeof resData === 'object' ? resData.model || null : null,
+      id: response ? response.id || null : null,
+      object: response ? response.object || null : null,
+      model: response ? response.model || null : null,
       status: proxyRes.statusCode,
+      responseStatus: response ? response.status || null : null,
     };
   }
   return { provider: 'anthropic', status: proxyRes.statusCode };
@@ -614,10 +689,12 @@ function handleOpenAISSE(ctx, proxyRes, clientRes) {
     }
 
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    const response = getOpenAIResponseFromEvents(events);
     const resWritePromise = config.storage.write(id, '_res.json', JSON.stringify(events))
       .catch(e => console.error('Write res.json failed:', e.message));
-    const responseMetadata = buildResponseMetadata('openai', null, proxyRes);
+    const responseMetadata = buildResponseMetadata('openai', response, proxyRes);
     responseMetadata.streaming = true;
+    const usage = response?.usage || null;
 
     const entry = {
       id, ts: ctx.ts, sessionId: reqSessionId, method: ctx.clientReq.method, url: ctx.clientReq.url,
@@ -626,21 +703,21 @@ function handleOpenAISSE(ctx, proxyRes, clientRes) {
       req: parsedBody, res: events,
       elapsed, status: proxyRes.statusCode, isSSE: true,
       tokens: null,
-      usage: null, cost: null,
+      usage, cost: null,
       responseMetadata,
       maxContext: null,
       cwd: store.sessionMeta[reqSessionId]?.cwd || null,
       receivedAt: startTime,
       thinkingDuration: null,
       duplicateToolCalls: null,
-      model: parsedBody?.model || null,
+      model: response?.model || parsedBody?.model || null,
       msgCount: Array.isArray(parsedBody?.input) ? parsedBody.input.length : 0,
       toolCount: Array.isArray(parsedBody?.tools) ? parsedBody.tools.length : 0,
       toolCalls: {},
       isSubagent: false,
       sessionInferred: true,
-      title: getOpenAIInputSummary(parsedBody?.input),
-      stopReason: '',
+      title: getOpenAIInputSummary(parsedBody?.input) || getOpenAIOutputSummary(response),
+      stopReason: response?.status || '',
       toolFail: false,
       sysHash: null,
       toolsHash: null,
@@ -660,9 +737,9 @@ function handleOpenAISSE(ctx, proxyRes, clientRes) {
       model: entry.model, msgCount: entry.msgCount, toolCount: entry.toolCount,
       toolCalls: entry.toolCalls, isSubagent: entry.isSubagent, sessionInferred: entry.sessionInferred,
       cwd: entry.cwd, isSSE: true,
-      usage: null, cost: null, maxContext: null,
+      usage, cost: null, maxContext: null,
       responseMetadata,
-      stopReason: '', title: entry.title, thinkingDuration: null,
+      stopReason: entry.stopReason, title: entry.title, thinkingDuration: null,
       toolFail: false,
       elapsed, status: proxyRes.statusCode,
       receivedAt: startTime,
@@ -721,15 +798,25 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
     const raw = Buffer.concat(resChunks).toString();
     let resData;
     try { resData = JSON.parse(raw); } catch { resData = raw; }
-    const resWritePromise = config.storage.write(id, '_res.json', typeof resData === 'string' ? resData : JSON.stringify(resData)).catch(e => console.error('Write res.json failed:', e.message));
 
     const provider = ctx.upstream?.provider || 'anthropic';
     const sessionId = reqSessionId;
+    let openAIEvents = null;
+    let openAIResponse = null;
+    if (provider === 'openai' && typeof resData === 'string') {
+      openAIEvents = parseSSEText(resData, Date.now());
+      if (openAIEvents) {
+        openAIResponse = getOpenAIResponseFromEvents(openAIEvents);
+        resData = openAIEvents;
+      }
+    }
+    const resWritePromise = config.storage.write(id, '_res.json', typeof resData === 'string' ? resData : JSON.stringify(resData))
+      .catch(e => console.error('Write res.json failed:', e.message));
     const maxContext = provider === 'anthropic' ? config.getMaxContext(parsedBody?.model, parsedBody?.system) : null;
     const isSubagent = provider === 'anthropic' && !store.extractCwd(parsedBody);
     const titleGenTitle = provider === 'anthropic' ? resolveTitleGenTitle(parsedBody, resData, startTime) : null;
     const title = provider === 'openai'
-      ? getOpenAIInputSummary(parsedBody?.input)
+      ? (getOpenAIInputSummary(parsedBody?.input) || getOpenAIOutputSummary(openAIResponse || resData))
       : (titleGenTitle
         || (isSubagent
           ? helpers.extractFirstUserText(parsedBody)
@@ -738,28 +825,32 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
              || helpers.extractToolResultSummary(parsedBody)))
         || null);
     const toolFail = provider === 'anthropic' ? helpers.hasToolFail(parsedBody) : false;
-    const stopReason = provider === 'openai' ? (resData?.status || '') : (resData?.stop_reason || '');
+    const stopReason = provider === 'openai' ? ((openAIResponse || resData)?.status || '') : (resData?.stop_reason || '');
+    const usage = provider === 'openai' ? ((openAIResponse || resData)?.usage || null) : null;
     const currMsgCount = provider === 'openai'
       ? (Array.isArray(parsedBody?.input) ? parsedBody.input.length : 0)
       : (parsedBody?.messages?.length || 0);
     const thinkingStripped = provider === 'anthropic'
       ? computeThinkingStripped(isSubagent, reqSessionId, currMsgCount, parsedBody)
       : undefined;
-    const responseMetadata = buildResponseMetadata(provider, resData, proxyRes);
+    const responseMetadata = buildResponseMetadata(provider, openAIResponse || resData, proxyRes);
+    if (openAIEvents) responseMetadata.streaming = true;
     const entry = {
       id, ts: ctx.ts, sessionId, method: ctx.clientReq.method, url: ctx.clientReq.url,
       provider,
       agent: provider === 'openai' ? 'codex' : 'claude',
       req: parsedBody, res: resData,
-      elapsed, status: proxyRes.statusCode, isSSE: false,
+      elapsed, status: proxyRes.statusCode, isSSE: !!openAIEvents,
       tokens: provider === 'anthropic' ? helpers.tokenizeRequest(parsedBody) : null,
-      usage: null, cost: null,
+      usage, cost: null,
       responseMetadata,
       maxContext,
       cwd: store.sessionMeta[sessionId]?.cwd || null,
       receivedAt: startTime,
       duplicateToolCalls: provider === 'anthropic' ? helpers.extractDuplicateToolCalls(parsedBody?.messages) : null,
-      model: (provider === 'openai' && resData && typeof resData === 'object' ? resData.model : null) || parsedBody?.model || null,
+      model: (provider === 'openai' && openAIResponse ? openAIResponse.model : null)
+        || (provider === 'openai' && resData && typeof resData === 'object' && !Array.isArray(resData) ? resData.model : null)
+        || parsedBody?.model || null,
       msgCount: currMsgCount,
       toolCount: parsedBody?.tools?.length || 0,
       toolCalls: provider === 'anthropic' ? helpers.extractToolCalls(parsedBody?.messages) : {},
@@ -786,8 +877,8 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
       agent: entry.agent,
       model: entry.model, msgCount: entry.msgCount, toolCount: entry.toolCount,
       toolCalls: entry.toolCalls, isSubagent: entry.isSubagent, sessionInferred: entry.sessionInferred,
-      cwd: entry.cwd, isSSE: false,
-      usage: null, cost: null, maxContext,
+      cwd: entry.cwd, isSSE: entry.isSSE,
+      usage, cost: null, maxContext,
       responseMetadata,
       stopReason, title, thinkingDuration: null,
       toolFail,
@@ -822,4 +913,14 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
   });
 }
 
-module.exports = { forwardRequest, resolveProxyAgent, applyModelPrefix, stripInjectedStats, setStatusLineEnabled, getStatusLineEnabled, parseSSEFrame };
+module.exports = {
+  forwardRequest,
+  resolveProxyAgent,
+  applyModelPrefix,
+  stripInjectedStats,
+  setStatusLineEnabled,
+  getStatusLineEnabled,
+  parseSSEFrame,
+  parseSSEText,
+  normalizeOpenAIResponseSummary,
+};

--- a/server/forward.js
+++ b/server/forward.js
@@ -106,8 +106,88 @@ function applyModelPrefix(parsedBody, prefix) {
   return true;
 }
 
-// Tunnel agent is module-level so the connection pool is reused across requests.
-const TUNNEL_AGENT = resolveProxyAgent(config.ANTHROPIC_PROTOCOL, process.env);
+function parseSSEFrame(rawFrame, receivedAt) {
+  const frame = { event: null, type: null, data: null };
+  if (receivedAt) frame._ts = receivedAt;
+
+  const dataLines = [];
+  for (const rawLine of String(rawFrame || '').split(/\n/)) {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+    if (!line || line.startsWith(':')) continue;
+    const sep = line.indexOf(':');
+    const field = sep >= 0 ? line.slice(0, sep) : line;
+    let value = sep >= 0 ? line.slice(sep + 1) : '';
+    if (value.startsWith(' ')) value = value.slice(1);
+
+    if (field === 'event') frame.event = value || null;
+    else if (field === 'data') dataLines.push(value);
+    else if (field === 'id') frame.id = value;
+    else if (field === 'retry') frame.retry = value;
+  }
+
+  const dataText = dataLines.join('\n');
+  if (!dataText) {
+    frame.type = frame.event || 'raw';
+    frame.raw = rawFrame;
+    return frame;
+  }
+  if (dataText === '[DONE]') {
+    frame.type = frame.event || 'done';
+    frame.data = '[DONE]';
+    return frame;
+  }
+
+  try {
+    const parsed = JSON.parse(dataText);
+    frame.data = parsed;
+    frame.type = parsed?.type || frame.event || null;
+  } catch {
+    frame.type = frame.event || 'raw';
+    frame.dataRaw = dataText;
+    frame.raw = rawFrame;
+    frame.parseError = true;
+  }
+  return frame;
+}
+
+function buildResponseMetadata(provider, resData, proxyRes) {
+  if (provider === 'openai') {
+    return {
+      provider: 'openai',
+      id: resData && typeof resData === 'object' ? resData.id || null : null,
+      object: resData && typeof resData === 'object' ? resData.object || null : null,
+      model: resData && typeof resData === 'object' ? resData.model || null : null,
+      status: proxyRes.statusCode,
+    };
+  }
+  return { provider: 'anthropic', status: proxyRes.statusCode };
+}
+
+function getOpenAIInputSummary(input) {
+  if (typeof input === 'string') return input.replace(/\s+/g, ' ').trim().slice(0, 80) || null;
+  if (!Array.isArray(input)) return null;
+  for (let i = input.length - 1; i >= 0; i--) {
+    const item = input[i] || {};
+    if (item.role && item.role !== 'user') continue;
+    const content = item.content;
+    if (typeof content === 'string') return content.replace(/\s+/g, ' ').trim().slice(0, 80) || null;
+    if (!Array.isArray(content)) continue;
+    const text = content.map(part => part?.text || '').filter(Boolean).join(' ').replace(/\s+/g, ' ').trim();
+    if (text) return text.slice(0, 80);
+  }
+  return null;
+}
+
+// Tunnel agents are module-level so connection pools are reused across requests.
+const TUNNEL_AGENTS = new Map();
+function getTunnelAgent(upstream) {
+  if (!upstream || upstream.protocol !== 'https') return null;
+  const key = upstream.provider || `${upstream.protocol}:${upstream.host}:${upstream.port}`;
+  if (!TUNNEL_AGENTS.has(key)) {
+    TUNNEL_AGENTS.set(key, resolveProxyAgent(upstream.protocol, process.env));
+  }
+  return TUNNEL_AGENTS.get(key);
+}
 
 // ── Strip injected proxy stats from conversation history ─────────────
 const STATS_PATTERN = /\n\n---\n📊 Context: .+$/s;
@@ -133,6 +213,8 @@ function stripInjectedStats(parsedBody) {
 // ── Forward request to Anthropic ─────────────────────────────────────
 function forwardRequest(ctx) {
   const { id, ts, startTime, parsedBody, rawBody, clientReq, clientRes, fwdHeaders, reqSessionId } = ctx;
+  const upstream = ctx.upstream || config.getUpstreamForRequest(clientReq.url);
+  const provider = upstream.provider || 'anthropic';
 
   // Counter + attribution prefix are committed here, not at request receipt.
   // This guarantees intercepted-then-rejected requests never advance the
@@ -140,7 +222,7 @@ function forwardRequest(ctx) {
   // Counter classification uses !extractCwd to match dashboard's isSubagent.
   if (!ctx.skipEntry && parsedBody) {
     const meta = reqSessionId ? (store.sessionMeta[reqSessionId] || (store.sessionMeta[reqSessionId] = {})) : null;
-    const isSubagent = !store.extractCwd(parsedBody);
+    const isSubagent = provider === 'anthropic' && !store.extractCwd(parsedBody);
     if (meta) {
       if (isSubagent) meta.subCount = (meta.subCount || 0) + 1;
       else meta.mainCount = (meta.mainCount || 0) + 1;
@@ -153,7 +235,9 @@ function forwardRequest(ctx) {
       cwdForPrefix = hub.lookupClientCwd();
     }
     const isOrphan = isSubagent && ctx.sessionInferred && !cwdForPrefix && (!reqSessionId || reqSessionId === 'direct-api');
-    const turnStep = helpers.computeTurnStep(parsedBody.messages);
+    const turnStep = provider === 'anthropic'
+      ? helpers.computeTurnStep(parsedBody.messages)
+      : { turn: 0, step: 0 };
     ctx.attribPrefix = helpers.renderAttributionPrefix({
       sessionId: reqSessionId,
       cwd: cwdForPrefix,
@@ -175,12 +259,13 @@ function forwardRequest(ctx) {
   const modelPrefixed = applyModelPrefix(parsedBody, config.REWRITE_MODEL_PREFIX);
   const bodyToSend = (ctx.bodyModified || statsStripped || modelPrefixed) ? Buffer.from(JSON.stringify(parsedBody)) : rawBody;
 
-  const transport = config.ANTHROPIC_PROTOCOL === 'http' ? http : https;
+  const transport = upstream.protocol === 'http' ? http : https;
+  const tunnelAgent = getTunnelAgent(upstream);
   const proxyReq = transport.request({
-    hostname: config.ANTHROPIC_HOST, port: config.ANTHROPIC_PORT,
-    path: config.ANTHROPIC_BASE_PATH + clientReq.url, method: clientReq.method,
+    hostname: upstream.host, port: upstream.port,
+    path: config.joinUpstreamPath(upstream, clientReq.url), method: clientReq.method,
     headers: { ...fwdHeaders, 'content-length': bodyToSend.length },
-    ...(TUNNEL_AGENT ? { agent: TUNNEL_AGENT } : {}),
+    ...(tunnelAgent ? { agent: tunnelAgent } : {}),
   }, (proxyRes) => {
     const isSSE = (proxyRes.headers['content-type'] || '').includes('text/event-stream');
 
@@ -221,6 +306,12 @@ function forwardRequest(ctx) {
 }
 
 function handleSSEResponse(ctx, proxyRes, clientRes) {
+  const provider = ctx.upstream?.provider || 'anthropic';
+  if (provider === 'openai') {
+    handleOpenAISSE(ctx, proxyRes, clientRes);
+    return;
+  }
+
   const { id, startTime, parsedBody, reqSessionId, fwdHeaders } = ctx;
   const resChunks = [];
   let sseLineBuf = '';
@@ -400,6 +491,8 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
     const thinkingStripped = computeThinkingStripped(isSubagent, reqSessionId, currMsgCount, parsedBody);
     const entry = {
       id, ts: ctx.ts, sessionId, method: ctx.clientReq.method, url: ctx.clientReq.url,
+      provider: 'anthropic',
+      agent: 'claude',
       req: parsedBody, res: events,
       elapsed, status: proxyRes.statusCode, isSSE: true,
       tokens: helpers.tokenizeRequest(parsedBody),
@@ -418,9 +511,9 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
       title,
       stopReason,
       toolFail,
-      sysHash: ctx.sysHash || null,
-      toolsHash: ctx.toolsHash || null,
-      coreHash: ctx.coreHash || null,
+      sysHash: provider === 'anthropic' ? ctx.sysHash || null : null,
+      toolsHash: provider === 'anthropic' ? ctx.toolsHash || null : null,
+      coreHash: provider === 'anthropic' ? ctx.coreHash || null : null,
       thinkingStripped,
     };
     entry.hasCredential = helpers.entryHasCredential(entry) || undefined;
@@ -434,6 +527,8 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
     // Persist to index (fire-and-forget after broadcast)
     const indexLine = JSON.stringify({
       id, ts: ctx.ts, sessionId,
+      provider: entry.provider,
+      agent: entry.agent,
       model: entry.model, msgCount: entry.msgCount, toolCount: entry.toolCount,
       toolCalls: entry.toolCalls, isSubagent: entry.isSubagent, sessionInferred: entry.sessionInferred,
       cwd: entry.cwd, isSSE: true,
@@ -442,7 +537,7 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
       toolFail,
       elapsed, status: proxyRes.statusCode,
       receivedAt: startTime,
-      sysHash: ctx.sysHash || null, toolsHash: ctx.toolsHash || null,
+      sysHash: entry.sysHash, toolsHash: entry.toolsHash,
       coreHash: entry.coreHash,
       thinkingStripped: entry.thinkingStripped,
       hasCredential: entry.hasCredential,
@@ -468,6 +563,125 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
       store.sessionCosts.set(sessionId, (store.sessionCosts.get(sessionId) || 0) + costInfo.cost);
       console.log(`  💰 $${costInfo.cost.toFixed(4)} this turn | $${store.sessionCosts.get(sessionId).toFixed(4)} session`);
     }
+    helpers.printSeparator();
+    console.log();
+  });
+}
+
+function handleOpenAISSE(ctx, proxyRes, clientRes) {
+  const { id, startTime, parsedBody, reqSessionId } = ctx;
+  const events = [];
+  let sseBuf = '';
+
+  const processFrames = (text, flush = false) => {
+    sseBuf += text.replace(/\r\n/g, '\n');
+    const parts = sseBuf.split('\n\n');
+    sseBuf = parts.pop();
+    for (const part of parts) {
+      if (!part.trim()) continue;
+      events.push(parseSSEFrame(part, Date.now()));
+    }
+    if (flush && sseBuf.trim()) {
+      events.push(parseSSEFrame(sseBuf, Date.now()));
+      sseBuf = '';
+    }
+  };
+
+  proxyRes.on('error', (err) => {
+    console.error(`\x1b[31m❌ UPSTREAM STREAM ERROR: ${err.message}\x1b[0m`);
+    if (reqSessionId) {
+      store.activeRequests[reqSessionId] = Math.max(0, (store.activeRequests[reqSessionId] || 1) - 1);
+      broadcastSessionStatus(reqSessionId);
+    }
+    if (!clientRes.writableEnded) clientRes.end();
+  });
+
+  proxyRes.on('data', chunk => {
+    processFrames(chunk.toString('utf8'));
+    clientRes.write(chunk);
+  });
+
+  proxyRes.on('end', () => {
+    processFrames('', true);
+    clientRes.end();
+
+    if (ctx.skipEntry) return;
+
+    if (reqSessionId) {
+      store.activeRequests[reqSessionId] = Math.max(0, (store.activeRequests[reqSessionId] || 1) - 1);
+      broadcastSessionStatus(reqSessionId);
+      if (store.sessionMeta[reqSessionId]) store.sessionMeta[reqSessionId].lastStopReason = null;
+    }
+
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    const resWritePromise = config.storage.write(id, '_res.json', JSON.stringify(events))
+      .catch(e => console.error('Write res.json failed:', e.message));
+    const responseMetadata = buildResponseMetadata('openai', null, proxyRes);
+    responseMetadata.streaming = true;
+
+    const entry = {
+      id, ts: ctx.ts, sessionId: reqSessionId, method: ctx.clientReq.method, url: ctx.clientReq.url,
+      provider: 'openai',
+      agent: 'codex',
+      req: parsedBody, res: events,
+      elapsed, status: proxyRes.statusCode, isSSE: true,
+      tokens: null,
+      usage: null, cost: null,
+      responseMetadata,
+      maxContext: null,
+      cwd: store.sessionMeta[reqSessionId]?.cwd || null,
+      receivedAt: startTime,
+      thinkingDuration: null,
+      duplicateToolCalls: null,
+      model: parsedBody?.model || null,
+      msgCount: Array.isArray(parsedBody?.input) ? parsedBody.input.length : 0,
+      toolCount: Array.isArray(parsedBody?.tools) ? parsedBody.tools.length : 0,
+      toolCalls: {},
+      isSubagent: false,
+      sessionInferred: true,
+      title: getOpenAIInputSummary(parsedBody?.input),
+      stopReason: '',
+      toolFail: false,
+      sysHash: null,
+      toolsHash: null,
+      coreHash: null,
+      thinkingStripped: undefined,
+    };
+    entry.hasCredential = helpers.entryHasCredential(entry) || undefined;
+    entry._writePromise = Promise.all([ctx.reqWritePromise, resWritePromise].filter(Boolean));
+    store.entries.push(entry);
+    store.trimEntries();
+    broadcast(entry);
+
+    const indexLine = JSON.stringify({
+      id, ts: ctx.ts, sessionId: reqSessionId,
+      provider: entry.provider,
+      agent: entry.agent,
+      model: entry.model, msgCount: entry.msgCount, toolCount: entry.toolCount,
+      toolCalls: entry.toolCalls, isSubagent: entry.isSubagent, sessionInferred: entry.sessionInferred,
+      cwd: entry.cwd, isSSE: true,
+      usage: null, cost: null, maxContext: null,
+      responseMetadata,
+      stopReason: '', title: entry.title, thinkingDuration: null,
+      toolFail: false,
+      elapsed, status: proxyRes.statusCode,
+      receivedAt: startTime,
+      sysHash: null, toolsHash: null,
+      coreHash: null,
+      hasCredential: entry.hasCredential,
+    });
+    config.storage.appendIndex(indexLine + '\n').catch(e => console.error('Write index failed:', e.message));
+
+    entry.req = null;
+    entry.res = null;
+    entry._loaded = false;
+
+    const code = proxyRes.statusCode;
+    const ok = code >= 200 && code < 300;
+    const glyph = ok ? '✓' : '✗';
+    const color = ok ? '\x1b[32m' : '\x1b[31m';
+    const prefix = ctx.attribPrefix || '';
+    console.log(`${color}📥 [${helpers.taipeiTime()}]  ${prefix}  ${glyph} ${code}  ${elapsed}s\x1b[0m`);
     helpers.printSeparator();
     console.log();
   });
@@ -509,35 +723,46 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
     try { resData = JSON.parse(raw); } catch { resData = raw; }
     const resWritePromise = config.storage.write(id, '_res.json', typeof resData === 'string' ? resData : JSON.stringify(resData)).catch(e => console.error('Write res.json failed:', e.message));
 
+    const provider = ctx.upstream?.provider || 'anthropic';
     const sessionId = reqSessionId;
-    const maxContext = config.getMaxContext(parsedBody?.model, parsedBody?.system);
-    const isSubagent = !store.extractCwd(parsedBody);
-    const titleGenTitle = resolveTitleGenTitle(parsedBody, resData, startTime);
-    const title = titleGenTitle
-      || (isSubagent
-        ? helpers.extractFirstUserText(parsedBody)
-        : (helpers.extractResponseTitle(resData)
-           || helpers.extractLastUserText(parsedBody)
-           || helpers.extractToolResultSummary(parsedBody)))
-      || null;
-    const toolFail = helpers.hasToolFail(parsedBody);
-    const stopReason = resData?.stop_reason || '';
-    const currMsgCount = parsedBody?.messages?.length || 0;
-    const thinkingStripped = computeThinkingStripped(isSubagent, reqSessionId, currMsgCount, parsedBody);
+    const maxContext = provider === 'anthropic' ? config.getMaxContext(parsedBody?.model, parsedBody?.system) : null;
+    const isSubagent = provider === 'anthropic' && !store.extractCwd(parsedBody);
+    const titleGenTitle = provider === 'anthropic' ? resolveTitleGenTitle(parsedBody, resData, startTime) : null;
+    const title = provider === 'openai'
+      ? getOpenAIInputSummary(parsedBody?.input)
+      : (titleGenTitle
+        || (isSubagent
+          ? helpers.extractFirstUserText(parsedBody)
+          : (helpers.extractResponseTitle(resData)
+             || helpers.extractLastUserText(parsedBody)
+             || helpers.extractToolResultSummary(parsedBody)))
+        || null);
+    const toolFail = provider === 'anthropic' ? helpers.hasToolFail(parsedBody) : false;
+    const stopReason = provider === 'openai' ? (resData?.status || '') : (resData?.stop_reason || '');
+    const currMsgCount = provider === 'openai'
+      ? (Array.isArray(parsedBody?.input) ? parsedBody.input.length : 0)
+      : (parsedBody?.messages?.length || 0);
+    const thinkingStripped = provider === 'anthropic'
+      ? computeThinkingStripped(isSubagent, reqSessionId, currMsgCount, parsedBody)
+      : undefined;
+    const responseMetadata = buildResponseMetadata(provider, resData, proxyRes);
     const entry = {
       id, ts: ctx.ts, sessionId, method: ctx.clientReq.method, url: ctx.clientReq.url,
+      provider,
+      agent: provider === 'openai' ? 'codex' : 'claude',
       req: parsedBody, res: resData,
       elapsed, status: proxyRes.statusCode, isSSE: false,
-      tokens: helpers.tokenizeRequest(parsedBody),
+      tokens: provider === 'anthropic' ? helpers.tokenizeRequest(parsedBody) : null,
       usage: null, cost: null,
+      responseMetadata,
       maxContext,
       cwd: store.sessionMeta[sessionId]?.cwd || null,
       receivedAt: startTime,
-      duplicateToolCalls: helpers.extractDuplicateToolCalls(parsedBody?.messages),
-      model: parsedBody?.model || null,
+      duplicateToolCalls: provider === 'anthropic' ? helpers.extractDuplicateToolCalls(parsedBody?.messages) : null,
+      model: (provider === 'openai' && resData && typeof resData === 'object' ? resData.model : null) || parsedBody?.model || null,
       msgCount: currMsgCount,
       toolCount: parsedBody?.tools?.length || 0,
-      toolCalls: helpers.extractToolCalls(parsedBody?.messages),
+      toolCalls: provider === 'anthropic' ? helpers.extractToolCalls(parsedBody?.messages) : {},
       isSubagent,
       sessionInferred: ctx.sessionInferred || false,
       title,
@@ -557,10 +782,13 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
 
     const indexLine = JSON.stringify({
       id, ts: ctx.ts, sessionId,
+      provider: entry.provider,
+      agent: entry.agent,
       model: entry.model, msgCount: entry.msgCount, toolCount: entry.toolCount,
       toolCalls: entry.toolCalls, isSubagent: entry.isSubagent, sessionInferred: entry.sessionInferred,
       cwd: entry.cwd, isSSE: false,
       usage: null, cost: null, maxContext,
+      responseMetadata,
       stopReason, title, thinkingDuration: null,
       toolFail,
       elapsed, status: proxyRes.statusCode,
@@ -594,4 +822,4 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
   });
 }
 
-module.exports = { forwardRequest, resolveProxyAgent, applyModelPrefix, stripInjectedStats, setStatusLineEnabled, getStatusLineEnabled };
+module.exports = { forwardRequest, resolveProxyAgent, applyModelPrefix, stripInjectedStats, setStatusLineEnabled, getStatusLineEnabled, parseSSEFrame };

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -154,6 +154,30 @@ function parseSkillsFromMessages(messages) {
 
 function analyzeContext(body) {
   if (!body) return null;
+  if (body.provider === 'openai' || body.instructions != null || body.input != null) {
+    const instructionsTokens = safeCountTokens(
+      body.instructions == null
+        ? ''
+        : (typeof body.instructions === 'string' ? body.instructions : JSON.stringify(body.instructions))
+    );
+    const inputTokens = safeCountTokens(
+      body.input == null
+        ? ''
+        : (typeof body.input === 'string' ? body.input : JSON.stringify(body.input))
+    );
+    const toolsCat = categorizeTools(body.tools);
+    const toolTokens = {};
+    for (const [cat, arr] of Object.entries(toolsCat.byCategory)) {
+      toolTokens[cat] = arr.length > 0 ? safeCountTokens(JSON.stringify(arr)) : 0;
+    }
+    return {
+      systemBreakdown: { coreInstructions: instructionsTokens },
+      claudeMd: {},
+      messageTokens: inputTokens,
+      loadedSkills: [],
+      toolsBreakdown: { mcpPlugins: toolsCat.mcpPlugins, counts: toolsCat.counts, toolTokens },
+    };
+  }
   const systemBreakdown = parseSystemBlocks(body.system);
   const claudeMd = parseClaudeMdFromMessages(body.messages);
   const loadedSkills = parseSkillsFromMessages(body.messages);
@@ -189,7 +213,10 @@ function analyzeContext(body) {
 function tokenizeRequest(body) {
   if (!body) return null;
   const breakdown = {};
-  if (body.system) {
+  if (body.instructions != null) {
+    const text = typeof body.instructions === 'string' ? body.instructions : JSON.stringify(body.instructions);
+    breakdown.system = safeCountTokens(text);
+  } else if (body.system) {
     const text = typeof body.system === 'string' ? body.system : JSON.stringify(body.system);
     breakdown.system = safeCountTokens(text);
   }
@@ -233,6 +260,9 @@ function tokenizeRequest(body) {
       return { role: m.role, tokens, blocks };
     });
     breakdown.messages = total;
+  } else if (body.input != null) {
+    const text = typeof body.input === 'string' ? body.input : JSON.stringify(body.input);
+    breakdown.messages = safeCountTokens(text);
   }
   breakdown.total = (breakdown.system || 0) + (breakdown.tools || 0) + (breakdown.messages || 0);
   breakdown.contextBreakdown = analyzeContext(body);

--- a/server/hub.js
+++ b/server/hub.js
@@ -197,7 +197,7 @@ function releaseForkLock() {
 
 // ── Fork detached hub process ───────────────────────────────────────
 
-function forkHub(port) {
+function forkHub(port, opts = {}) {
   const { spawn } = require('child_process');
   ensureHubDir();
   truncateHubLog();
@@ -205,12 +205,14 @@ function forkHub(port) {
   const fd = fs.openSync(HUB_LOG_PATH, 'a');
   const hubScript = path.resolve(__dirname, 'index.js');
   const args = ['--port', String(port), '--hub-mode'];
+  const env = { ...process.env };
+  if (opts.displayName && !env.CCXRAY_DISPLAY_NAME) env.CCXRAY_DISPLAY_NAME = opts.displayName;
 
   const child = spawn(process.execPath, [hubScript, ...args], {
     detached: true,
     stdio: ['ignore', fd, fd],
     windowsHide: true,
-    env: { ...process.env },
+    env,
   });
   child.unref();
   fs.closeSync(fd);

--- a/server/index.js
+++ b/server/index.js
@@ -107,6 +107,40 @@ function serveStatic(url, clientRes) {
   }
 }
 
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+function buildForwardHeaders(clientHeaders, upstream) {
+  const fwdHeaders = { ...clientHeaders };
+  const connectionTokens = String(clientHeaders.connection || '')
+    .split(',')
+    .map(token => token.trim().toLowerCase())
+    .filter(Boolean);
+
+  for (const header of HOP_BY_HOP_HEADERS) delete fwdHeaders[header];
+  for (const header of connectionTokens) delete fwdHeaders[header];
+  delete fwdHeaders.host;
+  delete fwdHeaders['accept-encoding'];
+  fwdHeaders.host = upstream.host;
+  return fwdHeaders;
+}
+
+function getCodexRawSessionId() {
+  return 'codex-raw';
+}
+
+function getCodexCwdFallback() {
+  return hub.lookupClientCwd() || (agentCommand === 'codex' ? process.cwd() : null);
+}
+
 // ── Server ──────────────────────────────────────────────────────────
 const server = http.createServer((clientReq, clientRes) => {
 
@@ -147,14 +181,14 @@ const server = http.createServer((clientReq, clientRes) => {
     // Quota-check probes: forward to Anthropic (rate limit headers still captured)
     // but skip all logging, session tracking, and entry creation
     if (parsedBody && store.isQuotaCheck(parsedBody)) {
-      const fwdHeaders = { ...clientReq.headers };
-      delete fwdHeaders['host'];
-      delete fwdHeaders['connection'];
-      delete fwdHeaders['accept-encoding'];
-      fwdHeaders['host'] = config.ANTHROPIC_HOST;
-      forwardRequest({ id, ts, startTime, parsedBody, rawBody, clientReq, clientRes, fwdHeaders, reqSessionId: null, reqWritePromise: null, skipEntry: true });
+      const upstream = config.getUpstreamForRequestAndHeaders(clientReq.url, clientReq.headers);
+      const fwdHeaders = buildForwardHeaders(clientReq.headers, upstream);
+      forwardRequest({ id, ts, startTime, parsedBody, rawBody, clientReq, clientRes, fwdHeaders, reqSessionId: null, reqWritePromise: null, skipEntry: true, upstream });
       return;
     }
+
+    const upstream = config.getUpstreamForRequestAndHeaders(clientReq.url, clientReq.headers);
+    const provider = upstream.provider || 'anthropic';
 
     let reqWritePromise = null;
     let sysHash = null;
@@ -167,16 +201,20 @@ const server = http.createServer((clientReq, clientRes) => {
         ? crypto.createHash('sha256').update(JSON.stringify(parsedBody.tools)).digest('hex').slice(0, 12)
         : null;
 
-      if (sysHash) config.storage.writeSharedIfAbsent(`sys_${sysHash}.json`, JSON.stringify(parsedBody.system))
-        .catch(e => console.error('Write sys failed:', e.message));
-      if (toolsHash) config.storage.writeSharedIfAbsent(`tools_${toolsHash}.json`, JSON.stringify(parsedBody.tools))
-        .catch(e => console.error('Write tools failed:', e.message));
+      if (provider === 'anthropic') {
+        if (sysHash) config.storage.writeSharedIfAbsent(`sys_${sysHash}.json`, JSON.stringify(parsedBody.system))
+          .catch(e => console.error('Write sys failed:', e.message));
+        if (toolsHash) config.storage.writeSharedIfAbsent(`tools_${toolsHash}.json`, JSON.stringify(parsedBody.tools))
+          .catch(e => console.error('Write tools failed:', e.message));
+      }
 
       const currMessages = Array.isArray(parsedBody.messages) ? parsedBody.messages : [];
       const peekSid = store.extractSessionId(parsedBody);
       let stripped;
 
-      if (peekSid && config.storage.supportsDelta) {
+      if (provider === 'openai') {
+        stripped = parsedBody;
+      } else if (peekSid && config.storage.supportsDelta) {
         const prev = sessionLastReq.get(peekSid);
         const sharedCount = prev ? findSharedPrefix(prev.messages, currMessages) : 0;
         const forceFull = !prev ||
@@ -206,14 +244,17 @@ const server = http.createServer((clientReq, clientRes) => {
     }
 
     const { sessionId: reqSessionId, isNewSession, inferred: sessionInferred } = parsedBody
-      ? store.detectSession(parsedBody)
-      : { sessionId: store.getCurrentSessionId(), isNewSession: false };
+      ? (provider === 'openai'
+        ? { sessionId: getCodexRawSessionId(), isNewSession: false, inferred: true }
+        : store.detectSession(parsedBody))
+      : { sessionId: provider === 'openai' ? getCodexRawSessionId() : store.getCurrentSessionId(), isNewSession: false };
 
     // Extract and store cwd
     if (parsedBody && reqSessionId) {
-      const cwd = store.extractCwd(parsedBody);
+      const cwd = provider === 'openai' ? getCodexCwdFallback() : store.extractCwd(parsedBody);
       if (cwd) {
         if (!store.sessionMeta[reqSessionId]) store.sessionMeta[reqSessionId] = {};
+        store.sessionMeta[reqSessionId].provider = provider;
         store.sessionMeta[reqSessionId].cwd = cwd;
       }
     }
@@ -253,6 +294,7 @@ const server = http.createServer((clientReq, clientRes) => {
     if (reqSessionId) {
       store.activeRequests[reqSessionId] = (store.activeRequests[reqSessionId] || 0) + 1;
       if (!store.sessionMeta[reqSessionId]) store.sessionMeta[reqSessionId] = {};
+      store.sessionMeta[reqSessionId].provider = provider;
       store.sessionMeta[reqSessionId].lastSeenAt = Date.now();
       broadcastSessionStatus(reqSessionId);
     }
@@ -263,13 +305,9 @@ const server = http.createServer((clientReq, clientRes) => {
     if (isNewSession) store.printSessionBanner(reqSessionId);
 
     // Build context for forwarding
-    const fwdHeaders = { ...clientReq.headers };
-    delete fwdHeaders['host'];
-    delete fwdHeaders['connection'];
-    delete fwdHeaders['accept-encoding'];
-    fwdHeaders['host'] = config.ANTHROPIC_HOST;
+    const fwdHeaders = buildForwardHeaders(clientReq.headers, upstream);
 
-    const ctx = { id, ts, startTime, parsedBody, rawBody, clientReq, clientRes, fwdHeaders, reqSessionId, reqWritePromise, sysHash, toolsHash, coreHash, sessionInferred };
+    const ctx = { id, ts, startTime, parsedBody, rawBody, clientReq, clientRes, fwdHeaders, reqSessionId, reqWritePromise, sysHash, toolsHash, coreHash, sessionInferred, upstream };
 
     // ── Intercept check ──
     const lastStop = store.sessionMeta[reqSessionId]?.lastStopReason;
@@ -502,6 +540,9 @@ async function startServer() {
     const upstreamUrl = `${config.ANTHROPIC_PROTOCOL}://${config.ANTHROPIC_HOST}:${config.ANTHROPIC_PORT}`;
     const upstreamNote = config.ANTHROPIC_BASE_URL_SOURCE === 'ANTHROPIC_BASE_URL' ? ' (from ANTHROPIC_BASE_URL)' : '';
     console.log(`   Upstream → ${upstreamUrl}${upstreamNote}`);
+    const openaiUrl = `${config.OPENAI_PROTOCOL}://${config.OPENAI_HOST}:${config.OPENAI_PORT}${config.OPENAI_BASE_PATH}`;
+    const openaiNote = config.OPENAI_BASE_URL_SOURCE === 'OPENAI_BASE_URL' ? ' (from OPENAI_BASE_URL)' : '';
+    console.log(`   OpenAI Upstream → ${openaiUrl}${openaiNote}`);
     console.log(`   Logs → ${config.LOGS_DIR}`);
     console.log();
     console.log(`   Usage: ANTHROPIC_BASE_URL=http://localhost:${actualPort} claude\x1b[0m`);
@@ -540,7 +581,7 @@ async function startServer() {
     return;
   }
 
-  // Claude mode without explicit port: try hub discovery
+  // Agent mode without explicit port: try hub discovery
   const existingHub = await hub.discoverHub(config.PORT);
   if (existingHub) {
     await startClientMode(existingHub);

--- a/server/index.js
+++ b/server/index.js
@@ -17,8 +17,9 @@ const { broadcastSessionStatus, broadcastPendingRequest } = require('./sse-broad
 const { authMiddleware } = require('./auth');
 const { extractAgentType, splitB2IntoBlocks } = require('./system-prompt');
 const { findSharedPrefix } = require('./delta-helpers');
+const providers = require('./providers');
 
-// ── CLI: parse flags and detect "claude" subcommand ──
+// ── CLI: parse flags and detect provider launchers ──
 const portIdx = process.argv.indexOf('--port');
 let explicitPort = false;
 if (portIdx !== -1) {
@@ -34,12 +35,25 @@ if (portIdx !== -1) {
 }
 const hubMode = process.argv.includes('--hub-mode');
 if (hubMode) process.argv.splice(process.argv.indexOf('--hub-mode'), 1);
-const claudeMode = process.argv[2] === 'claude';
-const claudeArgs = claudeMode ? process.argv.slice(3) : [];
+const noBrowser = process.argv.includes('--no-browser');
+if (noBrowser) process.argv.splice(process.argv.indexOf('--no-browser'), 1);
+const cliCommand = process.argv[2];
+const unknownCommand = cliCommand
+  && cliCommand !== 'status'
+  && !cliCommand.startsWith('-')
+  && !providers.isAgentProvider(cliCommand);
+if (unknownCommand) {
+  console.error(`\x1b[31mError: unsupported provider "${cliCommand}". Supported providers: ${providers.supportedProviderList()}\x1b[0m`);
+  process.exit(1);
+}
+const agentCommand = providers.isAgentProvider(cliCommand) ? cliCommand : null;
+const agentMode = Boolean(agentCommand);
+const agentArgs = agentMode ? process.argv.slice(3) : [];
+const DISPLAY_NAME = providers.getDisplayName(agentCommand, process.env);
 
-// In claude/hub mode, mute startup logs so they don't pollute output.
+// In agent/hub mode, mute startup logs so they don't pollute output.
 const _origLog = console.log;
-if (claudeMode || hubMode) console.log = () => {};
+if (agentMode || hubMode) console.log = () => {};
 
 // ── Delta log storage ────────────────────────────────────────────────
 // sessionLastReq tracks the most recent req per session for delta writes.
@@ -71,7 +85,7 @@ function rebuildIndexHTML(port) { serverPort = port; }
 function serveStatic(url, clientRes) {
   const pathname = url.split('?')[0];
   if (pathname === '/' || pathname === '/index.html') {
-    const script = `<script>window.__PROXY_CONFIG__=${JSON.stringify({ DEFAULT_CONTEXT: config.DEFAULT_CONTEXT, PORT: serverPort, statusLine: getStatusLineEnabled() })}</script>`;
+    const script = `<script>window.__PROXY_CONFIG__=${JSON.stringify({ DEFAULT_CONTEXT: config.DEFAULT_CONTEXT, PORT: serverPort, statusLine: getStatusLineEnabled(), APP_NAME: DISPLAY_NAME })}</script>`;
     const html = rawIndexHTML ? rawIndexHTML.replace('<!--__PROXY_CONFIG__-->', script) : '<html><body>Error loading dashboard</body></html>';
     clientRes.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
     clientRes.end(html);
@@ -282,30 +296,48 @@ const server = http.createServer((clientReq, clientRes) => {
 });
 
 
-// ── Spawn Claude Code with proxy env ──
-function spawnClaude(port, args) {
+// ── Spawn agent CLI with proxy routing ──
+function spawnAgent(command, port, args, onExit) {
   const { spawn } = require('child_process');
-  const child = spawn('claude', args, {
+  const launch = providers.getAgentLaunch(command, port, args);
+  let finished = false;
+  const finish = (code) => {
+    if (finished) return;
+    finished = true;
+    onExit(code);
+  };
+  if (!launch) {
+    console.error(`\x1b[31mError: unsupported provider "${command}". Supported providers: ${providers.supportedProviderList()}\x1b[0m`);
+    finish(1);
+    return;
+  }
+  const child = spawn(launch.bin, launch.args, {
     stdio: 'inherit',
-    env: { ...process.env, ANTHROPIC_BASE_URL: `http://localhost:${port}` },
+    env: launch.env,
   });
   child.on('error', (err) => {
     if (err.code === 'ENOENT') {
-      console.error('\x1b[31mError: "claude" command not found. Install Claude Code first:\x1b[0m');
-      console.error('\x1b[31m  npm install -g @anthropic-ai/claude-code\x1b[0m');
+      console.error(`\x1b[31mError: "${launch.bin}" command not found. Install ${launch.label} first:\x1b[0m`);
+      console.error(`\x1b[31m${launch.installHint}\x1b[0m`);
     } else {
-      console.error(`\x1b[31mFailed to start claude: ${err.message}\x1b[0m`);
+      console.error(`\x1b[31mFailed to start ${launch.bin}: ${err.message}\x1b[0m`);
     }
-    process.exit(1);
+    finish(1);
   });
   child.on('exit', (code, signal) => {
-    server.close();
-    process.exit(code ?? (signal === 'SIGINT' ? 130 : 1));
+    finish(code ?? (signal === 'SIGINT' ? 130 : 1));
   });
-  // SIGINT is already sent to claude by the terminal (same process group).
-  // Just prevent Node's default exit so we wait for claude's exit event.
+  // SIGINT is already sent to the child by the terminal (same process group).
+  // Just prevent Node's default exit so we wait for the child exit event.
   process.on('SIGINT', () => {});
   process.on('SIGTERM', () => child.kill('SIGTERM'));
+}
+
+function spawnStandaloneAgent(port, command, args) {
+  spawnAgent(command, port, args, (code) => {
+    server.close();
+    process.exit(code);
+  });
 }
 
 // ── "status" subcommand ──
@@ -368,7 +400,7 @@ async function startClientMode(lock) {
     const upstreamSuffix = config.ANTHROPIC_BASE_URL_SOURCE === 'ANTHROPIC_BASE_URL'
       ? `  →  ${config.ANTHROPIC_PROTOCOL}://${config.ANTHROPIC_HOST}:${config.ANTHROPIC_PORT} (from ANTHROPIC_BASE_URL)`
       : '';
-    _origLog(`\x1b[90mccxray → http://localhost:${lock.port} (hub)${upstreamSuffix}\x1b[0m`);
+    _origLog(`\x1b[90m${DISPLAY_NAME} → http://localhost:${lock.port} (hub)${upstreamSuffix}\x1b[0m`);
   }
 
   try {
@@ -380,7 +412,7 @@ async function startClientMode(lock) {
 
     // Auto-open browser for the first client connecting to this hub
     if (reg.firstClient) {
-      const noOpen = process.argv.includes('--no-browser')
+      const noOpen = noBrowser
         || process.env.BROWSER === 'none'
         || process.env.CI
         || process.env.SSH_TTY;
@@ -401,28 +433,12 @@ async function startClientMode(lock) {
     hub.registerClient(newLock.port, process.pid, process.cwd()).catch(() => {});
   });
 
-  // Spawn claude pointing to hub
-  const { spawn } = require('child_process');
-  const child = spawn('claude', claudeArgs, {
-    stdio: 'inherit',
-    env: { ...process.env, ANTHROPIC_BASE_URL: `http://localhost:${lock.port}` },
-  });
-  child.on('error', (err) => {
-    if (err.code === 'ENOENT') {
-      console.error('\x1b[31mError: "claude" command not found. Install Claude Code first:\x1b[0m');
-      console.error('\x1b[31m  npm install -g @anthropic-ai/claude-code\x1b[0m');
-    } else {
-      console.error(`\x1b[31mFailed to start claude: ${err.message}\x1b[0m`);
-    }
-    hub.unregisterClient(lock.port, process.pid).finally(() => process.exit(1));
-  });
-  child.on('exit', (code, signal) => {
+  // Spawn agent pointing to hub
+  spawnAgent(agentCommand, lock.port, agentArgs, (code) => {
     hub.unregisterClient(lock.port, process.pid).finally(() => {
-      process.exit(code ?? (signal === 'SIGINT' ? 130 : 1));
+      process.exit(code);
     });
   });
-  process.on('SIGINT', () => {});
-  process.on('SIGTERM', () => child.kill('SIGTERM'));
 }
 
 // ── Hub/Server startup ──
@@ -433,11 +449,11 @@ async function startServer() {
   await pruneLogs();
   warmUpCosts();
 
-  // Claude mode (with --port, standalone): scan up to 10 ports.
+  // Agent mode (with --port, standalone): scan up to 10 ports.
   // Hub mode: fixed port, but retry if old hub is still releasing it (race with idle shutdown).
   // EADDRINUSE in hub mode usually means the previous hub process hasn't fully exited yet —
   // port release takes a few ms after process.exit(). Retry up to 5s before giving up.
-  const maxAttempts = (claudeMode && !hubMode) ? 10 : 0;
+  const maxAttempts = (agentMode && !hubMode) ? 10 : 0;
   let actualPort;
   if (hubMode) {
     const HUB_BIND_RETRIES = 5;
@@ -464,7 +480,7 @@ async function startServer() {
   rebuildIndexHTML(actualPort);
 
   // Hub mode only: write lockfile as readiness signal, start client lifecycle
-  // Do NOT write lockfile in claudeMode with --port (that's independent mode)
+  // Do NOT write lockfile in agent mode with --port (that's independent mode)
   if (hubMode) {
     hub.setHubPort(actualPort);
     hub.writeHubLock(actualPort, process.pid);
@@ -477,11 +493,11 @@ async function startServer() {
   // Banner
   if (hubMode) {
     // Hub runs silently (logs go to hub.log)
-  } else if (claudeMode) {
-    _origLog(`\x1b[90mccxray → http://localhost:${actualPort}\x1b[0m`);
+  } else if (agentMode) {
+    _origLog(`\x1b[90m${DISPLAY_NAME} → http://localhost:${actualPort}\x1b[0m`);
   } else {
     console.log();
-    console.log(`\x1b[35m🔌 Claude API Proxy listening on http://localhost:${actualPort}\x1b[0m`);
+    console.log(`\x1b[35m🔌 ${DISPLAY_NAME} proxy listening on http://localhost:${actualPort}\x1b[0m`);
     console.log(`\x1b[90m   Dashboard → http://localhost:${actualPort}/`);
     const upstreamUrl = `${config.ANTHROPIC_PROTOCOL}://${config.ANTHROPIC_HOST}:${config.ANTHROPIC_PORT}`;
     const upstreamNote = config.ANTHROPIC_BASE_URL_SOURCE === 'ANTHROPIC_BASE_URL' ? ' (from ANTHROPIC_BASE_URL)' : '';
@@ -494,7 +510,7 @@ async function startServer() {
 
   // Auto-open dashboard in browser (not in hub mode)
   const noOpen = hubMode
-    || process.argv.includes('--no-browser')
+    || noBrowser
     || process.env.BROWSER === 'none'
     || process.env.CI
     || process.env.SSH_TTY;
@@ -504,13 +520,13 @@ async function startServer() {
     exec(`${cmd} http://localhost:${actualPort}`);
   }
 
-  if (claudeMode) spawnClaude(actualPort, claudeArgs);
+  if (agentMode) spawnStandaloneAgent(actualPort, agentCommand, agentArgs);
 }
 
 // ── Main entry ──
 (async () => {
   // Hub mode or explicit port or standalone: start server directly
-  if (hubMode || explicitPort || !claudeMode) {
+  if (hubMode || explicitPort || !agentMode) {
     try {
       await startServer();
     } catch (err) {

--- a/server/providers.js
+++ b/server/providers.js
@@ -1,0 +1,68 @@
+'use strict';
+
+// Provider launchers are centralized here so startup and hub recovery stay
+// provider-agnostic. Each CLI has its own routing contract for pointing at the
+// ccxray proxy, so new launchers should be additive registry entries instead
+// of new command-specific branches in server/index.js.
+
+const AGENT_PROVIDERS = Object.freeze({
+  claude: Object.freeze({
+    id: 'claude',
+    label: 'Claude Code',
+    displayName: 'ccxray',
+    upstream: 'anthropic',
+    installHint: '  npm install -g @anthropic-ai/claude-code',
+    createLaunch({ port, args, env }) {
+      return {
+        bin: 'claude',
+        args: [...args],
+        env: { ...env, ANTHROPIC_BASE_URL: `http://localhost:${port}` },
+      };
+    },
+  }),
+});
+
+function listAgentProviderIds() {
+  return Object.keys(AGENT_PROVIDERS);
+}
+
+function getAgentProvider(id) {
+  return AGENT_PROVIDERS[id] || null;
+}
+
+function isAgentProvider(id) {
+  return Boolean(getAgentProvider(id));
+}
+
+function supportedProviderList() {
+  return listAgentProviderIds().join(', ');
+}
+
+function getDisplayName(id, env = process.env) {
+  if (env.CCXRAY_DISPLAY_NAME) return env.CCXRAY_DISPLAY_NAME;
+  return getAgentProvider(id)?.displayName || 'ccxray';
+}
+
+function getAgentLaunch(id, port, args = [], env = process.env) {
+  const provider = getAgentProvider(id);
+  if (!provider) return null;
+  const launch = provider.createLaunch({ port, args, env });
+  return {
+    provider: provider.id,
+    label: provider.label,
+    displayName: provider.displayName,
+    upstream: provider.upstream,
+    installHint: provider.installHint,
+    ...launch,
+  };
+}
+
+module.exports = {
+  AGENT_PROVIDERS,
+  getAgentLaunch,
+  getAgentProvider,
+  getDisplayName,
+  isAgentProvider,
+  listAgentProviderIds,
+  supportedProviderList,
+};

--- a/server/providers.js
+++ b/server/providers.js
@@ -20,6 +20,21 @@ const AGENT_PROVIDERS = Object.freeze({
       };
     },
   }),
+
+  codex: Object.freeze({
+    id: 'codex',
+    label: 'Codex CLI',
+    displayName: 'ccxray',
+    upstream: 'openai',
+    installHint: '  npm install -g @openai/codex',
+    createLaunch({ port, args, env }) {
+      return {
+        bin: 'codex',
+        args: ['-c', `openai_base_url="http://localhost:${port}/v1"`, ...args],
+        env: { ...env },
+      };
+    },
+  }),
 });
 
 function listAgentProviderIds() {

--- a/server/restore.js
+++ b/server/restore.js
@@ -5,6 +5,7 @@ const config = require('./config');
 const store = require('./store');
 const { calculateCost } = require('./pricing');
 const { extractAgentType, splitB2IntoBlocks } = require('./system-prompt');
+const { normalizeOpenAIResponseSummary } = require('./forward');
 
 // ── Lazy-load req/res from disk on demand ────────────────────────────
 
@@ -50,7 +51,15 @@ function loadEntryReqRes(entry) {
     } catch { entry.req = null; }
     try {
       const raw = await config.storage.read(entry.id, '_res.json');
-      try { entry.res = JSON.parse(raw); } catch { entry.res = raw; }
+      let resData;
+      try { resData = JSON.parse(raw); } catch { resData = raw; }
+      if (entry.provider === 'openai') {
+        const normalized = normalizeOpenAIResponseSummary(entry, resData);
+        Object.assign(entry, normalized.summary);
+        entry.res = normalized.resData;
+      } else {
+        entry.res = resData;
+      }
     } catch { entry.res = null; }
     entry._loaded = true;
     entry._loadingPromise = null;
@@ -90,6 +99,15 @@ async function restoreFromLogs() {
     try { meta = JSON.parse(line); } catch { continue; }
 
     if (cutoffStr && meta.id.slice(0, 10) < cutoffStr) continue;
+
+    if (meta.provider === 'openai' && (!meta.model || !meta.stopReason || !meta.usage || !meta.isSSE)) {
+      try {
+        const raw = await config.storage.read(meta.id, '_res.json');
+        let resData;
+        try { resData = JSON.parse(raw); } catch { resData = raw; }
+        meta = normalizeOpenAIResponseSummary(meta, resData).summary;
+      } catch {}
+    }
 
     store.entries.push({ ...meta, req: null, res: null, _loaded: false });
 

--- a/server/restore.js
+++ b/server/restore.js
@@ -15,34 +15,38 @@ function loadEntryReqRes(entry) {
     if (entry._writePromise) await entry._writePromise.catch(() => {});
     try {
       const stripped = JSON.parse(await config.storage.read(entry.id, '_req.json'));
-      const sys = stripped.sysHash
-        ? await config.storage.readShared(`sys_${stripped.sysHash}.json`).then(JSON.parse).catch(() => null)
-        : null;
-      const tools = stripped.toolsHash
-        ? await config.storage.readShared(`tools_${stripped.toolsHash}.json`).then(JSON.parse).catch(() => null)
-        : null;
+      if (entry.provider === 'openai' || stripped.provider === 'openai') {
+        entry.req = stripped;
+      } else {
+        const sys = stripped.sysHash
+          ? await config.storage.readShared(`sys_${stripped.sysHash}.json`).then(JSON.parse).catch(() => null)
+          : null;
+        const tools = stripped.toolsHash
+          ? await config.storage.readShared(`tools_${stripped.toolsHash}.json`).then(JSON.parse).catch(() => null)
+          : null;
 
-      // Delta format: reconstruct full messages by following prevId chain.
-      // Each hop loads the previous entry (itself potentially a delta) via the
-      // same lazy-load mechanism, so the chain is resolved depth-first with
-      // per-entry promise deduplication. Missing prev entries (pruned) degrade
-      // gracefully — the delta portion is returned as-is.
-      let messages = stripped.messages || [];
-      if (stripped.prevId != null && stripped.msgOffset != null) {
-        const prevEntry = store.entries.find(e => e.id === stripped.prevId);
-        if (prevEntry) {
-          await loadEntryReqRes(prevEntry);
-          if (Array.isArray(prevEntry.req?.messages)) {
-            messages = [...prevEntry.req.messages.slice(0, stripped.msgOffset), ...messages];
+        // Delta format: reconstruct full messages by following prevId chain.
+        // Each hop loads the previous entry (itself potentially a delta) via the
+        // same lazy-load mechanism, so the chain is resolved depth-first with
+        // per-entry promise deduplication. Missing prev entries (pruned) degrade
+        // gracefully — the delta portion is returned as-is.
+        let messages = stripped.messages || [];
+        if (stripped.prevId != null && stripped.msgOffset != null) {
+          const prevEntry = store.entries.find(e => e.id === stripped.prevId);
+          if (prevEntry) {
+            await loadEntryReqRes(prevEntry);
+            if (Array.isArray(prevEntry.req?.messages)) {
+              messages = [...prevEntry.req.messages.slice(0, stripped.msgOffset), ...messages];
+            }
           }
         }
-      }
 
-      entry.req = { ...stripped, system: sys, tools, messages };
-      delete entry.req.sysHash;
-      delete entry.req.toolsHash;
-      delete entry.req.prevId;
-      delete entry.req.msgOffset;
+        entry.req = { ...stripped, system: sys, tools, messages };
+        delete entry.req.sysHash;
+        delete entry.req.toolsHash;
+        delete entry.req.prevId;
+        delete entry.req.msgOffset;
+      }
     } catch { entry.req = null; }
     try {
       const raw = await config.storage.read(entry.id, '_res.json');

--- a/server/sse-broadcast.js
+++ b/server/sse-broadcast.js
@@ -7,6 +7,8 @@ function summarizeEntry(entry) {
   const tok = entry.tokens;
   return {
     id: entry.id, ts: entry.ts, sessionId: entry.sessionId,
+    provider: entry.provider || 'anthropic',
+    agent: entry.agent || (entry.provider === 'openai' ? 'codex' : 'claude'),
     method: entry.method, url: entry.url,
     elapsed: entry.elapsed, status: entry.status, isSSE: entry.isSSE,
     receivedAt: entry.receivedAt || null,

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -23,7 +23,7 @@ after(() => {
 
 function runSnippet(snippet, env = {}) {
   return new Promise((resolve) => {
-    // Start from process.env, sanitise ambient ANTHROPIC_* vars that would
+    // Start from process.env, sanitise ambient provider vars that would
     // leak from a developer's shell and corrupt test results, then apply
     // the caller's explicit overrides on top.
     const sanitised = { ...process.env };
@@ -31,6 +31,10 @@ function runSnippet(snippet, env = {}) {
     delete sanitised.ANTHROPIC_TEST_HOST;
     delete sanitised.ANTHROPIC_TEST_PORT;
     delete sanitised.ANTHROPIC_TEST_PROTOCOL;
+    delete sanitised.OPENAI_BASE_URL;
+    delete sanitised.OPENAI_TEST_HOST;
+    delete sanitised.OPENAI_TEST_PORT;
+    delete sanitised.OPENAI_TEST_PROTOCOL;
     Object.assign(sanitised, env);
 
     const child = spawn(process.execPath, ['-e', snippet], {
@@ -56,6 +60,10 @@ describe('parseBaseUrl()', () => {
     delete process.env.ANTHROPIC_TEST_HOST;
     delete process.env.ANTHROPIC_TEST_PORT;
     delete process.env.ANTHROPIC_TEST_PROTOCOL;
+    delete process.env.OPENAI_BASE_URL;
+    delete process.env.OPENAI_TEST_HOST;
+    delete process.env.OPENAI_TEST_PORT;
+    delete process.env.OPENAI_TEST_PROTOCOL;
     // Re-require after clearing env (module may already be cached; that's fine
     // since parseBaseUrl is a pure function not affected by env at call time).
     ({ parseBaseUrl } = require('../server/config'));
@@ -192,6 +200,149 @@ describe('upstream priority chain', () => {
   });
 });
 
+describe('provider-aware OpenAI upstream configuration', () => {
+  const snippet = `
+    const c = require(${JSON.stringify(CONFIG_SCRIPT)});
+    process.stdout.write(JSON.stringify({
+      anthropic: {
+        host: c.ANTHROPIC_HOST,
+        port: c.ANTHROPIC_PORT,
+        protocol: c.ANTHROPIC_PROTOCOL,
+        source: c.ANTHROPIC_BASE_URL_SOURCE,
+        basePath: c.ANTHROPIC_BASE_PATH,
+      },
+      openai: {
+        host: c.OPENAI_HOST,
+        port: c.OPENAI_PORT,
+        protocol: c.OPENAI_PROTOCOL,
+        source: c.OPENAI_BASE_URL_SOURCE,
+        basePath: c.OPENAI_BASE_PATH,
+      },
+      providers: {
+        messages: c.getProviderForRequest('/v1/messages'),
+        responses: c.getProviderForRequest('/v1/responses'),
+        models: c.getProviderForRequest('/v1/models?client_version=0.125.0'),
+      },
+      chatgpt: {
+        source: c.UPSTREAMS.openaiChatGPT.source,
+        host: c.UPSTREAMS.openaiChatGPT.host,
+        port: c.UPSTREAMS.openaiChatGPT.port,
+        protocol: c.UPSTREAMS.openaiChatGPT.protocol,
+        basePath: c.UPSTREAMS.openaiChatGPT.basePath,
+        stripPathPrefix: c.UPSTREAMS.openaiChatGPT.stripPathPrefix,
+      },
+      paths: {
+        responses: c.joinUpstreamPath(c.getUpstream('openai'), '/v1/responses'),
+        completions: c.joinUpstreamPath(c.getUpstream('openai'), '/chat/completions'),
+        chatgptResponses: c.joinUpstreamPath(c.getUpstreamForRequestAndHeaders('/v1/responses', {'chatgpt-account-id': 'acct'}), '/v1/responses'),
+      },
+    }));
+  `;
+
+  it('defaults OpenAI to api.openai.com with /v1 base path without changing Anthropic defaults', async () => {
+    const { stdout } = await runSnippet(snippet, { CCXRAY_HOME: TEST_HOME });
+    const result = JSON.parse(stdout);
+    assert.deepEqual(result.anthropic, {
+      host: 'api.anthropic.com',
+      port: 443,
+      protocol: 'https',
+      source: 'default',
+      basePath: '',
+    });
+    assert.deepEqual(result.openai, {
+      host: 'api.openai.com',
+      port: 443,
+      protocol: 'https',
+      source: 'default',
+      basePath: '/v1',
+    });
+    assert.equal(result.providers.messages, 'anthropic');
+    assert.equal(result.providers.responses, 'openai');
+    assert.equal(result.providers.models, 'openai');
+    assert.deepEqual(result.chatgpt, {
+      host: 'chatgpt.com',
+      port: 443,
+      protocol: 'https',
+      source: 'chatgpt-default',
+      basePath: '/backend-api/codex',
+      stripPathPrefix: '/v1',
+    });
+    assert.equal(result.paths.chatgptResponses, '/backend-api/codex/responses');
+  });
+
+  it('OPENAI_BASE_URL overrides only the OpenAI upstream and preserves /v1 request paths', async () => {
+    const { stdout } = await runSnippet(snippet, {
+      OPENAI_BASE_URL: 'http://localhost:9000/v1',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    const result = JSON.parse(stdout);
+    assert.equal(result.anthropic.host, 'api.anthropic.com');
+    assert.equal(result.openai.host, 'localhost');
+    assert.equal(result.openai.port, 9000);
+    assert.equal(result.openai.protocol, 'http');
+    assert.equal(result.openai.source, 'OPENAI_BASE_URL');
+    assert.equal(result.openai.basePath, '/v1');
+    assert.equal(result.paths.responses, '/v1/responses');
+    assert.equal(result.paths.completions, '/v1/chat/completions');
+  });
+
+  it('CHATGPT_BASE_URL routes ChatGPT-auth Codex traffic without the /v1 prefix', async () => {
+    const { stdout } = await runSnippet(snippet, {
+      CHATGPT_BASE_URL: 'http://localhost:8123/backend-api/codex',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    const result = JSON.parse(stdout);
+    assert.equal(result.chatgpt.host, 'localhost');
+    assert.equal(result.chatgpt.port, 8123);
+    assert.equal(result.chatgpt.protocol, 'http');
+    assert.equal(result.chatgpt.source, 'CHATGPT_BASE_URL');
+    assert.equal(result.chatgpt.basePath, '/backend-api/codex');
+    assert.equal(result.paths.chatgptResponses, '/backend-api/codex/responses');
+  });
+
+  it('OPENAI_TEST_* overrides OPENAI_BASE_URL', async () => {
+    const { stdout } = await runSnippet(snippet, {
+      OPENAI_TEST_HOST: 'openai-test.example.com',
+      OPENAI_TEST_PORT: '9100',
+      OPENAI_TEST_PROTOCOL: 'http',
+      OPENAI_BASE_URL: 'https://api.example.com/v1',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    const result = JSON.parse(stdout);
+    assert.equal(result.openai.host, 'openai-test.example.com');
+    assert.equal(result.openai.port, 9100);
+    assert.equal(result.openai.protocol, 'http');
+    assert.equal(result.openai.basePath, '');
+    assert.equal(result.openai.source, 'test-override');
+  });
+
+  it('emits warning when partial OPENAI_TEST_* override is set', async () => {
+    const snippet = `require(${JSON.stringify(CONFIG_SCRIPT)});`;
+    const { stderr } = await runSnippet(snippet, {
+      OPENAI_TEST_PORT: '9000',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    assert.ok(
+      stderr.includes('partial OPENAI_TEST_* override') || stderr.includes('OPENAI_TEST_HOST') || stderr.includes('OPENAI_TEST_PROTOCOL'),
+      `Expected partial OpenAI override warning in stderr, got: ${stderr}`
+    );
+  });
+
+  it('falls back to OpenAI defaults when OPENAI_BASE_URL is malformed', async () => {
+    const { stdout, stderr } = await runSnippet(snippet, {
+      OPENAI_BASE_URL: 'not-a-url',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    const result = JSON.parse(stdout);
+    assert.equal(result.openai.host, 'api.openai.com');
+    assert.equal(result.openai.source, 'default');
+    assert.ok(
+      stderr.includes('OPENAI_BASE_URL') && stderr.includes('not a valid URL'),
+      `Expected malformed OPENAI_BASE_URL warning in stderr, got: ${stderr}`
+    );
+  });
+});
+
 // ── 4.3: Partial ANTHROPIC_TEST_* override warning ─────────────────
 
 describe('partial ANTHROPIC_TEST_* override', () => {
@@ -266,5 +417,26 @@ describe('self-loop detection', () => {
       !stderr.includes('points back at the proxy itself'),
       `Unexpected loop warning in stderr: ${stderr}`
     );
+  });
+
+  it('emits warning when OPENAI_BASE_URL points at the proxy itself', async () => {
+    const snippet = `require(${JSON.stringify(CONFIG_SCRIPT)});`;
+    const { stderr } = await runSnippet(snippet, {
+      PROXY_PORT: '5577',
+      OPENAI_BASE_URL: 'http://localhost:5577/v1',
+      CCXRAY_HOME: TEST_HOME,
+    });
+    assert.ok(
+      stderr.includes('openai upstream') && (stderr.includes('points back at the proxy itself') || stderr.includes('loop')),
+      `Expected OpenAI loop warning in stderr, got: ${stderr}`
+    );
+  });
+});
+
+describe('model context fallback', () => {
+  it('uses fallback context for Codex OpenAI models when dynamic pricing data is unavailable', () => {
+    const { getMaxContext } = require('../server/config');
+    assert.equal(getMaxContext('gpt-5.1-codex', null), 400_000);
+    assert.equal(getMaxContext('gpt-5.2-codex-20260401', null), 400_000);
   });
 });

--- a/test/dashboard-codex-e2e.test.js
+++ b/test/dashboard-codex-e2e.test.js
@@ -1,0 +1,179 @@
+'use strict';
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+const puppeteer = require('puppeteer');
+
+const SERVER_SCRIPT = path.join(__dirname, '..', 'server', 'index.js');
+const PROJECT_CWD = path.resolve(__dirname, '..');
+const PROJECT_NAME = path.basename(PROJECT_CWD);
+const tmpDirs = [];
+
+function makeOpenAISSE() {
+  return [
+    'event: response.created',
+    'data: ' + JSON.stringify({
+      type: 'response.created',
+      response: { id: 'resp_dashboard', object: 'response', model: 'gpt-5.5', status: 'in_progress' },
+    }),
+    '',
+    'event: response.completed',
+    'data: ' + JSON.stringify({
+      type: 'response.completed',
+      response: {
+        id: 'resp_dashboard',
+        object: 'response',
+        model: 'gpt-5.5',
+        status: 'completed',
+        usage: { input_tokens: 29096, output_tokens: 58, total_tokens: 29154 },
+        output: [{ type: 'message', content: [{ type: 'output_text', text: 'dashboard ok' }] }],
+      },
+    }),
+    '',
+  ].join('\n');
+}
+
+function writeFixtureHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-dashboard-codex-'));
+  tmpDirs.push(home);
+  const logsDir = path.join(home, 'logs');
+  fs.mkdirSync(path.join(logsDir, 'shared'), { recursive: true });
+  const id = '2026-05-03T23-38-05-284';
+  fs.writeFileSync(path.join(logsDir, `${id}_res.json`), makeOpenAISSE());
+  fs.writeFileSync(path.join(logsDir, 'index.ndjson'), JSON.stringify({
+    id,
+    ts: '23:38:05',
+    sessionId: 'codex-raw',
+    provider: 'openai',
+    agent: 'codex',
+    method: 'POST',
+    url: '/v1/responses',
+    elapsed: '2.3',
+    status: 200,
+    isSSE: false,
+    receivedAt: 1777822685284,
+    usage: null,
+    cost: null,
+    maxContext: null,
+    cwd: PROJECT_CWD,
+    model: null,
+    msgCount: 0,
+    toolCount: 0,
+    toolCalls: {},
+    isSubagent: false,
+    sessionInferred: false,
+    title: null,
+    stopReason: '',
+    responseMetadata: { provider: 'openai', status: 200 },
+  }) + '\n');
+  return home;
+}
+
+async function findFreePort() {
+  return new Promise(resolve => {
+    const server = http.createServer();
+    server.listen(0, () => {
+      const port = server.address().port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+function waitForPort(port, timeoutMs = 8000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      const req = http.get(`http://localhost:${port}/_api/health`, { timeout: 1000 }, res => {
+        res.resume();
+        res.on('end', () => resolve());
+      });
+      req.on('error', () => {
+        if (Date.now() - start > timeoutMs) return reject(new Error('server did not start'));
+        setTimeout(check, 100);
+      });
+      req.on('timeout', () => {
+        req.destroy();
+        if (Date.now() - start > timeoutMs) return reject(new Error('server did not start'));
+        setTimeout(check, 100);
+      });
+    };
+    check();
+  });
+}
+
+function killAndWait(child) {
+  return new Promise(resolve => {
+    if (!child || child.exitCode !== null) return resolve();
+    child.on('exit', resolve);
+    child.kill('SIGTERM');
+    setTimeout(() => {
+      try { child.kill('SIGKILL'); } catch {}
+      resolve();
+    }, 3000);
+  });
+}
+
+describe('Codex dashboard status E2E', () => {
+  after(() => {
+    for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('renders restored Codex completed responses as successful, not critical', async () => {
+    const home = writeFixtureHome();
+    const port = await findFreePort();
+    const child = spawn(process.execPath, [SERVER_SCRIPT, '--port', String(port), '--no-browser'], {
+      env: { ...process.env, CCXRAY_HOME: home, BROWSER: 'none', RESTORE_DAYS: '0' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let browser;
+    try {
+      await waitForPort(port);
+      browser = await puppeteer.launch({
+        headless: true,
+        args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      });
+      const page = await browser.newPage();
+      await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 1 });
+      await page.goto(`http://localhost:${port}/?p=${encodeURIComponent(PROJECT_NAME)}&s=codex-raw`, { waitUntil: 'domcontentloaded' });
+      await page.waitForFunction(() => {
+        const turn = document.querySelector('.turn-item[data-session-id="codex-raw"]');
+        const header = document.querySelector('#col-sections .ch-line2');
+        return !!turn && !!header && header.textContent.includes('completed');
+      });
+
+      const state = await page.evaluate(() => {
+        const turn = document.querySelector('.turn-item[data-session-id="codex-raw"]');
+        const header = document.querySelector('#col-sections .ch-line2');
+        const model = turn?.querySelector('.turn-model');
+        return {
+          projectText: document.querySelector('.project-item.selected .pi-label')?.textContent || '',
+          sessionText: document.querySelector('.session-item.selected .sid')?.textContent || '',
+          url: location.search,
+          hasOkDot: !!turn?.querySelector('.status-dot-ok'),
+          hasErrDot: !!turn?.querySelector('.status-dot-err'),
+          isCritical: turn?.classList.contains('risk-critical') || false,
+          modelText: model?.textContent || '',
+          sectionText: header?.textContent || '',
+        };
+      });
+
+      assert.equal(state.projectText, PROJECT_NAME);
+      assert.equal(state.sessionText, 'Codex Raw');
+      assert.match(state.url, /s=codex-raw/);
+      assert.equal(state.hasOkDot, true);
+      assert.equal(state.hasErrDot, false);
+      assert.equal(state.isCritical, false);
+      assert.match(state.modelText, /gpt-5\.5/);
+      assert.match(state.sectionText, /200/);
+      assert.match(state.sectionText, /completed/);
+    } finally {
+      if (browser) await browser.close();
+      await killAndWait(child);
+    }
+  });
+});

--- a/test/delta-restore.test.js
+++ b/test/delta-restore.test.js
@@ -9,7 +9,7 @@ const os = require('os');
 const config = require('../server/config');
 const store = require('../server/store');
 const { createLocalStorage } = require('../server/storage/local');
-const { loadEntryReqRes } = require('../server/restore');
+const { loadEntryReqRes, restoreFromLogs } = require('../server/restore');
 
 // loadEntryReqRes uses config.storage and store.entries as singletons.
 // Swap config.storage to a tmp dir for the duration of these tests, and
@@ -33,6 +33,7 @@ describe('loadEntryReqRes — delta chain reconstruction', () => {
 
   beforeEach(() => {
     store.entries.length = 0;
+    for (const sid of Object.keys(store.sessionMeta)) delete store.sessionMeta[sid];
   });
 
   // Helper: write an entry's _req.json and register it in store.entries
@@ -152,5 +153,62 @@ describe('loadEntryReqRes — delta chain reconstruction', () => {
     await loadEntryReqRes(entry);
     // Reconstruction: prev[0..2] + [] = full prev messages
     assert.deepEqual(entry.req.messages, msgs);
+  });
+
+  it('normalizes OpenAI SSE-shaped summaries when restoring from index', async () => {
+    const id = '2026-05-03T23-38-05-284';
+    const rawSSE = [
+      'event: response.created',
+      'data: ' + JSON.stringify({
+        type: 'response.created',
+        response: { id: 'resp_restore', object: 'response', model: 'gpt-5.5', status: 'in_progress' },
+      }),
+      '',
+      'event: response.completed',
+      'data: ' + JSON.stringify({
+        type: 'response.completed',
+        response: {
+          id: 'resp_restore',
+          object: 'response',
+          model: 'gpt-5.5',
+          status: 'completed',
+          usage: { input_tokens: 29, output_tokens: 5, total_tokens: 34 },
+          output: [{ type: 'message', content: [{ type: 'output_text', text: 'restored ok' }] }],
+        },
+      }),
+      '',
+    ].join('\n');
+    await config.storage.write(id, '_res.json', rawSSE);
+    await config.storage.appendIndex(JSON.stringify({
+      id,
+      ts: '23:38:05',
+      sessionId: 'codex-raw',
+      provider: 'openai',
+      agent: 'codex',
+      method: 'POST',
+      url: '/v1/responses',
+      status: 200,
+      isSSE: false,
+      model: null,
+      usage: null,
+      responseMetadata: { provider: 'openai', status: 200 },
+      stopReason: '',
+      receivedAt: 1777822685284,
+    }) + '\n');
+
+    await restoreFromLogs();
+    const entry = store.entries.find(e => e.id === id);
+
+    assert.ok(entry, 'expected restored OpenAI entry');
+    assert.equal(entry.isSSE, true);
+    assert.equal(entry.model, 'gpt-5.5');
+    assert.equal(entry.stopReason, 'completed');
+    assert.equal(entry.usage.input_tokens, 29);
+    assert.equal(entry.responseMetadata.id, 'resp_restore');
+    assert.equal(entry.responseMetadata.responseStatus, 'completed');
+
+    await loadEntryReqRes(entry);
+    assert.equal(Array.isArray(entry.res), true);
+    assert.equal(entry.res[entry.res.length - 1].type, 'response.completed');
   });
 });

--- a/test/forward-proxy.test.js
+++ b/test/forward-proxy.test.js
@@ -2,7 +2,16 @@
 
 const { describe, it, beforeEach } = require('node:test');
 const assert = require('node:assert/strict');
-const { resolveProxyAgent, applyModelPrefix, stripInjectedStats, setStatusLineEnabled, getStatusLineEnabled, parseSSEFrame } = require('../server/forward');
+const {
+  resolveProxyAgent,
+  applyModelPrefix,
+  stripInjectedStats,
+  setStatusLineEnabled,
+  getStatusLineEnabled,
+  parseSSEFrame,
+  parseSSEText,
+  normalizeOpenAIResponseSummary,
+} = require('../server/forward');
 
 describe('resolveProxyAgent', () => {
   it('returns null when no proxy env vars are set', () => {
@@ -147,5 +156,50 @@ describe('parseSSEFrame', () => {
     assert.equal(frame.type, 'response.output_text.delta');
     assert.equal(frame.parseError, true);
     assert.equal(frame.dataRaw, '{"delta":');
+  });
+});
+
+describe('OpenAI Responses summary normalization', () => {
+  it('parses SSE-shaped text and derives completed status metadata', () => {
+    const raw = [
+      'event: response.created',
+      'data: ' + JSON.stringify({
+        type: 'response.created',
+        response: { id: 'resp_1', object: 'response', model: 'gpt-5.5', status: 'in_progress' },
+      }),
+      '',
+      'event: response.completed',
+      'data: ' + JSON.stringify({
+        type: 'response.completed',
+        response: {
+          id: 'resp_1',
+          object: 'response',
+          model: 'gpt-5.5',
+          status: 'completed',
+          usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+          output: [{ type: 'message', content: [{ type: 'output_text', text: 'done' }] }],
+        },
+      }),
+      '',
+    ].join('\n');
+
+    const events = parseSSEText(raw, 123);
+    assert.equal(events.length, 2);
+    assert.equal(events[1].type, 'response.completed');
+
+    const normalized = normalizeOpenAIResponseSummary({
+      provider: 'openai',
+      status: 200,
+      responseMetadata: { provider: 'openai', status: 200 },
+    }, raw);
+
+    assert.equal(normalized.summary.isSSE, true);
+    assert.equal(normalized.summary.model, 'gpt-5.5');
+    assert.equal(normalized.summary.stopReason, 'completed');
+    assert.equal(normalized.summary.usage.input_tokens, 10);
+    assert.equal(normalized.summary.title, 'done');
+    assert.equal(normalized.summary.responseMetadata.id, 'resp_1');
+    assert.equal(normalized.summary.responseMetadata.responseStatus, 'completed');
+    assert.equal(Array.isArray(normalized.resData), true);
   });
 });

--- a/test/forward-proxy.test.js
+++ b/test/forward-proxy.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it, beforeEach } = require('node:test');
 const assert = require('node:assert/strict');
-const { resolveProxyAgent, applyModelPrefix, stripInjectedStats, setStatusLineEnabled, getStatusLineEnabled } = require('../server/forward');
+const { resolveProxyAgent, applyModelPrefix, stripInjectedStats, setStatusLineEnabled, getStatusLineEnabled, parseSSEFrame } = require('../server/forward');
 
 describe('resolveProxyAgent', () => {
   it('returns null when no proxy env vars are set', () => {
@@ -124,5 +124,28 @@ describe('statusLineEnabled flag', () => {
     setStatusLineEnabled(false);
     setStatusLineEnabled(true);
     assert.equal(getStatusLineEnabled(), true);
+  });
+});
+
+describe('parseSSEFrame', () => {
+  it('captures OpenAI Responses SSE event names and data as raw events', () => {
+    const frame = parseSSEFrame(
+      'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"hello"}',
+      123
+    );
+
+    assert.equal(frame.event, 'response.output_text.delta');
+    assert.equal(frame.type, 'response.output_text.delta');
+    assert.equal(frame.data.delta, 'hello');
+    assert.equal(frame._ts, 123);
+  });
+
+  it('preserves malformed SSE data for raw inspection', () => {
+    const frame = parseSSEFrame('event: response.output_text.delta\ndata: {"delta":', 123);
+
+    assert.equal(frame.event, 'response.output_text.delta');
+    assert.equal(frame.type, 'response.output_text.delta');
+    assert.equal(frame.parseError, true);
+    assert.equal(frame.dataRaw, '{"delta":');
   });
 });

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -48,6 +48,21 @@ describe('agent provider registry', () => {
     assert.match(launch.installHint, /openai\/codex/);
   });
 
+  it('builds the Codex desktop app launch through the registry', () => {
+    const launch = providers.getAgentLaunch('codex', 5577, ['app', '/repo'], {
+      PATH: '/usr/bin',
+    });
+
+    assert.equal(launch.bin, 'codex');
+    assert.deepEqual(launch.args, [
+      '-c',
+      'openai_base_url="http://localhost:5577/v1"',
+      'app',
+      '/repo',
+    ]);
+    assert.equal(launch.env.PATH, '/usr/bin');
+  });
+
   it('centralizes display names and unsupported-provider handling', () => {
     assert.equal(providers.getDisplayName('claude', {}), 'ccxray');
     assert.equal(providers.getDisplayName('codex', {}), 'ccxray');

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -7,8 +7,8 @@ const providers = require('../server/providers');
 
 describe('agent provider registry', () => {
   it('lists the supported provider launchers', () => {
-    assert.deepEqual(providers.listAgentProviderIds(), ['claude']);
-    assert.equal(providers.supportedProviderList(), 'claude');
+    assert.deepEqual(providers.listAgentProviderIds(), ['claude', 'codex']);
+    assert.equal(providers.supportedProviderList(), 'claude, codex');
   });
 
   it('builds the Claude launch through the registry', () => {
@@ -26,10 +26,32 @@ describe('agent provider registry', () => {
     assert.match(launch.installHint, /anthropic-ai\/claude-code/);
   });
 
+  it('builds the Codex launch through the registry', () => {
+    const launch = providers.getAgentLaunch('codex', 5577, ['exec', 'hello'], {
+      PATH: '/usr/bin',
+      ANTHROPIC_BASE_URL: 'https://anthropic.example.com',
+    });
+
+    assert.equal(launch.provider, 'codex');
+    assert.equal(launch.label, 'Codex CLI');
+    assert.equal(launch.upstream, 'openai');
+    assert.equal(launch.displayName, 'ccxray');
+    assert.equal(launch.bin, 'codex');
+    assert.deepEqual(launch.args, [
+      '-c',
+      'openai_base_url="http://localhost:5577/v1"',
+      'exec',
+      'hello',
+    ]);
+    assert.equal(launch.env.PATH, '/usr/bin');
+    assert.equal(launch.env.ANTHROPIC_BASE_URL, 'https://anthropic.example.com');
+    assert.match(launch.installHint, /openai\/codex/);
+  });
+
   it('centralizes display names and unsupported-provider handling', () => {
     assert.equal(providers.getDisplayName('claude', {}), 'ccxray');
-    assert.equal(providers.getDisplayName('unknown-ai', {}), 'ccxray');
-    assert.equal(providers.getDisplayName('claude', { CCXRAY_DISPLAY_NAME: 'customray' }), 'customray');
+    assert.equal(providers.getDisplayName('codex', {}), 'ccxray');
+    assert.equal(providers.getDisplayName('codex', { CCXRAY_DISPLAY_NAME: 'customray' }), 'customray');
     assert.equal(providers.getAgentLaunch('unknown-ai', 5577, []), null);
     assert.equal(providers.getAgentProvider('unknown-ai'), null);
     assert.equal(providers.isAgentProvider('unknown-ai'), false);

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const providers = require('../server/providers');
+
+describe('agent provider registry', () => {
+  it('lists the supported provider launchers', () => {
+    assert.deepEqual(providers.listAgentProviderIds(), ['claude']);
+    assert.equal(providers.supportedProviderList(), 'claude');
+  });
+
+  it('builds the Claude launch through the registry', () => {
+    const launch = providers.getAgentLaunch('claude', 5577, ['--continue'], {
+      PATH: '/usr/bin',
+    });
+
+    assert.equal(launch.provider, 'claude');
+    assert.equal(launch.label, 'Claude Code');
+    assert.equal(launch.upstream, 'anthropic');
+    assert.equal(launch.bin, 'claude');
+    assert.deepEqual(launch.args, ['--continue']);
+    assert.equal(launch.env.PATH, '/usr/bin');
+    assert.equal(launch.env.ANTHROPIC_BASE_URL, 'http://localhost:5577');
+    assert.match(launch.installHint, /anthropic-ai\/claude-code/);
+  });
+
+  it('centralizes display names and unsupported-provider handling', () => {
+    assert.equal(providers.getDisplayName('claude', {}), 'ccxray');
+    assert.equal(providers.getDisplayName('unknown-ai', {}), 'ccxray');
+    assert.equal(providers.getDisplayName('claude', { CCXRAY_DISPLAY_NAME: 'customray' }), 'customray');
+    assert.equal(providers.getAgentLaunch('unknown-ai', 5577, []), null);
+    assert.equal(providers.getAgentProvider('unknown-ai'), null);
+    assert.equal(providers.isAgentProvider('unknown-ai'), false);
+  });
+});

--- a/test/startup.test.js
+++ b/test/startup.test.js
@@ -661,6 +661,31 @@ describe('OpenAI Responses raw capture', () => {
       req.on('data', c => { body += c; });
       req.on('end', () => {
         receivedReq = { method: req.method, url: req.url, headers: req.headers, body };
+        if (req.url.includes('stream=1')) {
+          res.writeHead(200, { 'Content-Type': 'application/json', 'x-openai-mock': 'responses-stream' });
+          res.end([
+            'event: response.created',
+            'data: ' + JSON.stringify({
+              type: 'response.created',
+              response: { id: 'resp_stream_v0', object: 'response', model: 'gpt-5.5', status: 'in_progress' },
+            }),
+            '',
+            'event: response.completed',
+            'data: ' + JSON.stringify({
+              type: 'response.completed',
+              response: {
+                id: 'resp_stream_v0',
+                object: 'response',
+                model: 'gpt-5.5',
+                status: 'completed',
+                usage: { input_tokens: 10, output_tokens: 3, total_tokens: 13 },
+                output: [{ type: 'message', content: [{ type: 'output_text', text: 'stream ok' }] }],
+              },
+            }),
+            '',
+          ].join('\n'));
+          return;
+        }
         res.writeHead(200, { 'Content-Type': 'application/json', 'x-openai-mock': 'responses' });
         res.end(JSON.stringify({
           id: 'resp_raw_v0',
@@ -727,6 +752,38 @@ describe('OpenAI Responses raw capture', () => {
     const resLog = JSON.parse(fs.readFileSync(path.join(logsDir, `${entry.id}_res.json`), 'utf8'));
     assert.equal(resLog.id, 'resp_raw_v0');
     assert.equal(resLog.output[0].content[0].text, 'codex ok');
+  });
+
+  it('normalizes OpenAI SSE-shaped responses even without event-stream headers', async () => {
+    const requestBody = JSON.stringify({
+      model: 'gpt-5.5',
+      input: 'stream the result',
+      stream: true,
+    });
+
+    const response = await sendOpenAIResponsesRequest(proxyPort, requestBody, '/v1/responses?stream=1');
+
+    assert.equal(response.status, 200);
+
+    await new Promise(r => setTimeout(r, 500));
+
+    const logsDir = path.join(TEST_HOME, 'logs');
+    const indexEntries = fs.readFileSync(path.join(logsDir, 'index.ndjson'), 'utf8')
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line));
+    const entry = indexEntries.find(e => e.responseMetadata?.id === 'resp_stream_v0');
+    assert.ok(entry, 'expected OpenAI stream index entry');
+    assert.equal(entry.isSSE, true);
+    assert.equal(entry.model, 'gpt-5.5');
+    assert.equal(entry.stopReason, 'completed');
+    assert.equal(entry.usage.input_tokens, 10);
+    assert.equal(entry.responseMetadata.responseStatus, 'completed');
+
+    const resLog = JSON.parse(fs.readFileSync(path.join(logsDir, `${entry.id}_res.json`), 'utf8'));
+    const finalEvent = resLog[resLog.length - 1];
+    assert.equal(finalEvent.type, 'response.completed');
+    assert.equal(finalEvent.data.response.output[0].content[0].text, 'stream ok');
   });
 });
 

--- a/test/startup.test.js
+++ b/test/startup.test.js
@@ -646,6 +646,90 @@ describe('SSE streaming proxy', () => {
   });
 });
 
+// ── OpenAI Responses raw capture ────────────────────────────────────
+
+describe('OpenAI Responses raw capture', () => {
+  let mockUpstream;
+  let mockPort;
+  let proxyChild;
+  let proxyPort;
+  let receivedReq = null;
+
+  before(async () => {
+    mockUpstream = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', c => { body += c; });
+      req.on('end', () => {
+        receivedReq = { method: req.method, url: req.url, headers: req.headers, body };
+        res.writeHead(200, { 'Content-Type': 'application/json', 'x-openai-mock': 'responses' });
+        res.end(JSON.stringify({
+          id: 'resp_raw_v0',
+          object: 'response',
+          model: 'gpt-5.1-codex',
+          status: 'completed',
+          output: [{ type: 'message', content: [{ type: 'output_text', text: 'codex ok' }] }],
+        }));
+      });
+    });
+    await new Promise(r => mockUpstream.listen(0, r));
+    mockPort = mockUpstream.address().port;
+
+    proxyPort = await findFreePort();
+    proxyChild = spawnServer(['--port', String(proxyPort)], {
+      env: {
+        OPENAI_TEST_HOST: 'localhost',
+        OPENAI_TEST_PORT: String(mockPort),
+        OPENAI_TEST_PROTOCOL: 'http',
+      },
+    });
+    await waitForPort(proxyPort);
+  });
+
+  after(async () => {
+    await killAndWait(proxyChild);
+    await new Promise(r => mockUpstream.close(r));
+  });
+
+  it('forwards /v1/responses to OpenAI upstream and logs full raw req/res JSON', async () => {
+    const requestBody = JSON.stringify({
+      model: 'gpt-5.1-codex',
+      instructions: 'You are Codex in raw capture mode.',
+      input: 'inspect the repository',
+      tools: [{ type: 'function', name: 'shell' }],
+    });
+
+    const response = await sendOpenAIResponsesRequest(proxyPort, requestBody, '/v1/responses?trace=1');
+
+    assert.equal(response.status, 200);
+    assert.ok(receivedReq, 'mock OpenAI upstream should receive the request');
+    assert.equal(receivedReq.method, 'POST');
+    assert.equal(receivedReq.url, '/v1/responses?trace=1');
+    assert.equal(JSON.parse(receivedReq.body).instructions, 'You are Codex in raw capture mode.');
+
+    await new Promise(r => setTimeout(r, 500));
+
+    const logsDir = path.join(TEST_HOME, 'logs');
+    const indexPath = path.join(logsDir, 'index.ndjson');
+    const indexEntries = fs.readFileSync(indexPath, 'utf8')
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line));
+    const entry = indexEntries.find(e => e.provider === 'openai' && e.agent === 'codex' && e.model === 'gpt-5.1-codex');
+    assert.ok(entry, 'expected OpenAI index entry');
+    assert.equal(entry.sessionId, 'codex-raw');
+    assert.equal(entry.cost, null);
+
+    const reqLog = JSON.parse(fs.readFileSync(path.join(logsDir, `${entry.id}_req.json`), 'utf8'));
+    assert.equal(reqLog.instructions, 'You are Codex in raw capture mode.');
+    assert.equal(reqLog.input, 'inspect the repository');
+    assert.equal(reqLog.prevId, undefined);
+
+    const resLog = JSON.parse(fs.readFileSync(path.join(logsDir, `${entry.id}_res.json`), 'utf8'));
+    assert.equal(resLog.id, 'resp_raw_v0');
+    assert.equal(resLog.output[0].content[0].text, 'codex ok');
+  });
+});
+
 // ── Intercept lifecycle E2E ──────────────────────────────────────────
 
 describe('Intercept lifecycle', () => {
@@ -1330,6 +1414,21 @@ function sendProxyRequest(port, body) {
       let data = '';
       res.on('data', c => { data += c; });
       res.on('end', () => resolve({ status: res.statusCode, body: data }));
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+function sendOpenAIResponsesRequest(port, body, urlPath = '/v1/responses') {
+  return new Promise((resolve, reject) => {
+    const req = http.request(`http://localhost:${port}${urlPath}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body), Authorization: 'Bearer test-key' },
+    }, res => {
+      let data = '';
+      res.on('data', c => { data += c; });
+      res.on('end', () => resolve({ status: res.statusCode, body: data, headers: res.headers }));
     });
     req.on('error', reject);
     req.end(body);

--- a/test/startup.test.js
+++ b/test/startup.test.js
@@ -213,6 +213,16 @@ describe('E3: --port validation', () => {
   });
 });
 
+describe('provider launcher selection', () => {
+  it('rejects unsupported provider commands instead of silently starting standalone mode', async () => {
+    const { stderr, code } = await spawnAndCollect(['unknown-ai'], 3000);
+
+    assert.equal(code, 1);
+    assert.ok(stderr.includes('unsupported provider "unknown-ai"'), stderr);
+    assert.ok(stderr.includes('claude'), stderr);
+  });
+});
+
 // ── R4: EADDRINUSE handling ────────────────────────────────────────
 
 describe('R4: port conflict', () => {
@@ -297,6 +307,94 @@ describe('R2: hub crash recovery', () => {
 });
 
 // ── E2: claude not found (ENOENT) ──────────────────────────────────
+
+describe('claude launcher mode', () => {
+  function createFakeClaudeCapture() {
+    const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-fake-claude-'));
+    const capturePath = path.join(fakeBin, 'capture.json');
+    const claudePath = path.join(fakeBin, 'claude');
+    fs.writeFileSync(claudePath, [
+      '#!/bin/sh',
+      'node -e \'const fs=require("fs"); fs.writeFileSync(process.env.CCXRAY_TEST_CLAUDE_CAPTURE, JSON.stringify({ argv: process.argv.slice(1), anthropicBaseUrl: process.env.ANTHROPIC_BASE_URL || null }));\' -- "$@"',
+    ].join('\n'));
+    fs.chmodSync(claudePath, 0o755);
+    return { fakeBin, capturePath };
+  }
+
+  it('spawns claude through the provider registry and forwards user args', async () => {
+    const port = await findFreePort();
+    const { fakeBin, capturePath } = createFakeClaudeCapture();
+    try {
+      const nodeBin = path.dirname(process.execPath);
+      const { code, stderr } = await spawnAndCollect(
+        ['--port', String(port), 'claude', '--continue'],
+        8000,
+        {
+          PATH: `${fakeBin}${path.delimiter}${nodeBin}`,
+          CCXRAY_TEST_CLAUDE_CAPTURE: capturePath,
+        }
+      );
+
+      assert.equal(code, 0, stderr);
+      const capture = JSON.parse(fs.readFileSync(capturePath, 'utf8'));
+      assert.deepEqual(capture.argv, ['--continue']);
+      assert.equal(capture.anthropicBaseUrl, `http://localhost:${port}`);
+    } finally {
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('consumes --no-browser as a ccxray flag before launching claude', async () => {
+    const port = await findFreePort();
+    const { fakeBin, capturePath } = createFakeClaudeCapture();
+    try {
+      const nodeBin = path.dirname(process.execPath);
+      const { code, stderr } = await spawnAndCollect(
+        ['--port', String(port), 'claude', '--no-browser'],
+        8000,
+        {
+          PATH: `${fakeBin}${path.delimiter}${nodeBin}`,
+          CCXRAY_TEST_CLAUDE_CAPTURE: capturePath,
+        }
+      );
+
+      assert.equal(code, 0, stderr);
+      const capture = JSON.parse(fs.readFileSync(capturePath, 'utf8'));
+      assert.deepEqual(capture.argv, []);
+      assert.equal(capture.anthropicBaseUrl, `http://localhost:${port}`);
+    } finally {
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('uses hub discovery and registration for claude mode without explicit port', async () => {
+    const port = await findFreePort();
+    const hubChild = spawnServer(['--port', String(port), '--hub-mode']);
+    await waitForPort(port);
+
+    const { fakeBin, capturePath } = createFakeClaudeCapture();
+    const nodeBin = path.dirname(process.execPath);
+    try {
+      const { code, stderr } = await spawnAndCollect(
+        ['claude', '--continue'],
+        8000,
+        {
+          PATH: `${fakeBin}${path.delimiter}${nodeBin}`,
+          CCXRAY_TEST_CLAUDE_CAPTURE: capturePath,
+        }
+      );
+
+      assert.equal(code, 0, stderr);
+      const capture = JSON.parse(fs.readFileSync(capturePath, 'utf8'));
+      assert.deepEqual(capture.argv, ['--continue']);
+      assert.equal(capture.anthropicBaseUrl, `http://localhost:${port}`);
+    } finally {
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+      await killAndWait(hubChild);
+      try { fs.unlinkSync(path.join(TEST_HOME, 'hub.json')); } catch {}
+    }
+  });
+});
 
 describe('E2: claude not found', () => {
   it('reports error when claude binary is missing', async () => {

--- a/test/startup.test.js
+++ b/test/startup.test.js
@@ -396,6 +396,84 @@ describe('claude launcher mode', () => {
   });
 });
 
+describe('codex desktop app launcher mode', () => {
+  function createFakeCodexCapture() {
+    const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-fake-codex-'));
+    const capturePath = path.join(fakeBin, 'capture.json');
+    const codexPath = path.join(fakeBin, 'codex');
+    fs.writeFileSync(codexPath, [
+      '#!/usr/bin/env node',
+      "'use strict';",
+      "const fs = require('fs');",
+      "const http = require('http');",
+      "const argv = process.argv.slice(2);",
+      "const configIdx = argv.indexOf('-c');",
+      "const configArg = configIdx === -1 ? null : argv[configIdx + 1];",
+      "const match = configArg && configArg.match(/openai_base_url=\"([^\"]+)\"/);",
+      "const openaiBaseUrl = match ? match[1] : null;",
+      "function writeCapture(extra = {}) {",
+      "  fs.writeFileSync(process.env.CCXRAY_TEST_CODEX_CAPTURE, JSON.stringify({ argv, configArg, openaiBaseUrl, cwd: process.cwd(), ...extra }));",
+      "}",
+      "function probeHealth(baseUrl) {",
+      "  return new Promise(resolve => {",
+      "    if (!baseUrl) return resolve(false);",
+      "    const req = http.get(new URL('/_api/health', baseUrl), { timeout: 1000 }, res => {",
+      "      let data = '';",
+      "      res.on('data', c => { data += c; });",
+      "      res.on('end', () => {",
+      "        try { resolve(JSON.parse(data).ok === true); } catch { resolve(false); }",
+      "      });",
+      "    });",
+      "    req.on('error', () => resolve(false));",
+      "    req.on('timeout', () => { req.destroy(); resolve(false); });",
+      "  });",
+      "}",
+      "(async () => {",
+      "  const healthOk = await probeHealth(openaiBaseUrl);",
+      "  writeCapture({ healthOk });",
+      "  process.exit(healthOk ? 0 : 2);",
+      "})().catch(err => {",
+      "  writeCapture({ error: err.message });",
+      "  process.exit(1);",
+      "});",
+    ].join('\n'));
+    fs.chmodSync(codexPath, 0o755);
+    return { fakeBin, capturePath };
+  }
+
+  it('launches codex app on macOS with the OpenAI proxy override', { skip: process.platform !== 'darwin' ? 'codex app is a macOS desktop launch path' : false }, async () => {
+    const port = await findFreePort();
+    const workspacePath = path.join(TEST_HOME, 'codex-desktop-workspace');
+    fs.mkdirSync(workspacePath, { recursive: true });
+    const { fakeBin, capturePath } = createFakeCodexCapture();
+
+    try {
+      const nodeBin = path.dirname(process.execPath);
+      const { code, stderr } = await spawnAndCollect(
+        ['--port', String(port), 'codex', 'app', workspacePath],
+        8000,
+        {
+          PATH: `${fakeBin}${path.delimiter}${nodeBin}`,
+          CCXRAY_TEST_CODEX_CAPTURE: capturePath,
+        }
+      );
+
+      assert.equal(code, 0, stderr);
+      const capture = JSON.parse(fs.readFileSync(capturePath, 'utf8'));
+      assert.deepEqual(capture.argv, [
+        '-c',
+        `openai_base_url="http://localhost:${port}/v1"`,
+        'app',
+        workspacePath,
+      ]);
+      assert.equal(capture.openaiBaseUrl, `http://localhost:${port}/v1`);
+      assert.equal(capture.healthOk, true);
+    } finally {
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('E2: claude not found', () => {
   it('reports error when claude binary is missing', async () => {
     const port = await findFreePort();


### PR DESCRIPTION
## Summary

V0 for Codex support: capture raw OpenAI Responses traffic through the existing proxy without adding the parsed renderer UI.

- Adds the provider launcher registry and the Codex launcher entry.
- Wires `ccxray codex` through `openai_base_url="http://localhost:<port>/v1"` while preserving Codex args/auth.
- Covers `ccxray codex app <path>` with a macOS-gated startup E2E using a fake `codex` binary, verifying the desktop-app launch path receives the injected OpenAI proxy URL and can reach ccxray health.
- Adds OpenAI upstream routing for `/v1/responses` plus raw JSON/SSE request and response logging.
- Normalizes OpenAI Responses stream status so restored Codex turns show completed/errored state correctly.
- Adds the `Codex Raw` session label and a dashboard regression for restored completed Responses traffic.

Gemini is intentionally out of this PR stack.

## Stack

- Fork V0 PR: https://github.com/shhtheonlyperson/ccxray/pull/4
- Fork V1 renderer PR: https://github.com/shhtheonlyperson/ccxray/pull/5

## Atomic Commits

- `9d13139` Add provider launcher registry
- `2135918` Add Codex launcher registry entry
- `657a008` Add OpenAI upstream routing configuration
- `c5551f7` Capture Codex raw Responses traffic
- `0799a8c` Normalize Codex Responses stream status
- `b21a822` Add Codex dashboard E2E and named session label
- `8ed57f8` Document Codex launcher support
- `35aa369` Add Codex desktop app launch E2E

## Deferred To V1 / Later

- Parsed Codex renderer and detail-section UI: https://github.com/shhtheonlyperson/ccxray/pull/5
- Header-based session/subagent detection.
- Codex-specific System Prompt and cost-budget refinements.
- Intercept editor/provider polish.

## Screenshots

<details open>
<summary>Completed Raw Codex Turn</summary>

![Completed Raw Codex Turn](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/aafc64d5ba219fe65d6ac653e7669ed124a3e032/screenshots/codex-status-completed.png)

</details>

<details open>
<summary>Raw Response Events</summary>

![Raw Response Events](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/aafc64d5ba219fe65d6ac653e7669ed124a3e032/screenshots/codex-response-events.png)

</details>

## Tests

- `node --test test/providers.test.js test/startup.test.js`: 50 passing, 0 failing.
- `npm test` on V0 after adding desktop launch coverage: 418 passing, 0 failing.
- `git diff --check c44d262f793348370de228865e2de9b9e7399bba`: clean.
