### PR TITLE
refactor: consolidate CCXRAY_HOME resolution into server/paths.js

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -15,14 +15,14 @@
 
 const crypto = require('crypto');
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
 const config = require('./config');
+const { resolveCcxrayHome } = require('./paths');
 
 // ─── Root secret resolution ──────────────────────────────────────────
 
 function getHubDir() {
-  return process.env.CCXRAY_HOME || path.join(os.homedir(), '.ccxray');
+  return resolveCcxrayHome();
 }
 
 function ensureHubDir() {

--- a/server/hub.js
+++ b/server/hub.js
@@ -2,11 +2,11 @@
 
 const fs = require('fs');
 const path = require('path');
-const os = require('os');
 const net = require('net');
 const http = require('http');
+const { resolveCcxrayHome } = require('./paths');
 
-const HUB_DIR = process.env.CCXRAY_HOME || path.join(os.homedir(), '.ccxray');
+const HUB_DIR = resolveCcxrayHome();
 const HUB_LOCK_PATH = path.join(HUB_DIR, 'hub.json');
 const HUB_LOG_PATH = path.join(HUB_DIR, 'hub.log');
 const SOCK_PATH = path.join(HUB_DIR, 'hub.sock');

--- a/server/paths.js
+++ b/server/paths.js
@@ -3,12 +3,11 @@
 const path = require('path');
 const os = require('os');
 
-// Single source of truth for ccxray's on-disk locations. config.js and
-// storage/index.js both resolve the logs dir from here, so the startup banner
-// and legacy-migration target can no longer drift from where logs actually
-// get written. hub.js, settings.js, ratelimit-log.js, and auth.js still
-// duplicate the home-dir resolution inline and are candidates for future
-// consolidation here.
+// Single source of truth for ccxray's on-disk locations. config.js,
+// storage/index.js, hub.js, settings.js, ratelimit-log.js, and auth.js all
+// resolve their ccxray home/logs paths from here, so the startup banner,
+// legacy-migration target, and every other consumer stay in sync and can no
+// longer drift from where logs actually get written.
 //
 // Precedence (mirrors the storage adapter's historical resolution):
 //   logs dir : LOGS_DIR  >  <home>/logs

--- a/server/ratelimit-log.js
+++ b/server/ratelimit-log.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
+const { resolveCcxrayHome } = require('./paths');
 
 // Append-only log of `anthropic-ratelimit-*` headers observed from upstream responses.
 // Used for future calibration of plan-specific limits (Max 5x vs 20x tokens5h quota).
 // File: ~/.ccxray/ratelimit-samples.jsonl (respects CCXRAY_HOME env)
 
-const CCXRAY_HOME = process.env.CCXRAY_HOME || path.join(os.homedir(), '.ccxray');
+const CCXRAY_HOME = resolveCcxrayHome();
 const SAMPLES_FILE = path.join(CCXRAY_HOME, 'ratelimit-samples.jsonl');
 
 // Dedupe per model: skip writing if headers identical to last sample for

--- a/server/settings.js
+++ b/server/settings.js
@@ -2,9 +2,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const os = require('os');
+const { resolveCcxrayHome } = require('./paths');
 
-const SETTINGS_DIR = process.env.CCXRAY_HOME || path.join(os.homedir(), '.ccxray');
+const SETTINGS_DIR = resolveCcxrayHome();
 const SETTINGS_PATH = path.join(SETTINGS_DIR, 'settings.json');
 
 const DEFAULTS = {


### PR DESCRIPTION
Closes #51. Follow-up to #50.

#50 introduced `server/paths.js` as the single source of truth for ccxray's on-disk locations, wiring `config.js` + `storage/index.js` to it. Four other modules still inlined the same `process.env.CCXRAY_HOME || path.join(os.homedir(), '.ccxray')` expression.

## Change
Replace the inline resolution with `resolveCcxrayHome()` and drop the now-unused `os` import in each:
- `server/hub.js` — `HUB_DIR`
- `server/settings.js` — `SETTINGS_DIR`
- `server/ratelimit-log.js` — `CCXRAY_HOME`
- `server/auth.js` — `getHubDir()` (call kept inside the function, preserving per-call env read)

Plus: refreshed the now-accurate `paths.js` header comment.

## Guarantees
- **Pure de-duplication** — `resolveCcxrayHome()` returns exactly `env.CCXRAY_HOME || path.join(os.homedir(), '.ccxray')`, identical to each removed expression. No precedence or behavior change.
- 6 inlined copies of the home-dir rule → 1 definition. The `CCXRAY_HOME` contract can no longer drift the way `config.LOGS_DIR` did in #31.

## Verification
- `node -c` on all 5 touched files; confirmed `os` fully removed (0 refs) in the 4 consumers.
- Full suite: **772/772** (hub / settings / auth / ratelimit-log all have existing behavior tests).

## Reviewed
Codex (gpt-5.5, xhigh) — no blockers; the one nit (stale `paths.js` comment) is included in this PR.

## Out of scope
S3 banner / legacy-migration regression tests (the other #51 checklist items) — left for a separate change to keep this PR a clean mechanical refactor.