### PR TITLE
feat(#89): System Prompt UX — provider grouping, prompt badge, bidirectional navigation

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -4,8 +4,11 @@ const DEFAULT_MAX_CTX = window.__PROXY_CONFIG__?.DEFAULT_CONTEXT || 200000;
 // ── Active Tab State ─────────────────────────────────────────────────
 let activeTab = 'dashboard';
 
+let _switchTabPush = false; // true → next syncViewParam uses pushState
+
 function switchTab(tab, forceDiff) {
   if (activeTab === tab) return;
+  _switchTabPush = true; // cross-tab = history entry
   activeTab = tab;
 
   // Update tab buttons
@@ -38,6 +41,7 @@ function switchTab(tab, forceDiff) {
 
   // Sync URL
   syncViewParam();
+  _switchTabPush = false;
   if (typeof renderCmdBar === 'function') renderCmdBar();
 }
 
@@ -50,7 +54,9 @@ function syncViewParam() {
     if (activeTab === 'dashboard') params.delete('view');
     else params.set('view', activeTab);
     const qs = params.toString();
-    history.replaceState(null, '', window.location.pathname + (qs ? '?' + qs : ''));
+    const url = window.location.pathname + (qs ? '?' + qs : '');
+    if (_switchTabPush) history.pushState(null, '', url);
+    else history.replaceState(null, '', url);
   }
 }
 
@@ -63,6 +69,17 @@ function restoreTabFromUrl() {
     switchTab(view);
   }
 }
+
+// Back/Forward button restores tab state
+window.addEventListener('popstate', () => {
+  const view = new URLSearchParams(window.location.search).get('view');
+  const target = (view === 'usage' || view === 'sysprompt') ? view : 'dashboard';
+  if (activeTab !== target) {
+    _switchTabPush = false; // popstate should not push again
+    activeTab = ''; // force switchTab to run
+    switchTab(target);
+  }
+});
 
 // ── Theme Toggle ─────────────────────────────────────────────────────
 function toggleTheme() {

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -383,6 +383,8 @@ function addEntry(e) {
     toolsHash: e.toolsHash || null,
     thinkingStripped: e.thinkingStripped || false,
     provider: e.provider || 'anthropic',
+    agent: e.agent || null,
+    cwd: e.cwd || null,
   });
 
   if (isRetry) return;

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -380,6 +380,7 @@ function addEntry(e) {
     toolSources: e.toolSources || null,
     title: e.title || null,
     coreHash: e.coreHash || null,
+    toolsHash: e.toolsHash || null,
     thinkingStripped: e.thinkingStripped || false,
     provider: e.provider || 'anthropic',
   });
@@ -524,11 +525,12 @@ function addEntry(e) {
   if (toolFail) riskMarkers.push('tool-fail');
   if (dupesMax >= 2) riskMarkers.push('dupes\xD7' + dupesMax);
   if (e.thinkingStripped === true) riskMarkers.push('thinking-stripped');
-  if (e.coreHash) {
+  if (e.coreHash || e.toolsHash) {
     for (let i = allEntries.length - 2; i >= 0; i--) {
       const prev = allEntries[i];
       if (prev.sessionId === sid && !prev.isSubagent) {
-        if (prev.coreHash && prev.coreHash !== e.coreHash) riskMarkers.push('sys-changed');
+        if (prev.coreHash && e.coreHash && prev.coreHash !== e.coreHash) riskMarkers.push('sys-changed');
+        if (prev.toolsHash && e.toolsHash && prev.toolsHash !== e.toolsHash) riskMarkers.push('tools-changed');
         break;
       }
     }

--- a/public/messages.js
+++ b/public/messages.js
@@ -1,14 +1,14 @@
 // ── Messages column helpers ──
 const INJECTED_TAG_RE = /^<(system-reminder|user-prompt-submit-hook|context|antml:function_calls)[^>]*>/;
 
-// P1: coreHash → agentLabel map, lazy-fetched from versions API
+// P1: coreHash → {label, key} map, lazy-fetched from versions API
 // ponytail: one fetch, no retry, badge falls back to entry.agent until loaded
 let _hashAgentMap = null;
 function _seedHashAgentMap() {
   if (_hashAgentMap) return;
   _hashAgentMap = {};
   fetch('/_api/sysprompt/versions').then(r => r.json()).then(d => {
-    (d.versions || []).forEach(v => { if (v.coreHash) _hashAgentMap[v.coreHash] = v.agentLabel || v.agentKey; });
+    (d.versions || []).forEach(v => { if (v.coreHash) _hashAgentMap[v.coreHash] = { label: v.agentLabel || v.agentKey, key: v.agentKey }; });
   }).catch(() => {});
 }
 
@@ -588,18 +588,24 @@ function renderPromptBadgeHtml(entry) {
   const provider = entry.provider || 'anthropic';
   const providerClass = provider === 'openai' ? 'provider-openai' : (provider === 'anthropic' ? 'provider-anthropic' : 'provider-unknown');
   const dot = provider === 'openai' ? '◆' : '●';
-  const agent = (_hashAgentMap && _hashAgentMap[entry.coreHash]) || entry.agent || 'Unknown';
+  const mapped = _hashAgentMap && _hashAgentMap[entry.coreHash];
+  const agent = (mapped && mapped.label) || entry.agent || 'Unknown';
+  const agentKey = (mapped && mapped.key) || '';
   const hash = entry.coreHash;
 
   let badge;
   if (hash) {
     const shortHash = hash.slice(0, 5);
+    const dlParams = agentKey ? 'agent=' + encodeURIComponent(agentKey) + '&hash=' + encodeURIComponent(hash) : '';
+    const dlScript = dlParams
+      ? 'var p=new URLSearchParams(location.search);p.set(\"agent\",\"' + escapeHtml(agentKey) + '\");p.set(\"hash\",\"' + escapeHtml(hash) + '\");history.replaceState(null,\"\",\"?\"+p);'
+      : '';
     badge = '<span class="provider-dot ' + providerClass + '">' + dot + '</span> '
       + '<span class="prompt-agent">' + escapeHtml(agent) + '</span> · '
       + '<span class="prompt-ver">' + escapeHtml(shortHash) + '</span>'
-      + ' <a class="prompt-link" onclick="switchTab(\'sysprompt\',true);'
+      + ' <a class="prompt-link" onclick="' + dlScript + 'switchTab(\'sysprompt\',true);'
       + 'setTimeout(()=>openSystemPromptPanel&&openSystemPromptPanel(true),100)"'
-      + ' title="View in System Prompt">→ prompt</a>';
+      + ' title="View in System Prompt">View in System Prompt</a>';
   } else if (entry.isSubagent) {
     badge = '<span class="provider-dot provider-unknown">○</span> '
       + '<span class="prompt-agent">' + escapeHtml(agent) + '</span> (subagent)';

--- a/public/messages.js
+++ b/public/messages.js
@@ -597,8 +597,9 @@ function renderPromptBadgeHtml(entry) {
   if (hash) {
     const shortHash = hash.slice(0, 5);
     const dlParams = agentKey ? 'agent=' + encodeURIComponent(agentKey) + '&hash=' + encodeURIComponent(hash) : '';
+    // ponytail: single quotes inside onclick="" to avoid attribute breakout
     const dlScript = dlParams
-      ? 'var p=new URLSearchParams(location.search);p.set(\"agent\",\"' + escapeHtml(agentKey) + '\");p.set(\"hash\",\"' + escapeHtml(hash) + '\");history.replaceState(null,\"\",\"?\"+p);'
+      ? "var p=new URLSearchParams(location.search);p.set('agent','" + escapeHtml(agentKey) + "');p.set('hash','" + escapeHtml(hash) + "');history.replaceState(null,'','?'+p);"
       : '';
     badge = '<span class="provider-dot ' + providerClass + '">' + dot + '</span> '
       + '<span class="prompt-agent">' + escapeHtml(agent) + '</span> · '

--- a/public/messages.js
+++ b/public/messages.js
@@ -571,6 +571,74 @@ function renderEditedBanner(req, msgIdx) {
     + original + '</div>';
 }
 
+function renderPromptBadgeHtml(entry) {
+  if (!entry) return '';
+  const provider = entry.provider || 'anthropic';
+  const providerClass = provider === 'openai' ? 'provider-openai' : (provider === 'anthropic' ? 'provider-anthropic' : 'provider-unknown');
+  const dot = provider === 'openai' ? '◆' : '●';
+  const agent = entry.agent || 'Unknown';
+  const hash = entry.coreHash;
+
+  let badge;
+  if (hash) {
+    const shortHash = hash.slice(0, 5);
+    badge = '<span class="provider-dot ' + providerClass + '">' + dot + '</span> '
+      + '<span class="prompt-agent">' + escapeHtml(agent) + '</span> · '
+      + '<span class="prompt-ver">' + escapeHtml(shortHash) + '</span>'
+      + ' <a class="prompt-link" onclick="switchTab(\'sysprompt\',true);'
+      + 'setTimeout(()=>openSystemPromptPanel&&openSystemPromptPanel(true),100)"'
+      + ' title="View in System Prompt">→ prompt</a>';
+  } else if (entry.isSubagent) {
+    badge = '<span class="provider-dot provider-unknown">○</span> '
+      + '<span class="prompt-agent">' + escapeHtml(agent) + '</span> (subagent)';
+  } else {
+    return '';
+  }
+
+  // Tools-changed warning: compare with previous non-subagent turn in same session
+  let toolsWarning = '';
+  if (entry.toolsHash && typeof allEntries !== 'undefined') {
+    const myIdx = allEntries.indexOf(entry);
+    if (myIdx > 0) {
+      for (let i = myIdx - 1; i >= 0; i--) {
+        const prev = allEntries[i];
+        if (prev.sessionId === entry.sessionId && !prev.isSubagent) {
+          if (prev.toolsHash && prev.toolsHash !== entry.toolsHash) {
+            toolsWarning = '<div class="tools-warning">⚠ tools changed · cache miss'
+              + ' <a class="tools-compare-toggle" data-a="' + prev.toolsHash + '" data-b="' + entry.toolsHash + '"'
+              + ' onclick="toggleToolsDiff(this)">compare tools</a>'
+              + '<div class="tools-diff" style="display:none"></div></div>';
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  return '<div class="prompt-badge">' + badge + '</div>' + toolsWarning;
+}
+
+function toggleToolsDiff(el) {
+  const diffEl = el.parentElement.querySelector('.tools-diff');
+  if (!diffEl) return;
+  if (diffEl.style.display !== 'none') { diffEl.style.display = 'none'; return; }
+  diffEl.style.display = 'block';
+  if (diffEl.dataset.loaded) return;
+  diffEl.textContent = 'Loading...';
+  const a = el.dataset.a, b = el.dataset.b;
+  fetch('/_api/tools-diff?a=' + a + '&b=' + b).then(r => {
+    if (!r.ok) throw new Error(r.status);
+    return r.json();
+  }).then(data => {
+    diffEl.dataset.loaded = '1';
+    const lines = [];
+    (data.added || []).forEach(n => lines.push('<div class="tools-added">+ ' + escapeHtml(n) + '</div>'));
+    (data.removed || []).forEach(n => lines.push('<div class="tools-removed">- ' + escapeHtml(n) + '</div>'));
+    const summary = '(' + (data.added || []).length + ' added, ' + (data.removed || []).length + ' removed)';
+    diffEl.innerHTML = lines.join('') + '<div class="tools-diff-summary">' + summary + '</div>';
+  }).catch(() => { diffEl.textContent = 'diff unavailable'; diffEl.dataset.loaded = '1'; });
+}
+
 function renderStepDetailHtml(req, tok) {
   if (selectedMessageIdx < 0) return '';
   const selection = typeof getSelectedStepSelection === 'function' ? getSelectedStepSelection() : null;

--- a/public/messages.js
+++ b/public/messages.js
@@ -1,6 +1,17 @@
 // ── Messages column helpers ──
 const INJECTED_TAG_RE = /^<(system-reminder|user-prompt-submit-hook|context|antml:function_calls)[^>]*>/;
 
+// P1: coreHash → agentLabel map, lazy-fetched from versions API
+// ponytail: one fetch, no retry, badge falls back to entry.agent until loaded
+let _hashAgentMap = null;
+function _seedHashAgentMap() {
+  if (_hashAgentMap) return;
+  _hashAgentMap = {};
+  fetch('/_api/sysprompt/versions').then(r => r.json()).then(d => {
+    (d.versions || []).forEach(v => { if (v.coreHash) _hashAgentMap[v.coreHash] = v.agentLabel || v.agentKey; });
+  }).catch(() => {});
+}
+
 // ── Credential highlight ──────────────────────────────────────────────
 const CRED_PATTERNS = [
   /sk-ant-[a-zA-Z0-9_-]{20,}/g,
@@ -573,10 +584,11 @@ function renderEditedBanner(req, msgIdx) {
 
 function renderPromptBadgeHtml(entry) {
   if (!entry) return '';
+  _seedHashAgentMap();
   const provider = entry.provider || 'anthropic';
   const providerClass = provider === 'openai' ? 'provider-openai' : (provider === 'anthropic' ? 'provider-anthropic' : 'provider-unknown');
   const dot = provider === 'openai' ? '◆' : '●';
-  const agent = entry.agent || 'Unknown';
+  const agent = (_hashAgentMap && _hashAgentMap[entry.coreHash]) || entry.agent || 'Unknown';
   const hash = entry.coreHash;
 
   let badge;

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2053,7 +2053,11 @@ function syncUrlFromState() {
   writeTargetToUrlParams(targetFromCurrentSelection(), params);
   const qs = params.toString();
   const newUrl = qs ? '?' + qs : location.pathname;
-  history.replaceState(null, '', newUrl);
+  if (typeof _switchTabPush !== 'undefined' && _switchTabPush) {
+    history.pushState(null, '', newUrl);
+  } else {
+    history.replaceState(null, '', newUrl);
+  }
 }
 
 function formatCurrentStepBreadcrumb() {

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2603,7 +2603,9 @@ function renderDetailCol() {
       currentSteps.forEach(s => { if (s.type === 'tool-group') s.calls.forEach(c => { toolFreq[c.name] = (toolFreq[c.name] || 0) + 1; }); });
       const totalSteps = currentSteps.filter(s => s.type === 'tool-group').length;
       const errorCount = currentSteps.filter(s => s.type === 'tool-group' && s.calls.some(c => c.isError)).length;
-      const summaryHtml = '<div style="padding:4px 8px 6px;border-bottom:1px solid var(--border);font-size:11px;color:var(--dim)">'
+      const focusedBadge = (typeof renderPromptBadgeHtml === 'function') ? renderPromptBadgeHtml(e) : '';
+      const summaryHtml = focusedBadge
+        + '<div style="padding:4px 8px 6px;border-bottom:1px solid var(--border);font-size:11px;color:var(--dim)">'
         + totalSteps + ' steps · ' + (totalSteps - errorCount) + '✓'
         + (errorCount ? ' <span style="color:var(--red)">' + errorCount + '✗</span>' : '')
         + '</div>';

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2569,7 +2569,9 @@ function renderDetailCol() {
         currentSteps.forEach(s => { if (s.type === 'tool-group') s.calls.forEach(c => { toolFreqPreview[c.name] = (toolFreqPreview[c.name] || 0) + 1; }); });
         const totalPreview = currentSteps.filter(s => s.type === 'tool-group').length;
         const errorPreview = currentSteps.filter(s => s.type === 'tool-group' && s.calls.some(c => c.isError)).length;
-        const summaryPreview = '<div style="padding:4px 8px 6px;border-bottom:1px solid var(--border);font-size:11px;color:var(--dim)">'
+        const promptBadge = (typeof renderPromptBadgeHtml === 'function') ? renderPromptBadgeHtml(e) : '';
+        const summaryPreview = promptBadge
+          + '<div style="padding:4px 8px 6px;border-bottom:1px solid var(--border);font-size:11px;color:var(--dim)">'
           + totalPreview + ' steps · ' + (totalPreview - errorPreview) + '✓'
           + (errorPreview ? ' <span style="color:var(--red)">' + errorPreview + '✗</span>' : '')
           + '</div>';

--- a/public/style.css
+++ b/public/style.css
@@ -629,3 +629,30 @@
   .edit-summary-line { font-size: 11px; color: var(--dim); white-space: pre-wrap; word-break: break-word; }
   .edit-original { margin-top: 6px; }
   .edit-original summary { cursor: pointer; font-size: 11px; color: var(--yellow); }
+
+/* ── Prompt badge (#89) ── */
+.prompt-badge { padding: 4px 10px; font-size: 11px; color: var(--dim); border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 4px; }
+.prompt-badge-sub { opacity: 0.5; }
+.provider-dot { font-size: 10px; }
+.provider-anthropic { color: #a855f7; }
+.provider-openai { color: #22c55e; }
+.provider-unknown { color: #6b7280; }
+.prompt-link { color: var(--accent); text-decoration: none; cursor: pointer; margin-left: 6px; font-size: 10px; }
+.prompt-link:hover { text-decoration: underline; }
+.tools-warning { padding: 4px 10px; font-size: 11px; color: #f59e0b; background: rgba(245,158,11,0.08); border-bottom: 1px solid var(--border); }
+.tools-compare-toggle { color: var(--accent); cursor: pointer; text-decoration: none; margin-left: 8px; font-size: 10px; }
+.tools-compare-toggle:hover { text-decoration: underline; }
+.tools-diff { padding: 4px 10px; font-family: monospace; font-size: 11px; }
+.tools-added { color: #22c55e; }
+.tools-removed { color: #f87171; }
+.tools-diff-summary { color: var(--dim); margin-top: 2px; }
+/* ── Agent group headers (#89) ── */
+.agent-group-header { padding: 6px 10px 2px; font-size: 10px; color: var(--dim); text-transform: uppercase; letter-spacing: 0.08em; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: var(--surface); z-index: 1; }
+.version-sessions { font-size: 10px; color: var(--dim); cursor: pointer; padding: 0 10px 4px; }
+.version-sessions:hover { color: var(--fg); }
+.session-list { padding: 0 10px 4px 20px; font-size: 10px; font-family: monospace; }
+.session-list a { color: var(--accent); text-decoration: none; display: block; padding: 1px 0; }
+.session-list a:hover { text-decoration: underline; }
+.sysprompt-breadcrumb { padding: 6px 12px; font-size: 11px; border-bottom: 1px solid var(--border); background: var(--surface); }
+.sysprompt-breadcrumb a { color: var(--accent); text-decoration: none; cursor: pointer; }
+.sysprompt-breadcrumb a:hover { text-decoration: underline; }

--- a/public/system-prompt-ui.js
+++ b/public/system-prompt-ui.js
@@ -115,6 +115,10 @@ async function openSystemPromptPanel(forceDiff) {
   const data = await fetch('/_api/sysprompt/versions').then(r => r.json());
   spAllVersions = data.versions || [];
   spAgents = buildAgentList(spAllVersions, data.agents);
+  // Keep badge agent map in sync
+  if (typeof _hashAgentMap !== 'undefined') {
+    (data.versions || []).forEach(v => { if (v.coreHash) _hashAgentMap[v.coreHash] = v.agentLabel || v.agentKey; });
+  }
 
   if (!spAgents.length) {
     if (panel) panel.innerHTML = '<div style="color:var(--dim);font-size:11px">No versions found.</div>';

--- a/public/system-prompt-ui.js
+++ b/public/system-prompt-ui.js
@@ -26,19 +26,23 @@ function buildAgentList(allVersions, apiAgents) {
   const agentMap = {};
   for (const v of allVersions) {
     const k = v.agentKey;
-    if (!agentMap[k]) agentMap[k] = { key: k, label: v.agentLabel || k, count: 0, latestCoreHash: '', uniqueHashes: new Set() };
+    if (!agentMap[k]) agentMap[k] = { key: k, label: v.agentLabel || k, count: 0, latestCoreHash: '', uniqueHashes: new Set(), provider: v.provider || 'anthropic' };
     agentMap[k].count++;
     if (v.coreHash) agentMap[k].uniqueHashes.add(v.coreHash);
     if (!agentMap[k].latestCoreHash) agentMap[k].latestCoreHash = v.coreHash || '';
   }
-  // Also include agents from API that may have 0 versions in current data
   for (const a of (apiAgents || [])) {
-    if (!agentMap[a.key]) agentMap[a.key] = { key: a.key, label: a.label, count: 0, latestCoreHash: '', uniqueHashes: new Set() };
+    if (!agentMap[a.key]) agentMap[a.key] = { key: a.key, label: a.label, count: 0, latestCoreHash: '', uniqueHashes: new Set(), provider: a.provider || 'anthropic' };
+    else if (a.provider) agentMap[a.key].provider = a.provider;
   }
   const agents = Object.values(agentMap);
+  // ponytail: sort by provider group (anthropic first), then version count desc, then alpha
+  const providerOrder = { anthropic: 0, openai: 1 };
   agents.sort((a, b) => {
-    const ia = AGENT_ORDER.indexOf(a.key), ib = AGENT_ORDER.indexOf(b.key);
-    return (ia === -1 ? 999 : ia) - (ib === -1 ? 999 : ib);
+    const pa = providerOrder[a.provider] ?? 2, pb = providerOrder[b.provider] ?? 2;
+    if (pa !== pb) return pa - pb;
+    if (b.count !== a.count) return b.count - a.count;
+    return a.key.localeCompare(b.key);
   });
   return agents;
 }
@@ -47,10 +51,20 @@ function renderAgentList() {
   const container = document.getElementById('sp-agent-list');
   if (!container) return;
   let html = '<div class="sp-version-list-title">Agents</div>';
+  const providerLabels = { anthropic: 'Claude Code', openai: 'Codex' };
+  const providerDots = { anthropic: '<span class="provider-dot provider-anthropic">●</span>', openai: '<span class="provider-dot provider-openai">◆</span>' };
+  let lastProvider = null;
   for (const a of spAgents) {
+    const p = a.provider || 'anthropic';
+    if (p !== lastProvider) {
+      const groupLabel = providerLabels[p] || 'Other';
+      html += '<div class="agent-group-header">── ' + escapeHtml(groupLabel) + ' ──</div>';
+      lastProvider = p;
+    }
     const isActive = a.key === spSelectedAgent;
     html += '<div class="sp-agent-item' + (isActive ? ' active' : '') + '" onclick="selectAgent(\'' + a.key + '\')">';
-    html += '<div class="sp-agent-label">' + escapeHtml(a.label) + '</div>';
+    const dot = providerDots[p] || '<span class="provider-dot provider-unknown">○</span>';
+    html += '<div class="sp-agent-label">' + dot + ' ' + escapeHtml(a.label) + '</div>';
     const changes = a.uniqueHashes ? a.uniqueHashes.size : 0;
     const changesStr = changes > 1 ? ' · ' + changes + ' changes' : '';
     html += '<div class="sp-agent-meta">' + a.count + ' ver' + (a.count !== 1 ? 's' : '') + changesStr + '</div>';
@@ -107,8 +121,14 @@ async function openSystemPromptPanel(forceDiff) {
     return;
   }
 
-  // Select first agent (or keep current if still valid)
-  if (!spSelectedAgent || !spAgents.find(a => a.key === spSelectedAgent)) {
+  // URL deep-link: ?agent=X&hash=Y from Dashboard prompt badge
+  const urlParams = new URLSearchParams(window.location.search);
+  const deepAgent = urlParams.get('agent');
+  const deepHash = urlParams.get('hash');
+
+  if (deepAgent && spAgents.find(a => a.key === deepAgent)) {
+    spSelectedAgent = deepAgent;
+  } else if (!spSelectedAgent || !spAgents.find(a => a.key === spSelectedAgent)) {
     spSelectedAgent = spAgents[0].key;
   }
   spVersions = spAllVersions.filter(v => v.agentKey === spSelectedAgent);
@@ -117,7 +137,13 @@ async function openSystemPromptPanel(forceDiff) {
   if (latest) localStorage.setItem('sysprompt_last_seen', latest);
   if (badge) badge.style.display = 'none';
 
-  spSelectedIdx = 0;
+  // Deep-link to specific version by coreHash
+  let deepIdx = 0;
+  if (deepHash) {
+    const found = spVersions.findIndex(v => v.coreHash === deepHash);
+    if (found >= 0) deepIdx = found;
+  }
+  spSelectedIdx = deepIdx;
   spMode = hasBadge ? 'diff' : 'content';
   spFocusedCol = 'agents';
   renderAgentList();
@@ -176,6 +202,9 @@ function renderVersionList() {
     html += `<span class="sp-size-col" style="text-align:right">${size}</span>`;
     html += `<span class="sp-delta-col" style="min-width:38px;text-align:right">${delta}</span>`;
     html += '</div>';
+    if (v.sessionCount > 0) {
+      html += `<div class="version-sessions" data-hash="${v.coreHash}" onclick="toggleVersionSessions(this, '${v.coreHash}')">${v.sessionCount} session${v.sessionCount > 1 ? 's' : ''} ▸</div>`;
+    }
   }
   container.innerHTML = html;
   container.classList.toggle('focused', spFocusedCol === 'versions');
@@ -470,3 +499,35 @@ document.addEventListener('keydown', (e) => {
     prevHunk();
   }
 });
+
+function toggleVersionSessions(el, coreHash) {
+  const existing = el.nextElementSibling;
+  if (existing && existing.classList.contains('session-list')) {
+    existing.remove();
+    el.textContent = el.textContent.replace('▾', '▸');
+    return;
+  }
+  el.textContent = el.textContent.replace('▸', '▾');
+  // Build session list from client-side allEntries
+  const sessions = {};
+  if (typeof allEntries !== 'undefined') {
+    for (const e of allEntries) {
+      if (e.coreHash === coreHash && e.sessionId) {
+        if (!sessions[e.sessionId]) sessions[e.sessionId] = { count: 0, cwd: e.cwd || '', ts: e.ts || '' };
+        sessions[e.sessionId].count++;
+      }
+    }
+  }
+  const entries = Object.entries(sessions);
+  if (!entries.length) return;
+  const listEl = document.createElement('div');
+  listEl.className = 'session-list';
+  for (const [sid, info] of entries) {
+    const project = (info.cwd || '').split('/').pop() || '?';
+    const a = document.createElement('a');
+    a.textContent = '├ ' + project + ' / ' + info.ts + '  ' + info.count + ' turns';
+    a.onclick = () => { if (typeof switchTab === 'function') switchTab('dashboard'); };
+    listEl.appendChild(a);
+  }
+  el.after(listEl);
+}

--- a/public/system-prompt-ui.js
+++ b/public/system-prompt-ui.js
@@ -117,7 +117,7 @@ async function openSystemPromptPanel(forceDiff) {
   spAgents = buildAgentList(spAllVersions, data.agents);
   // Keep badge agent map in sync
   if (typeof _hashAgentMap !== 'undefined') {
-    (data.versions || []).forEach(v => { if (v.coreHash) _hashAgentMap[v.coreHash] = v.agentLabel || v.agentKey; });
+    (data.versions || []).forEach(v => { if (v.coreHash) _hashAgentMap[v.coreHash] = { label: v.agentLabel || v.agentKey, key: v.agentKey }; });
   }
 
   if (!spAgents.length) {

--- a/server/restore.js
+++ b/server/restore.js
@@ -282,7 +282,7 @@ async function buildVersionIndex() {
           store.versionIndex.set(idxKey, {
             reqId: null, sharedFile: filename, b2Len: b2.length, coreLen, coreHash,
             firstSeen,
-            agentKey, agentLabel, version: ver,
+            agentKey, agentLabel, version: ver, provider: isOpenAI ? 'openai' : 'anthropic',
           });
         } else {
           if (ver > existing.version) existing.version = ver;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -70,12 +70,52 @@ function handleApiRoutes(clientReq, clientRes) {
     const urlParams = new URLSearchParams(clientReq.url.split('?')[1] || '');
     const filterAgent = urlParams.get('agent') || null;
     const allAgents = [...new Set([...store.versionIndex.values()].map(v => v.agentKey))].sort();
+    const sessionsByHash = {};
+    for (const e of store.entries) {
+      if (!e.coreHash || !e.sessionId) continue;
+      if (!sessionsByHash[e.coreHash]) sessionsByHash[e.coreHash] = new Set();
+      sessionsByHash[e.coreHash].add(e.sessionId);
+    }
     const vEntries = [...store.versionIndex.values()]
       .filter(v => !filterAgent || v.agentKey === filterAgent)
       .sort((a, b) => (b.firstSeen || '').localeCompare(a.firstSeen || '') || b.version.localeCompare(a.version));
-    const versions = vEntries.map(({ version, reqId, b2Len, coreLen, coreHash, firstSeen, agentKey, agentLabel }) => ({ version, reqId, b2Len, coreLen, coreHash, firstSeen, agentKey, agentLabel }));
+    const versions = vEntries.map(({ version, reqId, b2Len, coreLen, coreHash, firstSeen, agentKey, agentLabel, provider }) => ({
+      version, reqId, b2Len, coreLen, coreHash, firstSeen, agentKey, agentLabel,
+      provider: provider || 'anthropic',
+      sessionCount: sessionsByHash[coreHash] ? sessionsByHash[coreHash].size : 0,
+    }));
+    const agentInfo = allAgents.map(k => {
+      const entry = store.versionIndex.get([...store.versionIndex.keys()].find(ik => ik.startsWith(k + '::')));
+      return { key: k, label: entry?.agentLabel || k, provider: entry?.provider || 'anthropic' };
+    });
     clientRes.writeHead(200, { 'Content-Type': 'application/json' });
-    clientRes.end(JSON.stringify({ versions, agents: allAgents.map(k => ({ key: k, label: store.versionIndex.get([...store.versionIndex.keys()].find(ik => ik.startsWith(k + '::')))?.agentLabel || k })) }));
+    clientRes.end(JSON.stringify({ versions, agents: agentInfo }));
+    return true;
+  }
+
+  if (clientReq.url.startsWith('/_api/tools-diff')) {
+    const params = new URLSearchParams(clientReq.url.split('?')[1] || '');
+    const hashA = params.get('a'), hashB = params.get('b');
+    if (!hashA || !hashB) {
+      clientRes.writeHead(400, { 'Content-Type': 'application/json' });
+      clientRes.end(JSON.stringify({ error: 'missing a or b param' }));
+      return true;
+    }
+    const readTools = async (h) => {
+      for (const prefix of ['tools_', 'openai_tools_']) {
+        try { return JSON.parse(await config.storage.readShared(`${prefix}${h}.json`)); } catch {}
+      }
+      return null;
+    };
+    const extractNames = (tools) => (tools || []).map(t => t.name || t.function?.name).filter(Boolean);
+    Promise.all([readTools(hashA), readTools(hashB)]).then(([a, b]) => {
+      if (!a && !b) { clientRes.writeHead(404, { 'Content-Type': 'application/json' }); clientRes.end(JSON.stringify({ error: 'shared files not found' })); return; }
+      const namesA = new Set(extractNames(a)), namesB = new Set(extractNames(b));
+      const added = [...namesB].filter(n => !namesA.has(n));
+      const removed = [...namesA].filter(n => !namesB.has(n));
+      clientRes.writeHead(200, { 'Content-Type': 'application/json' });
+      clientRes.end(JSON.stringify({ added, removed }));
+    }).catch(() => { clientRes.writeHead(500, { 'Content-Type': 'application/json' }); clientRes.end(JSON.stringify({ error: 'internal error' })); });
     return true;
   }
 

--- a/server/sse-broadcast.js
+++ b/server/sse-broadcast.js
@@ -34,6 +34,7 @@ function summarizeEntry(entry) {
     toolFail: entry.toolFail || false,
     hasCredential: entry.hasCredential || undefined,
     coreHash: entry.coreHash || null,
+    toolsHash: entry.toolsHash || null,
     thinkingStripped: entry.thinkingStripped || false,
     tokens: tok ? {
       system: tok.system, tools: tok.tools, messages: tok.messages, total: tok.total,

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -94,9 +94,9 @@ function registerPromptVersion(ctx) {
       const sharedFile = sysHash ? `sys_${sysHash}.json` : null;
       store.versionIndex.set(idxKey, {
         reqId: null, sharedFile, b2Len: b2.length, coreLen: coreText.length,
-        coreHash, firstSeen: now, agentKey, agentLabel, version: liveVer,
+        coreHash, firstSeen: now, agentKey, agentLabel, version: liveVer, provider: 'anthropic',
       });
-      const vData = JSON.stringify({ _type: 'version_detected', version: liveVer, b2Len: b2.length, agentKey, agentLabel });
+      const vData = JSON.stringify({ _type: 'version_detected', version: liveVer, b2Len: b2.length, agentKey, agentLabel, provider: 'anthropic' });
       for (const res of store.sseClients) res.write(`data: ${vData}\n\n`);
     }
   }

--- a/server/wire-parsers/openai.js
+++ b/server/wire-parsers/openai.js
@@ -197,9 +197,9 @@ function registerPromptVersion(ctx) {
   store.versionIndex.set(idxKey, {
     reqId: null, sharedFile: sf, b2Len: promptText.length,
     coreLen: promptText.length, coreHash, firstSeen: now,
-    agentKey, agentLabel, version: coreHash,
+    agentKey, agentLabel, version: coreHash, provider: 'openai',
   });
-  const vData = JSON.stringify({ _type: 'version_detected', version: coreHash, b2Len: promptText.length, agentKey, agentLabel });
+  const vData = JSON.stringify({ _type: 'version_detected', version: coreHash, b2Len: promptText.length, agentKey, agentLabel, provider: 'openai' });
   for (const res of store.sseClients) res.write(`data: ${vData}\n\n`);
   return { coreHash, agentKey, agentLabel };
 }

--- a/test/sysprompt-ux.test.js
+++ b/test/sysprompt-ux.test.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+// ── Server: summarizeEntry includes toolsHash ──────────────────────────
+
+describe('sysprompt-ux #89', () => {
+
+  describe('summarizeEntry includes toolsHash', () => {
+    const { summarizeEntry } = require('../server/sse-broadcast');
+
+    it('passes through toolsHash when present', () => {
+      const entry = {
+        id: 'th-1', sessionId: 's1', provider: 'anthropic',
+        toolsHash: 'abc123def456',
+        usage: { input_tokens: 1 }, isSubagent: false,
+      };
+      const summary = summarizeEntry(entry);
+      assert.equal(summary.toolsHash, 'abc123def456');
+    });
+
+    it('defaults toolsHash to null when absent', () => {
+      const entry = {
+        id: 'th-2', sessionId: 's2', provider: 'anthropic',
+        usage: { input_tokens: 1 }, isSubagent: false,
+      };
+      const summary = summarizeEntry(entry);
+      assert.equal(summary.toolsHash, null);
+    });
+  });
+
+  // ── Server: versionIndex includes provider ──────────────────────────
+
+  describe('versionIndex provider field', () => {
+    const store = require('../server/store');
+
+    beforeEach(() => {
+      store.versionIndex.clear();
+    });
+
+    it('anthropic registerPromptVersion sets provider to anthropic', () => {
+      const { registerPromptVersion } = require('../server/wire-parsers/anthropic');
+      // Build a ctx that passes the filters in registerPromptVersion:
+      // needs parsedBody.system with >= 3 blocks, b2 >= 500 chars, cc_version in b0
+      const b0 = 'cc_version=2.1.177.test; session_id=test-sess';
+      const b1 = 'identity block';
+      const b2 = 'A'.repeat(600); // >= 500 chars
+      const ctx = {
+        parsedBody: { system: [{ text: b0 }, { text: b1 }, { text: b2 }] },
+        sysHash: 'fakesyshash1',
+      };
+      registerPromptVersion(ctx);
+
+      const entries = [...store.versionIndex.values()];
+      assert.ok(entries.length > 0, 'should have created a version entry');
+      assert.equal(entries[0].provider, 'anthropic');
+    });
+
+    it('openai registerPromptVersion sets provider to openai', () => {
+      const { registerPromptVersion } = require('../server/wire-parsers/openai');
+      const ctx = {
+        parsedBody: { instructions: 'You are a helpful assistant. '.repeat(30) },
+        sysHash: 'fakesyshash2',
+      };
+      registerPromptVersion(ctx);
+
+      const entries = [...store.versionIndex.values()];
+      assert.ok(entries.length > 0, 'should have created a version entry');
+      assert.equal(entries[0].provider, 'openai');
+    });
+  });
+
+  // ── Server: /_api/sysprompt/versions includes provider + sessionCount ──
+
+  describe('/_api/sysprompt/versions response', () => {
+    const store = require('../server/store');
+
+    beforeEach(() => {
+      store.versionIndex.clear();
+      store.entries.length = 0;
+    });
+
+    it('versions include provider and sessionCount', async () => {
+      // Seed versionIndex
+      store.versionIndex.set('orchestrator::hash1', {
+        reqId: null, sharedFile: null, b2Len: 1000, coreLen: 800,
+        coreHash: 'hash1', firstSeen: '2026-06-19', agentKey: 'orchestrator',
+        agentLabel: 'Orchestrator', version: '2.1.177.test', provider: 'anthropic',
+      });
+
+      // Seed entries with matching coreHash
+      store.entries.push(
+        { id: 'e1', sessionId: 'sess-a', coreHash: 'hash1' },
+        { id: 'e2', sessionId: 'sess-a', coreHash: 'hash1' },
+        { id: 'e3', sessionId: 'sess-b', coreHash: 'hash1' },
+      );
+
+      // Simulate API call
+      const { handleApiRoutes } = require('../server/routes/api');
+      const result = await new Promise((resolve) => {
+        const clientReq = { url: '/_api/sysprompt/versions', method: 'GET' };
+        const chunks = [];
+        const clientRes = {
+          writeHead: () => {},
+          end: (data) => { resolve(JSON.parse(data)); },
+        };
+        handleApiRoutes(clientReq, clientRes);
+      });
+
+      assert.ok(result.versions.length > 0);
+      const v = result.versions[0];
+      assert.equal(v.provider, 'anthropic');
+      assert.equal(v.sessionCount, 2, 'should count 2 unique sessions');
+
+      assert.ok(result.agents.length > 0);
+      assert.equal(result.agents[0].provider, 'anthropic');
+    });
+  });
+
+  // ── Server: /_api/tools-diff endpoint ──────────────────────────────
+
+  describe('/_api/tools-diff', () => {
+    it('returns 400 when params missing', async () => {
+      const { handleApiRoutes } = require('../server/routes/api');
+      const result = await new Promise((resolve) => {
+        const clientReq = { url: '/_api/tools-diff', method: 'GET' };
+        let statusCode;
+        const clientRes = {
+          writeHead: (code) => { statusCode = code; },
+          end: (data) => { resolve({ statusCode, body: JSON.parse(data) }); },
+        };
+        handleApiRoutes(clientReq, clientRes);
+      });
+      assert.equal(result.statusCode, 400);
+    });
+  });
+
+  // ── Server: version_detected SSE event includes provider ─────────
+
+  describe('version_detected SSE event includes provider', () => {
+    const store = require('../server/store');
+
+    beforeEach(() => {
+      store.versionIndex.clear();
+      // Drain any existing SSE clients
+      store.sseClients.length = 0;
+    });
+
+    it('anthropic version_detected includes provider', () => {
+      const { registerPromptVersion } = require('../server/wire-parsers/anthropic');
+
+      let captured = null;
+      const fakeRes = {
+        write: (chunk) => { captured = chunk; },
+      };
+      store.sseClients.push(fakeRes);
+
+      const b0 = 'cc_version=2.1.999.sse; session_id=sse-test';
+      const b2 = 'B'.repeat(600);
+      const ctx = {
+        parsedBody: { system: [{ text: b0 }, { text: 'id' }, { text: b2 }] },
+        sysHash: 'ssehash1',
+      };
+      registerPromptVersion(ctx);
+
+      store.sseClients.length = 0;
+
+      assert.ok(captured, 'should have broadcast version_detected');
+      const match = captured.match(/^data: (.+)\n\n$/);
+      assert.ok(match, 'should be SSE format');
+      const data = JSON.parse(match[1]);
+      assert.equal(data._type, 'version_detected');
+      assert.equal(data.provider, 'anthropic');
+    });
+  });
+});


### PR DESCRIPTION
## 摘要

System Prompt 頁面重新設計 + Dashboard↔System Prompt 的完整雙向導航鏈。
Badge 顯示真正的 agent type（Orchestrator/Explorer），點擊可 deep-link 到對應版本，Back 鍵能正確回來。

## Changes

### Server (4 files)
- **versionIndex**: stores `provider`, `agentKey`, `agentLabel` per prompt version
- **summarizeEntry**: includes `toolsHash` for tools-changed detection
- **`/_api/sysprompt/versions`**: returns `sessionCount`, `provider`, `agents[]` with provider info
- **`/_api/tools-diff`**: new endpoint — given two toolsHash values, returns added/removed tool names

### Dashboard (4 files)
- **Prompt badge** in timeline: shows `● Orchestrator · 63cc1 View in System Prompt`
  - Provider dot (● anthropic / ◆ openai) conveys provider visually
  - Agent label resolved from `coreHash→agentLabel` lazy-fetched map (not `entry.agent`)
  - "View in System Prompt" link sets `?agent=X&hash=Y` URL params for deep-link
- **Tools-changed warning**: compares `toolsHash` with previous main turn in same session; fetches diff on expand
- **`allEntries`**: now stores `agent`, `cwd` fields (fixes "Unknown" badge and "?" project name)
- **Focused mode**: prompt badge now renders in both non-focused and focused (split-pane) timeline

### System Prompt tab (1 file)
- **Provider grouping**: agents grouped by provider (Claude Code / Codex) with provider icons
- **Session count**: each version shows how many sessions used it
- **Deep-link resolution**: reads `?agent=X&hash=Y` from URL to auto-select agent and version
- **`_hashAgentMap` sync**: updates the badge's agent map when versions are fetched

### Navigation (2 files)
- **pushState**: cross-tab navigation (Dashboard↔Usage↔System Prompt) creates history entries
- **popstate listener**: Back/Forward buttons restore the correct tab
- Tab-internal navigation stays `replaceState` (avoids per-turn history pollution)

## Deliberate simplifications

1. **Agent map lazy fetch**: `_hashAgentMap` is seeded on first `renderPromptBadgeHtml` call. First frame may briefly show `entry.agent` ("claude") before the map loads; subsequent SSE re-renders show the correct label. No prefetch needed — the flash is imperceptible.

2. **pushState only on cross-tab**: Tab-internal turn/section selection uses `replaceState`. This matches Chrome DevTools / VS Code / Grafana behavior — Back should return to the previous view, not step through 47 turns.

3. **Inline onclick for deep-link**: The badge onclick sets two URL params + calls `switchTab`. This is the terminal state — no additional params or conditional branches are expected. Event delegation would add 15 lines of glue for zero behavioral gain.

## Test plan

- [x] TDD tests 7/7 pass (`test/sysprompt-ux.test.js`)
- [x] Full suite 900/0 (flaky OpenAI WS tests excluded)
- [x] Smoke test with real data (`CCXRAY_HOME=~/.ccxray --port 5615`)
- [x] Browser e2e: badge shows "Orchestrator", deep-link navigates correctly, Back button works
- [x] Verified onclick attribute uses single quotes (no HTML breakout)

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)