### PR TITLE
feat(#46): 多帳號花費分析 — Claude + Codex Usage 頁面

### DIFF
--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -356,11 +356,24 @@ function renderMonthlySummary(monthlyResp) {
     fp.appendChild(container);
   }
 
-  const months = monthlyResp.monthly || [];
-  if (!months.length) { container.innerHTML = ''; return; }
+  const allMonths = monthlyResp.monthly || [];
+  if (!allMonths.length) { container.innerHTML = ''; return; }
   const accounts = collectAccounts(_costPageCache?.dailyData || []);
 
-  let html = '<div class="cost-card-label">Monthly</div>';
+  const years = [...new Set(allMonths.map(m => m.month.slice(0, 4)))].sort();
+  if (!window._costYearFilter || !years.includes(window._costYearFilter)) window._costYearFilter = years[years.length - 1];
+  const months = allMonths.filter(m => m.month.startsWith(window._costYearFilter));
+
+  let html = '<div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">';
+  html += '<div class="cost-card-label" style="margin-bottom:0">Monthly</div>';
+  if (years.length > 1) {
+    html += '<select id="cp-year-filter" style="font-size:10px;background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:3px;padding:1px 4px;cursor:pointer">';
+    for (const y of years) html += `<option value="${y}"${y === window._costYearFilter ? ' selected' : ''}>${y}</option>`;
+    html += '</select>';
+  } else {
+    html += `<span style="font-size:10px;color:var(--dim)">${esc(years[0])}</span>`;
+  }
+  html += '</div>';
   html += '<div style="display:flex;flex-direction:column;gap:4px">';
 
   const f = _costActiveFilter;
@@ -370,7 +383,7 @@ function renderMonthlySummary(monthlyResp) {
     const cost = filteredCost(m, f);
     const pct = Math.min(100, (cost / maxCost) * 100);
     html += `<div style="display:flex;align-items:center;gap:8px;font-size:11px">`;
-    html += `<span style="width:56px;text-align:right;color:var(--text);flex-shrink:0">${m.month}</span>`;
+    html += `<span style="width:36px;text-align:right;color:var(--text);flex-shrink:0">${m.month.slice(5)}</span>`;
     html += `<div style="flex:1;height:14px;background:var(--border);border-radius:3px;overflow:hidden;display:flex">`;
 
     if (f || !m.byAccount || !Object.keys(m.byAccount).length) {
@@ -390,4 +403,6 @@ function renderMonthlySummary(monthlyResp) {
   }
   html += '</div>';
   container.innerHTML = html;
+  const yearSel = document.getElementById('cp-year-filter');
+  if (yearSel) yearSel.onchange = () => { window._costYearFilter = yearSel.value; renderMonthlySummary(monthlyResp); };
 }

--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -1,6 +1,8 @@
 // ── Cost Budget: Client-side ──────────────────────────────────────────
 function esc(s) { return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'); }
 
+let _costActiveFilter = null; // null = All
+let _costPageCache = null;
 
 function showCostPage() {
   switchTab('usage');
@@ -25,11 +27,36 @@ async function loadCostPage() {
     return fallback;
   }
 
-  fetchWithRetry('/_api/costs/current-block', { active: false })
-    .then(blockData => renderAccounts(blockData));
+  const [blockData, dailyData, monthlyResp] = await Promise.all([
+    fetchWithRetry('/_api/costs/current-block', { active: false }),
+    fetchWithRetry('/_api/costs/daily', []),
+    fetchWithRetry('/_api/costs/monthly', { monthly: [], currentMonth: null }),
+  ]);
+
+  _costPageCache = { blockData, dailyData, monthlyResp };
+  renderAccounts(blockData);
+  renderDailyHeatmap(dailyData);
+  renderMonthlySummary(monthlyResp);
 }
 
+// ── Account brand colors ──────────────────────────────────────────────
+const _acctColors = {
+  anthropic: '#e8956a',
+  openai: '#74aa9c',
+};
+function acctColor(accountId) {
+  if (!accountId) return 'var(--dim)';
+  return accountId.startsWith('codex') ? _acctColors.openai : _acctColors.anthropic;
+}
+function acctLabel(accountId) {
+  if (!accountId) return 'Unknown';
+  const [provider, ...rest] = accountId.split('-');
+  const alias = rest.join('-');
+  const name = provider === 'codex' ? 'Codex' : 'Claude';
+  return alias === 'default' ? name : `${name} · ${alias}`;
+}
 
+// ── Accounts card ─────────────────────────────────────────────────────
 function renderAccounts(blockData) {
   const card = document.getElementById('cp-accounts');
   const el = document.getElementById('cp-accounts-content');
@@ -110,4 +137,163 @@ function renderAccountCard(label, win) {
   </div>`;
 }
 
-// Escape handler moved to unified fullscreen-page listener in app.js
+// ── Filter bar ────────────────────────────────────────────────────────
+function collectAccounts(dailyData) {
+  const set = new Set();
+  for (const d of dailyData) {
+    if (d.byAccount) for (const k of Object.keys(d.byAccount)) set.add(k);
+  }
+  return [...set].sort();
+}
+
+function renderFilterBar(container, accounts) {
+  if (!accounts.length) return;
+  let html = '<div id="cp-filter-bar" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:12px;max-width:400px">';
+  html += `<button class="cp-filter-btn${_costActiveFilter === null ? ' active' : ''}" data-filter="" style="font-size:10px;padding:2px 8px;border-radius:10px;border:1px solid var(--border);background:${_costActiveFilter === null ? 'var(--accent)' : 'var(--surface)'};color:${_costActiveFilter === null ? '#000' : 'var(--dim)'};cursor:pointer">All</button>`;
+  for (const id of accounts) {
+    const active = _costActiveFilter === id;
+    const color = acctColor(id);
+    html += `<button class="cp-filter-btn${active ? ' active' : ''}" data-filter="${esc(id)}" style="font-size:10px;padding:2px 8px;border-radius:10px;border:1px solid ${active ? color : 'var(--border)'};background:${active ? color : 'var(--surface)'};color:${active ? '#000' : color};cursor:pointer">${esc(acctLabel(id))}</button>`;
+  }
+  html += '</div>';
+  container.insertAdjacentHTML('afterbegin', html);
+  container.querySelector('#cp-filter-bar').addEventListener('click', e => {
+    const btn = e.target.closest('.cp-filter-btn');
+    if (!btn) return;
+    _costActiveFilter = btn.dataset.filter || null;
+    // ponytail: re-render from cache, don't re-fetch
+    if (_costPageCache) {
+      renderAccounts(_costPageCache.blockData);
+      renderDailyHeatmap(_costPageCache.dailyData);
+      renderMonthlySummary(_costPageCache.monthlyResp);
+    } else {
+      loadCostPage();
+    }
+  });
+}
+
+// ── Daily heatmap ─────────────────────────────────────────────────────
+function renderDailyHeatmap(dailyData) {
+  let container = document.getElementById('cp-daily');
+  if (!container) {
+    const fp = document.querySelector('#cost-page .fp-content');
+    if (!fp) return;
+    container = document.createElement('div');
+    container.id = 'cp-daily';
+    container.className = 'cost-card';
+    fp.appendChild(container);
+  }
+  const accounts = collectAccounts(dailyData);
+
+  // Filter to last 30 days with data (or all if filter active)
+  const recent = dailyData.slice(-30);
+  const maxCost = Math.max(...recent.map(d => {
+    if (_costActiveFilter) return (d.byAccount?.[_costActiveFilter]?.costUSD || 0);
+    return d.costUSD || 0;
+  }), 0.01);
+
+  let html = '<div class="cost-card-label">Daily Cost (last 30 days)</div>';
+  html += '<div style="display:flex;flex-direction:column;gap:2px">';
+
+  for (const day of recent) {
+    const cost = _costActiveFilter
+      ? (day.byAccount?.[_costActiveFilter]?.costUSD || 0)
+      : (day.costUSD || 0);
+    const pct = Math.min(100, (cost / maxCost) * 100);
+    const weekday = new Date(day.date + 'T12:00:00').toLocaleDateString('en', { weekday: 'short' });
+    const isWeekend = weekday === 'Sat' || weekday === 'Sun';
+
+    html += `<div style="display:flex;align-items:center;gap:8px;font-size:10px;height:16px;opacity:${cost === 0 ? 0.3 : 1}">`;
+    html += `<span style="width:56px;text-align:right;color:${isWeekend ? 'var(--dim)' : 'var(--text)'};flex-shrink:0">${day.date.slice(5)} ${weekday}</span>`;
+    html += `<div style="flex:1;height:10px;background:var(--border);border-radius:3px;overflow:hidden;display:flex">`;
+
+    if (_costActiveFilter || !day.byAccount || !Object.keys(day.byAccount).length) {
+      const color = _costActiveFilter ? acctColor(_costActiveFilter) : 'var(--accent)';
+      html += `<div style="height:100%;width:${pct}%;background:${color};border-radius:3px;min-width:${cost > 0 ? 2 : 0}px"></div>`;
+    } else {
+      // Stacked segments by account
+      const sorted = Object.entries(day.byAccount).sort((a, b) => a[0].localeCompare(b[0]));
+      for (const [acctId, acctData] of sorted) {
+        const aPct = Math.max(0, (acctData.costUSD / maxCost) * 100);
+        if (aPct <= 0) continue;
+        html += `<div style="height:100%;width:${aPct}%;background:${acctColor(acctId)};min-width:1px" title="${esc(acctLabel(acctId))}: $${acctData.costUSD.toFixed(2)}"></div>`;
+      }
+    }
+    html += `</div>`;
+    html += `<span style="width:48px;text-align:right;color:var(--dim);flex-shrink:0">$${cost.toFixed(2)}</span>`;
+    html += `</div>`;
+  }
+  html += '</div>';
+
+  // 30-day total
+  const total30 = recent.reduce((s, d) => {
+    return s + (_costActiveFilter ? (d.byAccount?.[_costActiveFilter]?.costUSD || 0) : (d.costUSD || 0));
+  }, 0);
+  const activeDays = recent.filter(d => (_costActiveFilter ? (d.byAccount?.[_costActiveFilter]?.costUSD || 0) : (d.costUSD || 0)) > 0).length;
+  const avgPerDay = activeDays > 0 ? total30 / activeDays : 0;
+  html += `<div style="display:flex;justify-content:space-between;font-size:11px;margin-top:8px;padding-top:8px;border-top:1px solid var(--border)">`;
+  html += `<span style="color:var(--dim)">30-day total: <span style="color:var(--text);font-weight:600">$${total30.toFixed(2)}</span></span>`;
+  html += `<span style="color:var(--dim)">avg $${avgPerDay.toFixed(2)}/active day</span>`;
+  html += `</div>`;
+
+  container.innerHTML = html;
+
+  // Re-render filter bar properly (with event handler)
+  const fp = document.querySelector('#cost-page .fp-content');
+  if (fp) {
+    let existing = document.getElementById('cp-filter-bar');
+    if (existing) existing.remove();
+    if (accounts.length > 0) renderFilterBar(fp, accounts);
+  }
+}
+
+// ── Monthly summary ───────────────────────────────────────────────────
+function renderMonthlySummary(monthlyResp) {
+  let container = document.getElementById('cp-monthly');
+  if (!container) {
+    const fp = document.querySelector('#cost-page .fp-content');
+    if (!fp) return;
+    container = document.createElement('div');
+    container.id = 'cp-monthly';
+    container.className = 'cost-card';
+    fp.appendChild(container);
+  }
+
+  const months = monthlyResp.monthly || [];
+  if (!months.length) { container.innerHTML = ''; return; }
+
+  let html = '<div class="cost-card-label">Monthly</div>';
+  html += '<div style="display:flex;flex-direction:column;gap:4px">';
+
+  const maxCost = Math.max(...months.map(m => {
+    if (_costActiveFilter) return (m.byAccount?.[_costActiveFilter]?.costUSD || 0);
+    return m.costUSD || 0;
+  }), 0.01);
+
+  for (const m of months) {
+    const cost = _costActiveFilter
+      ? (m.byAccount?.[_costActiveFilter]?.costUSD || 0)
+      : (m.costUSD || 0);
+    const pct = Math.min(100, (cost / maxCost) * 100);
+    html += `<div style="display:flex;align-items:center;gap:8px;font-size:11px">`;
+    html += `<span style="width:56px;text-align:right;color:var(--text);flex-shrink:0">${m.month}</span>`;
+    html += `<div style="flex:1;height:14px;background:var(--border);border-radius:3px;overflow:hidden;display:flex">`;
+
+    if (_costActiveFilter || !m.byAccount || !Object.keys(m.byAccount).length) {
+      const color = _costActiveFilter ? acctColor(_costActiveFilter) : 'var(--accent)';
+      html += `<div style="height:100%;width:${pct}%;background:${color};border-radius:3px;min-width:${cost > 0 ? 2 : 0}px"></div>`;
+    } else {
+      const sorted = Object.entries(m.byAccount).sort((a, b) => a[0].localeCompare(b[0]));
+      for (const [acctId, acctData] of sorted) {
+        const aPct = Math.max(0, (acctData.costUSD / maxCost) * 100);
+        if (aPct <= 0) continue;
+        html += `<div style="height:100%;width:${aPct}%;background:${acctColor(acctId)};min-width:1px" title="${esc(acctLabel(acctId))}: $${acctData.costUSD.toFixed(2)}"></div>`;
+      }
+    }
+    html += `</div>`;
+    html += `<span style="width:56px;text-align:right;color:var(--dim);flex-shrink:0">$${cost.toFixed(2)}</span>`;
+    html += `</div>`;
+  }
+  html += '</div>';
+  container.innerHTML = html;
+}

--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -145,6 +145,9 @@ function collectAccounts(dailyData) {
   for (const d of dailyData) {
     if (d.byAccount) for (const k of Object.keys(d.byAccount)) set.add(k);
   }
+  // Include accounts from rate-limit data even if they have no cost history
+  const accts = _costPageCache?.blockData?.accounts;
+  if (accts) for (const a of accts) { if (a.id) set.add(a.id); }
   return [...set].sort();
 }
 

--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -79,7 +79,6 @@ function renderAccounts(blockData) {
   for (let idx = 0; idx < accounts.length; idx++) {
     const acct = accounts[idx];
     const nameStr = acct.label || (acct.provider === 'openai' ? 'Codex' : 'Claude');
-    const planStr = acct.planType ? ` · ${acct.planType}` : '';
     const freshDot = acct.fresh
       ? '<span style="color:var(--green)">●</span> live'
       : '<span style="color:var(--dim)">○</span> cached';
@@ -87,7 +86,7 @@ function renderAccounts(blockData) {
 
     html += `<div style="${sep}">`;
     html += `<div style="display:flex;justify-content:space-between;font-size:11px;margin-bottom:8px">`;
-    html += `<span style="font-weight:600;color:${brandColor(acct)}">${esc(nameStr)}${esc(planStr)}</span>`;
+    html += `<span style="font-weight:600;color:${brandColor(acct)}">${esc(nameStr)}${acct.planType ? ` <span style="font-weight:400;color:var(--dim);font-size:10px">${esc(acct.planType)}</span>` : ''}</span>`;
     html += `<span style="font-size:10px;color:var(--dim)">${freshDot}</span>`;
     html += `</div>`;
 

--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -34,9 +34,9 @@ async function loadCostPage() {
   ]);
 
   _costPageCache = { blockData, dailyData, monthlyResp };
-  renderAccounts(blockData);
   renderDailyHeatmap(dailyData);
   renderMonthlySummary(monthlyResp);
+  renderAccounts(blockData);
 }
 
 // ── Account brand colors ──────────────────────────────────────────────
@@ -112,6 +112,9 @@ function renderAccounts(blockData) {
   }
 
   el.innerHTML = html;
+  // Move accounts card to end of fp-content (after daily/monthly)
+  const fp = card.parentElement;
+  if (fp) fp.appendChild(card);
   const copyBtn = document.getElementById('cp-copy-cmd');
   if (copyBtn) {
     const originalSvg = copyBtn.innerHTML;
@@ -163,9 +166,9 @@ function renderFilterBar(container, accounts) {
     _costActiveFilter = btn.dataset.filter || null;
     // ponytail: re-render from cache, don't re-fetch
     if (_costPageCache) {
-      renderAccounts(_costPageCache.blockData);
       renderDailyHeatmap(_costPageCache.dailyData);
       renderMonthlySummary(_costPageCache.monthlyResp);
+      renderAccounts(_costPageCache.blockData);
     } else {
       loadCostPage();
     }

--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -48,12 +48,15 @@ function acctColor(accountId) {
   if (!accountId) return 'var(--dim)';
   return accountId.startsWith('codex') ? _acctColors.openai : _acctColors.anthropic;
 }
-function acctLabel(accountId) {
+function acctLabel(accountId, allAccounts) {
   if (!accountId) return 'Unknown';
   const [provider, ...rest] = accountId.split('-');
   const alias = rest.join('-');
   const name = provider === 'codex' ? 'Codex' : 'Claude';
-  return alias === 'default' ? name : `${name} · ${alias}`;
+  if (alias !== 'default') return `${name} · ${alias}`;
+  // ponytail: show "default" when other accounts of same provider exist
+  if (allAccounts && allAccounts.some(a => a !== accountId && a.startsWith(provider + '-'))) return `${name} · default`;
+  return name;
 }
 
 // ── Accounts card ─────────────────────────────────────────────────────
@@ -151,14 +154,39 @@ function collectAccounts(dailyData) {
   return [...set].sort();
 }
 
+// ponytail: filter can be null (All), "claude:*" / "codex:*" (provider), or "claude-personal" (account)
+function filterMatchesAccount(filter, acctId) {
+  if (!filter) return true;
+  if (filter.endsWith(':*')) return acctId.startsWith(filter.slice(0, -2) + '-') || acctId === filter.slice(0, -2);
+  return filter === acctId;
+}
+function filteredCost(day, filter) {
+  if (!filter) return day.costUSD || 0;
+  if (!day.byAccount) return 0;
+  if (!filter.endsWith(':*')) return day.byAccount[filter]?.costUSD || 0;
+  let sum = 0;
+  for (const [k, v] of Object.entries(day.byAccount)) { if (filterMatchesAccount(filter, k)) sum += v.costUSD || 0; }
+  return sum;
+}
+
 function renderFilterBar(container, accounts) {
   if (!accounts.length) return;
+  const providers = [...new Set(accounts.map(a => a.split('-')[0]))].sort();
+  const hasMultiProvider = providers.length > 1;
+  const btn = (filter, label, color) => {
+    const active = _costActiveFilter === filter;
+    return `<button class="cp-filter-btn${active ? ' active' : ''}" data-filter="${esc(filter)}" style="font-size:10px;padding:2px 8px;border-radius:10px;border:1px solid ${active ? (color || 'var(--accent)') : 'var(--border)'};background:${active ? (color || 'var(--accent)') : 'var(--surface)'};color:${active ? '#000' : (color || 'var(--dim)')};cursor:pointer">${esc(label)}</button>`;
+  };
   let html = '<div id="cp-filter-bar" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:12px;max-width:400px">';
-  html += `<button class="cp-filter-btn${_costActiveFilter === null ? ' active' : ''}" data-filter="" style="font-size:10px;padding:2px 8px;border-radius:10px;border:1px solid var(--border);background:${_costActiveFilter === null ? 'var(--accent)' : 'var(--surface)'};color:${_costActiveFilter === null ? '#000' : 'var(--dim)'};cursor:pointer">All</button>`;
+  html += btn('', 'All', null);
+  if (hasMultiProvider) {
+    for (const p of providers) {
+      const name = p === 'codex' ? 'Codex' : 'Claude';
+      html += btn(p + ':*', name, acctColor(p + '-x'));
+    }
+  }
   for (const id of accounts) {
-    const active = _costActiveFilter === id;
-    const color = acctColor(id);
-    html += `<button class="cp-filter-btn${active ? ' active' : ''}" data-filter="${esc(id)}" style="font-size:10px;padding:2px 8px;border-radius:10px;border:1px solid ${active ? color : 'var(--border)'};background:${active ? color : 'var(--surface)'};color:${active ? '#000' : color};cursor:pointer">${esc(acctLabel(id))}</button>`;
+    html += btn(id, acctLabel(id, accounts), acctColor(id));
   }
   html += '</div>';
   container.insertAdjacentHTML('afterbegin', html);
@@ -192,18 +220,14 @@ function renderDailyHeatmap(dailyData) {
 
   // Filter to last 30 days with data (or all if filter active)
   const recent = dailyData.slice(-30);
-  const maxCost = Math.max(...recent.map(d => {
-    if (_costActiveFilter) return (d.byAccount?.[_costActiveFilter]?.costUSD || 0);
-    return d.costUSD || 0;
-  }), 0.01);
+  const f = _costActiveFilter;
+  const maxCost = Math.max(...recent.map(d => filteredCost(d, f)), 0.01);
 
   let html = '<div class="cost-card-label">Daily Cost (last 30 days)</div>';
   html += '<div style="display:flex;flex-direction:column;gap:2px">';
 
   for (const day of recent) {
-    const cost = _costActiveFilter
-      ? (day.byAccount?.[_costActiveFilter]?.costUSD || 0)
-      : (day.costUSD || 0);
+    const cost = filteredCost(day, f);
     const pct = Math.min(100, (cost / maxCost) * 100);
     const weekday = new Date(day.date + 'T12:00:00').toLocaleDateString('en', { weekday: 'short' });
     const isWeekend = weekday === 'Sat' || weekday === 'Sun';
@@ -212,16 +236,15 @@ function renderDailyHeatmap(dailyData) {
     html += `<span style="width:56px;text-align:right;color:${isWeekend ? 'var(--dim)' : 'var(--text)'};flex-shrink:0">${day.date.slice(5)} ${weekday}</span>`;
     html += `<div style="flex:1;height:10px;background:var(--border);border-radius:3px;overflow:hidden;display:flex">`;
 
-    if (_costActiveFilter || !day.byAccount || !Object.keys(day.byAccount).length) {
-      const color = _costActiveFilter ? acctColor(_costActiveFilter) : 'var(--accent)';
+    if (f || !day.byAccount || !Object.keys(day.byAccount).length) {
+      const color = f ? acctColor(f.endsWith(':*') ? f.slice(0,-2)+'-x' : f) : 'var(--accent)';
       html += `<div style="height:100%;width:${pct}%;background:${color};border-radius:3px;min-width:${cost > 0 ? 2 : 0}px"></div>`;
     } else {
-      // Stacked segments by account
       const sorted = Object.entries(day.byAccount).sort((a, b) => a[0].localeCompare(b[0]));
       for (const [acctId, acctData] of sorted) {
         const aPct = Math.max(0, (acctData.costUSD / maxCost) * 100);
         if (aPct <= 0) continue;
-        html += `<div style="height:100%;width:${aPct}%;background:${acctColor(acctId)};min-width:1px" title="${esc(acctLabel(acctId))}: $${acctData.costUSD.toFixed(2)}"></div>`;
+        html += `<div style="height:100%;width:${aPct}%;background:${acctColor(acctId)};min-width:1px" title="${esc(acctLabel(acctId, accounts))}: $${acctData.costUSD.toFixed(2)}"></div>`;
       }
     }
     html += `</div>`;
@@ -231,10 +254,8 @@ function renderDailyHeatmap(dailyData) {
   html += '</div>';
 
   // 30-day total
-  const total30 = recent.reduce((s, d) => {
-    return s + (_costActiveFilter ? (d.byAccount?.[_costActiveFilter]?.costUSD || 0) : (d.costUSD || 0));
-  }, 0);
-  const activeDays = recent.filter(d => (_costActiveFilter ? (d.byAccount?.[_costActiveFilter]?.costUSD || 0) : (d.costUSD || 0)) > 0).length;
+  const total30 = recent.reduce((s, d) => s + filteredCost(d, f), 0);
+  const activeDays = recent.filter(d => filteredCost(d, f) > 0).length;
   const avgPerDay = activeDays > 0 ? total30 / activeDays : 0;
   html += `<div style="display:flex;justify-content:space-between;font-size:11px;margin-top:8px;padding-top:8px;border-top:1px solid var(--border)">`;
   html += `<span style="color:var(--dim)">30-day total: <span style="color:var(--text);font-weight:600">$${total30.toFixed(2)}</span></span>`;
@@ -266,33 +287,30 @@ function renderMonthlySummary(monthlyResp) {
 
   const months = monthlyResp.monthly || [];
   if (!months.length) { container.innerHTML = ''; return; }
+  const accounts = collectAccounts(_costPageCache?.dailyData || []);
 
   let html = '<div class="cost-card-label">Monthly</div>';
   html += '<div style="display:flex;flex-direction:column;gap:4px">';
 
-  const maxCost = Math.max(...months.map(m => {
-    if (_costActiveFilter) return (m.byAccount?.[_costActiveFilter]?.costUSD || 0);
-    return m.costUSD || 0;
-  }), 0.01);
+  const f = _costActiveFilter;
+  const maxCost = Math.max(...months.map(m => filteredCost(m, f)), 0.01);
 
   for (const m of months) {
-    const cost = _costActiveFilter
-      ? (m.byAccount?.[_costActiveFilter]?.costUSD || 0)
-      : (m.costUSD || 0);
+    const cost = filteredCost(m, f);
     const pct = Math.min(100, (cost / maxCost) * 100);
     html += `<div style="display:flex;align-items:center;gap:8px;font-size:11px">`;
     html += `<span style="width:56px;text-align:right;color:var(--text);flex-shrink:0">${m.month}</span>`;
     html += `<div style="flex:1;height:14px;background:var(--border);border-radius:3px;overflow:hidden;display:flex">`;
 
-    if (_costActiveFilter || !m.byAccount || !Object.keys(m.byAccount).length) {
-      const color = _costActiveFilter ? acctColor(_costActiveFilter) : 'var(--accent)';
+    if (f || !m.byAccount || !Object.keys(m.byAccount).length) {
+      const color = f ? acctColor(f.endsWith(':*') ? f.slice(0,-2)+'-x' : f) : 'var(--accent)';
       html += `<div style="height:100%;width:${pct}%;background:${color};border-radius:3px;min-width:${cost > 0 ? 2 : 0}px"></div>`;
     } else {
       const sorted = Object.entries(m.byAccount).sort((a, b) => a[0].localeCompare(b[0]));
       for (const [acctId, acctData] of sorted) {
         const aPct = Math.max(0, (acctData.costUSD / maxCost) * 100);
         if (aPct <= 0) continue;
-        html += `<div style="height:100%;width:${aPct}%;background:${acctColor(acctId)};min-width:1px" title="${esc(acctLabel(acctId))}: $${acctData.costUSD.toFixed(2)}"></div>`;
+        html += `<div style="height:100%;width:${aPct}%;background:${acctColor(acctId)};min-width:1px" title="${esc(acctLabel(acctId, accounts))}: $${acctData.costUSD.toFixed(2)}"></div>`;
       }
     }
     html += `</div>`;

--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -169,39 +169,112 @@ function filteredCost(day, filter) {
   return sum;
 }
 
+function _applyFilter(filter) {
+  _costActiveFilter = filter || null;
+  if (_costPageCache) {
+    renderDailyHeatmap(_costPageCache.dailyData);
+    renderMonthlySummary(_costPageCache.monthlyResp);
+    renderAccounts(_costPageCache.blockData);
+  } else {
+    loadCostPage();
+  }
+}
+
+function _providerBtnLabel(provider, filter) {
+  const name = provider === 'codex' ? 'Codex' : 'Claude';
+  if (!filter || !filter.startsWith(provider)) return name;
+  if (filter === provider + ':*') return name;
+  const alias = filter.slice(provider.length + 1);
+  return `${name} · ${alias}`;
+}
+
+function _isProviderActive(provider, filter) {
+  if (!filter) return false;
+  return filter === provider + ':*' || (filter.startsWith(provider + '-'));
+}
+
 function renderFilterBar(container, accounts) {
   if (!accounts.length) return;
   const providers = [...new Set(accounts.map(a => a.split('-')[0]))].sort();
-  const hasMultiProvider = providers.length > 1;
-  const btn = (filter, label, color) => {
-    const active = _costActiveFilter === filter;
-    return `<button class="cp-filter-btn${active ? ' active' : ''}" data-filter="${esc(filter)}" style="font-size:10px;padding:2px 8px;border-radius:10px;border:1px solid ${active ? (color || 'var(--accent)') : 'var(--border)'};background:${active ? (color || 'var(--accent)') : 'var(--surface)'};color:${active ? '#000' : (color || 'var(--dim)')};cursor:pointer">${esc(label)}</button>`;
-  };
-  let html = '<div id="cp-filter-bar" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:12px;max-width:400px">';
-  html += btn('', 'All', null);
-  if (hasMultiProvider) {
-    for (const p of providers) {
-      const name = p === 'codex' ? 'Codex' : 'Claude';
-      html += btn(p + ':*', name, acctColor(p + '-x'));
+  const f = _costActiveFilter;
+  const allActive = !f;
+
+  const btnStyle = (active, color) =>
+    `font-size:10px;padding:2px 8px;border:none;cursor:pointer;background:${active ? (color || 'var(--accent)') : 'var(--surface)'};color:${active ? '#000' : (color || 'var(--dim)')}`;
+  const arrowStyle = (active, color) =>
+    `font-size:10px;padding:2px 4px 2px 0;border:none;cursor:pointer;background:${active ? (color || 'var(--accent)') : 'var(--surface)'};color:${active ? '#000' : (color || 'var(--dim)')}`;
+
+  let html = '<div id="cp-filter-bar" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:12px;max-width:400px;align-items:flex-start">';
+  html += `<button class="cp-filter-btn" data-filter="" style="${btnStyle(allActive, null)};border-radius:10px;border:1px solid ${allActive ? 'var(--accent)' : 'var(--border)'}">All</button>`;
+
+  for (const p of providers) {
+    const color = acctColor(p + '-x');
+    const active = _isProviderActive(p, f);
+    const label = _providerBtnLabel(p, f);
+    const pAccounts = accounts.filter(a => a.startsWith(p + '-'));
+    const borderColor = active ? color : 'var(--border)';
+
+    html += `<span class="cp-provider-group" data-provider="${esc(p)}" style="position:relative;display:inline-flex;border-radius:10px;border:1px solid ${borderColor}">`;
+    html += `<button class="cp-filter-btn cp-provider-btn" data-filter="${esc(p + ':*')}" style="${btnStyle(active, color)};border-radius:10px 0 0 10px;padding-left:8px">${esc(label)}</button>`;
+    html += `<button class="cp-arrow-btn" data-provider="${esc(p)}" style="${arrowStyle(active, color)};border-radius:0 10px 10px 0">▾</button>`;
+
+    html += `<div class="cp-dropdown" data-provider="${esc(p)}" style="display:none;position:absolute;top:calc(100% + 4px);left:0;z-index:100;background:var(--surface);border:1px solid var(--border);border-radius:6px;min-width:140px;padding:4px 0;box-shadow:0 4px 12px rgba(0,0,0,0.3)">`;
+    const providerName = p === 'codex' ? 'Codex' : 'Claude';
+    html += `<div class="cp-dropdown-item" data-filter="${esc(p + ':*')}" style="padding:4px 10px;font-size:10px;cursor:pointer;color:${color}">All ${esc(providerName)}</div>`;
+    for (const id of pAccounts) {
+      const alias = id.slice(p.length + 1);
+      html += `<div class="cp-dropdown-item" data-filter="${esc(id)}" style="padding:4px 10px 4px 18px;font-size:10px;cursor:pointer;color:var(--text)">· ${esc(alias)}</div>`;
     }
-  }
-  for (const id of accounts) {
-    html += btn(id, acctLabel(id, accounts), acctColor(id));
+    html += `</div>`;
+    html += `</span>`;
   }
   html += '</div>';
   container.insertAdjacentHTML('afterbegin', html);
-  container.querySelector('#cp-filter-bar').addEventListener('click', e => {
-    const btn = e.target.closest('.cp-filter-btn');
-    if (!btn) return;
-    _costActiveFilter = btn.dataset.filter || null;
-    // ponytail: re-render from cache, don't re-fetch
-    if (_costPageCache) {
-      renderDailyHeatmap(_costPageCache.dailyData);
-      renderMonthlySummary(_costPageCache.monthlyResp);
-      renderAccounts(_costPageCache.blockData);
-    } else {
-      loadCostPage();
+
+  const bar = container.querySelector('#cp-filter-bar');
+
+  // All button + provider button clicks
+  bar.addEventListener('click', e => {
+    const filterBtn = e.target.closest('.cp-filter-btn:not(.cp-provider-btn)');
+    if (filterBtn && filterBtn.dataset.filter === '') { _applyFilter(null); return; }
+    const provBtn = e.target.closest('.cp-provider-btn');
+    if (provBtn) { _applyFilter(provBtn.dataset.filter); return; }
+    const arrow = e.target.closest('.cp-arrow-btn');
+    if (arrow) {
+      e.stopPropagation();
+      const p = arrow.dataset.provider;
+      const dd = bar.querySelector(`.cp-dropdown[data-provider="${p}"]`);
+      const wasOpen = dd.style.display !== 'none';
+      bar.querySelectorAll('.cp-dropdown').forEach(d => d.style.display = 'none');
+      if (!wasOpen) dd.style.display = '';
+      return;
     }
+    const item = e.target.closest('.cp-dropdown-item');
+    if (item) {
+      bar.querySelectorAll('.cp-dropdown').forEach(d => d.style.display = 'none');
+      _applyFilter(item.dataset.filter);
+      return;
+    }
+  });
+
+  // Close dropdown on outside click
+  const closeHandler = e => {
+    if (!e.target.closest('.cp-provider-group')) {
+      bar.querySelectorAll('.cp-dropdown').forEach(d => d.style.display = 'none');
+    }
+  };
+  document.removeEventListener('click', window._cpDropdownClose);
+  window._cpDropdownClose = closeHandler;
+  document.addEventListener('click', closeHandler);
+
+  // Hover highlight on dropdown items
+  bar.addEventListener('mouseover', e => {
+    const item = e.target.closest('.cp-dropdown-item');
+    if (item) item.style.background = 'var(--surface-hover)';
+  });
+  bar.addEventListener('mouseout', e => {
+    const item = e.target.closest('.cp-dropdown-item');
+    if (item) item.style.background = '';
   });
 }
 

--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -157,7 +157,7 @@ function collectAccounts(dailyData) {
 // ponytail: filter can be null (All), "claude:*" / "codex:*" (provider), or "claude-personal" (account)
 function filterMatchesAccount(filter, acctId) {
   if (!filter) return true;
-  if (filter.endsWith(':*')) return acctId.startsWith(filter.slice(0, -2) + '-') || acctId === filter.slice(0, -2);
+  if (filter.endsWith(':*')) return acctId.startsWith(filter.slice(0, -2) + '-');
   return filter === acctId;
 }
 function filteredCost(day, filter) {
@@ -257,15 +257,15 @@ function renderFilterBar(container, accounts) {
     }
   });
 
-  // Close dropdown on outside click
-  const closeHandler = e => {
-    if (!e.target.closest('.cp-provider-group')) {
-      bar.querySelectorAll('.cp-dropdown').forEach(d => d.style.display = 'none');
-    }
-  };
-  document.removeEventListener('click', window._cpDropdownClose);
-  window._cpDropdownClose = closeHandler;
-  document.addEventListener('click', closeHandler);
+  // Close dropdown on outside click — single handler, no leak
+  if (!window._cpDropdownClose) {
+    window._cpDropdownClose = e => {
+      if (!e.target.closest('.cp-provider-group')) {
+        document.querySelectorAll('#cp-filter-bar .cp-dropdown').forEach(d => d.style.display = 'none');
+      }
+    };
+    document.addEventListener('click', window._cpDropdownClose);
+  }
 
   // Hover highlight on dropdown items
   bar.addEventListener('mouseover', e => {

--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -114,9 +114,6 @@ function renderAccounts(blockData) {
   }
 
   el.innerHTML = html;
-  // Move accounts card to end of fp-content (after daily/monthly)
-  const fp = card.parentElement;
-  if (fp) fp.appendChild(card);
   const copyBtn = document.getElementById('cp-copy-cmd');
   if (copyBtn) {
     const originalSvg = copyBtn.innerHTML;
@@ -204,7 +201,7 @@ function renderFilterBar(container, accounts) {
   const arrowStyle = (active, color) =>
     `font-size:10px;padding:2px 4px 2px 0;border:none;cursor:pointer;background:${active ? (color || 'var(--accent)') : 'var(--surface)'};color:${active ? '#000' : (color || 'var(--dim)')}`;
 
-  let html = '<div id="cp-filter-bar" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:12px;max-width:400px;align-items:flex-start">';
+  let html = '<div id="cp-filter-bar" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:12px;align-items:flex-start">';
   html += `<button class="cp-filter-btn" data-filter="" style="${btnStyle(allActive, null)};border-radius:10px;border:1px solid ${allActive ? 'var(--accent)' : 'var(--border)'}">All</button>`;
 
   for (const p of providers) {
@@ -282,7 +279,7 @@ function renderFilterBar(container, accounts) {
 function renderDailyHeatmap(dailyData) {
   let container = document.getElementById('cp-daily');
   if (!container) {
-    const fp = document.querySelector('#cost-page .fp-content');
+    const fp = document.getElementById('cp-right');
     if (!fp) return;
     container = document.createElement('div');
     container.id = 'cp-daily';
@@ -296,7 +293,8 @@ function renderDailyHeatmap(dailyData) {
   const f = _costActiveFilter;
   const maxCost = Math.max(...recent.map(d => filteredCost(d, f)), 0.01);
 
-  let html = '<div class="cost-card-label">Daily Cost (last 30 days)</div>';
+  const dateRange = recent.length ? `${recent[0].date} – ${recent[recent.length - 1].date}` : '';
+  let html = `<div class="cost-card-label">Daily Cost <span style="text-transform:none;letter-spacing:0">(${esc(dateRange)})</span></div>`;
   html += '<div style="display:flex;flex-direction:column;gap:2px">';
 
   for (const day of recent) {
@@ -331,14 +329,14 @@ function renderDailyHeatmap(dailyData) {
   const activeDays = recent.filter(d => filteredCost(d, f) > 0).length;
   const avgPerDay = activeDays > 0 ? total30 / activeDays : 0;
   html += `<div style="display:flex;justify-content:space-between;font-size:11px;margin-top:8px;padding-top:8px;border-top:1px solid var(--border)">`;
-  html += `<span style="color:var(--dim)">30-day total: <span style="color:var(--text);font-weight:600">$${total30.toFixed(2)}</span></span>`;
+  html += `<span style="color:var(--dim)">Last ${recent.length} days: <span style="color:var(--text);font-weight:600">$${total30.toFixed(2)}</span></span>`;
   html += `<span style="color:var(--dim)">avg $${avgPerDay.toFixed(2)}/active day</span>`;
   html += `</div>`;
 
   container.innerHTML = html;
 
   // Re-render filter bar properly (with event handler)
-  const fp = document.querySelector('#cost-page .fp-content');
+  const fp = document.getElementById('cp-right');
   if (fp) {
     let existing = document.getElementById('cp-filter-bar');
     if (existing) existing.remove();
@@ -350,7 +348,7 @@ function renderDailyHeatmap(dailyData) {
 function renderMonthlySummary(monthlyResp) {
   let container = document.getElementById('cp-monthly');
   if (!container) {
-    const fp = document.querySelector('#cost-page .fp-content');
+    const fp = document.getElementById('cp-right');
     if (!fp) return;
     container = document.createElement('div');
     container.id = 'cp-monthly';

--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -34,8 +34,8 @@ async function loadCostPage() {
   ]);
 
   _costPageCache = { blockData, dailyData, monthlyResp };
-  renderDailyHeatmap(dailyData);
   renderMonthlySummary(monthlyResp);
+  renderDailyHeatmap(dailyData);
   renderAccounts(blockData);
 }
 
@@ -169,8 +169,8 @@ function filteredCost(day, filter) {
 function _applyFilter(filter) {
   _costActiveFilter = filter || null;
   if (_costPageCache) {
-    renderDailyHeatmap(_costPageCache.dailyData);
     renderMonthlySummary(_costPageCache.monthlyResp);
+    renderDailyHeatmap(_costPageCache.dailyData);
     renderAccounts(_costPageCache.blockData);
   } else {
     loadCostPage();

--- a/public/index.html
+++ b/public/index.html
@@ -105,9 +105,14 @@
       <button class="fp-close" onclick="hideCostPage()">&times;</button>
     </div>
     <div class="fp-content">
-      <div id="cp-accounts" class="cost-card" style="display:none">
-        <div class="cost-card-label">Accounts</div>
-        <div id="cp-accounts-content"></div>
+      <div id="cp-layout" style="display:flex;gap:16px;align-items:flex-start">
+        <div id="cp-left" style="flex-shrink:0;width:280px">
+          <div id="cp-accounts" class="cost-card" style="display:none">
+            <div class="cost-card-label">Accounts</div>
+            <div id="cp-accounts-content"></div>
+          </div>
+        </div>
+        <div id="cp-right" style="flex:1;min-width:0"></div>
       </div>
     </div>
   </div>

--- a/public/style.css
+++ b/public/style.css
@@ -546,6 +546,7 @@
 
   /* ── Fullscreen Page: Cost-specific ── */
   .cost-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 14px; max-width: 400px; }
+  .cost-card + .cost-card { margin-top: 12px; }
   .cost-card-label { font-size: 10px; color: var(--dim); margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.05em; }
 
   /* ── Fullscreen Page: Changelog-specific ── */

--- a/server/cost-budget.js
+++ b/server/cost-budget.js
@@ -146,16 +146,22 @@ function groupByDay(entries) {
   const days = {};
   for (const e of entries) {
     const date = new Date(e.timestamp).toLocaleDateString('sv-SE');
-    if (!days[date]) days[date] = { date, totalTokens: 0, costUSD: 0, models: new Set(), sessions: new Set() };
+    if (!days[date]) days[date] = { date, totalTokens: 0, costUSD: 0, models: new Set(), sessions: new Set(), byAccount: {} };
     const d = days[date];
-    d.totalTokens +=
+    const tokens =
       (e.usage.input_tokens || 0) +
       (e.usage.output_tokens || 0) +
       (e.usage.cache_creation_input_tokens || 0) +
       (e.usage.cache_read_input_tokens || 0);
+    d.totalTokens += tokens;
     d.costUSD += e.costUSD || 0;
     if (e.model) d.models.add(e.model);
     if (e.sessionId) d.sessions.add(e.sessionId);
+    if (e.accountId) {
+      const a = d.byAccount[e.accountId] || (d.byAccount[e.accountId] = { totalTokens: 0, costUSD: 0 });
+      a.totalTokens += tokens;
+      a.costUSD += e.costUSD || 0;
+    }
   }
   const result = [];
   const now = new Date();
@@ -163,8 +169,12 @@ function groupByDay(entries) {
     const d = new Date(now);
     d.setDate(d.getDate() - i);
     const dateStr = d.toLocaleDateString('sv-SE');
-    const day = days[dateStr] || { date: dateStr, totalTokens: 0, costUSD: 0, models: new Set(), sessions: new Set() };
-    result.push({ date: day.date, totalTokens: day.totalTokens, costUSD: Math.round(day.costUSD * 100) / 100, models: [...day.models], sessionCount: day.sessions.size });
+    const day = days[dateStr] || { date: dateStr, totalTokens: 0, costUSD: 0, models: new Set(), sessions: new Set(), byAccount: {} };
+    const byAccount = {};
+    for (const [k, v] of Object.entries(day.byAccount)) {
+      byAccount[k] = { totalTokens: v.totalTokens, costUSD: Math.round(v.costUSD * 100) / 100 };
+    }
+    result.push({ date: day.date, totalTokens: day.totalTokens, costUSD: Math.round(day.costUSD * 100) / 100, models: [...day.models], sessionCount: day.sessions.size, byAccount });
   }
   return result;
 }
@@ -174,18 +184,30 @@ function groupByMonth(entries) {
   for (const e of entries) {
     const d = new Date(e.timestamp);
     const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
-    if (!months[key]) months[key] = { month: key, totalTokens: 0, costUSD: 0, models: new Set() };
+    if (!months[key]) months[key] = { month: key, totalTokens: 0, costUSD: 0, models: new Set(), byAccount: {} };
     const m = months[key];
-    m.totalTokens +=
+    const tokens =
       (e.usage.input_tokens || 0) +
       (e.usage.output_tokens || 0) +
       (e.usage.cache_creation_input_tokens || 0) +
       (e.usage.cache_read_input_tokens || 0);
+    m.totalTokens += tokens;
     m.costUSD += e.costUSD || 0;
     if (e.model) m.models.add(e.model);
+    if (e.accountId) {
+      const a = m.byAccount[e.accountId] || (m.byAccount[e.accountId] = { totalTokens: 0, costUSD: 0 });
+      a.totalTokens += tokens;
+      a.costUSD += e.costUSD || 0;
+    }
   }
   return Object.values(months)
-    .map(m => ({ month: m.month, totalTokens: m.totalTokens, costUSD: Math.round(m.costUSD * 100) / 100, models: [...m.models] }))
+    .map(m => {
+      const byAccount = {};
+      for (const [k, v] of Object.entries(m.byAccount)) {
+        byAccount[k] = { totalTokens: v.totalTokens, costUSD: Math.round(v.costUSD * 100) / 100 };
+      }
+      return { month: m.month, totalTokens: m.totalTokens, costUSD: Math.round(m.costUSD * 100) / 100, models: [...m.models], byAccount };
+    })
     .sort((a, b) => a.month.localeCompare(b.month));
 }
 

--- a/server/cost-worker.js
+++ b/server/cost-worker.js
@@ -9,8 +9,6 @@ const readline = require('readline');
 const os = require('os');
 
 function calculateCostSimple(usage, model) {
-  // Simplified cost calc — doesn't need full pricing module
-  // Rates per token (not per million)
   const rates = {
     'claude-sonnet-4-5-20250514': { input: 3e-6, output: 15e-6, cache_read: 0.3e-6, cache_create: 3.75e-6 },
     'claude-opus-4-5-20250514': { input: 15e-6, output: 75e-6, cache_read: 1.5e-6, cache_create: 18.75e-6 },
@@ -21,12 +19,11 @@ function calculateCostSimple(usage, model) {
     'o3': { input: 2e-6, output: 8e-6, cache_read: 0.5e-6, cache_create: 0 },
     'o4-mini': { input: 1.1e-6, output: 4.4e-6, cache_read: 0.55e-6, cache_create: 0 },
   };
-  // Find matching rate by prefix
   let r = null;
   for (const [k, v] of Object.entries(rates)) {
     if (model && model.startsWith(k.split('-202')[0])) { r = v; break; }
   }
-  if (!r) r = { input: 3e-6, output: 15e-6, cache_read: 0.3e-6, cache_create: 3.75e-6 }; // default sonnet
+  if (!r) r = { input: 3e-6, output: 15e-6, cache_read: 0.3e-6, cache_create: 3.75e-6 };
   return (usage.input_tokens || 0) * r.input
     + (usage.output_tokens || 0) * r.output
     + (usage.cache_read_input_tokens || 0) * r.cache_read
@@ -46,7 +43,31 @@ async function collectJsonlFiles(dir, results = []) {
   return results;
 }
 
-function processFile(filePath) {
+// ponytail: shared home discovery for both Claude and Codex
+function discoverHomes(prefix) {
+  const home = os.homedir();
+  const results = [];
+  const inodes = new Set();
+  let items;
+  try { items = fs.readdirSync(home); } catch { return results; }
+  for (const d of items) {
+    if (!d.startsWith(prefix) || d.includes('.bak')) continue;
+    const isNamed = d.startsWith(prefix + '-');
+    if (d !== prefix && !isNamed) continue;
+    const subdir = prefix === '.codex'
+      ? path.join(home, d, 'sessions')
+      : path.join(home, d, 'projects');
+    try {
+      const ino = fs.statSync(subdir).ino;
+      if (inodes.has(ino)) continue;
+      inodes.add(ino);
+      results.push({ dir: subdir, alias: isNamed ? d.slice(prefix.length + 1) : 'default' });
+    } catch {}
+  }
+  return results;
+}
+
+function processFile(filePath, accountId) {
   return new Promise((resolve) => {
     const localEntries = [];
     let rl;
@@ -70,30 +91,69 @@ function processFile(filePath) {
       if (totalTokens === 0) return;
       const costUSD = calculateCostSimple(usage, model);
       const sessionId = path.basename(filePath, '.jsonl');
-      localEntries.push({ timestamp: new Date(timestamp).getTime(), usage, costUSD, model, sessionId, messageId });
+      localEntries.push({ timestamp: new Date(timestamp).getTime(), usage, costUSD, model, sessionId, messageId, accountId });
     });
     rl.on('close', () => resolve(localEntries));
     rl.on('error', () => resolve(localEntries));
   });
 }
 
-async function run() {
-  const homedir = os.homedir();
-  const dirs = [
-    path.join(homedir, '.claude', 'projects'),
-    path.join(homedir, '.config', 'claude', 'projects'),
-  ];
-  const seen = new Set();
-  const entries = [];
+function processCodexFile(filePath, accountId) {
+  return new Promise((resolve) => {
+    const localEntries = [];
+    let rl;
+    try {
+      const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
+      rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    } catch { resolve(localEntries); return; }
 
-  for (const baseDir of dirs) {
-    try { await fs.promises.access(baseDir); } catch { continue; }
-    const jsonlFiles = await collectJsonlFiles(baseDir);
+    let lastModel = 'unknown';
+    const sessionId = path.basename(filePath, '.jsonl');
+
+    rl.on('line', (line) => {
+      let obj;
+      try { obj = JSON.parse(line); } catch { return; }
+      const payload = obj.payload;
+      if (!payload) return;
+
+      if (payload.model) lastModel = payload.model;
+
+      if (payload.type !== 'token_count') return;
+      const tu = payload.info && payload.info.last_token_usage;
+      if (!tu) return;
+
+      const cached = tu.cached_input_tokens || 0;
+      const usage = {
+        input_tokens: Math.max(0, (tu.input_tokens || 0) - cached),
+        output_tokens: (tu.output_tokens || 0) + (tu.reasoning_output_tokens || 0),
+        cache_read_input_tokens: cached,
+        cache_creation_input_tokens: 0,
+      };
+      const totalTokens = usage.input_tokens + usage.output_tokens + usage.cache_read_input_tokens;
+      if (totalTokens === 0) return;
+
+      if (!obj.timestamp) return;
+      const costUSD = calculateCostSimple(usage, lastModel);
+      const tsMs = new Date(obj.timestamp).getTime();
+      const messageId = `${tsMs}::${sessionId}`;
+      localEntries.push({ timestamp: tsMs, usage, costUSD, model: lastModel, sessionId, messageId, accountId });
+    });
+    rl.on('close', () => resolve(localEntries));
+    rl.on('error', () => resolve(localEntries));
+  });
+}
+
+async function scanHomes(homes, processFn, seen, entries) {
+  for (const { dir, alias } of homes) {
+    const provider = processFn === processCodexFile ? 'codex' : 'claude';
+    const accountId = `${provider}-${alias}`;
+    try { await fs.promises.access(dir); } catch { continue; }
+    const jsonlFiles = await collectJsonlFiles(dir);
 
     const BATCH_SIZE = 20;
     for (let i = 0; i < jsonlFiles.length; i += BATCH_SIZE) {
       const batch = jsonlFiles.slice(i, i + BATCH_SIZE);
-      const results = await Promise.all(batch.map(processFile));
+      const results = await Promise.all(batch.map(f => processFn(f, accountId)));
       for (const localEntries of results) {
         for (const e of localEntries) {
           if (e.messageId && seen.has(e.messageId)) continue;
@@ -103,9 +163,27 @@ async function run() {
       }
     }
   }
+}
+
+async function run() {
+  const seen = new Set();
+  const entries = [];
+
+  const claudeHomes = discoverHomes('.claude');
+  // ponytail: XDG path for Linux — discoverHomes only scans $HOME/.claude*
+  const xdgClaude = path.join(os.homedir(), '.config', 'claude', 'projects');
+  try {
+    const ino = fs.statSync(xdgClaude).ino;
+    if (!claudeHomes.some(h => { try { return fs.statSync(h.dir).ino === ino; } catch { return false; } })) {
+      claudeHomes.push({ dir: xdgClaude, alias: 'default' });
+    }
+  } catch {}
+  const codexHomes = discoverHomes('.codex');
+
+  await scanHomes(claudeHomes, processFile, seen, entries);
+  await scanHomes(codexHomes, processCodexFile, seen, entries);
 
   entries.sort((a, b) => a.timestamp - b.timestamp);
-  // Use stdout instead of IPC — process.send() can fail silently with large payloads
   process.stdout.write(JSON.stringify(entries));
 }
 

--- a/server/cost-worker.js
+++ b/server/cost-worker.js
@@ -64,6 +64,7 @@ function discoverHomes(prefix) {
       results.push({ dir: subdir, alias: isNamed ? d.slice(prefix.length + 1) : 'default' });
     } catch {}
   }
+  results._inodes = inodes;
   return results;
 }
 
@@ -173,10 +174,8 @@ async function run() {
   // ponytail: XDG path for Linux — discoverHomes only scans $HOME/.claude*
   const xdgClaude = path.join(os.homedir(), '.config', 'claude', 'projects');
   try {
-    const ino = fs.statSync(xdgClaude).ino;
-    if (!claudeHomes.some(h => { try { return fs.statSync(h.dir).ino === ino; } catch { return false; } })) {
-      claudeHomes.push({ dir: xdgClaude, alias: 'default' });
-    }
+    const xdgIno = fs.statSync(xdgClaude).ino;
+    if (!claudeHomes._inodes.has(xdgIno)) claudeHomes.push({ dir: xdgClaude, alias: 'default' });
   } catch {}
   const codexHomes = discoverHomes('.codex');
 

--- a/server/routes/costs.js
+++ b/server/routes/costs.js
@@ -194,7 +194,7 @@ function handleCostRoutes(clientReq, clientRes) {
     sendLoadingOrData(clientRes, data => {
       const now = new Date();
       const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-      const currentMonthData = data.monthly.find(m => m.month === currentMonth) || { month: currentMonth, totalTokens: 0, costUSD: 0, models: [] };
+      const currentMonthData = data.monthly.find(m => m.month === currentMonth) || { month: currentMonth, totalTokens: 0, costUSD: 0, models: [], byAccount: {} };
       clientRes.writeHead(200, { 'Content-Type': 'application/json' });
       clientRes.end(JSON.stringify({ monthly: data.monthly, currentMonth: currentMonthData }));
     });


### PR DESCRIPTION
## 摘要

掃描所有 `~/.claude*` 和 `~/.codex*` 目錄的 JSONL 花費資料，按帳號分類顯示在 Usage 頁面。支援 provider 層級和個別帳號的篩選，包含 daily heatmap、monthly summary 和 rate-limit 卡片的兩欄 layout。

## Changes

### Server — cost-worker.js
- `discoverHomes(prefix)` scans `$HOME` for `.claude*` / `.codex*` directories with inode dedup
- `processCodexFile()` parses Codex `token_count` events from `~/.codex*/sessions/` JSONL
- XDG path (`~/.config/claude/projects`) preserved for Linux compatibility
- Every entry tagged with `accountId` (e.g. `claude-personal`, `codex-default`)

### Server — cost-budget.js
- `groupByDay` / `groupByMonth` add `byAccount` breakdown alongside totals
- Zero overhead — bucketing happens in the existing aggregation loop

### Server — routes/costs.js
- `currentMonth` fallback includes `byAccount: {}` for shape consistency

### Client — cost-budget-ui.js
- **Provider toggle+dropdown filter**: `[All] [Claude ▾] [Codex ▾]`
  - Click body → provider total; click ▾ → dropdown to pick individual account
  - Selected account shown in button label (e.g. `Claude · personal ▾`)
  - Filter state: `null` (All), `claude:*` (provider), `claude-personal` (account)
  - Re-renders from cache on filter change (no re-fetch)
- **Daily heatmap**: 30-day stacked bars with date range label, per-account color coding
- **Monthly summary**: year filter dropdown, month-only labels
- **Two-column layout**: Accounts (280px left) | Filter → Monthly → Daily (right)
- planType shown as dim suffix, not part of account name

### Data coverage (this machine)
| Account | Entries |
|---------|---------|
| claude-personal | 33,156 |
| claude-default | 99 |
| codex-personal | 2,881 |
| codex-default | 924 |
| codex-work | 48 |

## Test plan
- [x] `npm test` — 879 pass, 0 fail
- [x] Worker output verified: 37k entries across 5 accounts
- [x] Smoke test: `/_api/costs/daily` and `/_api/costs/monthly` return `byAccount`
- [x] Browser verified: All / provider / account filter states, dropdown open/close
- [x] Code review (high effort, 7 angles) — findings fixed

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)