### PR TITLE
feat: provider-aware upstream loop guard

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -35,6 +35,8 @@ if (portIdx !== -1) {
 }
 const hubMode = process.argv.includes('--hub-mode');
 if (hubMode) process.argv.splice(process.argv.indexOf('--hub-mode'), 1);
+const allowUpstreamLoop = process.argv.includes('--allow-upstream-loop') || process.env.CCXRAY_ALLOW_UPSTREAM_LOOP === '1';
+if (process.argv.includes('--allow-upstream-loop')) process.argv.splice(process.argv.indexOf('--allow-upstream-loop'), 1);
 const noBrowser = process.argv.includes('--no-browser');
 if (noBrowser) process.argv.splice(process.argv.indexOf('--no-browser'), 1);
 const cliCommand = process.argv[2];
@@ -524,6 +526,20 @@ async function runPostListenStartupTasks() {
 }
 
 async function startServer() {
+  if (!allowUpstreamLoop) {
+    const localHosts = new Set(['localhost', '127.0.0.1', '::1']);
+    const upstreamFamily = providers.getAgentProvider(agentCommand)?.upstream ?? 'anthropic';
+    const upstream = config.UPSTREAMS[upstreamFamily];
+    if (upstream && localHosts.has(upstream.host) && upstream.port === config.PORT) {
+      const url = `${upstream.protocol}://${upstream.host}:${upstream.port}`;
+      const envVar = upstreamFamily === 'openai' ? 'OPENAI_BASE_URL' : 'ANTHROPIC_BASE_URL';
+      throw new Error(
+        `${envVar} points back to ccxray (${url}); unset it before starting ccxray.\n` +
+        'Pass --allow-upstream-loop or set CCXRAY_ALLOW_UPSTREAM_LOOP=1 to allow this.'
+      );
+    }
+  }
+
   await config.storage.init();
 
   // Agent mode (with --port, standalone): scan up to 10 ports.

--- a/test/startup.test.js
+++ b/test/startup.test.js
@@ -1629,3 +1629,72 @@ function spawnAndCollect(args, timeoutMs = 10000, envOverrides = {}) {
     }, timeoutMs);
   });
 }
+
+describe('Proxy loop startup guard', () => {
+  it('exits when ANTHROPIC_BASE_URL points back to itself (claude mode)', async () => {
+    const proxyPort = await findFreePort();
+    const { stderr, code } = await spawnAndCollect(['--port', String(proxyPort)], 10000, {
+      ANTHROPIC_BASE_URL: `http://localhost:${proxyPort}`,
+    });
+
+    assert.equal(code, 1);
+    assert.ok(stderr.includes('ANTHROPIC_BASE_URL points back to ccxray'), `Expected loop error, got: ${stderr}`);
+    assert.ok(stderr.includes('--allow-upstream-loop'), `Expected override hint, got: ${stderr}`);
+  });
+
+  it('exits when OPENAI_BASE_URL points back to itself (codex mode)', async () => {
+    const proxyPort = await findFreePort();
+    const { stderr, code } = await spawnAndCollect(['--port', String(proxyPort), 'codex'], 10000, {
+      OPENAI_BASE_URL: `http://localhost:${proxyPort}/v1`,
+    });
+
+    assert.equal(code, 1);
+    assert.ok(stderr.includes('OPENAI_BASE_URL points back to ccxray'), `Expected loop error, got: ${stderr}`);
+    assert.ok(stderr.includes('--allow-upstream-loop'), `Expected override hint, got: ${stderr}`);
+  });
+
+  it('does NOT exit when ANTHROPIC_BASE_URL loops but running codex (different upstream)', async () => {
+    const proxyPort = await findFreePort();
+    const proxyChild = spawnServer(['--port', String(proxyPort), 'codex'], {
+      env: { ANTHROPIC_BASE_URL: `http://localhost:${proxyPort}` },
+    });
+
+    try {
+      await waitForPort(proxyPort);
+      const health = await httpGet(proxyPort, '/_api/health');
+      assert.deepEqual(health, { ok: true });
+    } finally {
+      await killAndWait(proxyChild);
+    }
+  });
+
+  it('allows startup with --allow-upstream-loop override', async () => {
+    const proxyPort = await findFreePort();
+    const proxyChild = spawnServer(['--port', String(proxyPort), '--allow-upstream-loop'], {
+      env: { ANTHROPIC_BASE_URL: `http://localhost:${proxyPort}` },
+    });
+
+    try {
+      await waitForPort(proxyPort);
+      const health = await httpGet(proxyPort, '/_api/health');
+      assert.deepEqual(health, { ok: true });
+    } finally {
+      await killAndWait(proxyChild);
+    }
+  });
+
+  it('allows startup with CCXRAY_ALLOW_UPSTREAM_LOOP=1 override', async () => {
+    const proxyPort = await findFreePort();
+    const proxyChild = spawnServer(['--port', String(proxyPort)], {
+      env: { ANTHROPIC_BASE_URL: `http://localhost:${proxyPort}`, CCXRAY_ALLOW_UPSTREAM_LOOP: '1' },
+    });
+
+    try {
+      await waitForPort(proxyPort);
+      const health = await httpGet(proxyPort, '/_api/health');
+      assert.deepEqual(health, { ok: true });
+    } finally {
+      await killAndWait(proxyChild);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Integrates and extends PR #22 (upstream loop guard) to be provider-aware:

- **claude mode**: checks `ANTHROPIC_BASE_URL` → fails if it points back to the proxy port
- **codex mode**: checks `OPENAI_BASE_URL` → fails if it points back to the proxy port  
- **Cross-provider safety**: `ANTHROPIC_BASE_URL` looping is ignored when running `codex` (uses OpenAI upstream, so Anthropic URL is irrelevant)
- **Override**: `--allow-upstream-loop` flag or `CCXRAY_ALLOW_UPSTREAM_LOOP=1` env var

The original PR #22 guard was Anthropic-only and would have misfired for `ccxray codex` users who happen to have `ANTHROPIC_BASE_URL` set from a previous claude session. This version uses `providers.getAgentProvider(agentCommand)?.upstream` to select the correct upstream family per agent.

Closes #22

## Test plan

- [x] 441/441 tests pass (`npm test`)
- [x] ANTHROPIC loop → exit 1 with hint (claude mode)
- [x] OPENAI loop → exit 1 with hint (codex mode)
- [x] ANTHROPIC loop does NOT block codex (different upstream, should start normally)
- [x] `--allow-upstream-loop` overrides the guard
- [x] `CCXRAY_ALLOW_UPSTREAM_LOOP=1` overrides the guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)