### PR TITLE
feat(B4): provider-aware cache display + OpenAI usage normalization

### DIFF
--- a/docs/wire-protocol-reference.md
+++ b/docs/wire-protocol-reference.md
@@ -27,6 +27,7 @@
 
 | Date | Agent | Version | Change |
 |------|-------|---------|--------|
+| 2026-06-05 | ccxray | 1.11.x | Usage normalization: OpenAI `input_tokens` includes `cached_tokens` (subset), unlike Anthropic's disjoint fields. `normalizeUsageForProvider` now subtracts the overlap so canonical `input_tokens + cache_read + cache_creation = total context` holds for both providers. Normalized entries carry `_ccxrayUsageNormalized: true`. Historical entries normalized on restore (in-memory, index unchanged). Cache display: Codex sessions show `cache N% hit` instead of TTL countdown; topbar adapts per provider (`ephemeral-ttl` vs `server-managed`). `UPSTREAM_PROFILES` registry added to `providers.js`. |
 | 2026-06-04 | ccxray | 1.10.x | Fix: WS `stopReason` now extracts `response.status` from terminal events (`completed`/`incomplete`/`failed`/`cancelled`) instead of WS close reason. WS `title` extracts user input summary via `getOpenAIInputSummary` instead of hardcoded string. Non-terminal statuses (`in_progress`/`queued`) are ignored to prevent masking close/error reasons. |
 | 2026-06-02 | ccxray | 1.10.0 | Doc audit: 13 major + 25 minor corrections applied (F1–F38) |
 | 2026-06-01 | Codex | 0.133 | Baseline: all observations below recorded |
@@ -140,7 +141,7 @@
 
 | Field | Claude Code | Codex | Confidence |
 |-------|-------------|-------|------------|
-| Input tokens | `message_start.message.usage.input_tokens` | `response.usage.input_tokens` or `prompt_tokens` | `contractual` |
+| Input tokens | `message_start.message.usage.input_tokens` (non-cached only) | `response.usage.input_tokens` or `prompt_tokens` (**includes cached** — ccxray subtracts `cached_tokens` via `normalizeUsageForProvider` so canonical `input_tokens` = non-cached for both providers) | `contractual` |
 | Output tokens | `message_delta.usage.output_tokens` | `response.usage.output_tokens` or `completion_tokens` | `contractual` |
 | Cache creation | `usage.cache_creation_input_tokens` | N/A (no equivalent field) | `contractual` (Anthropic) |
 | Cache creation breakdown | `usage.cache_creation.ephemeral_5m_input_tokens`, `usage.cache_creation.ephemeral_1h_input_tokens` | N/A | `obs-fragile` |

--- a/public/cache-notify.js
+++ b/public/cache-notify.js
@@ -122,6 +122,19 @@ function fireNotification(sid, minsLeft) {
 function renderNotifyButton() {
   const el = document.getElementById('qt-notify');
   if (!el) return;
+
+  // Hide notification button when no ephemeral-TTL providers are visible
+  const vp = window.ccxraySettings?.visibleProviders;
+  if (Array.isArray(vp) && vp.length > 0) {
+    const hasEphemeral = vp.some(p =>
+      (typeof getCacheMode === 'function' ? getCacheMode(p) : 'ephemeral-ttl') === 'ephemeral-ttl'
+    );
+    if (!hasEphemeral) {
+      el.style.display = 'none';
+      return;
+    }
+  }
+
   const enabled = getNotifySetting();
   const permission = typeof Notification !== 'undefined' ? Notification.permission : 'unsupported';
   const denied = permission === 'denied';

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -235,7 +235,16 @@ function addEntry(e) {
   const entryCwd = e.cwd || null;
   if (!sessionsMap.has(sid)) {
     const shortSid = sid.slice(0, 8);
-    sessionsMap.set(sid, { id: sid, firstTs: e.ts, firstId: entryId, lastId: entryId, count: 0, mainCount: 0, subCount: 0, model, totalCost: 0, cwd: entryCwd, title: null, titleReqTs: 0, lastAssistantText: null, agent: e.agent || 'claude' });
+    sessionsMap.set(sid, { id: sid, firstTs: e.ts, firstId: entryId, lastId: entryId, count: 0, mainCount: 0, subCount: 0, model, totalCost: 0, cwd: entryCwd, title: null, titleReqTs: 0, lastAssistantText: null, agent: e.agent || 'claude', provider: e.provider || 'anthropic', latestCacheHitRatio: 0, latestCacheReadTokens: 0 });
+    // Live-update visibleProviders when a new provider appears
+    const settings = window.ccxraySettings;
+    if (!Array.isArray(settings.visibleProviders)) settings.visibleProviders = [];
+    const entryProvider = e.provider || 'anthropic';
+    if (!settings.visibleProviders.includes(entryProvider)) {
+      settings.visibleProviders.push(entryProvider);
+      if (typeof renderTopbarPlan === 'function') renderTopbarPlan();
+      if (typeof renderNotifyButton === 'function') renderNotifyButton();
+    }
     const sessEl = document.createElement('div');
     sessEl.className = 'session-item';
     sessEl.dataset.sessionId = sid;
@@ -261,6 +270,7 @@ function addEntry(e) {
   const sess = sessionsMap.get(sid);
   // Update cwd if not yet known or was only a quota-check
   if (entryCwd && (!sess.cwd || sess.cwd === '(quota-check)')) sess.cwd = entryCwd;
+  if (model && model !== '?') sess.model = model;
   sess.lastId = entryId;
   if (e.receivedAt) sess.lastReceivedAt = Number(e.receivedAt);
   const isSubagent = e.isSubagent || false;
@@ -300,16 +310,19 @@ function addEntry(e) {
   if (!_loading) renderProjectsCol();
 
   const statusClass = isHttpStatusOk(e.status) ? 'status-ok' : 'status-err';
-  const shortModel = model.replace('claude-', '').replace(/-[0-9]{8}$/, '');
+  const displayModel = (model && model !== '?') ? model : (sess.model || '?');
+  const shortModel = displayModel.replace('claude-', '').replace(/-[0-9]{8}$/, '');
 
   const ctxCacheCreate = usage ? (usage.cache_creation_input_tokens || 0) : 0;
   const ctxCacheRead   = usage ? (usage.cache_read_input_tokens || 0) : 0;
   const ctxInput       = usage ? (usage.input_tokens || 0) : 0;
   const ctxUsed = ctxCacheCreate + ctxCacheRead + ctxInput;
 
-  // Update session context alert badge for main turns
+  // Update session context alert badge + cache stats for main turns
   if (!isSubagent && ctxUsed > 0) {
     sess.latestMainCtxPct = Math.min(100, ctxUsed / (e.maxContext || DEFAULT_MAX_CTX) * 100);
+    sess.latestCacheReadTokens = ctxCacheRead;
+    sess.latestCacheHitRatio = ctxUsed > 0 ? ctxCacheRead / ctxUsed : 0;
     const sessElCtx = document.getElementById('sess-' + sid.slice(0, 8));
     if (sessElCtx) sessElCtx.innerHTML = renderSessionItem(sess, sid);
   }
@@ -326,7 +339,10 @@ function addEntry(e) {
     gapMs = Number.isFinite(rawGap) ? Math.max(0, rawGap) : null;
     if (gapMs !== null) {
       gapColor = gapMs < 5 * 60000 ? 'var(--green)' : gapMs < 60 * 60000 ? 'var(--yellow)' : 'var(--red)';
-      gapTitle = gapMs < 5 * 60000 ? 'Cache likely warm (< 5m)' : gapMs < 60 * 60000 ? 'Default cache expired (5m–1h)' : 'All cache expired (> 1h)';
+      const cacheMode = typeof getCacheMode === 'function' ? getCacheMode(e.provider || 'anthropic') : 'ephemeral-ttl';
+      gapTitle = cacheMode === 'ephemeral-ttl'
+        ? (gapMs < 5 * 60000 ? 'Cache likely warm (< 5m)' : gapMs < 60 * 60000 ? 'Default cache expired (5m–1h)' : 'All cache expired (> 1h)')
+        : 'Server cache (retention varies)';
     }
   }
 

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1460,22 +1460,28 @@ function renderSessionItem(sess, sid) {
   const ctxBarHtml = ctxBarInner
     ? '<div class="si-ctx-wrap">' + ctxBarInner + ctxAlertHtml + '</div>'
     : '';
-  // Cache TTL countdown row; only rendered if we have both a response time and
-  // a ttl-capable plan loaded (otherwise skip — api-key users with ttl=300_000
-  // still get a valid countdown, but undefined settings → skip).
-  const cacheTtlMs = window.ccxraySettings?.cacheTtlMs;
-  const cacheFmt = window.ccxrayFormatCacheCountdown;
-  // Only render for sessions whose cache is still alive — historical sessions
-  // omit the row entirely to avoid noisy "cache expired" lines on every old card.
+  // Cache row: provider-aware. ephemeral-ttl → TTL countdown; server-managed → hit ratio.
+  const sessCacheMode = typeof getCacheMode === 'function' ? getCacheMode(sess.provider) : 'ephemeral-ttl';
   let cacheRowHtml = '';
-  if (sess.lastReceivedAt && cacheTtlMs && cacheFmt) {
-    const info = cacheFmt(sess.lastReceivedAt, cacheTtlMs);
-    if (info.active) {
-      cacheRowHtml = '<div class="' + info.cls + '" data-active="1"' +
-        ' data-last-at="' + sess.lastReceivedAt + '" data-cache-ttl-ms="' + cacheTtlMs +
-        '" title="Cache TTL: ' + (cacheTtlMs / 60000) + 'm (' + (window.ccxraySettings.label || 'plan') + ')">' +
-        info.text + '</div>';
+  if (sessCacheMode === 'ephemeral-ttl') {
+    const cacheTtlMs = window.ccxraySettings?.cacheTtlMs;
+    const cacheFmt = window.ccxrayFormatCacheCountdown;
+    if (sess.lastReceivedAt && cacheTtlMs && cacheFmt) {
+      const info = cacheFmt(sess.lastReceivedAt, cacheTtlMs);
+      if (info.active) {
+        cacheRowHtml = '<div class="' + info.cls + '" data-active="1"' +
+          ' data-last-at="' + sess.lastReceivedAt + '" data-cache-ttl-ms="' + cacheTtlMs +
+          '" title="Cache TTL: ' + (cacheTtlMs / 60000) + 'm (' + (window.ccxraySettings.label || 'plan') + ')">' +
+          info.text + '</div>';
+      }
     }
+  } else if (sessCacheMode === 'server-managed' && sess.latestCacheReadTokens > 0) {
+    const pct = Math.round((sess.latestCacheHitRatio || 0) * 100);
+    const tokK = sess.latestCacheReadTokens >= 1000
+      ? Math.round(sess.latestCacheReadTokens / 1000) + 'K'
+      : String(sess.latestCacheReadTokens);
+    cacheRowHtml = '<div class="si-cache cache-server" title="Server-managed cache · last turn">' +
+      'cache ' + pct + '% hit · ' + tokK + ' tok</div>';
   }
   const isOnline = getStatusClass(sid) !== 'sdot-off';
   const isArmed = interceptSessionIds.has(sid);

--- a/public/settings.js
+++ b/public/settings.js
@@ -12,8 +12,16 @@ window.ccxraySettings = {
   tokens5h: 0,
   monthlyUSD: 0,
   autoCompactPct: 0.835,
+  visibleProviders: [],
+  providerProfiles: {},
   loaded: false,
 };
+
+function getCacheMode(provider) {
+  return window.ccxraySettings?.providerProfiles?.[provider]?.cache
+      || window.ccxraySettings?.providerProfiles?.anthropic?.cache
+      || 'ephemeral-ttl';
+}
 
 async function loadSettings() {
   try {
@@ -43,13 +51,42 @@ function renderTopbarPlan() {
   const el = document.getElementById('qt-plan');
   if (!el) return;
   const s = window.ccxraySettings;
-  const ttlLabel = s.cacheTtlMs >= 3_600_000 ? '1h' : `${Math.round(s.cacheTtlMs / 60000)}m`;
-  const sourceBadge = s.source === 'env' ? ' (env)'
-    : s.source === 'auto' ? ' (auto)'
-    : s.source === 'default' && s.confidence === 'insufficient' ? ' (detecting…)'
-    : '';
-  el.textContent = `Plan: ${s.label} · TTL ${ttlLabel}${sourceBadge}`;
-  el.title = `Plan detected via ${s.source} (confidence: ${s.confidence})`;
+  const vp = Array.isArray(s.visibleProviders) ? s.visibleProviders : [];
+
+  if (vp.length === 0) {
+    // No providers detected yet — show default Claude plan detecting display
+    const ttlLabel = s.cacheTtlMs >= 3_600_000 ? '1h' : `${Math.round(s.cacheTtlMs / 60000)}m`;
+    const sourceBadge = s.source === 'env' ? ' (env)'
+      : s.source === 'auto' ? ' (auto)'
+      : s.source === 'default' && s.confidence === 'insufficient' ? ' (detecting…)'
+      : '';
+    el.textContent = `Plan: ${s.label} · TTL ${ttlLabel}${sourceBadge}`;
+    el.title = `Plan detected via ${s.source} (confidence: ${s.confidence})`;
+  } else {
+    const modes = vp.map(p => getCacheMode(p));
+    const hasEphemeral = modes.includes('ephemeral-ttl');
+    const hasServerManaged = modes.includes('server-managed');
+
+    if (hasEphemeral && !hasServerManaged) {
+      // Pure Anthropic — unchanged
+      const ttlLabel = s.cacheTtlMs >= 3_600_000 ? '1h' : `${Math.round(s.cacheTtlMs / 60000)}m`;
+      const sourceBadge = s.source === 'env' ? ' (env)'
+        : s.source === 'auto' ? ' (auto)'
+        : s.source === 'default' && s.confidence === 'insufficient' ? ' (detecting…)'
+        : '';
+      el.textContent = `Plan: ${s.label} · TTL ${ttlLabel}${sourceBadge}`;
+      el.title = `Plan detected via ${s.source} (confidence: ${s.confidence})`;
+    } else if (hasServerManaged && !hasEphemeral) {
+      // Pure server-managed (e.g. Codex only)
+      el.textContent = 'Cache: server-managed';
+      el.title = 'Cache retention is controlled by the upstream provider';
+    } else {
+      // Mixed
+      const ttlLabel = s.cacheTtlMs >= 3_600_000 ? '1h' : `${Math.round(s.cacheTtlMs / 60000)}m`;
+      el.textContent = `Plan: ${s.label} · TTL ${ttlLabel} · Server cache`;
+      el.title = `Claude plan via ${s.source} + server-managed cache for other providers`;
+    }
+  }
   el.style.display = 'inline';
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -257,6 +257,7 @@
   .si-cache.cache-near { color: var(--yellow); }
   .si-cache.cache-close { color: var(--red); animation: cachePulse 1s ease-in-out infinite; }
   .si-cache.cache-expired { color: var(--dim); opacity: 0.55; font-style: italic; }
+  .si-cache.cache-server { color: var(--green); opacity: 0.8; }
   @keyframes cachePulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
   .launch-btn { background: none; border: 1px solid var(--border); color: var(--green); width: 18px; height: 18px; border-radius: 50%; cursor: pointer; font-size: 10px; display: inline-flex; align-items: center; justify-content: center; padding: 0; flex-shrink: 0; }
   .launch-btn:hover { background: var(--green); color: #000; border-color: var(--green); }

--- a/server/providers.js
+++ b/server/providers.js
@@ -80,6 +80,44 @@ const AGENT_PROVIDERS = Object.freeze({
 const PROVIDER_AGENT = Object.freeze({ anthropic: 'claude', openai: 'codex' });
 function agentForProvider(provider) { return PROVIDER_AGENT[provider] || 'claude'; }
 
+// Upstream wire-protocol profiles. Agent launchers describe "how to start";
+// upstream profiles describe "how the wire format differs".
+const UPSTREAM_PROFILES = Object.freeze({
+  anthropic: Object.freeze({
+    cache: 'ephemeral-ttl',
+    inputIncludesCached: false,
+    label: 'Anthropic',
+  }),
+  openai: Object.freeze({
+    cache: 'server-managed',
+    inputIncludesCached: true,
+    label: 'OpenAI',
+  }),
+});
+
+function getUpstreamProfile(upstream) {
+  return UPSTREAM_PROFILES[upstream] || null;
+}
+
+// Normalize usage so canonical fields have the same semantics across providers.
+// After normalization: input_tokens + cache_creation + cache_read = total context.
+// _ccxrayUsageNormalized flag prevents double-subtraction on re-processing.
+function normalizeUsageForProvider(provider, usage) {
+  if (!usage || usage._ccxrayUsageNormalized) return usage;
+  const profile = getUpstreamProfile(provider);
+  if (!profile?.inputIncludesCached) return usage;
+  const cached = usage.input_tokens_details?.cached_tokens
+              || usage.cache_read_input_tokens || 0;
+  if (cached <= 0) return usage;
+  return {
+    ...usage,
+    input_tokens: Math.max(0, (usage.input_tokens || 0) - cached),
+    cache_read_input_tokens: usage.cache_read_input_tokens ?? cached,
+    cache_creation_input_tokens: usage.cache_creation_input_tokens ?? 0,
+    _ccxrayUsageNormalized: true,
+  };
+}
+
 function listAgentProviderIds() {
   return Object.keys(AGENT_PROVIDERS);
 }
@@ -118,11 +156,14 @@ function getAgentLaunch(id, port, args = [], env = process.env) {
 module.exports = {
   AGENT_PROVIDERS,
   PROVIDER_AGENT,
+  UPSTREAM_PROFILES,
   agentForProvider,
   getAgentLaunch,
   getAgentProvider,
   getDisplayName,
+  getUpstreamProfile,
   isAgentProvider,
   listAgentProviderIds,
+  normalizeUsageForProvider,
   supportedProviderList,
 };

--- a/server/restore.js
+++ b/server/restore.js
@@ -8,6 +8,7 @@ const { extractAgentType, extractPromptAgentType, splitB2IntoBlocks } = require(
 const { normalizeOpenAIResponseSummary } = require('./forward');
 const { readSettings, serializeStars } = require('./settings');
 const { computeRetentionSets, isProtectedByStar } = require('./helpers');
+const { normalizeUsageForProvider } = require('./providers');
 
 // Pull stars from settings and shape for computeRetentionSets. Returns the
 // canonical empty shape on any failure — the prune/restore paths must never
@@ -150,6 +151,14 @@ async function restoreFromLogs() {
       meta.maxContext = Math.max(meta.maxContext || 0, inferred);
     }
 
+    if (meta.usage) {
+      const before = meta.usage;
+      meta.usage = normalizeUsageForProvider(meta.provider, meta.usage);
+      if (meta.usage !== before && meta.usage._ccxrayUsageNormalized && meta.model) {
+        meta.cost = calculateCost(meta.usage, meta.model);
+      }
+    }
+
     store.entries.push({ ...meta, req: null, res: null, _loaded: false });
 
     // Track earliest timestamp per sysHash for version dating
@@ -163,6 +172,7 @@ async function restoreFromLogs() {
 
     if (meta.sessionId) {
       if (!store.sessionMeta[meta.sessionId]) store.sessionMeta[meta.sessionId] = {};
+      if (meta.provider) store.sessionMeta[meta.sessionId].provider = meta.provider;
       if (meta.cwd) store.sessionMeta[meta.sessionId].cwd = meta.cwd;
       if (meta.receivedAt) store.sessionMeta[meta.sessionId].lastSeenAt = meta.receivedAt;
     }

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -8,6 +8,7 @@ const { tokenizeRequest } = require('../helpers');
 const { computeBlockDiff } = require('../system-prompt');
 const { getPlanConfig } = require('../plans');
 const { getEffectivePlan } = require('../plan-detector');
+const { UPSTREAM_PROFILES } = require('../providers');
 const forward = require('../forward');
 const { readSettings, writeSettings, serializeStars } = require('../settings');
 const { SENTINEL_SESSIONS, SENTINEL_PROJECTS } = require('../helpers');
@@ -21,6 +22,15 @@ function computeSettings() {
     .map(e => e.usage);
   const { plan, source, confidence } = getEffectivePlan({ recentUsages });
   const cfg = getPlanConfig(plan);
+
+  const fromMeta = Object.values(store.sessionMeta).map(m => m.provider).filter(Boolean);
+  const fromEntries = store.entries.map(e => e.provider).filter(Boolean);
+  const visibleProviders = [...new Set([...fromMeta, ...fromEntries])];
+
+  const providerProfiles = Object.fromEntries(
+    Object.entries(UPSTREAM_PROFILES).map(([k, v]) => [k, { cache: v.cache, label: v.label }])
+  );
+
   return {
     plan,
     label: cfg.label,
@@ -30,6 +40,8 @@ function computeSettings() {
     tokens5h: cfg.tokens5h,
     monthlyUSD: cfg.monthlyUSD,
     autoCompactPct: AUTO_COMPACT_PCT,
+    visibleProviders,
+    providerProfiles,
   };
 }
 

--- a/server/wire-parsers/openai.js
+++ b/server/wire-parsers/openai.js
@@ -3,6 +3,7 @@
 const crypto = require('crypto');
 const store = require('../store');
 const helpers = require('../helpers');
+const { normalizeUsageForProvider } = require('../providers');
 const config = require('../config');
 const { calculateCost } = require('../pricing');
 const { agentForProvider } = require('../providers');
@@ -109,7 +110,7 @@ function extractUsage(resData) {
   // Preserve provider-native detail
   if (usage.input_tokens_details) result.input_tokens_details = usage.input_tokens_details;
   if (usage.output_tokens_details) result.output_tokens_details = usage.output_tokens_details;
-  return result;
+  return normalizeUsageForProvider('openai', result);
 }
 
 // From openai-session.js:58-70

--- a/test/usage-normalizer.test.js
+++ b/test/usage-normalizer.test.js
@@ -1,0 +1,271 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { normalizeUsageForProvider, getUpstreamProfile, UPSTREAM_PROFILES } = require('../server/providers');
+const { calculateCost, getModelPricing } = require('../server/pricing');
+
+describe('UPSTREAM_PROFILES', () => {
+  it('anthropic profile has ephemeral-ttl cache and no cached-in-input', () => {
+    const p = UPSTREAM_PROFILES.anthropic;
+    assert.equal(p.cache, 'ephemeral-ttl');
+    assert.equal(p.inputIncludesCached, false);
+  });
+
+  it('openai profile has server-managed cache and cached-in-input', () => {
+    const p = UPSTREAM_PROFILES.openai;
+    assert.equal(p.cache, 'server-managed');
+    assert.equal(p.inputIncludesCached, true);
+  });
+
+  it('getUpstreamProfile returns null for unknown upstream', () => {
+    assert.equal(getUpstreamProfile('unknown'), null);
+    assert.equal(getUpstreamProfile(null), null);
+  });
+});
+
+describe('normalizeUsageForProvider', () => {
+  it('normalizes OpenAI usage: subtracts cached from input', () => {
+    const usage = {
+      input_tokens: 61154,
+      output_tokens: 678,
+      total_tokens: 61832,
+      cache_read_input_tokens: 58240,
+      cache_creation_input_tokens: 0,
+      input_tokens_details: { cached_tokens: 58240 },
+    };
+    const result = normalizeUsageForProvider('openai', usage);
+    assert.equal(result.input_tokens, 2914);
+    assert.equal(result.cache_read_input_tokens, 58240);
+    assert.equal(result.cache_creation_input_tokens, 0);
+    assert.equal(result._ccxrayUsageNormalized, true);
+    assert.equal(result.output_tokens, 678);
+    assert.equal(result.total_tokens, 61832);
+  });
+
+  it('clamps to 0 when cached > input', () => {
+    const usage = {
+      input_tokens: 50,
+      cache_read_input_tokens: 100,
+      input_tokens_details: { cached_tokens: 100 },
+    };
+    const result = normalizeUsageForProvider('openai', usage);
+    assert.equal(result.input_tokens, 0);
+    assert.equal(result.cache_read_input_tokens, 100);
+    assert.equal(result._ccxrayUsageNormalized, true);
+  });
+
+  it('no-op when cached=0', () => {
+    const usage = {
+      input_tokens: 1000,
+      output_tokens: 200,
+      cache_read_input_tokens: 0,
+      input_tokens_details: { cached_tokens: 0 },
+    };
+    const result = normalizeUsageForProvider('openai', usage);
+    assert.equal(result.input_tokens, 1000);
+    assert.equal(result._ccxrayUsageNormalized, undefined);
+    assert.equal(result, usage);
+  });
+
+  it('idempotent: already-normalized usage is returned unchanged', () => {
+    const usage = {
+      input_tokens: 2914,
+      cache_read_input_tokens: 58240,
+      _ccxrayUsageNormalized: true,
+      input_tokens_details: { cached_tokens: 58240 },
+    };
+    const result = normalizeUsageForProvider('openai', usage);
+    assert.equal(result, usage);
+    assert.equal(result.input_tokens, 2914);
+  });
+
+  it('no-op for anthropic provider', () => {
+    const usage = {
+      input_tokens: 2914,
+      cache_read_input_tokens: 58240,
+      cache_creation_input_tokens: 0,
+    };
+    const result = normalizeUsageForProvider('anthropic', usage);
+    assert.equal(result, usage);
+    assert.equal(result._ccxrayUsageNormalized, undefined);
+  });
+
+  it('no-op for unknown provider', () => {
+    const usage = { input_tokens: 1000, cache_read_input_tokens: 500 };
+    const result = normalizeUsageForProvider('unknown', usage);
+    assert.equal(result, usage);
+    assert.equal(result._ccxrayUsageNormalized, undefined);
+  });
+
+  it('consecutive calls produce same result', () => {
+    const usage = {
+      input_tokens: 61154,
+      input_tokens_details: { cached_tokens: 58240 },
+    };
+    const first = normalizeUsageForProvider('openai', usage);
+    const second = normalizeUsageForProvider('openai', first);
+    assert.equal(second, first);
+    assert.equal(second.input_tokens, 2914);
+    assert.equal(second._ccxrayUsageNormalized, true);
+  });
+
+  it('restored old entry: result has _ccxrayUsageNormalized flag', () => {
+    const oldIndexUsage = {
+      input_tokens: 61154,
+      cache_read_input_tokens: 58240,
+      cache_creation_input_tokens: 0,
+      input_tokens_details: { cached_tokens: 58240 },
+    };
+    const result = normalizeUsageForProvider('openai', oldIndexUsage);
+    assert.equal(result._ccxrayUsageNormalized, true);
+    assert.equal(result.input_tokens, 2914);
+    const again = normalizeUsageForProvider('openai', result);
+    assert.equal(again, result);
+  });
+
+  it('fallback: only cache_read_input_tokens, no input_tokens_details', () => {
+    const usage = {
+      input_tokens: 10000,
+      cache_read_input_tokens: 8000,
+      cache_creation_input_tokens: 0,
+    };
+    const result = normalizeUsageForProvider('openai', usage);
+    assert.equal(result.input_tokens, 2000);
+    assert.equal(result.cache_read_input_tokens, 8000);
+    assert.equal(result._ccxrayUsageNormalized, true);
+  });
+
+  it('guarantees cache_read and cache_creation fields exist', () => {
+    const usage = {
+      input_tokens: 5000,
+      input_tokens_details: { cached_tokens: 3000 },
+    };
+    const result = normalizeUsageForProvider('openai', usage);
+    assert.equal(result.cache_read_input_tokens, 3000);
+    assert.equal(result.cache_creation_input_tokens, 0);
+  });
+
+  it('null/undefined usage returns as-is', () => {
+    assert.equal(normalizeUsageForProvider('openai', null), null);
+    assert.equal(normalizeUsageForProvider('openai', undefined), undefined);
+  });
+});
+
+describe('cost calculation with normalized OpenAI usage', () => {
+  it('computes correct cost for gpt-5.5 after normalization', () => {
+    const rawUsage = {
+      input_tokens: 61154,
+      output_tokens: 678,
+      total_tokens: 61832,
+      cache_read_input_tokens: 58240,
+      cache_creation_input_tokens: 0,
+      input_tokens_details: { cached_tokens: 58240 },
+    };
+    const normalized = normalizeUsageForProvider('openai', rawUsage);
+    assert.equal(normalized.input_tokens, 2914);
+    assert.equal(normalized.cache_read_input_tokens, 58240);
+
+    const rates = getModelPricing('gpt-5.5');
+    if (!rates) return; // skip if model not in pricing table
+
+    const { cost } = calculateCost(normalized, 'gpt-5.5');
+    const expected =
+      (2914 / 1_000_000) * rates.input +
+      (678 / 1_000_000) * rates.output +
+      (0 / 1_000_000) * rates.cache_create +
+      (58240 / 1_000_000) * rates.cache_read;
+    assert.equal(cost, expected);
+  });
+});
+
+describe('restore-level: historical OpenAI cost recomputation', () => {
+  it('simulates restore flow: normalize usage then recompute cost', () => {
+    const staleCost = { cost: 999, rates: { input: 1 } };
+    const meta = {
+      provider: 'openai',
+      model: 'gpt-5.5',
+      usage: {
+        input_tokens: 61154,
+        output_tokens: 678,
+        total_tokens: 61832,
+        cache_read_input_tokens: 58240,
+        cache_creation_input_tokens: 0,
+        input_tokens_details: { cached_tokens: 58240 },
+      },
+      cost: staleCost,
+    };
+
+    const before = meta.usage;
+    meta.usage = normalizeUsageForProvider(meta.provider, meta.usage);
+
+    if (meta.usage !== before && meta.usage._ccxrayUsageNormalized && meta.model) {
+      meta.cost = calculateCost(meta.usage, meta.model);
+    }
+
+    assert.notEqual(meta.cost, staleCost);
+    assert.equal(meta.usage.input_tokens, 2914);
+    assert.equal(meta.usage._ccxrayUsageNormalized, true);
+
+    const rates = getModelPricing('gpt-5.5');
+    if (!rates) return;
+    const expectedCost =
+      (2914 / 1_000_000) * rates.input +
+      (678 / 1_000_000) * rates.output +
+      (0 / 1_000_000) * rates.cache_create +
+      (58240 / 1_000_000) * rates.cache_read;
+    assert.equal(meta.cost.cost, expectedCost);
+  });
+
+  it('does not recompute cost for already-normalized entries', () => {
+    const originalCost = { cost: 0.31, rates: {} };
+    const meta = {
+      provider: 'openai',
+      model: 'gpt-5.5',
+      usage: {
+        input_tokens: 2914,
+        cache_read_input_tokens: 58240,
+        _ccxrayUsageNormalized: true,
+      },
+      cost: originalCost,
+    };
+
+    const before = meta.usage;
+    meta.usage = normalizeUsageForProvider(meta.provider, meta.usage);
+
+    if (meta.usage !== before && meta.usage._ccxrayUsageNormalized && meta.model) {
+      meta.cost = calculateCost(meta.usage, meta.model);
+    }
+
+    assert.equal(meta.cost, originalCost);
+  });
+
+  it('accumulates recomputed cost into session total', () => {
+    const sessionCosts = new Map();
+    const entries = [
+      { provider: 'openai', model: 'gpt-5.5', sessionId: 'sess1',
+        usage: { input_tokens: 61154, output_tokens: 678, cache_read_input_tokens: 58240,
+                 input_tokens_details: { cached_tokens: 58240 } },
+        cost: { cost: 999 } },
+      { provider: 'openai', model: 'gpt-5.5', sessionId: 'sess1',
+        usage: { input_tokens: 10000, output_tokens: 200, cache_read_input_tokens: 8000,
+                 input_tokens_details: { cached_tokens: 8000 } },
+        cost: { cost: 999 } },
+    ];
+
+    for (const meta of entries) {
+      const before = meta.usage;
+      meta.usage = normalizeUsageForProvider(meta.provider, meta.usage);
+      if (meta.usage !== before && meta.usage._ccxrayUsageNormalized && meta.model) {
+        meta.cost = calculateCost(meta.usage, meta.model);
+      }
+      if (meta.cost?.cost != null && meta.sessionId) {
+        sessionCosts.set(meta.sessionId, (sessionCosts.get(meta.sessionId) || 0) + meta.cost.cost);
+      }
+    }
+
+    const total = sessionCosts.get('sess1');
+    assert.ok(total > 0);
+    assert.ok(total < 2);
+  });
+});


### PR DESCRIPTION
## Summary

- **UPSTREAM_PROFILES** registry in `providers.js` — declarative wire-level cache and usage semantics per provider (`ephemeral-ttl` vs `server-managed`, `inputIncludesCached`)
- **`normalizeUsageForProvider()`** pure function — canonicalizes OpenAI `input_tokens` (subtracts cached overlap) with `_ccxrayUsageNormalized` idempotency flag
- **Provider-aware UI** — topbar, session cards, notification button, gap tooltips all adapt via `getCacheMode()` helper instead of comparing provider strings
- **Historical data fix** — restore normalizes old Codex usage + recomputes cost (in-memory, index unchanged)
- **Model fallback** — session/turn cards use last-known non-null model instead of showing `?`

## Before / After

| Element | Before | After |
|---------|--------|-------|
| Topbar (Codex) | `Plan: API key · TTL 5m (detecting…)` | `Cache: server-managed` |
| Topbar (mixed) | Claude info only | `Plan: Max 5x · TTL 1h · Server cache` |
| Session card model | `? · 6t` | `gpt-5.5 · 6t` |
| Session card cache | `cache 4m left` (fake countdown) | `cache 99% hit · 70K tok` |
| Context bar | ~30% (double-counted) | ~15% (correct) |
| Cost | double-counted cached×input_rate | precise: `net_input×rate + cached×cache_rate` |
| 🔔 button (pure Codex) | visible (misleading) | hidden |

## Fixes double-counting bug

OpenAI's `input_tokens` **includes** `cached_tokens` (subset relationship), unlike Anthropic's disjoint fields. All downstream consumers (`ctxUsed`, `calculateCost`, minimap) assumed Anthropic semantics → Codex context inflated 95%, cost double-counted.

**Note**: Historical Codex session costs will decrease to correct values after this change. This is a calculation fix, not data loss.

## Test plan

- [x] 18 normalizer tests (idempotency, clamp, fallback, unknown provider, restore-level cost recomputation)
- [x] 768 total tests pass (0 failures)
- [x] Smoke test with mixed Claude + Codex logs (isolated CCXRAY_HOME + port 5602)
- [x] Browser-harness screenshots: topbar, session cards, turn cards verified
- [x] Console error check: `getCacheMode` defined, no undefined.cache errors
- [x] Reviewer approved (3 rounds: initial → cost recomputation fix → restore regression tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)