### PR TITLE
docs(#97): ADR for toolCalls vs skillCalls index contract

### DIFF
--- a/docs/decisions/0001-toolcalls-vs-skillcalls.md
+++ b/docs/decisions/0001-toolcalls-vs-skillcalls.md
@@ -1,0 +1,99 @@
+# 0001 — Keep `toolCalls` and `skillCalls` as separate index fields
+
+- Status: Accepted
+- Date: 2026-06-21
+- Related: #90 / PR #94 (`ccxray usage`), #97
+
+## Context
+
+Each log entry carries a summarized `toolCalls` index — a plain `{toolName: count}`
+map produced by `helpers.js:extractToolCalls` and persisted via `entry.js`. The
+dashboard reads it directly in several places:
+
+- `public/miller-columns.js` — `tc['Skill']` to decide whether a turn triggered a skill
+- `public/entry-rendering.js` — tool chips
+- tool-utilization counting
+
+So `toolCalls` is a **shared contract**, not a private detail.
+
+`ccxray usage` later needed *per-skill* granularity (which skill, how many
+invocations, how many sessions loaded it). An early PR #94 revision met that need
+by expanding `Skill` tool calls into `Skill:<name>` keys *inside* `extractToolCalls`.
+That polluted the shared map: every dashboard consumer suddenly saw keys like
+`Skill:superpowers:brainstorming` instead of `Skill`, and `tc['Skill']` stopped
+matching — a chain of dashboard breakage from one extraction change.
+
+## Decision
+
+Keep the two concerns in two fields:
+
+- `toolCalls` stays a plain `{toolName: count}` map. `Skill` and `Workflow` are
+  **not** expanded — the key remains the bare tool name.
+- A separate `skillCalls` `{skillName: count}` index field, produced by
+  `helpers.js:extractSkillCalls`, holds the per-skill breakdown. Only `ccxray usage`
+  reads it.
+
+`extractSkillCalls` counts only the model-initiated `Skill` tool_use, keyed by its
+`input.skill`. `Workflow` is excluded because it has no `skill` input.
+
+```
+              messages[].content[]  (tool_use blocks)
+                        │
+        ┌───────────────┴────────────────┐
+        ▼                                 ▼
+ extractToolCalls(msgs)           extractSkillCalls(msgs)
+ {Skill:3, Bash:1}                {"superpowers:brainstorming":2}
+        │                                 │
+        ▼                                 ▼
+   toolCalls  (index)               skillCalls  (index)
+        │                                 │
+   ┌────┴───────────┐                     │
+   ▼                ▼                      ▼
+ dashboard      ccxray usage         ccxray usage
+ tc['Skill'],   "Tools" section      "Skills" section
+ chips, util.   (aggregate)          (per-skill invocations/loads)
+```
+
+## Consequences
+
+- The dashboard needs **zero changes** to gain per-skill stats — it never reads
+  `skillCalls`.
+- Entries written before `skillCalls` existed have no such field. `usage.js`
+  degrades them to a single `(pre-tracking)` bucket (`invocations` from the legacy
+  `toolCalls.Skill` count, `loads: null`) rather than dropping them.
+- A small, deliberate denormalization: `toolCalls.Skill` equals the sum of
+  `skillCalls` values for the same entry. This redundancy is inherent to keeping
+  two indexes and is accepted.
+
+## Rejected alternative
+
+Expand `Skill:<name>` into `toolCalls` and teach every consumer to collapse it back
+to `Skill`. Rejected: it spreads contract knowledge across every reader, and the
+"collapse" step is exactly what broke the dashboard in the first place. A pollution
+of the shared map is strictly worse than a second, purpose-built field.
+
+**Do not merge the two fields back into one** to "save a field." The separation is
+the fix, not an oversight.
+
+## Provider scope: why `skillCalls` is Anthropic-only
+
+This is structural, not a missing feature. The Codex (OpenAI Responses) protocol
+has no concept of a skill *call*.
+
+`extractSkillCalls` relies on Claude Code's first-class `Skill` tool:
+
+```json
+{ "type": "tool_use", "name": "Skill", "input": { "skill": "<name>" } }
+```
+
+That is a discrete, countable, attributable event. Codex has no equivalent.
+Evidence from `test/fixtures/codex-sessions/*.jsonl`: the only `function_call`
+names are `exec_command` and `write_stdin` — no `Skill` tool. Codex advertises
+skills as **prompt instructions** (a `<skills_instructions>` block listing each
+`SKILL.md`), and follows them inline. There is nothing in the wire format to
+attribute to "skill X was invoked" — even a `cat SKILL.md` would surface as a
+generic `exec_command` (Bash).
+
+If Codex per-skill stats are ever wanted, they need a *different, lossy* mechanism
+(parse `<skills_instructions>` for the available set, then heuristically detect
+usage) — out of scope for the `skillCalls` field.

--- a/docs/normalization-map.md
+++ b/docs/normalization-map.md
@@ -147,6 +147,8 @@ Both providers share the same function. It branches on `body.messages` (Anthropi
 
 `helpers.js:extractSkillCalls(messages)` — companion that counts only the model-initiated `Skill` tool, keyed by the invoked skill name (e.g. `{ "superpowers:brainstorming": 2 }`). Persisted as the separate `skillCalls` index field and read by `ccxray usage` for per-skill stats. (`Workflow` has no `skill` input, so it is excluded.)
 
+Why two fields instead of one: see [ADR 0001 — toolCalls vs skillCalls](decisions/0001-toolcalls-vs-skillcalls.md). Short version: `toolCalls` is a dashboard contract, so per-skill detail lives in a separate index — don't merge them back.
+
 ### OpenAI
 
 `helpers.js:extractOpenAIToolCalls(responseEventsOrOutput)` — scans:


### PR DESCRIPTION
## What

Adds `docs/decisions/0001-toolcalls-vs-skillcalls.md` — a lightweight ADR recording why `toolCalls` and `skillCalls` are kept as **two separate index fields**, and cross-links it from `docs/normalization-map.md` §5.

## Why

`toolCalls` (`{toolName: count}`) is a shared dashboard contract (`tc['Skill']`, tool chips, tool-utilization). An early PR #94 revision expanded `Skill:<name>` keys *into* `toolCalls`, polluting that contract and breaking dashboard consumers. The fix added a separate `skillCalls` field. That decision lived only in a commit message — this ADR captures it so a future "merge the two fields" change doesn't repeat the regression.

Also documents why `skillCalls` is **structurally Anthropic-only**: the Codex (OpenAI Responses) protocol has no skill-*call* concept (skills are prompt instructions, not tool calls).

## Verification

All references checked against the worktree code, not just the issue text:
- `extractToolCalls` / `extractSkillCalls` — `server/helpers.js:717,735`
- `skillCalls` persisted — `server/entry.js`, `server/wire-parsers/anthropic.js:56`
- dashboard `tc['Skill']` — `public/miller-columns.js:2336,2341`
- legacy `(pre-tracking)` degrade — `server/usage.js:310`

Docs-only change; no code touched (no type-checker/tests apply).

Closes #97