### PR TITLE
fix(#84): round quota percentage to prevent floating-point artifacts

### DIFF
--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -126,7 +126,7 @@ function renderAccounts(blockData) {
 
 function renderAccountCard(label, win) {
   if (!win) return '';
-  const leftPct = win.leftPct ?? (100 - win.usedPct);
+  const leftPct = Math.round(win.leftPct ?? (100 - win.usedPct));
   const barColor = leftPct > 30 ? 'var(--green)' : leftPct > 10 ? 'var(--yellow)' : 'var(--red)';
   const resetStr = win.resetLabel ? `Resets in ${esc(win.resetLabel)}` : '';
   return `<div style="flex:1;background:var(--surface);border-radius:6px;padding:10px 12px">


### PR DESCRIPTION
## Summary
- `Math.round()` the quota left-percentage in `renderAccountCard` so `44.99999999999999%` displays as `45%`

Closes #84

## Test plan
- [ ] Open cost dashboard, verify percentages show whole numbers
- [ ] Confirm layout doesn't overflow on any account card