### PR TITLE
fix(test): defuse codex-adapter fixture mtime time bomb

### DIFF
--- a/test/codex-adapter.test.js
+++ b/test/codex-adapter.test.js
@@ -24,14 +24,19 @@ describe('codex-adapter', () => {
   });
 
   it('extracts rate_limits from real fixture and writes unified snapshot', () => {
-    const sessionsDir = path.join(__dirname, 'fixtures/codex-sessions');
     // #119: the adapter drops files older than CODEX_SCAN_MAX_AGE_MS (7 days),
-    // and fixture mtime is the checkout date — touch so old working trees pass.
-    const now = new Date();
-    for (const f of fs.readdirSync(sessionsDir).filter(f => f.endsWith('.jsonl'))) {
-      fs.utimesSync(path.join(sessionsDir, f), now, now);
+    // and fixture mtime is the checkout date — copy to a temp dir so the
+    // copies get a fresh mtime and the repo checkout stays untouched.
+    const fixturesDir = path.join(__dirname, 'fixtures/codex-sessions');
+    const sessionsDir = makeTmpDir();
+    try {
+      for (const f of fs.readdirSync(fixturesDir).filter(f => f.endsWith('.jsonl'))) {
+        fs.copyFileSync(path.join(fixturesDir, f), path.join(sessionsDir, f));
+      }
+      refreshCodex(sessionsDir, outDir);
+    } finally {
+      fs.rmSync(sessionsDir, { recursive: true, force: true });
     }
-    refreshCodex(sessionsDir, outDir);
 
     const files = fs.readdirSync(outDir).filter(f => f.endsWith('.json'));
     assert.equal(files.length, 1);

--- a/test/codex-adapter.test.js
+++ b/test/codex-adapter.test.js
@@ -25,6 +25,12 @@ describe('codex-adapter', () => {
 
   it('extracts rate_limits from real fixture and writes unified snapshot', () => {
     const sessionsDir = path.join(__dirname, 'fixtures/codex-sessions');
+    // #119: the adapter drops files older than CODEX_SCAN_MAX_AGE_MS (7 days),
+    // and fixture mtime is the checkout date — touch so old working trees pass.
+    const now = new Date();
+    for (const f of fs.readdirSync(sessionsDir).filter(f => f.endsWith('.jsonl'))) {
+      fs.utimesSync(path.join(sessionsDir, f), now, now);
+    }
     refreshCodex(sessionsDir, outDir);
 
     const files = fs.readdirSync(outDir).filter(f => f.endsWith('.json'));

--- a/test/codex-adapter.test.js
+++ b/test/codex-adapter.test.js
@@ -25,13 +25,17 @@ describe('codex-adapter', () => {
 
   it('extracts rate_limits from real fixture and writes unified snapshot', () => {
     // #119: the adapter drops files older than CODEX_SCAN_MAX_AGE_MS (7 days),
-    // and fixture mtime is the checkout date — copy to a temp dir so the
-    // copies get a fresh mtime and the repo checkout stays untouched.
+    // and fixture mtime is the checkout date — copy to a temp dir and touch
+    // the copies (copy can preserve source mtime on Windows); the repo
+    // checkout stays untouched.
     const fixturesDir = path.join(__dirname, 'fixtures/codex-sessions');
     const sessionsDir = makeTmpDir();
+    const now = new Date();
     try {
       for (const f of fs.readdirSync(fixturesDir).filter(f => f.endsWith('.jsonl'))) {
-        fs.copyFileSync(path.join(fixturesDir, f), path.join(sessionsDir, f));
+        const dest = path.join(sessionsDir, f);
+        fs.copyFileSync(path.join(fixturesDir, f), dest);
+        fs.utimesSync(dest, now, now);
       }
       refreshCodex(sessionsDir, outDir);
     } finally {


### PR DESCRIPTION
Closes #119

## 問題

`codex-adapter.test.js` 的 rate_limits 測試直接讀 repo 內真實 fixture，而 `refreshCodex` 會依 `CODEX_SCAN_MAX_AGE_MS`（7 天）按 mtime 過濾 session 檔。fixture mtime = checkout 時間，所以：

- 新 clone / CI：永遠綠
- 超過 7 天的 working tree：確定性 fail（expected 1, got 0）

不是 flaky，是 time bomb（#119 root cause 分析）。

## 修法

採 #119 建議選項 (1)：測試開頭 `fs.utimesSync` 把 fixture touch 到 now，讓 adapter 的 mtime 過濾不會吃掉它們。不動 adapter 本體。

## 驗證

- 把 worktree fixture mtime 倒退 20 天重現炸彈條件 → 測試 7/7 pass
- `CCXRAY_HOME=$(mktemp -d) npm test` → 983/983 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
