### PR TITLE
Set fallback token limit per 5hrs in cost-budget.js as max 20x plan correctly

### DIFF
--- a/server/cost-budget.js
+++ b/server/cost-budget.js
@@ -8,7 +8,7 @@ const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
 
 // Legacy fallbacks (Max 20x values). Prefer getEffectivePlanConfig() which
 // consults the detected plan; field accessors below wrap it for callers.
-const TOKEN_LIMIT = 220_000;
+const TOKEN_LIMIT = 880_000;
 const SUBSCRIPTION_USD = 200;
 
 function getEffectivePlanConfig() {


### PR DESCRIPTION
according to https://github.com/lis186/ccxray/blob/main/server/plans.js#L30, the Max 20x plan should got token limit per 5hrs to `880_000`, not `220_000` (which is for Max 5x)