### PR TITLE
fix(#71): guard keyboard hotkeys against modifier keys

### DIFF
--- a/public/keyboard-nav.js
+++ b/public/keyboard-nav.js
@@ -468,7 +468,8 @@ function toggleKbdOverlay() {
 
 // ── Keyboard navigation ──
 document.addEventListener('keydown', (e) => {
-  if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+  if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable) return;
+  if (e.metaKey || e.ctrlKey || e.altKey) return;
   const key = e.key;
 
   // kbd overlay: ? to open, Escape to close (highest priority after input guard)


### PR DESCRIPTION
## Summary
- Cmd+F / Ctrl+F no longer triggers the `f` star hotkey
- Added `contentEditable` guard for future-proofing input scenarios

Closes #71

## Test plan
- [x] browser-harness: Cmd+F blocked, Ctrl+F blocked, bare `f` still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)