### PR TITLE
fix: show short session id in breadcrumb instead of title

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1994,8 +1994,8 @@ function renderBreadcrumb() {
   if (projName) segments.push({ label: projName, action: () => { selectProject(projName); } });
   if (selectedSessionId) {
     const bcSess = sessionsMap.get(selectedSessionId);
-    const bcLabel = 'session: ' + formatSessionLabel(bcSess, selectedSessionId);
-    segments.push({ label: bcLabel, action: () => { selectSessionAndLatestTurn(selectedSessionId); } });
+    const bcLabel = 'session: ' + formatSessionIdLabel(selectedSessionId);
+    segments.push({ label: bcLabel, title: formatSessionTooltip(bcSess, selectedSessionId), action: () => { selectSessionAndLatestTurn(selectedSessionId); } });
   }
   if (selectedTurnIdx >= 0) {
     const e = allEntries[selectedTurnIdx];
@@ -2023,6 +2023,7 @@ function renderBreadcrumb() {
     const span = document.createElement('span');
     span.className = 'bc-seg';
     span.textContent = seg.label;
+    if (seg.title) span.title = seg.title;
     if (seg.action && i < segments.length - 1) {
       span.onclick = (e) => { e.stopPropagation(); seg.action(); };
     } else {


### PR DESCRIPTION
## Problem

The breadcrumb session segment rendered `formatSessionLabel()`, which returns the session **title** when one exists. A titled session therefore showed `session: 與遠端同步` in the breadcrumb instead of its id.

Session cards have always used the short session id (`formatSessionIdLabel`, `miller-columns.js:1426`) as the primary identifier, with the title as a subtitle — so the breadcrumb was inconsistent with the rest of the UI.

## Fix

- Breadcrumb session segment now uses `formatSessionIdLabel()` → `session: bf258f39`.
- The title is preserved as a hover tooltip via `formatSessionTooltip()` (`title · short id`).

## Verification

- `node --check` passes; helper outputs confirmed.
- Verified in a real browser (standalone read-only instance + browser-harness). Live breadcrumb DOM:
  ```
  session: bf258f39   title="…  · bf258f39"
  ```

Frontend-only change; a dashboard refresh applies it (no server restart needed).