### PR TITLE
Codex V1: session grouping, renderer, and prompt versions

### DIFF
--- a/public/messages.js
+++ b/public/messages.js
@@ -155,6 +155,18 @@ function getToolPreview(toolUse) {
   }
 }
 
+function getResponseEventPayload(ev) {
+  return ev && ev.data && typeof ev.data === 'object' ? ev.data : ev;
+}
+
+function getResponseEventItemId(payload, fallbackIndex) {
+  return payload.item_id || payload.output_item_id || payload.call_id || payload.id || payload.item?.id || String(fallbackIndex ?? '');
+}
+
+function getResponseFunctionCallName(item) {
+  return item?.name || item?.function?.name || item?.tool_name || item?.type || 'function_call';
+}
+
 function buildMergedSteps(messages, resEvents) {
   if ((!messages || !messages.length) && (!resEvents || !resEvents.length)) return [];
 
@@ -276,9 +288,12 @@ function buildMergedSteps(messages, resEvents) {
     let curThinkingStart = null;
     let curThinkingEnd = null;
     const curToolUses = [];  // { index, name, id, inputChunks[] }
+    const openAIToolUseById = new Map();
     let curText = '';
 
-    for (const ev of resEvents) {
+    for (let eventIndex = 0; eventIndex < resEvents.length; eventIndex++) {
+      const ev = resEvents[eventIndex];
+      const payload = getResponseEventPayload(ev);
       if (ev.type === 'content_block_start') {
         if (ev.content_block?.type === 'thinking') {
           curThinking = '';
@@ -300,6 +315,58 @@ function buildMergedSteps(messages, resEvents) {
         } else if (ev.delta?.type === 'text_delta') {
           curText += ev.delta.text || '';
         }
+      } else if (ev.type === 'response.output_text.delta') {
+        curText += ev.delta || payload.delta || '';
+      } else if (ev.type === 'response.output_text.done' && !curText) {
+        curText += ev.text || payload.text || '';
+      } else if (ev.type === 'response.reasoning_text.delta') {
+        if (curThinking === null) {
+          curThinking = '';
+          curThinkingStart = ev._ts || null;
+        }
+        curThinking += ev.delta || payload.delta || '';
+      } else if (ev.type === 'response.reasoning_summary_part.added') {
+        if (curThinking === null) {
+          curThinking = '';
+          curThinkingStart = ev._ts || null;
+        }
+        const part = payload.part || ev.part || {};
+        curThinking += part.text || payload.text || ev.text || '';
+      } else if (ev.type === 'response.reasoning_summary_text.delta') {
+        if (curThinking === null) {
+          curThinking = '';
+          curThinkingStart = ev._ts || null;
+        }
+        curThinking += ev.delta || payload.delta || '';
+      } else if (ev.type === 'response.output_item.added') {
+        const item = payload.item || ev.item || {};
+        if (item.type === 'function_call' || item.type === 'tool_call') {
+          const id = getResponseEventItemId(payload, eventIndex);
+          const toolUse = {
+            index: payload.output_index ?? eventIndex,
+            name: getResponseFunctionCallName(item),
+            id,
+            inputChunks: [],
+          };
+          if (item.arguments) toolUse.inputChunks.push(typeof item.arguments === 'string' ? item.arguments : JSON.stringify(item.arguments));
+          openAIToolUseById.set(id, toolUse);
+          curToolUses.push(toolUse);
+        }
+      } else if (ev.type === 'response.function_call_arguments.delta') {
+        const id = getResponseEventItemId(payload, payload.output_index ?? eventIndex);
+        const tu = openAIToolUseById.get(id) || curToolUses.find(t => t.index === payload.output_index);
+        if (tu) tu.inputChunks.push(ev.delta || payload.delta || '');
+      } else if (ev.type === 'response.output_item.done') {
+        const item = payload.item || ev.item || {};
+        if (item.type === 'function_call' || item.type === 'tool_call') {
+          const id = getResponseEventItemId(payload, eventIndex);
+          const tu = openAIToolUseById.get(id) || curToolUses.find(t => t.index === payload.output_index);
+          if (tu && item.arguments && !tu.inputChunks.length) {
+            tu.inputChunks.push(typeof item.arguments === 'string' ? item.arguments : JSON.stringify(item.arguments));
+          }
+        }
+      } else if (ev.type === 'response.completed' || ev.type === 'response.done') {
+        if (curThinkingStart && !curThinkingEnd) curThinkingEnd = ev._ts || null;
       } else if (ev.type === 'content_block_stop') {
         if (curThinkingStart && !curThinkingEnd) curThinkingEnd = ev._ts || null;
       }

--- a/public/system-prompt-ui.js
+++ b/public/system-prompt-ui.js
@@ -9,7 +9,7 @@ let spFocusedCol = 'agents'; // 'agents' | 'versions'
 let hideMinorEdit = false;
 let currentHunkIdx = 0;
 
-const AGENT_ORDER = ['orchestrator', 'general-purpose', 'plan', 'explore', 'web-search', 'codex-rescue', 'claude-code-guide', 'summarizer', 'title-generator', 'name-generator', 'translator', 'sdk-agent'];
+const AGENT_ORDER = ['orchestrator', 'general-purpose', 'default', 'explorer', 'worker', 'plan', 'explore', 'web-search', 'codex-rescue', 'claude-code-guide', 'summarizer', 'title-generator', 'name-generator', 'translator', 'sdk-agent'];
 
 function spRelativeTime(dateStr) {
   if (!dateStr) return '';

--- a/server/forward.js
+++ b/server/forward.js
@@ -715,14 +715,14 @@ function handleOpenAISSE(ctx, proxyRes, clientRes) {
       msgCount: Array.isArray(parsedBody?.input) ? parsedBody.input.length : 0,
       toolCount: Array.isArray(parsedBody?.tools) ? parsedBody.tools.length : 0,
       toolCalls: {},
-      isSubagent: false,
-      sessionInferred: true,
+      isSubagent: ctx.isSubagent || false,
+      sessionInferred: ctx.sessionInferred || false,
       title: getOpenAIInputSummary(parsedBody?.input) || getOpenAIOutputSummary(response),
       stopReason: response?.status || '',
       toolFail: false,
-      sysHash: null,
-      toolsHash: null,
-      coreHash: null,
+      sysHash: ctx.sysHash || null,
+      toolsHash: ctx.toolsHash || null,
+      coreHash: ctx.coreHash || null,
       thinkingStripped: undefined,
     };
     entry.hasCredential = helpers.entryHasCredential(entry) || undefined;
@@ -744,8 +744,8 @@ function handleOpenAISSE(ctx, proxyRes, clientRes) {
       toolFail: false,
       elapsed, status: proxyRes.statusCode,
       receivedAt: startTime,
-      sysHash: null, toolsHash: null,
-      coreHash: null,
+      sysHash: entry.sysHash, toolsHash: entry.toolsHash,
+      coreHash: entry.coreHash,
       hasCredential: entry.hasCredential,
     });
     config.storage.appendIndex(indexLine + '\n').catch(e => console.error('Write index failed:', e.message));
@@ -814,7 +814,9 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
     const resWritePromise = config.storage.write(id, '_res.json', typeof resData === 'string' ? resData : JSON.stringify(resData))
       .catch(e => console.error('Write res.json failed:', e.message));
     const maxContext = provider === 'anthropic' ? config.getMaxContext(parsedBody?.model, parsedBody?.system) : null;
-    const isSubagent = provider === 'anthropic' && !store.extractCwd(parsedBody);
+    const isSubagent = provider === 'openai'
+      ? Boolean(ctx.isSubagent)
+      : provider === 'anthropic' && !store.extractCwd(parsedBody);
     const titleGenTitle = provider === 'anthropic' ? resolveTitleGenTitle(parsedBody, resData, startTime) : null;
     const title = provider === 'openai'
       ? (getOpenAIInputSummary(parsedBody?.input) || getOpenAIOutputSummary(openAIResponse || resData))

--- a/server/index.js
+++ b/server/index.js
@@ -15,7 +15,7 @@ const { forwardRequest, setStatusLineEnabled, getStatusLineEnabled } = require('
 const { readSettings } = require('./settings');
 const { broadcastSessionStatus, broadcastPendingRequest } = require('./sse-broadcast');
 const { authMiddleware } = require('./auth');
-const { extractAgentType, splitB2IntoBlocks } = require('./system-prompt');
+const { extractAgentType, extractPromptAgentType, splitB2IntoBlocks } = require('./system-prompt');
 const { findSharedPrefix } = require('./delta-helpers');
 const providers = require('./providers');
 
@@ -139,8 +139,99 @@ function getCodexRawSessionId() {
   return 'codex-raw';
 }
 
+function firstHeader(headers, name) {
+  const value = headers?.[name.toLowerCase()];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function getCodexSessionId(headers, parsedBody) {
+  const direct = firstHeader(headers, 'session_id') || firstHeader(headers, 'x-openai-session-id');
+  if (direct) return String(direct);
+  return parsedBody?.metadata?.session_id || null;
+}
+
+function isOpenAISubagent(headers, parsedBody) {
+  const raw = firstHeader(headers, 'x-openai-subagent');
+  if (raw != null) {
+    const text = String(raw).toLowerCase();
+    return text !== '0' && text !== 'false' && text !== 'no';
+  }
+  return Boolean(parsedBody?.metadata?.is_subagent || parsedBody?.metadata?.isSubagent);
+}
+
+function getOpenAIAgentTypeFromHeaders(headers) {
+  const subagent = firstHeader(headers, 'x-openai-subagent');
+  const direct = firstHeader(headers, 'x-openai-agent-type') || firstHeader(headers, 'x-codex-agent-type');
+  const value = direct || subagent;
+  if (!value) return null;
+  const normalized = String(value).toLowerCase();
+  if (normalized === 'explorer' || normalized === 'worker' || normalized === 'default') return normalized;
+  return null;
+}
+
+function detectOpenAISession(headers, parsedBody) {
+  if (!parsedBody) return { sessionId: getCodexRawSessionId(), isNewSession: false, inferred: true };
+  if (!getCodexSessionId(headers, parsedBody)) {
+    return { sessionId: getCodexRawSessionId(), isNewSession: false, inferred: true };
+  }
+  const detected = store.detectSession(parsedBody);
+  return {
+    sessionId: detected.sessionId || getCodexRawSessionId(),
+    isNewSession: detected.isNewSession || false,
+    inferred: detected.inferred || false,
+  };
+}
+
 function getCodexCwdFallback() {
   return hub.lookupClientCwd() || (agentCommand === 'codex' ? process.cwd() : null);
+}
+
+function getOpenAICwd(parsedBody) {
+  return parsedBody?.metadata?.cwd || getCodexCwdFallback();
+}
+
+function withCodexMetadata(parsedBody, headers) {
+  if (!parsedBody || typeof parsedBody !== 'object') return parsedBody;
+  const sessionId = getCodexSessionId(headers, parsedBody);
+  const agentType = getOpenAIAgentTypeFromHeaders(headers);
+  if (!sessionId && !agentType) return parsedBody;
+  const metadata = parsedBody.metadata && typeof parsedBody.metadata === 'object'
+    ? { ...parsedBody.metadata }
+    : {};
+  if (sessionId && !metadata.session_id) metadata.session_id = sessionId;
+  if (agentType && !metadata.agent_type) metadata.agent_type = agentType;
+  return { ...parsedBody, metadata };
+}
+
+function registerPromptVersion({ provider, parsedBody, sharedFile, promptText, firstSeen, notify = true }) {
+  if (!promptText) return null;
+  const { key: agentKey, label: agentLabel } = extractPromptAgentType(provider, parsedBody);
+  if (!agentKey || agentKey === 'unknown') return null;
+  const coreHash = crypto.createHash('md5').update(promptText).digest('hex').slice(0, 12);
+  const idxKey = `${agentKey}::${coreHash}`;
+  const version = coreHash;
+  const existing = store.versionIndex.get(idxKey);
+  if (existing) {
+    if (sharedFile) existing.sharedFile = sharedFile;
+    return { coreHash, agentKey, agentLabel, version };
+  }
+  const now = firstSeen || new Date().toISOString().slice(0, 10);
+  store.versionIndex.set(idxKey, {
+    reqId: null,
+    sharedFile,
+    b2Len: promptText.length,
+    coreLen: promptText.length,
+    coreHash,
+    firstSeen: now,
+    agentKey,
+    agentLabel,
+    version,
+  });
+  if (notify) {
+    const vData = JSON.stringify({ _type: 'version_detected', version, b2Len: promptText.length, agentKey, agentLabel });
+    for (const res of store.sseClients) res.write(`data: ${vData}\n\n`);
+  }
+  return { coreHash, agentKey, agentLabel, version };
 }
 
 // ── Server ──────────────────────────────────────────────────────────
@@ -191,14 +282,22 @@ const server = http.createServer((clientReq, clientRes) => {
 
     const upstream = config.getUpstreamForRequestAndHeaders(clientReq.url, clientReq.headers);
     const provider = upstream.provider || 'anthropic';
+    if (provider === 'openai' && parsedBody) {
+      parsedBody = withCodexMetadata(parsedBody, clientReq.headers);
+    }
 
     let reqWritePromise = null;
     let sysHash = null;
     let toolsHash = null;
+    let coreHash = null;
     if (parsedBody) {
-      sysHash = parsedBody.system
-        ? crypto.createHash('sha256').update(JSON.stringify(parsedBody.system)).digest('hex').slice(0, 12)
-        : null;
+      sysHash = provider === 'openai'
+        ? (parsedBody.instructions != null
+          ? crypto.createHash('sha256').update(JSON.stringify(parsedBody.instructions)).digest('hex').slice(0, 12)
+          : null)
+        : (parsedBody.system
+          ? crypto.createHash('sha256').update(JSON.stringify(parsedBody.system)).digest('hex').slice(0, 12)
+          : null);
       toolsHash = parsedBody.tools
         ? crypto.createHash('sha256').update(JSON.stringify(parsedBody.tools)).digest('hex').slice(0, 12)
         : null;
@@ -208,6 +307,20 @@ const server = http.createServer((clientReq, clientRes) => {
           .catch(e => console.error('Write sys failed:', e.message));
         if (toolsHash) config.storage.writeSharedIfAbsent(`tools_${toolsHash}.json`, JSON.stringify(parsedBody.tools))
           .catch(e => console.error('Write tools failed:', e.message));
+      } else if (provider === 'openai') {
+        if (sysHash) {
+          config.storage.writeSharedIfAbsent(`openai_instructions_${sysHash}.json`, JSON.stringify(parsedBody.instructions))
+            .catch(e => console.error('Write OpenAI instructions failed:', e.message));
+          const promptInfo = typeof parsedBody.instructions === 'string' ? registerPromptVersion({
+            provider,
+            parsedBody,
+            sharedFile: `openai_instructions_${sysHash}.json`,
+            promptText: parsedBody.instructions,
+          }) : null;
+          coreHash = promptInfo?.coreHash || null;
+        }
+        if (toolsHash) config.storage.writeSharedIfAbsent(`openai_tools_${toolsHash}.json`, JSON.stringify(parsedBody.tools))
+          .catch(e => console.error('Write OpenAI tools failed:', e.message));
       }
 
       const currMessages = Array.isArray(parsedBody.messages) ? parsedBody.messages : [];
@@ -245,15 +358,16 @@ const server = http.createServer((clientReq, clientRes) => {
         .catch(e => console.error('Write req.json failed:', e.message));
     }
 
+    const detectedSession = parsedBody
+      ? (provider === 'openai' ? detectOpenAISession(clientReq.headers, parsedBody) : store.detectSession(parsedBody))
+      : null;
     const { sessionId: reqSessionId, isNewSession, inferred: sessionInferred } = parsedBody
-      ? (provider === 'openai'
-        ? { sessionId: getCodexRawSessionId(), isNewSession: false, inferred: true }
-        : store.detectSession(parsedBody))
+      ? detectedSession
       : { sessionId: provider === 'openai' ? getCodexRawSessionId() : store.getCurrentSessionId(), isNewSession: false };
 
     // Extract and store cwd
     if (parsedBody && reqSessionId) {
-      const cwd = provider === 'openai' ? getCodexCwdFallback() : store.extractCwd(parsedBody);
+      const cwd = provider === 'openai' ? getOpenAICwd(parsedBody) : store.extractCwd(parsedBody);
       if (cwd) {
         if (!store.sessionMeta[reqSessionId]) store.sessionMeta[reqSessionId] = {};
         store.sessionMeta[reqSessionId].provider = provider;
@@ -262,8 +376,7 @@ const server = http.createServer((clientReq, clientRes) => {
     }
 
     // Detect new cc_version for live requests; compute coreHash for all qualifying requests
-    let coreHash = null;
-    if (parsedBody && Array.isArray(parsedBody.system) && parsedBody.system.length >= 3) {
+    if (parsedBody && provider === 'anthropic' && Array.isArray(parsedBody.system) && parsedBody.system.length >= 3) {
       const b0 = (parsedBody.system[0].text || '');
       const b2 = (parsedBody.system[2].text || '');
       const liveM = b0.match(/cc_version=(\S+?)[; ]/);
@@ -309,7 +422,11 @@ const server = http.createServer((clientReq, clientRes) => {
     // Build context for forwarding
     const fwdHeaders = buildForwardHeaders(clientReq.headers, upstream);
 
-    const ctx = { id, ts, startTime, parsedBody, rawBody, clientReq, clientRes, fwdHeaders, reqSessionId, reqWritePromise, sysHash, toolsHash, coreHash, sessionInferred, upstream };
+    const ctx = {
+      id, ts, startTime, parsedBody, rawBody, clientReq, clientRes, fwdHeaders,
+      reqSessionId, reqWritePromise, sysHash, toolsHash, coreHash, sessionInferred, upstream,
+      isSubagent: provider === 'openai' ? isOpenAISubagent(clientReq.headers, parsedBody) : undefined,
+    };
 
     // ── Intercept check ──
     const lastStop = store.sessionMeta[reqSessionId]?.lastStopReason;

--- a/server/restore.js
+++ b/server/restore.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const config = require('./config');
 const store = require('./store');
 const { calculateCost } = require('./pricing');
-const { extractAgentType, splitB2IntoBlocks } = require('./system-prompt');
+const { extractAgentType, extractPromptAgentType, splitB2IntoBlocks } = require('./system-prompt');
 const { normalizeOpenAIResponseSummary } = require('./forward');
 const { readSettings, serializeStars } = require('./settings');
 const { computeRetentionSets, isProtectedByStar } = require('./helpers');
@@ -198,21 +198,25 @@ async function buildVersionIndex() {
   const sysHashToAgentKey = new Map();
 
   for (const filename of sharedFiles) {
-    if (!filename.startsWith('sys_')) continue;
+    if (!filename.startsWith('sys_') && !filename.startsWith('openai_instructions_')) continue;
     try {
       const sys = JSON.parse(await config.storage.readShared(filename));
-      if (!Array.isArray(sys) || sys.length < 3) continue;
-      const b0 = sys[0]?.text || '';
-      const b2 = sys[2]?.text || '';
+      const isOpenAI = filename.startsWith('openai_instructions_');
+      if (!isOpenAI && (!Array.isArray(sys) || sys.length < 3)) continue;
+      const b0 = isOpenAI ? '' : (sys[0]?.text || '');
+      const b2 = isOpenAI ? (typeof sys === 'string' ? sys : JSON.stringify(sys, null, 2)) : (sys[2]?.text || '');
       const m = b0.match(/cc_version=(\S+?)[; ]/);
-      const ver = m ? m[1] : null;
-      const { key: agentKey, label: agentLabel } = extractAgentType(sys);
-      const sysHash = filename.replace(/^sys_/, '').replace(/\.json$/, '');
+      const { key: agentKey, label: agentLabel } = isOpenAI
+        ? extractPromptAgentType('openai', { instructions: b2 })
+        : extractAgentType(sys);
+      const sysHash = filename.replace(/^sys_/, '').replace(/^openai_instructions_/, '').replace(/\.json$/, '');
       if (sysHash && agentKey) sysHashToAgentKey.set(sysHash, agentKey);
-      if (ver && b2.length >= 500) {
-        const coreText = splitB2IntoBlocks(b2).coreInstructions || '';
+      if (b2.length >= (isOpenAI ? 1 : 500)) {
+        const coreText = isOpenAI ? b2 : (splitB2IntoBlocks(b2).coreInstructions || '');
         const coreLen = coreText.length;
         const coreHash = crypto.createHash('md5').update(coreText).digest('hex').slice(0, 12);
+        const ver = isOpenAI ? coreHash : (m ? m[1] : null);
+        if (!ver) continue;
         const idxKey = `${agentKey}::${coreHash}`;
         const existing = store.versionIndex.get(idxKey);
         if (!existing || b2.length > existing.b2Len) {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -90,6 +90,7 @@ function handleApiRoutes(clientReq, clientRes) {
       if (ent.sharedFile) {
         try {
           const sys = JSON.parse(await config.storage.readShared(ent.sharedFile));
+          if (typeof sys === 'string') return sys;
           return Array.isArray(sys) && sys[2] ? (sys[2].text || '') : '';
         } catch {}
       }

--- a/server/store.js
+++ b/server/store.js
@@ -55,6 +55,7 @@ function extractCwd(req) {
 }
 
 function extractSessionId(req) {
+  if (typeof req?.metadata?.session_id === 'string') return req.metadata.session_id;
   const uid = req?.metadata?.user_id || '';
   // New format: user_id is JSON like {"session_id":"xxx-yyy"}
   const jsonMatch = uid.match(/"session_id"\s*:\s*"([a-f0-9-]+)"/);

--- a/server/system-prompt.js
+++ b/server/system-prompt.js
@@ -24,6 +24,11 @@ const BLOCK_OWNERS_SERVER = {
 
 // Known agent types by b2 prefix. Order matters — first match wins.
 const KNOWN_AGENTS = [
+  { prefix: 'You are Codex',                            key: 'default',           label: 'Codex Default' },
+  { prefix: 'You are an explorer agent',                key: 'explorer',          label: 'Codex Explorer' },
+  { prefix: 'You are an agent that explores',           key: 'explorer',          label: 'Codex Explorer' },
+  { prefix: 'You are a worker agent',                   key: 'worker',            label: 'Codex Worker' },
+  { prefix: 'You are an execution agent',               key: 'worker',            label: 'Codex Worker' },
   { prefix: 'You are an interactive agent',                key: 'orchestrator',      label: 'Orchestrator' },
   { prefix: 'You are an agent for Claude Code',            key: 'general-purpose',   label: 'General Purpose' },
   { prefix: 'You are a file search specialist',            key: 'explore',           label: 'Explore' },
@@ -66,6 +71,28 @@ function extractAgentType(sys) {
   }
   logUnknownAgent(b2, 'agent');
   return { key: 'agent', label: 'Agent' };
+}
+
+function extractPromptAgentType(provider, req) {
+  if (provider === 'openai') {
+    const explicit = req?.metadata?.agent_type || req?.metadata?.agentType || req?.metadata?.agent;
+    if (explicit === 'explorer') return { key: 'explorer', label: 'Codex Explorer' };
+    if (explicit === 'worker') return { key: 'worker', label: 'Codex Worker' };
+    if (explicit === 'default') return { key: 'default', label: 'Codex Default' };
+
+    const instructions = typeof req?.instructions === 'string' ? req.instructions : JSON.stringify(req?.instructions || '');
+    if (/explorer/i.test(instructions)) return { key: 'explorer', label: 'Codex Explorer' };
+    if (/worker|execution agent/i.test(instructions)) return { key: 'worker', label: 'Codex Worker' };
+
+    const hasCodexPrompt =
+      req?.instructions != null ||
+      req?.input != null ||
+      (Array.isArray(req?.tools) && req.tools.length > 0);
+    return hasCodexPrompt
+      ? { key: 'default', label: 'Codex Default' }
+      : { key: 'unknown', label: 'Unknown' };
+  }
+  return extractAgentType(req?.system);
 }
 
 function splitB2IntoBlocks(b2) {
@@ -182,6 +209,7 @@ function computeUnifiedDiff(textA, textB, labelA, labelB) {
 module.exports = {
   BLOCK_OWNERS_SERVER,
   extractAgentType,
+  extractPromptAgentType,
   splitB2IntoBlocks,
   computeBlockDiff,
   computeUnifiedDiff,

--- a/test/messages-ui.test.js
+++ b/test/messages-ui.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadMessagesContext() {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'public', 'messages.js'), 'utf8');
+  const context = { console };
+  vm.createContext(context);
+  vm.runInContext(source, context);
+  return context;
+}
+
+describe('dashboard timeline rendering helpers', () => {
+  it('renders OpenAI Responses output text deltas as assistant timeline text', () => {
+    const context = loadMessagesContext();
+    const steps = context.buildMergedSteps([], [
+      { type: 'response.output_text.delta', delta: 'Hi' },
+      { type: 'response.output_text.delta', delta: '. What' },
+      { type: 'response.output_text.delta', delta: ' next?' },
+    ]);
+
+    assert.equal(steps.length, 1);
+    assert.equal(steps[0].type, 'assistant-text');
+    assert.equal(steps[0].source, 'current');
+    assert.equal(steps[0].text, 'Hi. What next?');
+  });
+
+  it('falls back to OpenAI Responses output_text.done when deltas are absent', () => {
+    const context = loadMessagesContext();
+    const steps = context.buildMergedSteps([], [
+      { type: 'response.output_text.done', text: 'Done text' },
+    ]);
+
+    assert.equal(steps.length, 1);
+    assert.equal(steps[0].type, 'assistant-text');
+    assert.equal(steps[0].text, 'Done text');
+  });
+
+  it('renders OpenAI Responses reasoning deltas as current thinking', () => {
+    const context = loadMessagesContext();
+    const steps = context.buildMergedSteps([], [
+      { type: 'response.reasoning_text.delta', delta: 'Check repo. ' },
+      { type: 'response.reasoning_summary_part.added', part: { text: 'Found renderer path.' } },
+      { type: 'response.completed', _ts: 1200 },
+    ]);
+
+    assert.equal(steps.length, 1);
+    assert.equal(steps[0].type, 'tool-group');
+    assert.equal(steps[0].source, 'current');
+    assert.equal(steps[0].thinking, 'Check repo. Found renderer path.');
+  });
+
+  it('renders OpenAI Responses function-call events as pending tool calls', () => {
+    const context = loadMessagesContext();
+    const steps = context.buildMergedSteps([], [
+      {
+        type: 'response.output_item.added',
+        output_index: 0,
+        item: { id: 'call_1', type: 'function_call', name: 'shell' },
+      },
+      { type: 'response.function_call_arguments.delta', item_id: 'call_1', delta: '{"command":"' },
+      { type: 'response.function_call_arguments.delta', item_id: 'call_1', delta: 'npm test"}' },
+    ]);
+
+    assert.equal(steps.length, 1);
+    assert.equal(steps[0].type, 'tool-group');
+    assert.equal(steps[0].calls.length, 1);
+    assert.equal(steps[0].calls[0].name, 'shell');
+    assert.equal(JSON.stringify(steps[0].calls[0].input), JSON.stringify({ command: 'npm test' }));
+    assert.equal(steps[0].calls[0].pending, true);
+  });
+});

--- a/test/startup.test.js
+++ b/test/startup.test.js
@@ -863,6 +863,61 @@ describe('OpenAI Responses raw capture', () => {
     assert.equal(finalEvent.type, 'response.completed');
     assert.equal(finalEvent.data.response.output[0].content[0].text, 'stream ok');
   });
+
+  it('groups Codex turns by session_id header and marks OpenAI subagents', async () => {
+    const sessionId = 'codex-session-header-001';
+    const mainBody = JSON.stringify({
+      model: 'gpt-5.5',
+      instructions: 'You are Codex. Keep responses short.',
+      input: 'main turn',
+    });
+    const subagentBody = JSON.stringify({
+      model: 'gpt-5.5',
+      instructions: 'You are a worker agent for Codex. Execute the requested task.',
+      input: 'worker turn',
+    });
+
+    await sendOpenAIResponsesRequest(proxyPort, mainBody, '/v1/responses?trace=session-main', { session_id: sessionId });
+    await sendOpenAIResponsesRequest(proxyPort, subagentBody, '/v1/responses?trace=session-worker', {
+      session_id: sessionId,
+      'x-openai-subagent': 'worker',
+    });
+    await new Promise(r => setTimeout(r, 500));
+
+    const indexEntries = fs.readFileSync(path.join(TEST_HOME, 'logs', 'index.ndjson'), 'utf8')
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line))
+      .filter(e => e.sessionId === sessionId);
+
+    assert.equal(indexEntries.length, 2);
+    assert.equal(indexEntries[0].isSubagent, false);
+    assert.equal(indexEntries[0].sessionInferred, false);
+    assert.equal(indexEntries[1].isSubagent, true);
+    assert.equal(indexEntries[1].sessionInferred, false);
+  });
+
+  it('captures Codex instructions in the System Prompt version index', async () => {
+    const sessionId = 'codex-system-prompt-001';
+    const requestBody = JSON.stringify({
+      model: 'gpt-5.5',
+      instructions: 'You are an explorer agent for Codex. Inspect the codebase and report findings.',
+      input: 'inspect prompt index',
+    });
+
+    await sendOpenAIResponsesRequest(proxyPort, requestBody, '/v1/responses?trace=sysprompt', {
+      session_id: sessionId,
+      'x-openai-subagent': 'explorer',
+    });
+    await new Promise(r => setTimeout(r, 500));
+
+    const data = await httpGet(proxyPort, '/_api/sysprompt/versions');
+    const explorer = data.versions.find(v => v.agentKey === 'explorer');
+    assert.ok(explorer, 'expected Codex explorer prompt version');
+    assert.equal(explorer.agentLabel, 'Codex Explorer');
+    assert.ok(explorer.coreHash);
+    assert.ok(explorer.b2Len > 0);
+  });
 });
 
 // ── Intercept lifecycle E2E ──────────────────────────────────────────
@@ -1555,11 +1610,11 @@ function sendProxyRequest(port, body) {
   });
 }
 
-function sendOpenAIResponsesRequest(port, body, urlPath = '/v1/responses') {
+function sendOpenAIResponsesRequest(port, body, urlPath = '/v1/responses', extraHeaders = {}) {
   return new Promise((resolve, reject) => {
     const req = http.request(`http://localhost:${port}${urlPath}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body), Authorization: 'Bearer test-key' },
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body), Authorization: 'Bearer test-key', ...extraHeaders },
     }, res => {
       let data = '';
       res.on('data', c => { data += c; });

--- a/test/system-prompt.test.js
+++ b/test/system-prompt.test.js
@@ -4,6 +4,7 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const {
   extractAgentType,
+  extractPromptAgentType,
   splitB2IntoBlocks,
   computeBlockDiff,
   computeUnifiedDiff,
@@ -128,6 +129,43 @@ describe('system-prompt', () => {
         console.warn = originalWarn;
         _resetUnknownAgentSeen();
       }
+    });
+  });
+
+  describe('extractPromptAgentType', () => {
+    it('classifies OpenAI Responses prompts as Codex without using Claude buckets', () => {
+      const result = extractPromptAgentType('openai', {
+        instructions: 'You are Codex.',
+        input: 'hello',
+        tools: [{ type: 'function', name: 'shell' }],
+      });
+      assert.deepEqual(result, { key: 'default', label: 'Codex Default' });
+    });
+
+    it('classifies Codex native subagent types from metadata', () => {
+      assert.deepEqual(
+        extractPromptAgentType('openai', { metadata: { agent_type: 'explorer' }, instructions: 'inspect' }),
+        { key: 'explorer', label: 'Codex Explorer' }
+      );
+      assert.deepEqual(
+        extractPromptAgentType('openai', { metadata: { agent_type: 'worker' }, instructions: 'edit' }),
+        { key: 'worker', label: 'Codex Worker' }
+      );
+    });
+
+    it('returns unknown for empty OpenAI payloads', () => {
+      assert.deepEqual(extractPromptAgentType('openai', {}), { key: 'unknown', label: 'Unknown' });
+    });
+
+    it('preserves Claude-specific classification for Anthropic payloads', () => {
+      const result = extractPromptAgentType('anthropic', {
+        system: [
+          { text: 'billing' },
+          { text: 'identity' },
+          { text: 'You are an interactive agent that helps users' },
+        ],
+      });
+      assert.equal(result.key, 'orchestrator');
     });
   });
 


### PR DESCRIPTION
## 繁中摘要

- 這支 PR 只處理 issue #20 comment 裡的 Codex V1 範圍：session grouping、subagent flag、Responses parsed renderer、Codex System Prompt agents。
- 讀 `session_id` header 讓 Codex turns 正確分到同一個 session，讀 `x-openai-subagent` 標記 worker/explorer subagent。
- Dashboard 會解析 OpenAI Responses SSE 的 reasoning / output text / function-call events。
- System Prompt 頁面新增 Codex `default` / `explorer` / `worker` prompt versions。
- `~/.codex/sessions/.../rollup-*.jsonl` cost-worker scan 保留為 comment 指定的 separate follow-up。

## Scope

Addresses the V1 checklist from #20:

- `server/index.js`: read lowercase `session_id` for Codex/OpenAI requests instead of forcing `codex-raw` when the header is present.
- `server/forward.js`: preserve `x-openai-subagent` through OpenAI SSE and non-SSE entry/index records.
- `public/messages.js`: render OpenAI Responses SSE events in the timeline:
  - `response.output_item.added`
  - `response.output_text.delta`
  - `response.output_text.done`
  - `response.reasoning_text.delta`
  - `response.reasoning_summary_part.added`
  - `response.reasoning_summary_text.delta`
  - `response.function_call_arguments.delta`
  - `response.output_item.done`
- `server/system-prompt.js`: add Codex native agent buckets: `default`, `explorer`, `worker`.
- `server/index.js` / `server/restore.js`: capture Codex `instructions` shared files and index them in the System Prompt page.
- `public/system-prompt-ui.js`: add Codex buckets to agent ordering.

Out of scope by design: cost-worker scanning of `~/.codex/sessions/YYYY/MM/DD/rollup-*.jsonl`. That can land independently after this PR.

## Screenshots

Captured from an isolated local fixture with one Codex main turn, one `x-openai-subagent: worker` turn under the same `session_id`, and shared instruction files for `default` / `explorer` / `worker`.

<details open>
<summary>Session grouping</summary>

![Session grouping](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/codex-v1-session-grouping.png)
</details>

<details open>
<summary>Timeline</summary>

![Timeline](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/codex-v1-timeline.png)
</details>

<details>
<summary>Context: Instructions</summary>

![Instructions](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/codex-v1-instructions.png)
</details>

<details>
<summary>Context: Input</summary>

![Input](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/codex-v1-input.png)
</details>

<details>
<summary>Context: Tools</summary>

![Tools](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/codex-v1-tools.png)
</details>

<details>
<summary>Analysis: Cost Efficiency</summary>

![Cost Efficiency](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/codex-v1-cost-efficiency.png)
</details>

<details>
<summary>RAW: Request</summary>

![Request](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/codex-v1-request.png)
</details>

<details>
<summary>RAW: Response</summary>

![Response](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/codex-v1-response.png)
</details>

<details open>
<summary>System Prompt: Codex agents</summary>

![System Prompt agents](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/codex-v1-system-prompt-agents.png)
</details>

## Tests

- `node --test test/messages-ui.test.js test/system-prompt.test.js test/startup.test.js` — 76 passing
- `npm test` — 457 passing
- `node --check server/index.js && node --check server/forward.js && node --check server/restore.js && node --check server/system-prompt.js`