### PR TITLE
[codex] Add Codex WebSocket transport proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ skills-lock.json
 videos/
 ccxray-init.png
 docs/src/
+.tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ No build step. No linting. Restart to apply changes.
 | `server/routes/costs.js` | Cost budget endpoints |
 | `server/hub.js` | Multi-project hub: lockfile (`~/.ccxray/hub.json`), discovery (with orphan port probe fallback), client registration, idle shutdown (injectable via setOnShutdown), crash auto-recovery |
 | `server/auth.js` | API key auth middleware (enabled via `AUTH_TOKEN` env) |
+| `server/openai-session.js` | Shared OpenAI/Codex header + session helpers (session id extraction, agent type, turn-metadata sidecar) |
+| `server/ws-proxy.js` | OpenAI WebSocket transport proxy for `/v1/responses` and `/v1/realtime` upgrades. Tunables: `CCXRAY_WS_IDLE_TIMEOUT_MS` (default 60s), `CCXRAY_WS_MAX_QUEUE_BYTES` (default 4 MiB; caps client→upstream buffer while upstream is connecting) |
 | `server/storage/` | Storage adapters (local filesystem, S3/R2). `statShared()` for file mtime. `supportsDelta` flag gates delta-write eligibility |
 
 ### Client (`public/`)

--- a/server/config.js
+++ b/server/config.js
@@ -137,6 +137,7 @@ function getUpstream(provider) {
 function getProviderForRequest(urlPath) {
   const pathname = (urlPath || '').split('?')[0];
   if (pathname === '/v1/responses' || pathname.startsWith('/v1/responses/')) return 'openai';
+  if (pathname === '/v1/realtime' || pathname.startsWith('/v1/realtime/')) return 'openai';
   if (pathname === '/v1/models' || pathname.startsWith('/v1/models/')) return 'openai';
   return 'anthropic';
 }

--- a/server/index.js
+++ b/server/index.js
@@ -18,6 +18,13 @@ const { authMiddleware } = require('./auth');
 const { extractAgentType, extractPromptAgentType, splitB2IntoBlocks } = require('./system-prompt');
 const { findSharedPrefix } = require('./delta-helpers');
 const providers = require('./providers');
+const { handleWebSocketUpgrade } = require('./ws-proxy');
+const {
+  getCodexRawSessionId,
+  isOpenAISubagent,
+  detectOpenAISession,
+  withCodexMetadata,
+} = require('./openai-session');
 
 // ── CLI: parse flags and detect provider launchers ──
 const portIdx = process.argv.indexOf('--port');
@@ -135,72 +142,12 @@ function buildForwardHeaders(clientHeaders, upstream) {
   return fwdHeaders;
 }
 
-function getCodexRawSessionId() {
-  return 'codex-raw';
-}
-
-function firstHeader(headers, name) {
-  const value = headers?.[name.toLowerCase()];
-  return Array.isArray(value) ? value[0] : value;
-}
-
-function getCodexSessionId(headers, parsedBody) {
-  const direct = firstHeader(headers, 'session_id') || firstHeader(headers, 'x-openai-session-id');
-  if (direct) return String(direct);
-  return parsedBody?.metadata?.session_id || null;
-}
-
-function isOpenAISubagent(headers, parsedBody) {
-  const raw = firstHeader(headers, 'x-openai-subagent');
-  if (raw != null) {
-    const text = String(raw).toLowerCase();
-    return text !== '0' && text !== 'false' && text !== 'no';
-  }
-  return Boolean(parsedBody?.metadata?.is_subagent || parsedBody?.metadata?.isSubagent);
-}
-
-function getOpenAIAgentTypeFromHeaders(headers) {
-  const subagent = firstHeader(headers, 'x-openai-subagent');
-  const direct = firstHeader(headers, 'x-openai-agent-type') || firstHeader(headers, 'x-codex-agent-type');
-  const value = direct || subagent;
-  if (!value) return null;
-  const normalized = String(value).toLowerCase();
-  if (normalized === 'explorer' || normalized === 'worker' || normalized === 'default') return normalized;
-  return null;
-}
-
-function detectOpenAISession(headers, parsedBody) {
-  if (!parsedBody) return { sessionId: getCodexRawSessionId(), isNewSession: false, inferred: true };
-  if (!getCodexSessionId(headers, parsedBody)) {
-    return { sessionId: getCodexRawSessionId(), isNewSession: false, inferred: true };
-  }
-  const detected = store.detectSession(parsedBody);
-  return {
-    sessionId: detected.sessionId || getCodexRawSessionId(),
-    isNewSession: detected.isNewSession || false,
-    inferred: detected.inferred || false,
-  };
-}
-
 function getCodexCwdFallback() {
   return hub.lookupClientCwd() || (agentCommand === 'codex' ? process.cwd() : null);
 }
 
 function getOpenAICwd(parsedBody) {
   return parsedBody?.metadata?.cwd || getCodexCwdFallback();
-}
-
-function withCodexMetadata(parsedBody, headers) {
-  if (!parsedBody || typeof parsedBody !== 'object') return parsedBody;
-  const sessionId = getCodexSessionId(headers, parsedBody);
-  const agentType = getOpenAIAgentTypeFromHeaders(headers);
-  if (!sessionId && !agentType) return parsedBody;
-  const metadata = parsedBody.metadata && typeof parsedBody.metadata === 'object'
-    ? { ...parsedBody.metadata }
-    : {};
-  if (sessionId && !metadata.session_id) metadata.session_id = sessionId;
-  if (agentType && !metadata.agent_type) metadata.agent_type = agentType;
-  return { ...parsedBody, metadata };
 }
 
 function registerPromptVersion({ provider, parsedBody, sharedFile, promptText, firstSeen, notify = true }) {
@@ -317,6 +264,12 @@ const server = http.createServer((clientReq, clientRes) => {
             sharedFile: `openai_instructions_${sysHash}.json`,
             promptText: parsedBody.instructions,
           }) : null;
+          if (promptInfo) {
+            config.storage.writeSharedIfAbsent(`openai_prompt_meta_${sysHash}.json`, JSON.stringify({
+              agentKey: promptInfo.agentKey,
+              agentLabel: promptInfo.agentLabel,
+            })).catch(e => console.error('Write OpenAI prompt metadata failed:', e.message));
+          }
           coreHash = promptInfo?.coreHash || null;
         }
         if (toolsHash) config.storage.writeSharedIfAbsent(`openai_tools_${toolsHash}.json`, JSON.stringify(parsedBody.tools))
@@ -450,6 +403,10 @@ const server = http.createServer((clientReq, clientRes) => {
 
     forwardRequest(ctx);
   });
+});
+
+server.on('upgrade', (req, socket, head) => {
+  handleWebSocketUpgrade(req, socket, head);
 });
 
 

--- a/server/openai-session.js
+++ b/server/openai-session.js
@@ -50,6 +50,11 @@ function isOpenAISubagent(headers, parsedBody) {
   return Boolean(parsedBody?.metadata?.is_subagent || parsedBody?.metadata?.isSubagent);
 }
 
+// Used by both HTTP (parsedBody present) and WebSocket upgrade (no body) paths.
+// When parsedBody is null but headers carry session_id, we synthesize a minimal
+// body so store.detectSession honors header-derived sessions consistently —
+// otherwise WS upgrades and body-less HTTP retries would collapse into the
+// `codex-raw` bucket.
 function detectOpenAISession(headers, parsedBody) {
   const sessionId = getCodexSessionId(headers, parsedBody);
   if (!sessionId) {

--- a/server/openai-session.js
+++ b/server/openai-session.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const store = require('./store');
+
+function getCodexRawSessionId() {
+  return 'codex-raw';
+}
+
+function firstHeader(headers, name) {
+  const value = headers?.[name.toLowerCase()];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function parseCodexTurnMetadata(headers) {
+  const raw = firstHeader(headers, 'x-codex-turn-metadata');
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(String(raw));
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function getCodexSessionId(headers, parsedBody) {
+  const direct = firstHeader(headers, 'session_id') || firstHeader(headers, 'x-openai-session-id');
+  if (direct) return String(direct);
+  const turnMetadata = parseCodexTurnMetadata(headers);
+  if (typeof turnMetadata?.session_id === 'string') return turnMetadata.session_id;
+  return parsedBody?.metadata?.session_id || null;
+}
+
+function getOpenAIAgentTypeFromHeaders(headers) {
+  const subagent = firstHeader(headers, 'x-openai-subagent');
+  const direct = firstHeader(headers, 'x-openai-agent-type') || firstHeader(headers, 'x-codex-agent-type');
+  const turnMetadata = parseCodexTurnMetadata(headers);
+  const value = direct || turnMetadata?.agent_type || subagent;
+  if (!value) return null;
+  const normalized = String(value).toLowerCase();
+  if (normalized === 'explorer' || normalized === 'worker' || normalized === 'default') return normalized;
+  return null;
+}
+
+function isOpenAISubagent(headers, parsedBody) {
+  const raw = firstHeader(headers, 'x-openai-subagent');
+  if (raw != null) {
+    const text = String(raw).toLowerCase();
+    return text !== '0' && text !== 'false' && text !== 'no';
+  }
+  return Boolean(parsedBody?.metadata?.is_subagent || parsedBody?.metadata?.isSubagent);
+}
+
+function detectOpenAISession(headers, parsedBody) {
+  const sessionId = getCodexSessionId(headers, parsedBody);
+  if (!sessionId) {
+    return { sessionId: getCodexRawSessionId(), isNewSession: false, inferred: true };
+  }
+  const bodyForDetection = parsedBody || { metadata: { session_id: sessionId } };
+  const detected = store.detectSession(bodyForDetection);
+  return {
+    sessionId: detected.sessionId || sessionId || getCodexRawSessionId(),
+    isNewSession: detected.isNewSession || false,
+    inferred: detected.inferred || false,
+  };
+}
+
+function withCodexMetadata(parsedBody, headers) {
+  if (!parsedBody || typeof parsedBody !== 'object') return parsedBody;
+  const sessionId = getCodexSessionId(headers, parsedBody);
+  const agentType = getOpenAIAgentTypeFromHeaders(headers);
+  if (!sessionId && !agentType) return parsedBody;
+  const metadata = parsedBody.metadata && typeof parsedBody.metadata === 'object'
+    ? { ...parsedBody.metadata }
+    : {};
+  if (sessionId && !metadata.session_id) metadata.session_id = sessionId;
+  if (agentType && !metadata.agent_type) metadata.agent_type = agentType;
+  return { ...parsedBody, metadata };
+}
+
+module.exports = {
+  getCodexRawSessionId,
+  firstHeader,
+  parseCodexTurnMetadata,
+  getCodexSessionId,
+  getOpenAIAgentTypeFromHeaders,
+  isOpenAISubagent,
+  detectOpenAISession,
+  withCodexMetadata,
+};

--- a/server/restore.js
+++ b/server/restore.js
@@ -206,10 +206,19 @@ async function buildVersionIndex() {
       const b0 = isOpenAI ? '' : (sys[0]?.text || '');
       const b2 = isOpenAI ? (typeof sys === 'string' ? sys : JSON.stringify(sys, null, 2)) : (sys[2]?.text || '');
       const m = b0.match(/cc_version=(\S+?)[; ]/);
-      const { key: agentKey, label: agentLabel } = isOpenAI
-        ? extractPromptAgentType('openai', { instructions: b2 })
-        : extractAgentType(sys);
       const sysHash = filename.replace(/^sys_/, '').replace(/^openai_instructions_/, '').replace(/\.json$/, '');
+      let agentInfo = null;
+      if (isOpenAI) {
+        const meta = await config.storage.readShared(`openai_prompt_meta_${sysHash}.json`)
+          .then(JSON.parse)
+          .catch(() => null);
+        if (meta?.agentKey) {
+          agentInfo = { key: meta.agentKey, label: meta.agentLabel || meta.agentKey };
+        }
+      }
+      const { key: agentKey, label: agentLabel } = agentInfo || (isOpenAI
+        ? extractPromptAgentType('openai', { instructions: b2 })
+        : extractAgentType(sys));
       if (sysHash && agentKey) sysHashToAgentKey.set(sysHash, agentKey);
       if (b2.length >= (isOpenAI ? 1 : 500)) {
         const coreText = isOpenAI ? b2 : (splitB2IntoBlocks(b2).coreInstructions || '');

--- a/server/ws-proxy.js
+++ b/server/ws-proxy.js
@@ -43,7 +43,12 @@ const DEFAULT_IDLE_TIMEOUT_MS = parseInt(process.env.CCXRAY_WS_IDLE_TIMEOUT_MS |
 const IDLE_TIMEOUT_MS = Number.isFinite(DEFAULT_IDLE_TIMEOUT_MS) && DEFAULT_IDLE_TIMEOUT_MS > 0
   ? DEFAULT_IDLE_TIMEOUT_MS
   : 60000;
+const DEFAULT_MAX_QUEUE_BYTES = parseInt(process.env.CCXRAY_WS_MAX_QUEUE_BYTES || String(4 * 1024 * 1024), 10);
+const MAX_QUEUE_BYTES = Number.isFinite(DEFAULT_MAX_QUEUE_BYTES) && DEFAULT_MAX_QUEUE_BYTES > 0
+  ? DEFAULT_MAX_QUEUE_BYTES
+  : 4 * 1024 * 1024;
 const OPENAI_WS_PATHS = new Set(['/v1/responses', '/v1/realtime']);
+const WS_CLOSE_REASON_MAX_BYTES = 120; // WS spec caps reason at 123 bytes; leave headroom.
 
 function isUpgradeRequest(req) {
   return String(req.headers.upgrade || '').toLowerCase() === 'websocket';
@@ -119,17 +124,35 @@ function getWorkspaceCwd(turnMetadata) {
   return nested?.cwd || null;
 }
 
-function sendOrBuffer(target, queue, data, isBinary) {
+function safeSend(target, data, isBinary) {
   if (target.readyState === WebSocket.OPEN) {
     target.send(data, { binary: isBinary }, () => {});
-  } else if (target.readyState === WebSocket.CONNECTING) {
-    queue.push({ data, isBinary });
   }
 }
 
-function flushQueue(target, queue) {
-  while (queue.length && target.readyState === WebSocket.OPEN) {
-    const item = queue.shift();
+// Buffer one frame for a CONNECTING upstream. Returns true on overflow so the
+// caller can shut the pair down instead of growing memory unboundedly.
+function bufferOrSend(target, state, data, isBinary) {
+  if (target.readyState === WebSocket.OPEN) {
+    target.send(data, { binary: isBinary }, () => {});
+    return { overflow: false };
+  }
+  if (target.readyState !== WebSocket.CONNECTING) {
+    return { overflow: false };
+  }
+  const size = frameSize(data);
+  if (state.bufferedBytes + size > state.maxBytes) {
+    return { overflow: true, size };
+  }
+  state.queue.push({ data, isBinary });
+  state.bufferedBytes += size;
+  return { overflow: false };
+}
+
+function flushQueue(target, state) {
+  while (state.queue.length && target.readyState === WebSocket.OPEN) {
+    const item = state.queue.shift();
+    state.bufferedBytes = Math.max(0, state.bufferedBytes - frameSize(item.data));
     target.send(item.data, { binary: item.isBinary }, () => {});
   }
 }
@@ -140,6 +163,22 @@ function frameSize(data) {
   if (data instanceof ArrayBuffer) return data.byteLength;
   if (ArrayBuffer.isView(data)) return data.byteLength;
   return 0;
+}
+
+// WS close reason field is capped at 123 bytes by RFC 6455; the ws library
+// throws RangeError when it overflows. Clamp by codepoint to stay UTF-8 safe.
+function clampWsReason(reason) {
+  const str = typeof reason === 'string' ? reason : String(reason || '');
+  if (Buffer.byteLength(str) <= WS_CLOSE_REASON_MAX_BYTES) return str;
+  let bytes = 0;
+  let out = '';
+  for (const ch of str) {
+    const len = Buffer.byteLength(ch);
+    if (bytes + len > WS_CLOSE_REASON_MAX_BYTES) break;
+    bytes += len;
+    out += ch;
+  }
+  return out;
 }
 
 async function recordWebSocketEntry(ctx, result) {
@@ -308,8 +347,9 @@ function handleWebSocketUpgrade(req, socket, head) {
       frameCounts: { clientToUpstream: 0, upstreamToClient: 0 },
       byteCounts: { clientToUpstream: 0, upstreamToClient: 0 },
     };
-    const clientQueue = [];
-    const upstreamQueue = [];
+    // Only client→upstream needs queueing; clientWs is already OPEN inside this
+    // callback so upstream→client can always send directly via safeSend().
+    const upstreamBuffer = { queue: [], bufferedBytes: 0, maxBytes: MAX_QUEUE_BYTES };
     let finalized = false;
     let idleTimer = null;
 
@@ -334,7 +374,7 @@ function handleWebSocketUpgrade(req, socket, head) {
 
     function closeBoth(code, reason) {
       const closeCode = code || 1000;
-      const closeReason = reason || '';
+      const closeReason = clampWsReason(reason);
       if (clientWs.readyState === WebSocket.OPEN || clientWs.readyState === WebSocket.CONNECTING) {
         clientWs.close(closeCode, closeReason);
       }
@@ -343,17 +383,25 @@ function handleWebSocketUpgrade(req, socket, head) {
       }
     }
 
+    // Arm the idle timer before the upstream handshake completes so a stalled
+    // upstream (accepts TCP, never sends 101) is bounded by IDLE_TIMEOUT_MS.
+    refreshIdleTimer();
+
     clientWs.on('message', (data, isBinary) => {
       refreshIdleTimer();
       ctx.frameCounts.clientToUpstream += 1;
       ctx.byteCounts.clientToUpstream += frameSize(data);
-      sendOrBuffer(upstreamWs, upstreamQueue, data, isBinary);
+      const result = bufferOrSend(upstreamWs, upstreamBuffer, data, isBinary);
+      if (result.overflow) {
+        closeBoth(1009, 'client buffer exceeded');
+        finalize({ status: 507, error: { message: `Client send buffer exceeded ${MAX_QUEUE_BYTES} bytes while upstream was connecting` } });
+      }
     });
     upstreamWs.on('message', (data, isBinary) => {
       refreshIdleTimer();
       ctx.frameCounts.upstreamToClient += 1;
       ctx.byteCounts.upstreamToClient += frameSize(data);
-      sendOrBuffer(clientWs, clientQueue, data, isBinary);
+      safeSend(clientWs, data, isBinary);
     });
     clientWs.on('ping', data => {
       refreshIdleTimer();
@@ -373,21 +421,30 @@ function handleWebSocketUpgrade(req, socket, head) {
     });
     upstreamWs.on('open', () => {
       refreshIdleTimer();
-      flushQueue(upstreamWs, upstreamQueue);
-      flushQueue(clientWs, clientQueue);
+      flushQueue(upstreamWs, upstreamBuffer);
     });
-    upstreamWs.on('unexpected-response', (_request, response) => {
+    upstreamWs.on('unexpected-response', (request, response) => {
+      // ws gives us ownership when a listener is present: drain and destroy
+      // both ends so the underlying HTTP socket doesn't leak.
       const statusCode = response.statusCode || 502;
+      try { response.resume(); } catch {}
+      try { request.destroy(); } catch {}
       closeBoth(1011, `upstream ${statusCode}`);
       finalize({ status: statusCode, error: { message: `Upstream WebSocket rejected handshake: ${statusCode}` } });
     });
     clientWs.on('close', (code, reason) => {
-      if (upstreamWs.readyState === WebSocket.OPEN || upstreamWs.readyState === WebSocket.CONNECTING) upstreamWs.close(code, reason);
-      finalize({ status: 101, close: { side: 'client', code, reason: reason.toString() } });
+      const reasonStr = reason.toString();
+      if (upstreamWs.readyState === WebSocket.OPEN || upstreamWs.readyState === WebSocket.CONNECTING) {
+        upstreamWs.close(code, clampWsReason(reasonStr));
+      }
+      finalize({ status: 101, close: { side: 'client', code, reason: reasonStr } });
     });
     upstreamWs.on('close', (code, reason) => {
-      if (clientWs.readyState === WebSocket.OPEN || clientWs.readyState === WebSocket.CONNECTING) clientWs.close(code, reason);
-      finalize({ status: 101, close: { side: 'upstream', code, reason: reason.toString() } });
+      const reasonStr = reason.toString();
+      if (clientWs.readyState === WebSocket.OPEN || clientWs.readyState === WebSocket.CONNECTING) {
+        clientWs.close(code, clampWsReason(reasonStr));
+      }
+      finalize({ status: 101, close: { side: 'upstream', code, reason: reasonStr } });
     });
     clientWs.on('error', err => {
       closeBoth(1011, 'client error');

--- a/server/ws-proxy.js
+++ b/server/ws-proxy.js
@@ -1,0 +1,380 @@
+'use strict';
+
+const WebSocket = require('ws');
+const config = require('./config');
+const store = require('./store');
+const helpers = require('./helpers');
+const { broadcast, broadcastSessionStatus } = require('./sse-broadcast');
+const { AUTH_TOKEN } = require('./auth');
+const {
+  detectOpenAISession,
+  getCodexSessionId,
+  getOpenAIAgentTypeFromHeaders,
+  parseCodexTurnMetadata,
+} = require('./openai-session');
+
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+const WS_HANDSHAKE_HEADERS = new Set([
+  'sec-websocket-accept',
+  'sec-websocket-extensions',
+  'sec-websocket-key',
+  'sec-websocket-protocol',
+  'sec-websocket-version',
+]);
+
+const wss = new WebSocket.Server({
+  noServer: true,
+  handleProtocols(protocols) {
+    return protocols.values().next().value || false;
+  },
+});
+
+function isUpgradeRequest(req) {
+  return String(req.headers.upgrade || '').toLowerCase() === 'websocket';
+}
+
+function isOpenAIResponsesWebSocket(req, upstream) {
+  const pathname = (req.url || '').split('?')[0];
+  return upstream?.provider === 'openai' && pathname === '/v1/responses' && isUpgradeRequest(req);
+}
+
+function writeSocketResponse(socket, statusCode, reason) {
+  if (socket.destroyed) return;
+  socket.write(
+    `HTTP/1.1 ${statusCode} ${reason}\r\n` +
+    'Connection: close\r\n' +
+    'Content-Length: 0\r\n' +
+    '\r\n'
+  );
+  socket.destroy();
+}
+
+function isAuthorized(req) {
+  if (!AUTH_TOKEN) return true;
+  const authHeader = req.headers.authorization || '';
+  if (authHeader === `Bearer ${AUTH_TOKEN}`) return true;
+  try {
+    const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+    return url.searchParams.get('token') === AUTH_TOKEN;
+  } catch {
+    return false;
+  }
+}
+
+function buildWebSocketHeaders(clientHeaders, upstream) {
+  const headers = {};
+  const connectionTokens = String(clientHeaders.connection || '')
+    .split(',')
+    .map(token => token.trim().toLowerCase())
+    .filter(Boolean);
+
+  for (const [name, value] of Object.entries(clientHeaders)) {
+    const lower = name.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(lower)) continue;
+    if (WS_HANDSHAKE_HEADERS.has(lower)) continue;
+    if (connectionTokens.includes(lower)) continue;
+    if (lower === 'host') continue;
+    headers[name] = value;
+  }
+  headers.host = upstream.host;
+  return headers;
+}
+
+function getWebSocketProtocols(clientHeaders) {
+  const raw = clientHeaders['sec-websocket-protocol'];
+  if (!raw) return undefined;
+  return String(raw).split(',').map(v => v.trim()).filter(Boolean);
+}
+
+function getWebSocketUrl(upstream, requestUrl) {
+  const protocol = upstream.protocol === 'https' ? 'wss' : 'ws';
+  const path = config.joinUpstreamPath(upstream, requestUrl);
+  return `${protocol}://${upstream.host}:${upstream.port}${path}`;
+}
+
+function getWorkspaceCwd(turnMetadata) {
+  const workspaces = turnMetadata?.workspaces;
+  if (!workspaces || typeof workspaces !== 'object') return null;
+  if (typeof workspaces.cwd === 'string') return workspaces.cwd;
+  if (typeof workspaces.current === 'string') return workspaces.current;
+  const first = Object.values(workspaces).find(v => typeof v === 'string');
+  if (first) return first;
+  const nested = Object.values(workspaces).find(v => v && typeof v === 'object' && typeof v.cwd === 'string');
+  return nested?.cwd || null;
+}
+
+function sendOrBuffer(target, queue, data, isBinary) {
+  if (target.readyState === WebSocket.OPEN) {
+    target.send(data, { binary: isBinary }, () => {});
+  } else if (target.readyState === WebSocket.CONNECTING) {
+    queue.push({ data, isBinary });
+  }
+}
+
+function flushQueue(target, queue) {
+  while (queue.length && target.readyState === WebSocket.OPEN) {
+    const item = queue.shift();
+    target.send(item.data, { binary: item.isBinary }, () => {});
+  }
+}
+
+function frameSize(data) {
+  if (Buffer.isBuffer(data)) return data.length;
+  if (typeof data === 'string') return Buffer.byteLength(data);
+  if (data instanceof ArrayBuffer) return data.byteLength;
+  if (ArrayBuffer.isView(data)) return data.byteLength;
+  return 0;
+}
+
+async function recordWebSocketEntry(ctx, result) {
+  const elapsed = ((Date.now() - ctx.startTime) / 1000).toFixed(1);
+  const reqLog = {
+    transport: 'websocket',
+    capture: 'transport-only',
+    method: ctx.req.method,
+    url: ctx.req.url,
+    headers: {
+      openaiBeta: ctx.req.headers['openai-beta'] || null,
+      sessionId: ctx.sessionId,
+      agentType: ctx.agentType,
+    },
+    metadata: ctx.turnMetadata || null,
+  };
+  const resLog = {
+    transport: 'websocket',
+    capture: 'transport-only',
+    frameCounts: ctx.frameCounts,
+    byteCounts: ctx.byteCounts,
+    close: result.close || null,
+    error: result.error || null,
+  };
+
+  const reqWritePromise = config.storage.write(ctx.id, '_req.json', JSON.stringify(reqLog))
+    .catch(e => console.error('Write ws req.json failed:', e.message));
+  const resWritePromise = config.storage.write(ctx.id, '_res.json', JSON.stringify(resLog))
+    .catch(e => console.error('Write ws res.json failed:', e.message));
+
+  const responseMetadata = {
+    transport: 'websocket',
+    capture: 'transport-only',
+    frameCounts: ctx.frameCounts,
+    byteCounts: ctx.byteCounts,
+    close: result.close || null,
+    error: result.error || null,
+  };
+  const entry = {
+    id: ctx.id,
+    ts: ctx.ts,
+    sessionId: ctx.sessionId,
+    method: ctx.req.method,
+    url: ctx.req.url,
+    provider: 'openai',
+    agent: 'codex',
+    req: reqLog,
+    res: resLog,
+    elapsed,
+    status: result.status,
+    isSSE: false,
+    tokens: null,
+    usage: null,
+    cost: null,
+    responseMetadata,
+    maxContext: null,
+    cwd: store.sessionMeta[ctx.sessionId]?.cwd || null,
+    receivedAt: ctx.startTime,
+    duplicateToolCalls: null,
+    model: null,
+    msgCount: 0,
+    toolCount: 0,
+    toolCalls: {},
+    isSubagent: ctx.agentType === 'explorer' || ctx.agentType === 'worker',
+    sessionInferred: ctx.sessionInferred,
+    title: 'Codex WebSocket session',
+    stopReason: result.close?.reason || result.error?.message || null,
+    toolFail: false,
+    sysHash: null,
+    toolsHash: null,
+    coreHash: null,
+    thinkingStripped: undefined,
+  };
+  entry.hasCredential = helpers.entryHasCredential(entry) || undefined;
+  entry.toolSources = helpers.buildToolSources(entry) || undefined;
+  entry._writePromise = Promise.all([reqWritePromise, resWritePromise]);
+  store.entries.push(entry);
+  store.trimEntries();
+  broadcast(entry);
+
+  const indexLine = JSON.stringify({
+    id: entry.id,
+    ts: entry.ts,
+    sessionId: entry.sessionId,
+    provider: entry.provider,
+    agent: entry.agent,
+    model: entry.model,
+    msgCount: entry.msgCount,
+    toolCount: entry.toolCount,
+    toolCalls: entry.toolCalls,
+    isSubagent: entry.isSubagent,
+    sessionInferred: entry.sessionInferred,
+    cwd: entry.cwd,
+    isSSE: entry.isSSE,
+    usage: entry.usage,
+    cost: entry.cost,
+    maxContext: entry.maxContext,
+    responseMetadata,
+    stopReason: entry.stopReason,
+    title: entry.title,
+    thinkingDuration: null,
+    toolFail: entry.toolFail,
+    elapsed,
+    status: entry.status,
+    receivedAt: entry.receivedAt,
+    sysHash: null,
+    toolsHash: null,
+    coreHash: null,
+    thinkingStripped: entry.thinkingStripped,
+    hasCredential: entry.hasCredential,
+    toolSources: entry.toolSources,
+  });
+  config.storage.appendIndex(indexLine + '\n').catch(e => console.error('Write ws index failed:', e.message));
+  entry.req = null;
+  entry.res = null;
+  entry._loaded = false;
+}
+
+function handleWebSocketUpgrade(req, socket, head) {
+  const upstream = config.getUpstreamForRequestAndHeaders(req.url, req.headers);
+  if (!isOpenAIResponsesWebSocket(req, upstream)) {
+    writeSocketResponse(socket, 404, 'Not Found');
+    return true;
+  }
+  if (!isAuthorized(req)) {
+    writeSocketResponse(socket, 401, 'Unauthorized');
+    return true;
+  }
+
+  const id = helpers.timestamp();
+  const ts = helpers.taipeiTime();
+  const startTime = Date.now();
+  const detected = detectOpenAISession(req.headers, null);
+  const sessionId = detected.sessionId;
+  const turnMetadata = parseCodexTurnMetadata(req.headers);
+  const agentType = getOpenAIAgentTypeFromHeaders(req.headers);
+  const cwd = getWorkspaceCwd(turnMetadata);
+
+  if (!store.sessionMeta[sessionId]) store.sessionMeta[sessionId] = {};
+  store.sessionMeta[sessionId].provider = 'openai';
+  store.sessionMeta[sessionId].lastSeenAt = Date.now();
+  if (cwd) store.sessionMeta[sessionId].cwd = cwd;
+  if (agentType) store.sessionMeta[sessionId].agentType = agentType;
+  store.activeRequests[sessionId] = (store.activeRequests[sessionId] || 0) + 1;
+  broadcastSessionStatus(sessionId);
+  if (detected.isNewSession) store.printSessionBanner(sessionId);
+
+  wss.handleUpgrade(req, socket, head, clientWs => {
+    const upstreamUrl = getWebSocketUrl(upstream, req.url);
+    const upstreamWs = new WebSocket(upstreamUrl, getWebSocketProtocols(req.headers), {
+      headers: buildWebSocketHeaders(req.headers, upstream),
+    });
+    const ctx = {
+      id,
+      ts,
+      startTime,
+      req,
+      sessionId,
+      agentType,
+      turnMetadata,
+      sessionInferred: detected.inferred || !getCodexSessionId(req.headers, null),
+      frameCounts: { clientToUpstream: 0, upstreamToClient: 0 },
+      byteCounts: { clientToUpstream: 0, upstreamToClient: 0 },
+    };
+    const clientQueue = [];
+    const upstreamQueue = [];
+    let finalized = false;
+
+    function finalize(result) {
+      if (finalized) return;
+      finalized = true;
+      store.activeRequests[sessionId] = Math.max(0, (store.activeRequests[sessionId] || 1) - 1);
+      if (store.sessionMeta[sessionId]) store.sessionMeta[sessionId].lastStopReason = null;
+      broadcastSessionStatus(sessionId);
+      recordWebSocketEntry(ctx, result).catch(e => console.error('Record ws entry failed:', e.message));
+    }
+
+    function closeBoth(code, reason) {
+      const closeCode = code || 1000;
+      const closeReason = reason || '';
+      if (clientWs.readyState === WebSocket.OPEN || clientWs.readyState === WebSocket.CONNECTING) {
+        clientWs.close(closeCode, closeReason);
+      }
+      if (upstreamWs.readyState === WebSocket.OPEN || upstreamWs.readyState === WebSocket.CONNECTING) {
+        upstreamWs.close(closeCode, closeReason);
+      }
+    }
+
+    clientWs.on('message', (data, isBinary) => {
+      ctx.frameCounts.clientToUpstream += 1;
+      ctx.byteCounts.clientToUpstream += frameSize(data);
+      sendOrBuffer(upstreamWs, upstreamQueue, data, isBinary);
+    });
+    upstreamWs.on('message', (data, isBinary) => {
+      ctx.frameCounts.upstreamToClient += 1;
+      ctx.byteCounts.upstreamToClient += frameSize(data);
+      sendOrBuffer(clientWs, clientQueue, data, isBinary);
+    });
+    clientWs.on('ping', data => {
+      if (upstreamWs.readyState === WebSocket.OPEN) upstreamWs.ping(data, undefined, () => {});
+    });
+    upstreamWs.on('ping', data => {
+      if (clientWs.readyState === WebSocket.OPEN) clientWs.ping(data, undefined, () => {});
+    });
+    clientWs.on('pong', data => {
+      if (upstreamWs.readyState === WebSocket.OPEN) upstreamWs.pong(data, undefined, () => {});
+    });
+    upstreamWs.on('pong', data => {
+      if (clientWs.readyState === WebSocket.OPEN) clientWs.pong(data, undefined, () => {});
+    });
+    upstreamWs.on('open', () => {
+      flushQueue(upstreamWs, upstreamQueue);
+      flushQueue(clientWs, clientQueue);
+    });
+    upstreamWs.on('unexpected-response', (_request, response) => {
+      const statusCode = response.statusCode || 502;
+      closeBoth(1011, `upstream ${statusCode}`);
+      finalize({ status: statusCode, error: { message: `Upstream WebSocket rejected handshake: ${statusCode}` } });
+    });
+    clientWs.on('close', (code, reason) => {
+      if (upstreamWs.readyState === WebSocket.OPEN || upstreamWs.readyState === WebSocket.CONNECTING) upstreamWs.close(code, reason);
+      finalize({ status: 101, close: { side: 'client', code, reason: reason.toString() } });
+    });
+    upstreamWs.on('close', (code, reason) => {
+      if (clientWs.readyState === WebSocket.OPEN || clientWs.readyState === WebSocket.CONNECTING) clientWs.close(code, reason);
+      finalize({ status: 101, close: { side: 'upstream', code, reason: reason.toString() } });
+    });
+    clientWs.on('error', err => {
+      closeBoth(1011, 'client error');
+      finalize({ status: 502, error: { side: 'client', message: err.message } });
+    });
+    upstreamWs.on('error', err => {
+      closeBoth(1011, 'upstream error');
+      finalize({ status: 502, error: { side: 'upstream', message: err.message } });
+    });
+  });
+  return true;
+}
+
+module.exports = {
+  handleWebSocketUpgrade,
+  buildWebSocketHeaders,
+  isOpenAIResponsesWebSocket,
+};

--- a/server/ws-proxy.js
+++ b/server/ws-proxy.js
@@ -39,13 +39,19 @@ const wss = new WebSocket.Server({
   },
 });
 
+const DEFAULT_IDLE_TIMEOUT_MS = parseInt(process.env.CCXRAY_WS_IDLE_TIMEOUT_MS || '60000', 10);
+const IDLE_TIMEOUT_MS = Number.isFinite(DEFAULT_IDLE_TIMEOUT_MS) && DEFAULT_IDLE_TIMEOUT_MS > 0
+  ? DEFAULT_IDLE_TIMEOUT_MS
+  : 60000;
+const OPENAI_WS_PATHS = new Set(['/v1/responses', '/v1/realtime']);
+
 function isUpgradeRequest(req) {
   return String(req.headers.upgrade || '').toLowerCase() === 'websocket';
 }
 
-function isOpenAIResponsesWebSocket(req, upstream) {
+function isOpenAIWebSocket(req, upstream) {
   const pathname = (req.url || '').split('?')[0];
-  return upstream?.provider === 'openai' && pathname === '/v1/responses' && isUpgradeRequest(req);
+  return upstream?.provider === 'openai' && OPENAI_WS_PATHS.has(pathname) && isUpgradeRequest(req);
 }
 
 function writeSocketResponse(socket, statusCode, reason) {
@@ -143,6 +149,7 @@ async function recordWebSocketEntry(ctx, result) {
     capture: 'transport-only',
     method: ctx.req.method,
     url: ctx.req.url,
+    endpoint: ctx.endpoint,
     headers: {
       openaiBeta: ctx.req.headers['openai-beta'] || null,
       sessionId: ctx.sessionId,
@@ -167,6 +174,7 @@ async function recordWebSocketEntry(ctx, result) {
   const responseMetadata = {
     transport: 'websocket',
     capture: 'transport-only',
+    endpoint: ctx.endpoint,
     frameCounts: ctx.frameCounts,
     byteCounts: ctx.byteCounts,
     close: result.close || null,
@@ -254,7 +262,7 @@ async function recordWebSocketEntry(ctx, result) {
 
 function handleWebSocketUpgrade(req, socket, head) {
   const upstream = config.getUpstreamForRequestAndHeaders(req.url, req.headers);
-  if (!isOpenAIResponsesWebSocket(req, upstream)) {
+  if (!isOpenAIWebSocket(req, upstream)) {
     writeSocketResponse(socket, 404, 'Not Found');
     return true;
   }
@@ -271,6 +279,7 @@ function handleWebSocketUpgrade(req, socket, head) {
   const turnMetadata = parseCodexTurnMetadata(req.headers);
   const agentType = getOpenAIAgentTypeFromHeaders(req.headers);
   const cwd = getWorkspaceCwd(turnMetadata);
+  const endpoint = (req.url || '').split('?')[0];
 
   if (!store.sessionMeta[sessionId]) store.sessionMeta[sessionId] = {};
   store.sessionMeta[sessionId].provider = 'openai';
@@ -294,6 +303,7 @@ function handleWebSocketUpgrade(req, socket, head) {
       sessionId,
       agentType,
       turnMetadata,
+      endpoint,
       sessionInferred: detected.inferred || !getCodexSessionId(req.headers, null),
       frameCounts: { clientToUpstream: 0, upstreamToClient: 0 },
       byteCounts: { clientToUpstream: 0, upstreamToClient: 0 },
@@ -301,10 +311,21 @@ function handleWebSocketUpgrade(req, socket, head) {
     const clientQueue = [];
     const upstreamQueue = [];
     let finalized = false;
+    let idleTimer = null;
+
+    function refreshIdleTimer() {
+      clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => {
+        closeBoth(1011, 'idle timeout');
+        finalize({ status: 504, error: { message: `WebSocket idle timeout after ${IDLE_TIMEOUT_MS}ms` } });
+      }, IDLE_TIMEOUT_MS);
+      if (typeof idleTimer.unref === 'function') idleTimer.unref();
+    }
 
     function finalize(result) {
       if (finalized) return;
       finalized = true;
+      clearTimeout(idleTimer);
       store.activeRequests[sessionId] = Math.max(0, (store.activeRequests[sessionId] || 1) - 1);
       if (store.sessionMeta[sessionId]) store.sessionMeta[sessionId].lastStopReason = null;
       broadcastSessionStatus(sessionId);
@@ -323,28 +344,35 @@ function handleWebSocketUpgrade(req, socket, head) {
     }
 
     clientWs.on('message', (data, isBinary) => {
+      refreshIdleTimer();
       ctx.frameCounts.clientToUpstream += 1;
       ctx.byteCounts.clientToUpstream += frameSize(data);
       sendOrBuffer(upstreamWs, upstreamQueue, data, isBinary);
     });
     upstreamWs.on('message', (data, isBinary) => {
+      refreshIdleTimer();
       ctx.frameCounts.upstreamToClient += 1;
       ctx.byteCounts.upstreamToClient += frameSize(data);
       sendOrBuffer(clientWs, clientQueue, data, isBinary);
     });
     clientWs.on('ping', data => {
+      refreshIdleTimer();
       if (upstreamWs.readyState === WebSocket.OPEN) upstreamWs.ping(data, undefined, () => {});
     });
     upstreamWs.on('ping', data => {
+      refreshIdleTimer();
       if (clientWs.readyState === WebSocket.OPEN) clientWs.ping(data, undefined, () => {});
     });
     clientWs.on('pong', data => {
+      refreshIdleTimer();
       if (upstreamWs.readyState === WebSocket.OPEN) upstreamWs.pong(data, undefined, () => {});
     });
     upstreamWs.on('pong', data => {
+      refreshIdleTimer();
       if (clientWs.readyState === WebSocket.OPEN) clientWs.pong(data, undefined, () => {});
     });
     upstreamWs.on('open', () => {
+      refreshIdleTimer();
       flushQueue(upstreamWs, upstreamQueue);
       flushQueue(clientWs, clientQueue);
     });
@@ -376,5 +404,5 @@ function handleWebSocketUpgrade(req, socket, head) {
 module.exports = {
   handleWebSocketUpgrade,
   buildWebSocketHeaders,
-  isOpenAIResponsesWebSocket,
+  isOpenAIWebSocket,
 };

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -221,6 +221,7 @@ describe('provider-aware OpenAI upstream configuration', () => {
       providers: {
         messages: c.getProviderForRequest('/v1/messages'),
         responses: c.getProviderForRequest('/v1/responses'),
+        realtime: c.getProviderForRequest('/v1/realtime?model=gpt-realtime'),
         models: c.getProviderForRequest('/v1/models?client_version=0.125.0'),
       },
       chatgpt: {
@@ -258,6 +259,7 @@ describe('provider-aware OpenAI upstream configuration', () => {
     });
     assert.equal(result.providers.messages, 'anthropic');
     assert.equal(result.providers.responses, 'openai');
+    assert.equal(result.providers.realtime, 'openai');
     assert.equal(result.providers.models, 'openai');
     assert.deepEqual(result.chatgpt, {
       host: 'chatgpt.com',

--- a/test/startup.test.js
+++ b/test/startup.test.js
@@ -918,6 +918,37 @@ describe('OpenAI Responses raw capture', () => {
     assert.ok(explorer.coreHash);
     assert.ok(explorer.b2Len > 0);
   });
+
+  it('restores Codex prompt agent type from metadata sidecar instead of instruction text', async () => {
+    const sessionId = 'codex-system-prompt-restore-001';
+    const requestBody = JSON.stringify({
+      model: 'gpt-5.5',
+      instructions: 'Inspect the codebase and report findings.',
+      input: 'inspect prompt restore',
+    });
+
+    await sendOpenAIResponsesRequest(proxyPort, requestBody, '/v1/responses?trace=sysprompt-restore', {
+      session_id: sessionId,
+      'x-openai-subagent': 'worker',
+    });
+    await new Promise(r => setTimeout(r, 500));
+
+    await killAndWait(proxyChild);
+    proxyChild = spawnServer(['--port', String(proxyPort)], {
+      env: {
+        OPENAI_TEST_HOST: 'localhost',
+        OPENAI_TEST_PORT: String(mockPort),
+        OPENAI_TEST_PROTOCOL: 'http',
+      },
+    });
+    await waitForPort(proxyPort);
+    await new Promise(r => setTimeout(r, 500));
+
+    const data = await httpGet(proxyPort, '/_api/sysprompt/versions');
+    const worker = data.versions.find(v => v.agentKey === 'worker' && v.b2Len === 'Inspect the codebase and report findings.'.length);
+    assert.ok(worker, 'expected restored Codex worker prompt version');
+    assert.equal(worker.agentLabel, 'Codex Worker');
+  });
 });
 
 // ── Intercept lifecycle E2E ──────────────────────────────────────────

--- a/test/websocket-proxy.test.js
+++ b/test/websocket-proxy.test.js
@@ -284,4 +284,144 @@ describe('OpenAI Responses WebSocket proxy', () => {
     assert.equal(entry.status, 504);
     assert.match(entry.responseMetadata.error.message, /idle timeout/);
   });
+
+  it('fires idle timeout when upstream stalls before completing handshake', async () => {
+    // Accept TCP but never reply: simulates a slowloris-style upstream. Track
+    // the raw sockets so afterEach's upstreamServer.close() doesn't block on
+    // upgraded connections that we own directly.
+    const stalledSockets = [];
+    upstreamServer.on('upgrade', (_req, socket) => {
+      stalledSockets.push(socket);
+    });
+    try {
+      await startProxy({ CCXRAY_WS_IDLE_TIMEOUT_MS: '150' });
+
+      const sessionId = '019e0ab2-bcc2-7b72-a1bf-980edc2ea947';
+      const ws = new WebSocket(`ws://localhost:${proxyPort}/v1/responses`, {
+        headers: {
+          'openai-beta': 'responses_websockets=2026-02-06',
+          session_id: sessionId,
+        },
+      });
+      await new Promise((resolve, reject) => {
+        ws.on('open', resolve);
+        ws.on('error', reject);
+      });
+      const close = await new Promise(resolve => {
+        ws.on('close', (code, reason) => resolve({ code, reason: reason.toString() }));
+      });
+
+      assert.equal(close.code, 1011);
+      assert.equal(close.reason, 'idle timeout');
+
+      const entry = await waitForIndexEntry(path.join(testHome, 'logs'), e => e.sessionId === sessionId);
+      assert.equal(entry.status, 504);
+      assert.match(entry.responseMetadata.error.message, /idle timeout/);
+    } finally {
+      for (const socket of stalledSockets) {
+        try { socket.destroy(); } catch {}
+      }
+    }
+  });
+
+  it('rejects WebSocket upgrade with 401 when AUTH_TOKEN is set and credentials are missing', async () => {
+    upstreamWss = new WebSocket.Server({ server: upstreamServer, path: '/v1/responses' });
+    upstreamWss.on('connection', () => {
+      throw new Error('upstream should not be reached when auth fails');
+    });
+    await startProxy({ AUTH_TOKEN: 'sekret' });
+
+    const ws = new WebSocket(`ws://localhost:${proxyPort}/v1/responses`, {
+      headers: {
+        'openai-beta': 'responses_websockets=2026-02-06',
+        session_id: 'auth-fail-001',
+      },
+    });
+    const result = await new Promise(resolve => {
+      ws.on('unexpected-response', (_req, res) => {
+        res.resume();
+        resolve({ statusCode: res.statusCode });
+      });
+      ws.on('error', err => resolve({ error: err.message }));
+    });
+    assert.equal(result.statusCode, 401);
+  });
+
+  it('accepts WebSocket upgrade when AUTH_TOKEN is set and bearer matches', async () => {
+    upstreamWss = new WebSocket.Server({ server: upstreamServer, path: '/v1/responses' });
+    upstreamWss.on('connection', (ws) => {
+      ws.on('message', data => ws.send(`echo:${data.toString()}`));
+    });
+    await startProxy({ AUTH_TOKEN: 'sekret' });
+
+    const sessionId = '019e0ab2-bcc2-7b72-a1bf-980edc2ea948';
+    const ws = new WebSocket(`ws://localhost:${proxyPort}/v1/responses`, {
+      headers: {
+        authorization: 'Bearer sekret',
+        'openai-beta': 'responses_websockets=2026-02-06',
+        session_id: sessionId,
+      },
+    });
+    const messages = [];
+    ws.on('message', d => messages.push(d.toString()));
+    await new Promise((resolve, reject) => {
+      ws.on('open', resolve);
+      ws.on('error', reject);
+    });
+    ws.send('ping');
+    await new Promise(r => setTimeout(r, 200));
+    ws.close(1000, 'done');
+    await new Promise(r => ws.on('close', r));
+    assert.ok(messages.includes('echo:ping'));
+  });
+
+  it('returns 404 for upgrades on non-OpenAI WebSocket paths', async () => {
+    await startProxy();
+    const ws = new WebSocket(`ws://localhost:${proxyPort}/v1/messages`);
+    const result = await new Promise(resolve => {
+      ws.on('unexpected-response', (_req, res) => {
+        res.resume();
+        resolve({ statusCode: res.statusCode });
+      });
+      ws.on('error', err => resolve({ error: err.message }));
+    });
+    assert.equal(result.statusCode, 404);
+  });
+
+  it('forwards Sec-WebSocket-Protocol selection through to the upstream', async () => {
+    let upstreamProtocolHeader = null;
+    upstreamWss = new WebSocket.Server({
+      server: upstreamServer,
+      path: '/v1/responses',
+      handleProtocols(protocols) {
+        return protocols.values().next().value || false;
+      },
+    });
+    const upstreamConnected = new Promise(resolve => {
+      upstreamWss.on('connection', (_ws, req) => {
+        upstreamProtocolHeader = req.headers['sec-websocket-protocol'];
+        resolve();
+      });
+    });
+    await startProxy();
+
+    const sessionId = '019e0ab2-bcc2-7b72-a1bf-980edc2ea949';
+    const ws = new WebSocket(
+      `ws://localhost:${proxyPort}/v1/responses`,
+      ['codex-v1', 'codex-v2'],
+      { headers: { session_id: sessionId } },
+    );
+    await new Promise((resolve, reject) => {
+      ws.on('open', resolve);
+      ws.on('error', reject);
+    });
+    // Proxy → upstream handshake races the proxy → client one; wait for it.
+    await upstreamConnected;
+
+    assert.equal(ws.protocol, 'codex-v1');
+    // ws joins protocols with ", " when constructing the upstream request header.
+    assert.match(upstreamProtocolHeader || '', /codex-v1.*codex-v2/);
+    ws.close(1000, 'done');
+    await new Promise(r => ws.on('close', r));
+  });
 });

--- a/test/websocket-proxy.test.js
+++ b/test/websocket-proxy.test.js
@@ -1,0 +1,215 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawn } = require('child_process');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const net = require('net');
+const WebSocket = require('ws');
+
+const SERVER_SCRIPT = path.resolve(__dirname, '..', 'server', 'index.js');
+
+async function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+}
+
+function spawnServer(args, env) {
+  const child = spawn(process.execPath, [SERVER_SCRIPT, ...args], {
+    env: { ...process.env, BROWSER: 'none', ...env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', d => { stdout += d; });
+  child.stderr.on('data', d => { stderr += d; });
+  child.getOutput = () => ({ stdout, stderr });
+  return child;
+}
+
+function waitForPort(port, timeoutMs = 8000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      const req = http.get(`http://localhost:${port}/_api/health`, { timeout: 1000 }, res => {
+        res.resume();
+        res.on('end', () => resolve());
+      });
+      req.on('error', () => {
+        if (Date.now() - start > timeoutMs) return reject(new Error('timeout waiting for proxy'));
+        setTimeout(check, 100);
+      });
+      req.on('timeout', () => {
+        req.destroy();
+        if (Date.now() - start > timeoutMs) return reject(new Error('timeout waiting for proxy'));
+        setTimeout(check, 100);
+      });
+    };
+    check();
+  });
+}
+
+function killAndWait(child) {
+  return new Promise(resolve => {
+    if (!child || child.exitCode !== null) return resolve();
+    child.on('exit', resolve);
+    child.kill('SIGTERM');
+    setTimeout(() => {
+      try { child.kill('SIGKILL'); } catch {}
+      resolve();
+    }, 3000);
+  });
+}
+
+async function waitForIndexEntry(logsDir, predicate, timeoutMs = 4000) {
+  const indexPath = path.join(logsDir, 'index.ndjson');
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (fs.existsSync(indexPath)) {
+      const entries = fs.readFileSync(indexPath, 'utf8')
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map(line => JSON.parse(line));
+      const match = entries.find(predicate);
+      if (match) return match;
+    }
+    await new Promise(r => setTimeout(r, 100));
+  }
+  throw new Error('timeout waiting for index entry');
+}
+
+describe('OpenAI Responses WebSocket proxy', () => {
+  let testHome;
+  let upstreamServer;
+  let upstreamWss;
+  let upstreamPort;
+  let proxyChild;
+  let proxyPort;
+
+  beforeEach(async () => {
+    testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-ws-test-'));
+    upstreamServer = http.createServer();
+    await new Promise(resolve => upstreamServer.listen(0, resolve));
+    upstreamPort = upstreamServer.address().port;
+    proxyPort = await findFreePort();
+  });
+
+  afterEach(async () => {
+    await killAndWait(proxyChild);
+    if (upstreamWss) await new Promise(resolve => upstreamWss.close(resolve));
+    if (upstreamServer?.listening) await new Promise(resolve => upstreamServer.close(resolve));
+    fs.rmSync(testHome, { recursive: true, force: true });
+  });
+
+  async function startProxy() {
+    proxyChild = spawnServer(['--port', String(proxyPort)], {
+      CCXRAY_HOME: testHome,
+      OPENAI_TEST_HOST: 'localhost',
+      OPENAI_TEST_PORT: String(upstreamPort),
+      OPENAI_TEST_PROTOCOL: 'http',
+    });
+    await waitForPort(proxyPort);
+  }
+
+  it('forwards text and binary frames and records a transport entry by session_id header', async () => {
+    const received = { headers: null, text: null, binary: null };
+    upstreamWss = new WebSocket.Server({ server: upstreamServer, path: '/v1/responses' });
+    upstreamWss.on('connection', (ws, req) => {
+      received.headers = req.headers;
+      ws.on('message', (data, isBinary) => {
+        if (isBinary) {
+          received.binary = Buffer.from(data);
+          ws.send(data, { binary: true });
+        } else {
+          received.text = data.toString();
+          ws.send(`echo:${received.text}`);
+        }
+      });
+    });
+    await startProxy();
+
+    const sessionId = '019e0ab2-bcc2-7b72-a1bf-980edc2ea943';
+    const ws = new WebSocket(`ws://localhost:${proxyPort}/v1/responses`, {
+      headers: {
+        authorization: 'Bearer test-openai-key',
+        'openai-beta': 'responses_websockets=2026-02-06',
+        session_id: sessionId,
+        'x-codex-turn-metadata': JSON.stringify({
+          session_id: sessionId,
+          agent_type: 'worker',
+          workspaces: { cwd: '/tmp/ccxray-ws' },
+        }),
+      },
+    });
+
+    const messages = [];
+    ws.on('message', data => messages.push(Buffer.isBuffer(data) ? data : Buffer.from(data)));
+    await new Promise((resolve, reject) => {
+      ws.on('open', resolve);
+      ws.on('error', reject);
+    });
+    ws.send('hello');
+    ws.send(Buffer.from([1, 2, 3]), { binary: true });
+    await new Promise(resolve => setTimeout(resolve, 200));
+    ws.close(1000, 'done');
+    await new Promise(resolve => ws.on('close', resolve));
+
+    assert.equal(received.headers['openai-beta'], 'responses_websockets=2026-02-06');
+    assert.equal(received.headers.session_id, sessionId);
+    assert.equal(received.headers.authorization, 'Bearer test-openai-key');
+    assert.equal(received.text, 'hello');
+    assert.deepEqual(received.binary, Buffer.from([1, 2, 3]));
+    assert.ok(messages.some(msg => msg.toString() === 'echo:hello'));
+    assert.ok(messages.some(msg => msg.equals(Buffer.from([1, 2, 3]))));
+
+    const entry = await waitForIndexEntry(path.join(testHome, 'logs'), e => e.sessionId === sessionId);
+    assert.equal(entry.provider, 'openai');
+    assert.equal(entry.agent, 'codex');
+    assert.equal(entry.isSubagent, true);
+    assert.equal(entry.cwd, '/tmp/ccxray-ws');
+    assert.equal(entry.responseMetadata.transport, 'websocket');
+    assert.equal(entry.responseMetadata.capture, 'transport-only');
+    assert.equal(entry.responseMetadata.frameCounts.clientToUpstream, 2);
+    assert.equal(entry.responseMetadata.frameCounts.upstreamToClient, 2);
+
+    const reqLog = JSON.parse(fs.readFileSync(path.join(testHome, 'logs', `${entry.id}_req.json`), 'utf8'));
+    assert.equal(reqLog.transport, 'websocket');
+    assert.equal(reqLog.headers.sessionId, sessionId);
+    assert.equal(reqLog.headers.agentType, 'worker');
+  });
+
+  it('closes the client and records an error entry when upstream rejects the handshake', async () => {
+    upstreamServer.on('upgrade', (_req, socket) => {
+      socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\nContent-Length: 0\r\n\r\n');
+      socket.destroy();
+    });
+    await startProxy();
+
+    const sessionId = '019e0ab2-bcc2-7b72-a1bf-980edc2ea944';
+    const ws = new WebSocket(`ws://localhost:${proxyPort}/v1/responses`, {
+      headers: {
+        'openai-beta': 'responses_websockets=2026-02-06',
+        session_id: sessionId,
+      },
+    });
+
+    const close = await new Promise(resolve => {
+      ws.on('close', (code, reason) => resolve({ code, reason: reason.toString() }));
+    });
+    assert.equal(close.code, 1011);
+
+    const entry = await waitForIndexEntry(path.join(testHome, 'logs'), e => e.sessionId === sessionId);
+    assert.equal(entry.status, 401);
+    assert.match(entry.responseMetadata.error.message, /rejected handshake: 401/);
+  });
+});

--- a/test/websocket-proxy.test.js
+++ b/test/websocket-proxy.test.js
@@ -111,12 +111,13 @@ describe('OpenAI Responses WebSocket proxy', () => {
     fs.rmSync(testHome, { recursive: true, force: true });
   });
 
-  async function startProxy() {
+  async function startProxy(extraEnv = {}) {
     proxyChild = spawnServer(['--port', String(proxyPort)], {
       CCXRAY_HOME: testHome,
       OPENAI_TEST_HOST: 'localhost',
       OPENAI_TEST_PORT: String(upstreamPort),
       OPENAI_TEST_PROTOCOL: 'http',
+      ...extraEnv,
     });
     await waitForPort(proxyPort);
   }
@@ -211,5 +212,76 @@ describe('OpenAI Responses WebSocket proxy', () => {
     const entry = await waitForIndexEntry(path.join(testHome, 'logs'), e => e.sessionId === sessionId);
     assert.equal(entry.status, 401);
     assert.match(entry.responseMetadata.error.message, /rejected handshake: 401/);
+  });
+
+  it('routes /v1/realtime WebSocket upgrades to the OpenAI upstream', async () => {
+    const received = { url: null, text: null };
+    upstreamWss = new WebSocket.Server({ server: upstreamServer, path: '/v1/realtime' });
+    upstreamWss.on('connection', (ws, req) => {
+      received.url = req.url;
+      ws.on('message', data => {
+        received.text = data.toString();
+        ws.send('realtime-ok');
+      });
+    });
+    await startProxy();
+
+    const sessionId = '019e0ab2-bcc2-7b72-a1bf-980edc2ea945';
+    const ws = new WebSocket(`ws://localhost:${proxyPort}/v1/realtime?model=gpt-realtime`, {
+      headers: {
+        'openai-beta': 'realtime=v1',
+        session_id: sessionId,
+      },
+    });
+    const messages = [];
+    ws.on('message', data => messages.push(data.toString()));
+    await new Promise((resolve, reject) => {
+      ws.on('open', resolve);
+      ws.on('error', reject);
+    });
+    ws.send('hello realtime');
+    await new Promise(resolve => setTimeout(resolve, 200));
+    ws.close(1000, 'done');
+    await new Promise(resolve => ws.on('close', resolve));
+
+    assert.equal(received.url, '/v1/realtime?model=gpt-realtime');
+    assert.equal(received.text, 'hello realtime');
+    assert.ok(messages.includes('realtime-ok'));
+
+    const entry = await waitForIndexEntry(path.join(testHome, 'logs'), e => e.sessionId === sessionId);
+    assert.equal(entry.provider, 'openai');
+    assert.equal(entry.responseMetadata.transport, 'websocket');
+    assert.equal(entry.responseMetadata.endpoint, '/v1/realtime');
+    const reqLog = JSON.parse(fs.readFileSync(path.join(testHome, 'logs', `${entry.id}_req.json`), 'utf8'));
+    assert.equal(reqLog.url, '/v1/realtime?model=gpt-realtime');
+    assert.equal(reqLog.endpoint, '/v1/realtime');
+  });
+
+  it('closes idle WebSocket pairs and records a timeout entry', async () => {
+    upstreamWss = new WebSocket.Server({ server: upstreamServer, path: '/v1/responses' });
+    upstreamWss.on('connection', () => {});
+    await startProxy({ CCXRAY_WS_IDLE_TIMEOUT_MS: '100' });
+
+    const sessionId = '019e0ab2-bcc2-7b72-a1bf-980edc2ea946';
+    const ws = new WebSocket(`ws://localhost:${proxyPort}/v1/responses`, {
+      headers: {
+        'openai-beta': 'responses_websockets=2026-02-06',
+        session_id: sessionId,
+      },
+    });
+    await new Promise((resolve, reject) => {
+      ws.on('open', resolve);
+      ws.on('error', reject);
+    });
+    const close = await new Promise(resolve => {
+      ws.on('close', (code, reason) => resolve({ code, reason: reason.toString() }));
+    });
+
+    assert.equal(close.code, 1011);
+    assert.equal(close.reason, 'idle timeout');
+
+    const entry = await waitForIndexEntry(path.join(testHome, 'logs'), e => e.sessionId === sessionId);
+    assert.equal(entry.status, 504);
+    assert.match(entry.responseMetadata.error.message, /idle timeout/);
   });
 });


### PR DESCRIPTION
## 繁中摘要

- 這支 PR 先補 Codex/codex-rs 的 WebSocket transport 缺口，讓 `/v1/responses` 的 `Upgrade: websocket` 可以經過 ccxray，而不是 handshake 失敗或完全沒有 dashboard entry。
- WebSocket frame 目前只做 transport-level proxy：雙向轉送文字/二進位 frames，保留 OpenAI auth、`openai-beta`、`session_id`、`x-codex-turn-metadata` 等 headers。
- Dashboard 會先記錄 transport-only entry，包含 session id、agent type、cwd、frame/byte counts、close/error metadata；完整 conversation frame parsing 另開後續 draft PR 處理。
- 順手修正 Codex prompt restore 的 agent 分類漂移：重啟後會用 metadata sidecar 保留 `worker` / `explorer`，避免只靠 instruction text 猜回 `default`。

## Summary

- Adds an OpenAI Responses WebSocket upgrade path for Codex/codex-rs traffic.
- Forwards text and binary frames bidirectionally while preserving OpenAI auth, beta, session, and Codex metadata headers.
- Records a transport-only dashboard/log entry with session id, agent type, cwd, frame counts, byte counts, close/error metadata.
- Extracts shared OpenAI/Codex session header helpers and preserves prompt agent type across restore via a small shared metadata sidecar.

## Scope

This is intentionally transport-first. It does not parse conversation frames, reconstruct full request/response payloads, calculate cost from WS usage events, or support intercept/editing for WebSocket traffic yet. Those should be separate draft PRs after transport behavior is stable.

## Screenshots

Captured from isolated local fixtures. The before state represents the pre-#29 behavior for WebSocket-only Codex traffic: no usable dashboard turn is recorded for the WS upgrade path, and restored Codex prompt agent type falls back to instruction-text inference.

### Session grouping

| before | after |
| -- | -- |
| ![Before: no WebSocket session captured](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/pr29-before-session-grouping.png) | ![After: WebSocket transport entry grouped by session_id](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/pr29-after-session-grouping.png) |

### Transport request metadata

| before | after |
| -- | -- |
| ![Before: no request metadata available for the failed WebSocket path](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/pr29-before-session-grouping.png) | ![After: transport-only request metadata with session, agent, and cwd](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/pr29-after-transport-request.png) |

### Prompt agent restore

This full-page fixture uses two neutral Codex prompts whose text does not contain `worker` or `explorer`. Before, both restore into `Codex Default`; after, sidecar metadata restores separate `Codex Explorer` and `Codex Worker` buckets.

| before | after |
| -- | -- |
| ![Before: neutral restored prompts collapse into Codex Default](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/pr29-before-restore-agent-buckets-full.png) | ![After: metadata sidecars restore Codex Explorer and Codex Worker buckets](https://raw.githubusercontent.com/shhtheonlyperson/ccxray/pr-screenshots/screenshots/pr29-after-restore-agent-buckets-full.png) |

## Follow-up Fix / 後續修正

- Follow-up PR: shhtheonlyperson/ccxray#6 validates this transport work against a real ChatGPT-auth Codex `/goal say hello world` run.
- It fixes the launcher/config path by routing both `openai_base_url` and `chatgpt_base_url` through ccxray, keeps ccxray alive when Codex closes the WebSocket abnormally with code `1006`, and classifies Codex side-channel REST traffic as `codex/openai` instead of `claude/anthropic`.
- Net result: Codex no longer produces 0 ccxray entries on that runtime path; the main turn is captured as a `codex/openai/101` WebSocket transport entry.

## Validation

- `node --test test/config.test.js test/websocket-proxy.test.js`
- `node --test test/startup.test.js test/websocket-proxy.test.js`
- `npm test` — 462 passing

Refs #28





