### PR TITLE
fix: Codex resume command uses subcommand syntax

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1387,7 +1387,8 @@ function formatEntryDateShort(id) {
 
 
 function copySessionContinue(sid, btn, agent) {
-  navigator.clipboard.writeText((agent || 'claude') + ' --resume ' + sid).then(() => {
+  const cmd = agent === 'codex' ? 'codex resume ' + sid : (agent || 'claude') + ' --resume ' + sid;
+  navigator.clipboard.writeText(cmd).then(() => {
     const orig = btn.textContent;
     btn.textContent = '✓ copied!';
     btn.style.color = 'var(--green)';
@@ -1494,7 +1495,9 @@ function renderSessionItem(sess, sid) {
   const titleRow = sess.title
     ? '<div class="si-title">' + escapeHtml(sess.title) + '</div>'
     : '';
-  const resumeCmd = (sess.agent || 'claude') + ' --resume ' + sid;
+  const resumeCmd = (sess.agent || 'claude') === 'codex'
+    ? 'codex resume ' + sid
+    : (sess.agent || 'claude') + ' --resume ' + sid;
   const copyBtn = sid === 'direct-api' || sid === 'codex-raw'
     ? ''
     : '<button class="launch-btn" onclick="event.stopPropagation();copySessionContinue(&quot;' + escapeHtml(sid) + '&quot;,this,&quot;' + escapeHtml(sess.agent || 'claude') + '&quot;)" title="Copy: ' + escapeHtml(resumeCmd) + '">&#10697;</button>';


### PR DESCRIPTION
## Summary

The session card copy button generated `codex --resume <session_id>` which is invalid. Codex CLI uses subcommand syntax: `codex resume <session_id>`.

## Before / After

```
Before:  codex --resume 019e9585-7067-7e23-ba0e-85ba75027f8a  ← invalid
After:   codex resume 019e9585-7067-7e23-ba0e-85ba75027f8a    ← correct
Claude:  claude --resume ee89450f-...                          ← unchanged
```

One-line fix in `copySessionContinue()` and `resumeCmd` tooltip generation.

## Test plan

- [x] 768 tests pass
- [ ] Manual: click copy button on Codex session card, paste, verify command works

🤖 Generated with [Claude Code](https://claude.com/claude-code)