### PR TITLE
fix: swimlane turn hit-test covers the full bar span (#126)

### DIFF
--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -751,7 +751,9 @@ function _wfNearestTurn(lane, mx) {
   for (var i = 0; i < lane.turns.length; i++) {
     var s = _wfBarSpan(lane.turns[i]);
     var d = mx < s.x0 ? s.x0 - mx : (mx > s.x1 ? mx - s.x1 : 0);
-    if (d < bestD) { bestD = d; best = i; }
+    // <= : on overlap (d=0 for several bars) prefer the later turn, matching
+    // SVG paint order — later bars draw on top, so pick what the user sees
+    if (d <= bestD) { bestD = d; best = i; }
   }
   return { idx: best, dist: bestD };
 }

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -126,12 +126,16 @@ function wfLaneCostMedian(lane) {
   return lane._costMedian;
 }
 
-// Shared x-position for a turn's bar (matches xFn in _wfRenderSvgContent)
-function _wfBarX(t) {
+// Shared bar span for a turn (matches the tx/tw math in wfRenderLaneSvg)
+function _wfBarSpan(t) {
   var W = colTurns.clientWidth || 600;
   var chartW = W - WF_LABEL_W - 12;
   var tRange = wfState.viewT1 - wfState.viewT0 || 1;
-  return Math.max(WF_LABEL_W, WF_LABEL_W + ((Number(t.receivedAt) - wfState.viewT0) / tRange) * chartW);
+  var ts = Number(t.receivedAt) || 0;
+  var tend = ts + (parseFloat(t.elapsed) || 0) * 1000;
+  var x0 = Math.max(WF_LABEL_W, WF_LABEL_W + ((ts - wfState.viewT0) / tRange) * chartW);
+  var x1 = Math.max(x0 + WF_MIN_TURN_PX, WF_LABEL_W + ((tend - wfState.viewT0) / tRange) * chartW);
+  return { x0: x0, x1: x1 };
 }
 
 // ── Lane Inference ────────────────────────────────────────────────────────
@@ -739,10 +743,14 @@ function _wfLaneIdxAtY(svgEl, my) {
   return -1;
 }
 
+// #126: bars span x0..x1 (width ∝ duration) — distance is 0 inside the bar,
+// else distance to the nearer edge. Start-x-only distance made clicks/hovers
+// inside long bars (>40px from the left edge) read as empty space.
 function _wfNearestTurn(lane, mx) {
   var best = -1, bestD = Infinity;
   for (var i = 0; i < lane.turns.length; i++) {
-    var d = Math.abs(_wfBarX(lane.turns[i]) - mx);
+    var s = _wfBarSpan(lane.turns[i]);
+    var d = mx < s.x0 ? s.x0 - mx : (mx > s.x1 ? mx - s.x1 : 0);
     if (d < bestD) { bestD = d; best = i; }
   }
   return { idx: best, dist: bestD };

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -282,6 +282,26 @@ describe('workflow-timeline data layer', () => {
     assert.ok(Math.abs(near.dist - 3) < 0.01);
   });
 
+  it('_wfNearestTurn prefers the later turn on overlap (SVG paint order)', () => {
+    const ctx = loadWfModule();
+    // t2 starts while t1 is still running — spans overlap; later bar draws on top
+    ctx.allEntries = [
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 100, {}),
+      mkEntry('t2', 's1', 'claude-opus-4-6', 51000, 100, {}),
+    ];
+    ctx.wfState = ctx.wfBuildState('s1');
+    ctx.wfState.viewT0 = ctx.wfState.tMin;
+    ctx.wfState.viewT1 = ctx.wfState.tMax;
+    const lane = ctx.wfState.lanes[0];
+    const s1 = ctx._wfBarSpan(lane.turns[0]);
+    const s2 = ctx._wfBarSpan(lane.turns[1]);
+    const overlapMid = (s2.x0 + s1.x1) / 2;
+    assert.ok(overlapMid > s2.x0 && overlapMid < s1.x1, 'test setup: spans must overlap');
+    const near = ctx._wfNearestTurn(lane, overlapMid);
+    assert.equal(near.idx, 1);
+    assert.equal(near.dist, 0);
+  });
+
   it('lanes sorted by first turn receivedAt', () => {
     const ctx = loadWfModule();
     var entries = [

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -249,6 +249,39 @@ describe('workflow-timeline data layer', () => {
     assert.equal(ctx.wfOverviewBarGeom(28, 1).laneStep, 9);
   });
 
+  it('_wfNearestTurn hit-tests the full bar span, not just the start x (#126)', () => {
+    const ctx = loadWfModule();
+    // long turn (100s) followed by a short one, full session in view
+    ctx.allEntries = [
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 100, {}),
+      mkEntry('t2', 's1', 'claude-opus-4-6', 201000, 1, {}),
+    ];
+    ctx.wfState = ctx.wfBuildState('s1');
+    ctx.wfState.viewT0 = ctx.wfState.tMin;
+    ctx.wfState.viewT1 = ctx.wfState.tMax;
+    const lane = ctx.wfState.lanes[0];
+    const s1 = ctx._wfBarSpan(lane.turns[0]);
+    const s2 = ctx._wfBarSpan(lane.turns[1]);
+
+    // deep inside the long bar, >40px from its left edge — the old start-x
+    // distance rejected this as empty space (dist would be ~mid-bar width)
+    const mid = (s1.x0 + s1.x1) / 2;
+    assert.ok(mid - s1.x0 > 40, `test setup: bar must be wide (${s1.x1 - s1.x0}px)`);
+    let near = ctx._wfNearestTurn(lane, mid);
+    assert.equal(near.idx, 0);
+    assert.equal(near.dist, 0);
+
+    // just past the long bar's right edge → small edge distance, still turn 0
+    near = ctx._wfNearestTurn(lane, s1.x1 + 5);
+    assert.equal(near.idx, 0);
+    assert.ok(Math.abs(near.dist - 5) < 0.01);
+
+    // near the short bar's start → turn 1
+    near = ctx._wfNearestTurn(lane, s2.x0 - 3);
+    assert.equal(near.idx, 1);
+    assert.ok(Math.abs(near.dist - 3) < 0.01);
+  });
+
   it('lanes sorted by first turn receivedAt', () => {
     const ctx = loadWfModule();
     var entries = [


### PR DESCRIPTION
## 繁體中文摘要

修 #126(PR #125 codex 二審 R4 發現、確認為 #124 既有):swimlane 的 turn hit-test 只量「游標到 turn 起點」的距離,但 v8 turn bar 寬度 ∝ duration——點在長 bar 中段、距左緣 >40px 的位置會被當成空白(清除/選 lane 而非鎖 turn),hover spotlight 也可能對到隔壁 turn。

修法:`_wfBarX` 一般化為 `_wfBarSpan(t)`(x0..x1,與 `wfRenderLaneSvg` 的 tx/tw 同一套 clamp + min-width 公式);距離在 span 內為 0,否則取到較近邊緣的距離。40px lock 門檻與空白區行為不變。

## Hit-test

```
bar:      [x0 ██████████████████ x1]      (width ∝ duration)
                    ↑ click here, 84px from x0
old: dist = |x0 - mx| = 84  > 40  → treated as empty space, no lock
new: mx ∈ [x0, x1]  → dist = 0          → locks the turn
```

## Verification

- Unit: `_wfNearestTurn` span cases (inside long bar / past right edge / near next bar start) in `test/workflow-timeline.test.js`; 16/16 pass, full suite 981 pass (1 fail = known #119, unrelated)
- Browser smoke (isolated `CCXRAY_HOME`, session `157c0faa`, zoomed so the 254s turn spans 169px): mid-bar click 84px from the left edge locks the turn (previously missed); hover maps to the bar under cursor; empty-space click (>60px from every bar) still doesn't lock

Closes #126
