### PR TITLE
feat(N2): credential scanning for OpenAI/Codex

### DIFF
--- a/server/helpers.js
+++ b/server/helpers.js
@@ -589,7 +589,7 @@ function scanCredentials(text) {
 const CREDENTIAL_TEXT_KEYS = new Set([
   'text', 'output', 'arguments', 'delta', 'refusal',
   'file_data', 'file_url', 'filename', 'instructions',
-  'encrypted_content',
+  'encrypted_content', 'content',
 ]);
 
 function scanObjectForCredentials(obj, depth) {

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -586,17 +586,48 @@ function scanCredentials(text) {
   return false;
 }
 
-function entryHasCredential(entry) {
-  // Scan current response (assistant text deltas)
-  if (Array.isArray(entry.res)) {
-    for (const ev of entry.res) {
-      if (ev.type === 'content_block_delta' && ev.delta?.type === 'text_delta') {
-        if (scanCredentials(ev.delta.text)) return true;
-      }
+const CREDENTIAL_TEXT_KEYS = new Set([
+  'text', 'output', 'arguments', 'delta', 'refusal',
+  'file_data', 'file_url', 'filename', 'instructions',
+  'encrypted_content',
+]);
+
+function scanObjectForCredentials(obj, depth) {
+  if (depth > 20 || obj == null) return false;
+  if (typeof obj === 'string') return scanCredentials(obj);
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      if (scanObjectForCredentials(item, depth + 1)) return true;
+    }
+    return false;
+  }
+  if (typeof obj !== 'object') return false;
+  for (const key of Object.keys(obj)) {
+    const val = obj[key];
+    if (CREDENTIAL_TEXT_KEYS.has(key)) {
+      if (typeof val === 'string') { if (scanCredentials(val)) return true; }
+      else if (scanObjectForCredentials(val, depth + 1)) return true;
+    } else if (typeof val === 'object' && val !== null) {
+      if (scanObjectForCredentials(val, depth + 1)) return true;
     }
   }
-  // Scan messages history: assistant text blocks + tool_result content
-  const messages = entry.req?.messages;
+  return false;
+}
+
+function entryHasCredential(entry) {
+  // Scan response events (provider-agnostic: recurse into all events)
+  if (scanObjectForCredentials(entry.res, 0)) return true;
+
+  // Scan OpenAI request: instructions + input
+  const req = entry.req;
+  if (req) {
+    if (typeof req.instructions === 'string' && scanCredentials(req.instructions)) return true;
+    if (typeof req.input === 'string' && scanCredentials(req.input)) return true;
+    if (Array.isArray(req.input) && scanObjectForCredentials(req.input, 0)) return true;
+  }
+
+  // Scan Anthropic messages history (preserve existing behavior)
+  const messages = req?.messages;
   if (!Array.isArray(messages)) return false;
   for (const msg of messages) {
     if (!Array.isArray(msg.content)) continue;
@@ -809,6 +840,7 @@ module.exports = {
   extractOpenAIToolCalls,
   extractDuplicateToolCalls,
   scanCredentials,
+  scanObjectForCredentials,
   entryHasCredential,
   classifyToolSource,
   buildToolSources,

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -410,6 +410,18 @@ describe('helpers', () => {
       }), true);
     });
 
+    it('detects credential in OpenAI input message content (string)', () => {
+      assert.equal(entryHasCredential({
+        req: { input: [{ type: 'message', role: 'user', content: SK }] },
+      }), true);
+    });
+
+    it('detects credential in OpenAI response output item content (string)', () => {
+      assert.equal(entryHasCredential({
+        res: { output: [{ type: 'message', role: 'assistant', content: SK }] },
+      }), true);
+    });
+
     it('returns false for clean OpenAI entry', () => {
       assert.equal(entryHasCredential({
         req: { instructions: 'You are helpful', input: [

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -14,6 +14,7 @@ const {
   computeThinkingDuration,
   categorizeTools,
   scanCredentials,
+  scanObjectForCredentials,
   entryHasCredential,
   classifyToolSource,
   buildToolSources,
@@ -328,6 +329,119 @@ describe('helpers', () => {
         }]},
       };
       assert.equal(entryHasCredential(entry), false);
+    });
+
+    // ── OpenAI / Codex credential scanning ──
+    const SK = 'sk-ant-api03-' + 'a'.repeat(30);
+    const GHP = 'ghp_' + 'a'.repeat(36);
+    const AKIA = 'AKIA' + 'A'.repeat(16);
+
+    it('detects credential in OpenAI instructions', () => {
+      assert.equal(entryHasCredential({ req: { instructions: `Use key ${SK}` } }), true);
+    });
+
+    it('detects credential in OpenAI input string (top-level)', () => {
+      assert.equal(entryHasCredential({ req: { input: `deploy with ${SK}` } }), true);
+    });
+
+    it('detects credential in OpenAI input message content (input_text)', () => {
+      assert.equal(entryHasCredential({
+        req: { input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: SK }] }] },
+      }), true);
+    });
+
+    it('detects credential in OpenAI function_call_output.output (string)', () => {
+      assert.equal(entryHasCredential({
+        req: { input: [{ type: 'function_call_output', output: `token=${GHP}`, call_id: 'c1' }] },
+      }), true);
+    });
+
+    it('detects credential in OpenAI function_call_output.output (array)', () => {
+      assert.equal(entryHasCredential({
+        req: { input: [{ type: 'function_call_output', output: [{ type: 'output_text', text: AKIA }], call_id: 'c1' }] },
+      }), true);
+    });
+
+    it('detects credential in OpenAI function_call.arguments', () => {
+      assert.equal(entryHasCredential({
+        req: { input: [{ type: 'function_call', arguments: `{"key":"${SK}"}`, name: 'Bash', call_id: 'c1' }] },
+      }), true);
+    });
+
+    it('detects credential in OpenAI input_file.file_data', () => {
+      assert.equal(entryHasCredential({
+        req: { input: [{ type: 'message', role: 'user', content: [{ type: 'input_file', file_data: SK }] }] },
+      }), true);
+    });
+
+    it('detects credential in OpenAI reasoning summary text', () => {
+      assert.equal(entryHasCredential({
+        req: { input: [{ type: 'reasoning', summary: [{ type: 'summary_text', text: SK }] }] },
+      }), true);
+    });
+
+    it('detects credential in OpenAI response output_text.delta event', () => {
+      assert.equal(entryHasCredential({
+        res: [{ type: 'response.output_text.delta', delta: SK }],
+      }), true);
+    });
+
+    it('detects credential in OpenAI response function_call_arguments.delta', () => {
+      assert.equal(entryHasCredential({
+        res: [{ type: 'response.function_call_arguments.delta', delta: `{"token":"${GHP}"}` }],
+      }), true);
+    });
+
+    it('detects credential in OpenAI response reasoning_text.delta', () => {
+      assert.equal(entryHasCredential({
+        res: [{ type: 'response.reasoning_text.delta', delta: SK }],
+      }), true);
+    });
+
+    it('detects credential in OpenAI response refusal.delta', () => {
+      assert.equal(entryHasCredential({
+        res: [{ type: 'response.refusal.delta', delta: SK }],
+      }), true);
+    });
+
+    it('detects credential in OpenAI HTTP non-SSE response.output', () => {
+      assert.equal(entryHasCredential({
+        res: { output: [{ type: 'message', content: [{ type: 'output_text', text: SK }] }] },
+      }), true);
+    });
+
+    it('returns false for clean OpenAI entry', () => {
+      assert.equal(entryHasCredential({
+        req: { instructions: 'You are helpful', input: [
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+          { type: 'function_call_output', output: 'ok', call_id: 'c1' },
+        ]},
+        res: [{ type: 'response.output_text.delta', delta: 'hi there' }],
+      }), false);
+    });
+  });
+
+  describe('scanObjectForCredentials', () => {
+    const SK = 'sk-ant-api03-' + 'a'.repeat(30);
+
+    it('returns false for null/undefined', () => {
+      assert.equal(scanObjectForCredentials(null, 0), false);
+      assert.equal(scanObjectForCredentials(undefined, 0), false);
+    });
+
+    it('scans string directly', () => {
+      assert.equal(scanObjectForCredentials(SK, 0), true);
+      assert.equal(scanObjectForCredentials('clean', 0), false);
+    });
+
+    it('recurses into nested objects', () => {
+      assert.equal(scanObjectForCredentials({ a: { b: { text: SK } } }, 0), true);
+    });
+
+    it('respects depth cap', () => {
+      let obj = { text: SK };
+      for (let i = 0; i < 25; i++) obj = { nested: obj };
+      assert.equal(scanObjectForCredentials(obj, 0), false);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add recursive `scanObjectForCredentials()` that walks objects for known text-bearing keys (text, output, arguments, delta, refusal, file_data, file_url, filename, instructions, encrypted_content). Depth-capped at 20.
- `entryHasCredential()` now scans OpenAI `instructions`, `input` (string or array), and response events — not just Anthropic `messages`. Codex turns with leaked API keys / secrets now get the yellow warning bar.
- Design reviewed by codex (2 rounds: v1 too narrow, v2 recursive scanner approved with conditions).

## Test plan
- [x] 736 tests pass (0 failures, +18 new)
- [x] Covers: instructions, input string, input_text, function_call.arguments, function_call_output.output (string + array), input_file.file_data, reasoning summary, output_text.delta, function_call_arguments.delta, reasoning_text.delta, refusal.delta, HTTP response.output
- [x] Existing Anthropic tests unchanged and passing
- [x] Clean OpenAI entry returns false (no false positives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)