### PR TITLE
Guard against ccxray upstream loops

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -34,6 +34,8 @@ if (portIdx !== -1) {
 }
 const hubMode = process.argv.includes('--hub-mode');
 if (hubMode) process.argv.splice(process.argv.indexOf('--hub-mode'), 1);
+const allowUpstreamLoop = process.argv.includes('--allow-upstream-loop') || process.env.CCXRAY_ALLOW_UPSTREAM_LOOP === '1';
+if (process.argv.includes('--allow-upstream-loop')) process.argv.splice(process.argv.indexOf('--allow-upstream-loop'), 1);
 const claudeMode = process.argv[2] === 'claude';
 const claudeArgs = claudeMode ? process.argv.slice(3) : [];
 
@@ -67,6 +69,11 @@ try { rawIndexHTML = fs.readFileSync(path.join(PUBLIC_DIR, 'index.html'), 'utf8'
 let serverPort = 0;
 
 function rebuildIndexHTML(port) { serverPort = port; }
+
+function isUpstreamLoopForPort(port) {
+  const localHosts = new Set(['localhost', '127.0.0.1', '::1']);
+  return localHosts.has(config.ANTHROPIC_HOST) && config.ANTHROPIC_PORT === port;
+}
 
 function serveStatic(url, clientRes) {
   const pathname = url.split('?')[0];
@@ -427,6 +434,14 @@ async function startClientMode(lock) {
 
 // ── Hub/Server startup ──
 async function startServer() {
+  if (isUpstreamLoopForPort(config.PORT) && !allowUpstreamLoop) {
+    const url = `${config.ANTHROPIC_PROTOCOL}://${config.ANTHROPIC_HOST}:${config.ANTHROPIC_PORT}`;
+    throw new Error(
+      `ANTHROPIC_BASE_URL points back to ccxray (${url}); unset it before starting ccxray.\n` +
+      'Pass --allow-upstream-loop or set CCXRAY_ALLOW_UPSTREAM_LOOP=1 to allow this.'
+    );
+  }
+
   await config.storage.init();
   await fetchPricing();
   await restoreFromLogs();

--- a/test/startup.test.js
+++ b/test/startup.test.js
@@ -757,6 +757,36 @@ describe('Proxy error paths', () => {
   });
 });
 
+describe('Proxy loop startup guard', () => {
+  it('exits before serving when upstream points to itself', async () => {
+    const proxyPort = await findFreePort();
+    const { stderr, code } = await spawnAndCollect(['--port', String(proxyPort)], 10000, {
+      ANTHROPIC_BASE_URL: `http://localhost:${proxyPort}`,
+    });
+
+    assert.equal(code, 1);
+    assert.ok(stderr.includes('ANTHROPIC_BASE_URL points back to ccxray'), `Expected loop error, got: ${stderr}`);
+    assert.ok(stderr.includes('--allow-upstream-loop'), `Expected override hint, got: ${stderr}`);
+  });
+
+  it('allows startup when explicit loop override is present', async () => {
+    const proxyPort = await findFreePort();
+    const proxyChild = spawnServer(['--port', String(proxyPort), '--allow-upstream-loop'], {
+      env: {
+        ANTHROPIC_BASE_URL: `http://localhost:${proxyPort}`,
+      },
+    });
+
+    try {
+      await waitForPort(proxyPort);
+      const health = await httpGet(proxyPort, '/_api/health');
+      assert.deepEqual(health, { ok: true });
+    } finally {
+      await killAndWait(proxyChild);
+    }
+  });
+});
+
 describe('Proxy upstream error responses', () => {
   let mockUpstream;
   let mockPort;


### PR DESCRIPTION
## Summary
- fail startup when ANTHROPIC_BASE_URL points back to ccxray's own listener
- add explicit override via --allow-upstream-loop or CCXRAY_ALLOW_UPSTREAM_LOOP=1
- cover fail-fast and override startup paths

## Tests
- pnpm exec node --test test/startup.test.js