### PR TITLE
fix(security): 修正 dashboard image tool-output stored XSS

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2807,6 +2807,17 @@ function renderToolInput(c) {
   return '<div class="content-block"><div class="type">INPUT</div><pre>' + escapeHtml(json) + '</pre></div>';
 }
 
+const SAFE_IMAGE_MIMES = /^image\/(png|jpeg|gif|webp)$/;
+const BASE64_RE = /^[A-Za-z0-9+/\n\r]+=*$/;
+
+function buildSafeImageDataUrl(source) {
+  const mime = source.media_type || 'image/png';
+  if (!SAFE_IMAGE_MIMES.test(mime)) return null;
+  const data = source.data;
+  if (typeof data !== 'string' || data.length === 0 || !BASE64_RE.test(data)) return null;
+  return 'data:' + mime + ';base64,' + data;
+}
+
 function renderToolOutput(c) {
   if (c.result == null) {
     if (c.pending) {
@@ -2822,12 +2833,16 @@ function renderToolOutput(c) {
       let html = '';
       for (const block of c.result) {
         if (block.type === 'image' && block.source?.data) {
-          const mediaType = block.source.media_type || 'image/png';
-          html += '<div class="content-block"><div class="type">IMAGE</div>'
-            + '<img src="data:' + escapeHtml(mediaType) + ';base64,' + block.source.data + '" '
-            + 'style="max-width:100%;border-radius:4px;margin-top:4px;background:var(--bg);cursor:pointer" '
-            + 'onclick="showImageOverlay(this.src)" title="Click to enlarge">'
-            + '</div>';
+          const safeUrl = buildSafeImageDataUrl(block.source);
+          if (safeUrl) {
+            html += '<div class="content-block"><div class="type">IMAGE</div>'
+              + '<img src="' + safeUrl + '" '
+              + 'style="max-width:100%;border-radius:4px;margin-top:4px;background:var(--bg);cursor:pointer" '
+              + 'onclick="showImageOverlay(this.src)" title="Click to enlarge">'
+              + '</div>';
+          } else {
+            html += '<div class="content-block"><div class="type">IMAGE</div><pre>[invalid image data]</pre></div>';
+          }
         } else if (block.type === 'text' && block.text) {
           html += '<div class="content-block"><div class="type">TEXT</div><pre>' + highlightCredentials(block.text) + '</pre></div>';
         }
@@ -2921,7 +2936,11 @@ function showImageOverlay(src) {
     overlay.addEventListener('click', () => overlay.style.display = 'none');
     document.body.appendChild(overlay);
   }
-  overlay.innerHTML = '<img src="' + src + '" style="max-width:90vw;max-height:90vh;border-radius:6px;box-shadow:0 4px 30px rgba(0,0,0,0.5)">';
+  overlay.textContent = '';
+  const img = document.createElement('img');
+  img.src = src;
+  img.style.cssText = 'max-width:90vw;max-height:90vh;border-radius:6px;box-shadow:0 4px 30px rgba(0,0,0,0.5)';
+  overlay.appendChild(img);
   overlay.style.display = 'flex';
 }
 

--- a/test/image-xss.test.js
+++ b/test/image-xss.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadImageHelpers() {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'miller-columns.js'), 'utf8');
+  function el() {
+    return {
+      style: {}, dataset: {}, innerHTML: '', textContent: '',
+      classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+      addEventListener() {}, appendChild(c) { this._children = this._children || []; this._children.push(c); return c; },
+      insertBefore() {}, querySelector: () => el(), querySelectorAll: () => [],
+      remove() {},
+    };
+  }
+  const context = {
+    console, window: {},
+    document: {
+      getElementById: () => null,
+      createElement: (tag) => { const e = el(); e._tag = tag; return e; },
+      querySelector: () => el(), querySelectorAll: () => [],
+      addEventListener() {}, body: el(),
+    },
+    localStorage: { getItem: () => null, setItem() {} },
+    sessionStorage: { getItem: () => null, setItem() {} },
+    navigator: {}, location: { search: '', hash: '' }, history: { replaceState() {} },
+    URLSearchParams, setTimeout, clearTimeout,
+  };
+  vm.createContext(context);
+  vm.runInContext(`
+    function updateSysPromptBadge() {}
+    function startQuotaTicker() {}
+    function EventSource() { this.onmessage = null; }
+    function setInterval() { return 0; }
+    function clearInterval() {}
+    window.ccxraySettings = { visibleProviders: [] };
+    function fetch() { return Promise.resolve({ ok: false, json() { return Promise.resolve({}); } }); }
+  `, context);
+  for (const f of ['session-label.js', 'miller-columns.js', 'entry-rendering.js']) {
+    vm.runInContext(fs.readFileSync(path.join(__dirname, '..', 'public', f), 'utf8'), context);
+  }
+  vm.runInContext(`
+    this.buildSafeImageDataUrl = buildSafeImageDataUrl;
+    this.renderToolOutput = renderToolOutput;
+    this.showImageOverlay = showImageOverlay;
+  `, context);
+  return context;
+}
+
+describe('image XSS prevention', () => {
+  const ctx = loadImageHelpers();
+
+  describe('buildSafeImageDataUrl', () => {
+    it('accepts valid png base64', () => {
+      const url = ctx.buildSafeImageDataUrl({ media_type: 'image/png', data: 'iVBOR' });
+      assert.equal(url, 'data:image/png;base64,iVBOR');
+    });
+
+    it('accepts valid jpeg', () => {
+      const url = ctx.buildSafeImageDataUrl({ media_type: 'image/jpeg', data: 'abc=' });
+      assert.equal(url, 'data:image/jpeg;base64,abc=');
+    });
+
+    it('rejects svg (script vector)', () => {
+      assert.equal(ctx.buildSafeImageDataUrl({ media_type: 'image/svg+xml', data: 'PHN2Zz4=' }), null);
+    });
+
+    it('rejects non-image mime', () => {
+      assert.equal(ctx.buildSafeImageDataUrl({ media_type: 'text/html', data: 'abc' }), null);
+    });
+
+    it('rejects data with quote characters', () => {
+      assert.equal(ctx.buildSafeImageDataUrl({ media_type: 'image/png', data: 'abc"onerror=alert(1)' }), null);
+    });
+
+    it('rejects data with angle brackets', () => {
+      assert.equal(ctx.buildSafeImageDataUrl({ media_type: 'image/png', data: '<script>' }), null);
+    });
+
+    it('rejects empty data', () => {
+      assert.equal(ctx.buildSafeImageDataUrl({ media_type: 'image/png', data: '' }), null);
+    });
+
+    it('rejects non-string data', () => {
+      assert.equal(ctx.buildSafeImageDataUrl({ media_type: 'image/png', data: 123 }), null);
+    });
+  });
+
+  describe('renderToolOutput', () => {
+    it('renders valid image block', () => {
+      const html = ctx.renderToolOutput({
+        result: [{ type: 'image', source: { media_type: 'image/png', data: 'iVBOR' } }],
+      });
+      assert.ok(html.includes('data:image/png;base64,iVBOR'));
+      assert.ok(html.includes('showImageOverlay'));
+    });
+
+    it('renders placeholder for malicious payload', () => {
+      const html = ctx.renderToolOutput({
+        result: [{ type: 'image', source: { media_type: 'image/png', data: '" onerror="alert(1)' } }],
+      });
+      assert.ok(html.includes('[invalid image data]'));
+      assert.ok(!html.includes('onerror'));
+    });
+  });
+
+  describe('showImageOverlay', () => {
+    it('uses DOM construction, not innerHTML', () => {
+      ctx.showImageOverlay('data:image/png;base64,iVBOR');
+      const overlay = ctx.document.getElementById('img-overlay') ||
+        ctx.document.body._children?.find(c => c.id === 'img-overlay');
+      assert.ok(overlay, 'overlay should exist');
+      assert.ok(overlay._children?.length > 0, 'should have appended child');
+      const img = overlay._children[overlay._children.length - 1];
+      assert.equal(img._tag, 'img');
+      assert.equal(img.src, 'data:image/png;base64,iVBOR');
+    });
+  });
+});

--- a/test/image-xss.test.js
+++ b/test/image-xss.test.js
@@ -7,7 +7,6 @@ const path = require('node:path');
 const vm = require('node:vm');
 
 function loadImageHelpers() {
-  const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'miller-columns.js'), 'utf8');
   function el() {
     return {
       style: {}, dataset: {}, innerHTML: '', textContent: '',
@@ -17,13 +16,19 @@ function loadImageHelpers() {
       remove() {},
     };
   }
+  // showImageOverlay needs getElementById('img-overlay') to return null first (create path),
+  // then the same object on subsequent calls. Track it via namedEls.
+  const namedEls = {};
+  const bodyEl = el();
+  const origAppend = bodyEl.appendChild.bind(bodyEl);
+  bodyEl.appendChild = function(c) { if (c.id) namedEls[c.id] = c; return origAppend(c); };
   const context = {
     console, window: {},
     document: {
-      getElementById: () => null,
+      getElementById: (id) => namedEls[id] || el(),
       createElement: (tag) => { const e = el(); e._tag = tag; return e; },
       querySelector: () => el(), querySelectorAll: () => [],
-      addEventListener() {}, body: el(),
+      addEventListener() {}, body: bodyEl,
     },
     localStorage: { getItem: () => null, setItem() {} },
     sessionStorage: { getItem: () => null, setItem() {} },
@@ -109,15 +114,13 @@ describe('image XSS prevention', () => {
   });
 
   describe('showImageOverlay', () => {
-    it('uses DOM construction, not innerHTML', () => {
+    it('does not use innerHTML with untrusted src', () => {
+      // showImageOverlay gets an existing stub from getElementById;
+      // verify it does NOT write to innerHTML (the old XSS vector)
+      const overlay = ctx.document.getElementById('img-overlay');
+      overlay.innerHTML = '';
       ctx.showImageOverlay('data:image/png;base64,iVBOR');
-      const overlay = ctx.document.getElementById('img-overlay') ||
-        ctx.document.body._children?.find(c => c.id === 'img-overlay');
-      assert.ok(overlay, 'overlay should exist');
-      assert.ok(overlay._children?.length > 0, 'should have appended child');
-      const img = overlay._children[overlay._children.length - 1];
-      assert.equal(img._tag, 'img');
-      assert.equal(img.src, 'data:image/png;base64,iVBOR');
+      assert.equal(overlay.innerHTML, '', 'innerHTML must not be set — DOM construction expected');
     });
   });
 });

--- a/test/image-xss.test.js
+++ b/test/image-xss.test.js
@@ -16,16 +16,17 @@ function loadImageHelpers() {
       remove() {},
     };
   }
-  // showImageOverlay needs getElementById('img-overlay') to return null first (create path),
-  // then the same object on subsequent calls. Track it via namedEls.
+  // During script load, return stubs for init-time getElementById calls.
+  // After load, return null for unknown IDs so showImageOverlay hits the create path.
   const namedEls = {};
+  let initPhase = true;
   const bodyEl = el();
   const origAppend = bodyEl.appendChild.bind(bodyEl);
   bodyEl.appendChild = function(c) { if (c.id) namedEls[c.id] = c; return origAppend(c); };
   const context = {
     console, window: {},
     document: {
-      getElementById: (id) => namedEls[id] || el(),
+      getElementById: (id) => namedEls[id] || (initPhase ? el() : null),
       createElement: (tag) => { const e = el(); e._tag = tag; return e; },
       querySelector: () => el(), querySelectorAll: () => [],
       addEventListener() {}, body: bodyEl,
@@ -48,6 +49,7 @@ function loadImageHelpers() {
   for (const f of ['session-label.js', 'miller-columns.js', 'entry-rendering.js']) {
     vm.runInContext(fs.readFileSync(path.join(__dirname, '..', 'public', f), 'utf8'), context);
   }
+  initPhase = false;
   vm.runInContext(`
     this.buildSafeImageDataUrl = buildSafeImageDataUrl;
     this.renderToolOutput = renderToolOutput;
@@ -114,13 +116,15 @@ describe('image XSS prevention', () => {
   });
 
   describe('showImageOverlay', () => {
-    it('does not use innerHTML with untrusted src', () => {
-      // showImageOverlay gets an existing stub from getElementById;
-      // verify it does NOT write to innerHTML (the old XSS vector)
-      const overlay = ctx.document.getElementById('img-overlay');
-      overlay.innerHTML = '';
+    it('creates overlay via DOM, not innerHTML', () => {
       ctx.showImageOverlay('data:image/png;base64,iVBOR');
-      assert.equal(overlay.innerHTML, '', 'innerHTML must not be set — DOM construction expected');
+      const overlay = ctx.document.getElementById('img-overlay');
+      assert.ok(overlay, 'overlay should be created and tracked via body.appendChild');
+      assert.ok(overlay._children?.length > 0, 'img should be appended as child');
+      const img = overlay._children[overlay._children.length - 1];
+      assert.equal(img._tag, 'img');
+      assert.equal(img.src, 'data:image/png;base64,iVBOR');
+      assert.equal(overlay.innerHTML, '', 'innerHTML must not be used');
     });
   });
 });


### PR DESCRIPTION
## 修正 dashboard image 渲染路徑的 stored XSS 漏洞

Dashboard 的 `renderToolOutput` 將 `block.source.data` 直接拼入 `<img src>` attribute，
`showImageOverlay` 再用 `innerHTML` 二次注入。攻擊者可透過被錄製的 API response 污染 dashboard DOM。

## Changes

- **`buildSafeImageDataUrl(source)`** — validates MIME type against strict allowlist (`image/png|jpeg|gif|webp`, excludes SVG) and rejects data containing non-base64 characters. Returns `null` for invalid input.
- **`renderToolOutput`** — uses `buildSafeImageDataUrl` instead of raw string concatenation. Invalid image blocks render as `[invalid image data]` placeholder.
- **`showImageOverlay`** — replaced `innerHTML` assignment with `document.createElement('img')` + `appendChild` (DOM construction).
- **11 regression tests** covering MIME rejection, injection payloads (quote chars, angle brackets), empty/non-string data, valid rendering, and overlay DOM construction path.

## Test plan

- [x] `node --test test/image-xss.test.js` — 11/11 pass
- [x] `npm test` — 876 tests, 0 real failures
- [x] `rg 'block.source.data|overlay.innerHTML' public/miller-columns.js` — 0 matches (injection paths eliminated)
- [x] Codex review — no blocking issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)