### PR TITLE
fix(#68): preserve intentional tokens5h=0 for metered plans

### DIFF
--- a/public/quota-ticker.js
+++ b/public/quota-ticker.js
@@ -28,12 +28,11 @@ async function updateQuotaTicker() {
       barWrap.style.display = 'none';
     }
 
-    // Recommendation chip
+    // Recommendation chip — hidden for metered plans (tokens5h === 0)
     const chipEl = document.getElementById('qt-chip');
-    if (block.active && block.burnRate) {
+    const tokens5h = (window.ccxraySettings || {}).tokens5h ?? 220000;
+    if (block.active && block.burnRate && tokens5h > 0) {
       const br = block.burnRate.tokensPerMinute || 0;
-      // Capacity from plan's 5h tokens budget; fall back to legacy constant when settings absent
-      const tokens5h = (window.ccxraySettings || {}).tokens5h || 220000;
       const capacity = tokens5h / 300; // tokens per min at full speed
       const ratio = br / capacity;
       if (ratio < 0.3) {

--- a/server/cost-budget.js
+++ b/server/cost-budget.js
@@ -25,11 +25,11 @@ function getEffectivePlanConfig() {
 }
 
 function getEffectiveTokenLimit() {
-  return getEffectivePlanConfig()?.tokens5h || TOKEN_LIMIT;
+  return getEffectivePlanConfig()?.tokens5h ?? TOKEN_LIMIT;
 }
 
 function getEffectiveMonthlyUSD() {
-  return getEffectivePlanConfig()?.monthlyUSD || SUBSCRIPTION_USD;
+  return getEffectivePlanConfig()?.monthlyUSD ?? SUBSCRIPTION_USD;
 }
 
 // 5-minute server-side cache


### PR DESCRIPTION
## Summary
- `api-key` plan sets `tokens5h: 0` (metered, no fixed 5h window)
- `||` fallback treated `0` as falsy → fell back to legacy `220000` quota
- Replaced `||` with `??` in `server/cost-budget.js` (both `getEffectiveTokenLimit` and `getEffectiveMonthlyUSD`)
- Added `tokens5h > 0` guard in `public/quota-ticker.js` so recommendation chips ("Can parallelize" / "Slow down") are hidden for metered plans

Closes #68

## Test plan
- [x] `npm test` — all passing
- [x] Verified `api-key` plan keeps `tokens5h: 0` through `getEffectiveTokenLimit()`
- [x] Quota ticker hides chips when `tokens5h === 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)