### PR TITLE
fix(#81): RESTORE_DAYS 預設對齊 LOG_RETENTION_DAYS (3→14)

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -186,8 +186,9 @@ function joinUpstreamPath(upstream, requestUrl) {
   return basePath + (urlPath.startsWith('/') ? urlPath : `/${urlPath}`);
 }
 const LOGS_DIR = resolveLogsDir();
-const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || '3', 10);
 const LOG_RETENTION_DAYS = parseInt(process.env.LOG_RETENTION_DAYS || '14', 10);
+// ponytail: aligned with LOG_RETENTION_DAYS so the index is a cache, not a sole record
+const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || String(LOG_RETENTION_DAYS), 10);
 // 0 = only session-start anchor; N>0 = force full snapshot every N delta writes
 const DELTA_SNAPSHOT_N = parseInt(process.env.CCXRAY_DELTA_SNAPSHOT_N || '0', 10);
 const REWRITE_MODEL_PREFIX = process.env.CCXRAY_MODEL_PREFIX || '';


### PR DESCRIPTION
## 摘要

RESTORE_DAYS=3 讓 4-14 天的 entry 在 dashboard 完全不可見，即使 log 檔還在磁碟上。index 在這個窗口是孤本而非快取。預設值改成跟著 LOG_RETENTION_DAYS(14) 走，dashboard 顯示所有還沒被 prune 的 entry。

## Change

One-line default change in `server/config.js`:

```javascript
// Before:
const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || '3', 10);

// After:
const LOG_RETENTION_DAYS = parseInt(process.env.LOG_RETENTION_DAYS || '14', 10);
const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || String(LOG_RETENTION_DAYS), 10);
```

Default now follows `LOG_RETENTION_DAYS` dynamically. Env var override still works independently.

## Impact

- Dashboard shows 14 days of history instead of 3 (matching the prune window)
- Startup time: ~1–2s additional parse time on large indexes (80MB / 300K lines)
- Memory: bounded by MAX_ENTRIES=5000 regardless of RESTORE_DAYS

## Verification

- Worktree diff: old default=3, new default=14
- Full test suite: 892 pass / 0 fail
- Existing tests all use `RESTORE_DAYS=0` or same-day dates — unaffected

## Test plan
- [x] `node -e "require('./server/config').RESTORE_DAYS"` → 14
- [x] `npm test` — 892 pass / 0 fail
- [x] Worktree old-code check: default was 3

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)