### PR TITLE
fix: 清掉 Codex cache 文案的工程術語 (#45)

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -345,7 +345,7 @@ function addEntry(e) {
       const cacheMode = typeof getCacheMode === 'function' ? getCacheMode(e.provider || 'anthropic') : 'ephemeral-ttl';
       gapTitle = cacheMode === 'ephemeral-ttl'
         ? (gapMs < 5 * 60000 ? 'Cache likely warm (< 5m)' : gapMs < 60 * 60000 ? 'Default cache expired (5m–1h)' : 'All cache expired (> 1h)')
-        : 'Server cache (retention varies)';
+        : 'Cached automatically';
     }
   }
 

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1481,7 +1481,7 @@ function renderSessionItem(sess, sid) {
     const tokK = sess.latestCacheReadTokens >= 1000
       ? Math.round(sess.latestCacheReadTokens / 1000) + 'K'
       : String(sess.latestCacheReadTokens);
-    cacheRowHtml = '<div class="si-cache cache-server" title="Server-managed cache · last turn">' +
+    cacheRowHtml = '<div class="si-cache cache-server" title="Cached automatically · last turn">' +
       'cache ' + pct + '% hit · ' + tokK + ' tok</div>';
   }
   const isOnline = getStatusClass(sid) !== 'sdot-off';


### PR DESCRIPTION
## 摘要(正體中文)

Codex(server-managed cache)session 的兩處 cache 文案是使用者看不懂的工程術語:
- Gap tooltip:`Server cache (retention varies)`
- Session card cache row title:`Server-managed cache · last turn`

兩者都改成白話的 **`Cached automatically`**。ctx bar 本身已經用 cyan 色塊 + `cache:N%` 標籤在每個 turn 的可見表面顯示 cache hit ratio,所以 tooltip 不需要重複數字,只需要把術語拿掉。

Topbar 的 cache 文案(`settings.js`)**刻意延後**:它是 global 顯示、無 per-session 意義,在多帳號/多 provider 場景下沒有參考價值。

---

## Problem

Codex sessions (server-managed cache) surfaced engineering jargon that non-technical users couldn't parse. The gap tooltip read `Server cache (retention varies)` — which both leaked the term "server" and added a parenthetical ("retention varies") that conveys nothing actionable. The session-card cache row title read `Server-managed cache · last turn`, same problem.

Unlike Claude's gap tooltip (where cache has a known TTL, so "Cache likely warm (< 5m)" tells the user to hurry), Codex cache is automatic and server-controlled — there is nothing for the user to act on. The copy should say so in plain language.

## Why this minimal fix (not visual encoding)

An earlier exploration considered adding color/inline hit% to the Codex gap element. Rejected: the **ctx bar already visualizes cache** on every turn's visible surface — a cyan `cache-read` segment plus a `cache:N%` label. Repeating those numbers in the gap tooltip would be redundant (and raise new questions like "99% — good or bad? what do I do?"). The gap tooltip's only real defect was the jargon, so the fix is purely to remove it.

Notably, Codex's ctx bar only ever shows two segments (cache-read + input, never cache-write — `cache_creation_input_tokens` is hardcoded `0` for OpenAI), so the absence of the orange segment is itself the visual signal that the provider manages cache automatically.

## Changes

- `public/entry-rendering.js`: gap tooltip non-ephemeral branch → `Cached automatically`
- `public/miller-columns.js`: session-card cache row `title` → `Cached automatically · last turn`

The Claude (`ephemeral-ttl`) path is untouched — only the `else` branch of the existing ternary changed. The visible session-card text (`cache N% hit · NK tok`) is unchanged; only its `title` attribute changed.

## Tests

- Full suite: 817/817 pass
- `node --check` on both files

## Smoke (isolated env, real traffic)

`CCXRAY_HOME=/tmp/ccxray-smoke-45 node server/index.js --port 5603 --no-browser` + real `codex exec` (3-turn session). Verified the **actually-rendered DOM** via browser-harness (CDP):
- session-card `.si-cache` title = `Cached automatically · last turn` (visible text `cache 98% hit · 17K tok` unchanged)
- gap tooltip `.turn-elapsed-secondary` title = `Cached automatically`

Confirmed the topbar still shows the old `server-managed` string (the intentionally-deferred item), consistent with scope.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)