### PR TITLE
fix: config.LOGS_DIR honors CCXRAY_HOME (banner + legacy migration)

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -2,8 +2,8 @@
 
 const path = require('path');
 const fs = require('fs');
-const os = require('os');
 const { createStorage } = require('./storage');
+const { resolveLogsDir } = require('./paths');
 
 // ── Config ──────────────────────────────────────────────────────────
 const PORT = parseInt(process.env.PROXY_PORT || '5577', 10);
@@ -187,7 +187,7 @@ function joinUpstreamPath(upstream, requestUrl) {
   }
   return basePath + (urlPath.startsWith('/') ? urlPath : `/${urlPath}`);
 }
-const LOGS_DIR = path.join(os.homedir(), '.ccxray', 'logs');
+const LOGS_DIR = resolveLogsDir();
 const LEGACY_LOGS_DIR = path.join(__dirname, '..', 'logs');
 const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || '3', 10);
 const LOG_RETENTION_DAYS = parseInt(process.env.LOG_RETENTION_DAYS || '14', 10);

--- a/server/index.js
+++ b/server/index.js
@@ -801,7 +801,7 @@ async function startServer() {
     const openaiUrl = `${config.OPENAI_PROTOCOL}://${config.OPENAI_HOST}:${config.OPENAI_PORT}${config.OPENAI_BASE_PATH}`;
     const openaiNote = config.OPENAI_BASE_URL_SOURCE === 'OPENAI_BASE_URL' ? ' (from OPENAI_BASE_URL)' : '';
     console.log(`   OpenAI Upstream → ${openaiUrl}${openaiNote}`);
-    console.log(`   Logs → ${config.LOGS_DIR}`);
+    console.log(`   Logs → ${config.storage.location || config.LOGS_DIR}`);
     console.log();
     console.log(`   Usage: ANTHROPIC_BASE_URL=http://localhost:${actualPort} claude\x1b[0m`);
     console.log('\x1b[0m');

--- a/server/paths.js
+++ b/server/paths.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const path = require('path');
+const os = require('os');
+
+// Single source of truth for ccxray's on-disk locations. config.js and
+// storage/index.js both resolve the logs dir from here, so the startup banner
+// and legacy-migration target can no longer drift from where logs actually
+// get written. hub.js, settings.js, ratelimit-log.js, and auth.js still
+// duplicate the home-dir resolution inline and are candidates for future
+// consolidation here.
+//
+// Precedence (mirrors the storage adapter's historical resolution):
+//   logs dir : LOGS_DIR  >  <home>/logs
+//   home     : CCXRAY_HOME  >  ~/.ccxray
+
+function resolveCcxrayHome(env = process.env) {
+  return env.CCXRAY_HOME || path.join(os.homedir(), '.ccxray');
+}
+
+function resolveLogsDir(env = process.env) {
+  return env.LOGS_DIR || path.join(resolveCcxrayHome(env), 'logs');
+}
+
+module.exports = { resolveCcxrayHome, resolveLogsDir };

--- a/server/storage/index.js
+++ b/server/storage/index.js
@@ -53,10 +53,8 @@ function createStorage() {
     }
     case 'local':
     default: {
-      const path = require('path');
-      const os = require('os');
-      const logsDir = process.env.LOGS_DIR || path.join(process.env.CCXRAY_HOME || path.join(os.homedir(), '.ccxray'), 'logs');
-      adapter = createLocalStorage(logsDir);
+      const { resolveLogsDir } = require('../paths');
+      adapter = createLocalStorage(resolveLogsDir());
       break;
     }
   }

--- a/server/storage/interface.js
+++ b/server/storage/interface.js
@@ -30,6 +30,10 @@
  *   When true, the proxy may write _req.json in delta format (prevId + partial messages)
  *   instead of storing the full messages array every turn. Set false for high-latency or
  *   multi-writer backends (S3) where chain traversal on read would be too costly.
+ *
+ * @property {string} location
+ *   Human-readable destination for the startup banner (e.g. '/home/u/.ccxray/logs'
+ *   for local, 's3://bucket/logs/' for S3). Display-only; not used for I/O.
  */
 
 module.exports = {};

--- a/server/storage/local.js
+++ b/server/storage/local.js
@@ -16,6 +16,9 @@ function createLocalStorage(logsDir) {
   return {
     supportsDelta: true,
 
+    // Human-readable destination for the startup banner.
+    location: logsDir,
+
     async init() {
       await fsp.mkdir(logsDir, { recursive: true });
       await fsp.mkdir(sharedDir, { recursive: true });

--- a/server/storage/s3.js
+++ b/server/storage/s3.js
@@ -36,6 +36,9 @@ function createS3Storage(opts) {
   return {
     supportsDelta: false,
 
+    // Human-readable destination for the startup banner.
+    location: `s3://${bucket || '(unset)'}/${prefix}`,
+
     async init() {
       // Verify bucket access
       const { HeadBucketCommand } = require('@aws-sdk/client-s3');

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -35,6 +35,11 @@ function runSnippet(snippet, env = {}) {
     delete sanitised.OPENAI_TEST_HOST;
     delete sanitised.OPENAI_TEST_PORT;
     delete sanitised.OPENAI_TEST_PROTOCOL;
+    // Path/storage vars leak from a developer's shell (or the ccxray hub) and
+    // would corrupt logs-dir resolution tests. Clear them; callers re-add via env.
+    delete sanitised.CCXRAY_HOME;
+    delete sanitised.LOGS_DIR;
+    delete sanitised.STORAGE_BACKEND;
     Object.assign(sanitised, env);
 
     const child = spawn(process.execPath, ['-e', snippet], {
@@ -197,6 +202,89 @@ describe('upstream priority chain', () => {
     });
     const result = JSON.parse(stdout);
     assert.equal(result.basePath, '');
+  });
+});
+
+// ── Logs directory resolution (issue #31: config.LOGS_DIR must honor
+// CCXRAY_HOME, and must not drift from where the storage adapter writes) ──
+
+describe('logs directory resolution (CCXRAY_HOME)', () => {
+  // Prints the config-exported logs dir plus the storage adapter's self-reported
+  // destination, so we can assert they resolve to the same place.
+  const logsSnippet = `
+    const c = require(${JSON.stringify(CONFIG_SCRIPT)});
+    process.stdout.write(JSON.stringify({ logsDir: c.LOGS_DIR, location: c.storage.location }));
+  `;
+
+  it('honors CCXRAY_HOME for the logs directory', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-home-'));
+    try {
+      const { stdout, code } = await runSnippet(logsSnippet, { CCXRAY_HOME: home });
+      assert.equal(code, 0);
+      const r = JSON.parse(stdout);
+      assert.equal(r.logsDir, path.join(home, 'logs'));
+      assert.equal(r.location, path.join(home, 'logs'));
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('LOGS_DIR env takes precedence over CCXRAY_HOME', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-home-'));
+    const explicit = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-logs-'));
+    try {
+      const { stdout, code } = await runSnippet(logsSnippet, { CCXRAY_HOME: home, LOGS_DIR: explicit });
+      assert.equal(code, 0);
+      const r = JSON.parse(stdout);
+      assert.equal(r.logsDir, explicit);
+      assert.equal(r.location, explicit);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+      fs.rmSync(explicit, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to <home>/.ccxray/logs when neither is set', async () => {
+    // Pin HOME (POSIX) and USERPROFILE (Windows) to a temp dir so
+    // os.homedir() is deterministic cross-platform and we never touch the
+    // developer's real ~/.ccxray. No CCXRAY_HOME / LOGS_DIR set.
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-fakehome-'));
+    try {
+      const { stdout, code } = await runSnippet(logsSnippet, { HOME: fakeHome, USERPROFILE: fakeHome });
+      assert.equal(code, 0);
+      const r = JSON.parse(stdout);
+      assert.equal(r.logsDir, path.join(fakeHome, '.ccxray', 'logs'));
+    } finally {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  it('config.LOGS_DIR matches where the storage adapter actually writes (no drift)', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-home-'));
+    try {
+      // Write through config.storage and confirm the file lands under
+      // config.LOGS_DIR — proving createStorage() uses the same resolver.
+      const snippet = `
+        const c = require(${JSON.stringify(CONFIG_SCRIPT)});
+        (async () => {
+          await c.storage.init();
+          await c.storage.write('drift-check', '_req.json', 'x');
+          const fsm = require('fs'); const pm = require('path');
+          process.stdout.write(JSON.stringify({
+            logsDir: c.LOGS_DIR,
+            location: c.storage.location,
+            landed: fsm.existsSync(pm.join(c.LOGS_DIR, 'drift-check_req.json')),
+          }));
+        })();
+      `;
+      const { stdout, code } = await runSnippet(snippet, { CCXRAY_HOME: home });
+      assert.equal(code, 0);
+      const r = JSON.parse(stdout);
+      assert.equal(r.location, r.logsDir);
+      assert.equal(r.landed, true, 'storage.write should land under config.LOGS_DIR');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
Closes #31.

## Problem
`server/config.js` hardcoded `LOGS_DIR = ~/.ccxray/logs`, ignoring `CCXRAY_HOME` even though the storage layer (`server/storage/index.js`) resolved it correctly. With `CCXRAY_HOME` set, `config.LOGS_DIR` — used by the startup banner and the one-time legacy-logs migration — pointed at the wrong directory.

## Root cause
The logs path was computed independently in two places, so they drifted.

## Fix
- New `server/paths.js` as single source of truth: `resolveCcxrayHome()` / `resolveLogsDir()`, precedence `LOGS_DIR` > `CCXRAY_HOME` > `~/.ccxray/logs` (mirrors the storage layer's historical resolution exactly).
- `config.js` and `storage/index.js` both resolve from it → banner + migration target can no longer drift from where logs are written.
- Banner is now backend-aware: each storage adapter exposes a display-only `location` (local logs dir, or `s3://bucket/prefix`), so S3 setups stop showing a misleading local path.

## Tests
- `runSnippet` now sanitizes `CCXRAY_HOME`/`LOGS_DIR`/`STORAGE_BACKEND` so ambient shell/hub env can't corrupt results.
- New cases: `CCXRAY_HOME` honored, `LOGS_DIR` precedence, default fallback (`HOME`+`USERPROFILE` pinned to temp, cross-platform), and an end-to-end write proving `config.storage` lands files under `config.LOGS_DIR` (no drift).
- Full suite: **772/772**.

## Reviewed
Codex (gpt-5.5, xhigh) — no blockers; two minor polish items applied (cross-platform HOME pinning, honest `paths.js` comment).

## Not in this PR (tracked separately)
- `hub.js`, `settings.js`, `ratelimit-log.js`, `auth.js` still duplicate the `CCXRAY_HOME` home-dir resolution inline — candidates for consolidation into `paths.js`. Kept out to keep this PR focused on #31.
- S3 banner / legacy-migration target have no direct automated test (no bug found; S3 live-banner smoke is blocked by the optional `@aws-sdk/client-s3` not being installed in dev).