### PR TITLE
fix: per-conversation subagent lanes + cross-project attribution guards

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -382,6 +382,7 @@ function addEntry(e) {
     coreHash: e.coreHash || null,
     agentKey: e.agentKey || null,
     agentLabel: e.agentLabel || null,
+    convId: e.convId || null,
     toolsHash: e.toolsHash || null,
     thinkingStripped: e.thinkingStripped || false,
     provider: e.provider || 'anthropic',

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -144,8 +144,15 @@ function _wfBarSpan(t) {
 var WF_MAIN_AGENT_KEYS = { 'orchestrator': 1, 'sdk-agent': 1, 'default': 1 };
 
 function _wfPushToSubLane(laneMap, key, entry) {
-  if (!laneMap.has(key)) laneMap.set(key, { name: key, turns: [], model: entry.model, ctxWindow: entry.maxContext || 0, spawnParent: null, agentKey: entry.agentKey || null, agentLabel: entry.agentLabel || null });
+  if (!laneMap.has(key)) laneMap.set(key, { name: key, turns: [], model: entry.model, ctxWindow: entry.maxContext || 0, spawnParent: null, agentKey: entry.agentKey || null, agentLabel: entry.agentLabel || null, convId: entry.convId || null });
   laneMap.get(key).turns.push(entry);
+}
+
+// Sub-lane key: one lane per conversation. convId (hash of messages[0], set by
+// the server) separates N parallel instances of the same agent type (#117);
+// without it, same-key entries collapse into one shared lane (legacy data).
+function _wfSubLaneKey(base, entry) {
+  return entry.convId ? base + ':' + entry.convId : base;
 }
 
 function wfInferLanes(entries, childEntries) {
@@ -164,13 +171,13 @@ function wfInferLanes(entries, childEntries) {
       // Agent-identity classification (server-detected, authoritative):
       // main-agent keys → main lane regardless of model or isSubagent flag
       if (!WF_MAIN_AGENT_KEYS[e.agentKey]) {
-        _wfPushToSubLane(laneMap, 'agent-' + e.agentKey, e);
+        _wfPushToSubLane(laneMap, _wfSubLaneKey('agent-' + e.agentKey, e), e);
         sub = true;
       }
     } else {
       // Fallback heuristics for entries without agent identity (old data,
       // requests without a system prompt)
-      var subKey = 'subagent-' + wfShortModel(e.model);
+      var subKey = _wfSubLaneKey('subagent-' + wfShortModel(e.model), e);
       if (e.isSubagent || (mainLane.model && e.model !== mainLane.model)) {
         _wfPushToSubLane(laneMap, subKey, e);
         sub = true;
@@ -305,16 +312,16 @@ function wfAddEntry(entry) {
   var needsSub, key;
   if (entry.agentKey) {
     needsSub = !WF_MAIN_AGENT_KEYS[entry.agentKey];
-    key = 'agent-' + entry.agentKey;
+    key = _wfSubLaneKey('agent-' + entry.agentKey, entry);
   } else {
     var mainModel = wfState.lanes[0]?.model;
     needsSub = entry.isSubagent || (mainModel && entry.model !== mainModel);
-    key = 'subagent-' + wfShortModel(entry.model);
+    key = _wfSubLaneKey('subagent-' + wfShortModel(entry.model), entry);
   }
   if (needsSub) {
     var lane = wfState.lanes.find(function(l) { return l.name === key; });
     if (!lane) {
-      lane = { name: key, turns: [], model: entry.model, ctxWindow: entry.maxContext || 0, spawnParent: null, agentKey: entry.agentKey || null, agentLabel: entry.agentLabel || null };
+      lane = { name: key, turns: [], model: entry.model, ctxWindow: entry.maxContext || 0, spawnParent: null, agentKey: entry.agentKey || null, agentLabel: entry.agentLabel || null, convId: entry.convId || null };
       wfState.lanes.push(lane);
     }
     lane.turns.push(entry);
@@ -395,7 +402,7 @@ function wfRenderLaneSvg(lane, laneIdx, W, xFn) {
   var ctxK = Math.round((lane.ctxWindow || 0) / 1000);
   var dispName = lane.childSessionId
     ? (lane.agentLabel || wfShortModel(lane.model)) + ' ' + lane.childSessionId.slice(0, 8)
-    : (laneIdx === 0 ? lane.name : (lane.agentLabel || lane.name));
+    : (laneIdx === 0 ? lane.name : (lane.agentLabel || lane.name) + (lane.convId ? ' ' + lane.convId.slice(0, 4) : ''));
   var fullTitle = wfEsc(lane.name + ' · ' + (lane.agentLabel || '?') + ' · ' + (lane.model || '?') + ' · ' + ctxK + 'K');
   svg += '<text x="8" y="12" fill="var(--text)" style="font-size:11px;font-family:' + WF_MONO + '"><title>' + fullTitle + '</title>' + wfEsc(prefix + dispName) + '</text>';
   svg += '<text x="8" y="26" fill="var(--dim)" style="font-size:10px;font-family:' + WF_MONO + '">' + wfEsc(wfShortModel(lane.model) + ' · ' + ctxK + 'K') + '</text>';

--- a/scripts/audit-attribution.mjs
+++ b/scripts/audit-attribution.mjs
@@ -5,14 +5,14 @@
 //   node scripts/audit-attribution.mjs [--port 5577] [--deep]
 //
 // Invariants:
-//   I1  a session with its own cwd must not have a parentSessionId
-//   I2  a child session's cwd must equal its parent's cwd (or be absent)
+//   I1  a linked child's own cwd must not differ from its parent's cwd
+//       (equal = legal hinted child; parent cwd unknown = warning only)
 //   I4  a convId must not appear under more than one session
 //   I3  (--deep) every inferred entry's first-message content must be findable
 //       in its attributed session's other request bodies (content join).
 //       Reads _req.json files from CCXRAY_HOME/logs — slow, report-only.
 //
-// Exit code 1 on I1/I2 violations (hard invariants). I3/I4 are report-only:
+// Exit code 1 on I1 violations (hard invariant). I3/I4 are report-only:
 // I3 has known false negatives (pruned req files), I4 can be a legit re-run
 // of the same prompt. Silence is not success: every check prints its count.
 
@@ -42,19 +42,20 @@ for (const e of entries) {
 
 let hard = 0;
 
-console.log('I1: sessions with own cwd that have a parentSessionId');
+// I1/I2 share one semantic: a linked child whose own cwd CONTRADICTS its
+// parent is misattributed. A child whose cwd equals the parent's is legal
+// (explicitly-hinted Codex children may inherit one — linkParentSession
+// allows the hint path regardless of cwd), so equality is clean, difference
+// is a hard violation, and an unknown parent cwd is report-only (codex R1).
+console.log('I1: linked child with own cwd differing from parent cwd');
+let i1 = 0, i1warn = 0;
 for (const [sid, s] of sess) {
-  if (s.parent && s.cwd) { hard++; console.log(`  VIOLATION ${sid.slice(0, 8)} cwd=${s.cwd} → parent ${s.parent.slice(0, 8)}`); }
+  if (!s.parent || !s.cwd) continue;
+  const p = sess.get(s.parent);
+  if (p?.cwd && s.cwd !== p.cwd) { i1++; hard++; console.log(`  VIOLATION ${sid.slice(0, 8)} cwd=${s.cwd} ≠ parent cwd=${p.cwd}`); }
+  else if (!p?.cwd) { i1warn++; console.log(`  WARN ${sid.slice(0, 8)} cwd=${s.cwd} → parent ${s.parent.slice(0, 8)} (parent cwd unknown)`); }
 }
-console.log(`  ${hard ? hard + ' violation(s)' : 'clean'}\n`);
-
-console.log('I2: child cwd ≠ parent cwd');
-let i2 = 0;
-for (const [sid, s] of sess) {
-  const p = s.parent && sess.get(s.parent);
-  if (p && s.cwd && p.cwd && s.cwd !== p.cwd) { i2++; hard++; console.log(`  VIOLATION ${sid.slice(0, 8)} cwd=${s.cwd} ≠ parent cwd=${p.cwd}`); }
-}
-console.log(`  ${i2 ? i2 + ' violation(s)' : 'clean'}\n`);
+console.log(`  ${i1 ? i1 + ' violation(s)' : 'clean'}${i1warn ? ` (${i1warn} warning(s))` : ''}\n`);
 
 console.log('I4: convId under multiple sessions (report-only)');
 const conv = new Map();
@@ -77,6 +78,11 @@ if (deep) {
       // Longest single line: survives the line-number prefixes that Read tool
       // results carry inside the parent's stored history (whole-block substring
       // matching false-negatives on those).
+      // Delta-format siblings are not a blind spot: each stores only its NEW
+      // message suffix, so every message of a spliced conversation appears
+      // verbatim in exactly one file of the chain — scanning all raw siblings
+      // collectively covers the full history. The one gap is a pruned chain
+      // anchor, which surfaces as `unreadable`, not a false SUSPECT (codex R1).
       const line = blocks.join('\n').split('\n').sort((a, b) => b.length - a.length)[0]?.trim().slice(0, 120);
       if (!line || line.length < 20) { unreadable++; continue; }
       const needle = JSON.stringify(line).slice(1, -1);

--- a/scripts/audit-attribution.mjs
+++ b/scripts/audit-attribution.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Attribution audit — checks session-attribution invariants against a LIVE
+// ccxray server (parentSessionId lives only in server memory, not in the index).
+//
+//   node scripts/audit-attribution.mjs [--port 5577] [--deep]
+//
+// Invariants:
+//   I1  a session with its own cwd must not have a parentSessionId
+//   I2  a child session's cwd must equal its parent's cwd (or be absent)
+//   I4  a convId must not appear under more than one session
+//   I3  (--deep) every inferred entry's first-message content must be findable
+//       in its attributed session's other request bodies (content join).
+//       Reads _req.json files from CCXRAY_HOME/logs — slow, report-only.
+//
+// Exit code 1 on I1/I2 violations (hard invariants). I3/I4 are report-only:
+// I3 has known false negatives (pruned req files), I4 can be a legit re-run
+// of the same prompt. Silence is not success: every check prints its count.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+const port = args.includes('--port') ? args[args.indexOf('--port') + 1] : '5577';
+const deep = args.includes('--deep');
+const logsDir = path.join(process.env.CCXRAY_HOME || path.join(process.env.HOME, '.ccxray'), 'logs');
+
+const res = await fetch(`http://127.0.0.1:${port}/_api/entries`);
+if (!res.ok) { console.error(`fetch failed: ${res.status}`); process.exit(2); }
+const entries = (await res.json()).entries;
+console.log(`${entries.length} entries from :${port}\n`);
+
+// Aggregate per session
+const sess = new Map();
+for (const e of entries) {
+  let s = sess.get(e.sessionId);
+  if (!s) sess.set(e.sessionId, s = { cwd: null, parent: null, n: 0, inferred: [] });
+  if (e.cwd) s.cwd = e.cwd;
+  if (e.parentSessionId) s.parent = e.parentSessionId;
+  s.n++;
+  if (e.sessionInferred && e.sessionId !== 'direct-api') s.inferred.push(e);
+}
+
+let hard = 0;
+
+console.log('I1: sessions with own cwd that have a parentSessionId');
+for (const [sid, s] of sess) {
+  if (s.parent && s.cwd) { hard++; console.log(`  VIOLATION ${sid.slice(0, 8)} cwd=${s.cwd} → parent ${s.parent.slice(0, 8)}`); }
+}
+console.log(`  ${hard ? hard + ' violation(s)' : 'clean'}\n`);
+
+console.log('I2: child cwd ≠ parent cwd');
+let i2 = 0;
+for (const [sid, s] of sess) {
+  const p = s.parent && sess.get(s.parent);
+  if (p && s.cwd && p.cwd && s.cwd !== p.cwd) { i2++; hard++; console.log(`  VIOLATION ${sid.slice(0, 8)} cwd=${s.cwd} ≠ parent cwd=${p.cwd}`); }
+}
+console.log(`  ${i2 ? i2 + ' violation(s)' : 'clean'}\n`);
+
+console.log('I4: convId under multiple sessions (report-only)');
+const conv = new Map();
+for (const e of entries) if (e.convId) (conv.get(e.convId) || conv.set(e.convId, new Set()).get(e.convId)).add(e.sessionId);
+let i4 = 0;
+for (const [c, sids] of conv) if (sids.size > 1) { i4++; console.log(`  ${c} in ${[...sids].map(x => x.slice(0, 8)).join(', ')}`); }
+console.log(`  ${i4 ? i4 + ' shared convId(s)' : 'clean'}\n`);
+
+if (deep) {
+  console.log('I3 (--deep): content join of inferred entries');
+  const bySess = new Map();
+  for (const e of entries) (bySess.get(e.sessionId) || bySess.set(e.sessionId, []).get(e.sessionId)).push(e);
+  let ok = 0, suspect = 0, unreadable = 0;
+  for (const [sid, s] of sess) {
+    for (const e of s.inferred) {
+      let req;
+      try { req = JSON.parse(fs.readFileSync(path.join(logsDir, `${e.id}_req.json`), 'utf8')); } catch { unreadable++; continue; }
+      const c = req.messages?.[0]?.content;
+      const blocks = typeof c === 'string' ? [c] : Array.isArray(c) ? c.filter(b => b.type === 'text').map(b => b.text) : [];
+      // Longest single line: survives the line-number prefixes that Read tool
+      // results carry inside the parent's stored history (whole-block substring
+      // matching false-negatives on those).
+      const line = blocks.join('\n').split('\n').sort((a, b) => b.length - a.length)[0]?.trim().slice(0, 120);
+      if (!line || line.length < 20) { unreadable++; continue; }
+      const needle = JSON.stringify(line).slice(1, -1);
+      let found = false;
+      for (const sib of bySess.get(sid) || []) {
+        if (sib.id === e.id) continue;
+        try { if (fs.readFileSync(path.join(logsDir, `${sib.id}_req.json`), 'utf8').includes(needle)) { found = true; break; } } catch {}
+      }
+      if (found) ok++;
+      else { suspect++; console.log(`  SUSPECT ${e.id} → ${sid.slice(0, 8)} ${JSON.stringify(line.slice(0, 60))}`); }
+    }
+  }
+  console.log(`  confirmed=${ok} suspect=${suspect} unreadable=${unreadable}\n`);
+}
+
+process.exit(hard ? 1 : 0);

--- a/scripts/audit-attribution.mjs
+++ b/scripts/audit-attribution.mjs
@@ -78,20 +78,22 @@ if (deep) {
       // Longest single line: survives the line-number prefixes that Read tool
       // results carry inside the parent's stored history (whole-block substring
       // matching false-negatives on those).
-      // Delta-format siblings are not a blind spot: each stores only its NEW
-      // message suffix, so every message of a spliced conversation appears
-      // verbatim in exactly one file of the chain — scanning all raw siblings
-      // collectively covers the full history. The one gap is a pruned chain
-      // anchor, which surfaces as `unreadable`, not a false SUSPECT (codex R1).
+      // Delta-format siblings are mostly covered: each stores its NEW message
+      // suffix, so appended history appears verbatim in some file of the chain
+      // (snapshot anchors and forced-full turns duplicate content — that only
+      // helps the scan). The real gap is missing files: a pruned sibling could
+      // have held the needle, so an unmatched entry with unreadable siblings
+      // counts as unreadable, not SUSPECT (codex R1/R2).
       const line = blocks.join('\n').split('\n').sort((a, b) => b.length - a.length)[0]?.trim().slice(0, 120);
       if (!line || line.length < 20) { unreadable++; continue; }
       const needle = JSON.stringify(line).slice(1, -1);
-      let found = false;
+      let found = false, sibMissing = false;
       for (const sib of bySess.get(sid) || []) {
         if (sib.id === e.id) continue;
-        try { if (fs.readFileSync(path.join(logsDir, `${sib.id}_req.json`), 'utf8').includes(needle)) { found = true; break; } } catch {}
+        try { if (fs.readFileSync(path.join(logsDir, `${sib.id}_req.json`), 'utf8').includes(needle)) { found = true; break; } } catch { sibMissing = true; }
       }
       if (found) ok++;
+      else if (sibMissing) unreadable++;
       else { suspect++; console.log(`  SUSPECT ${e.id} → ${sid.slice(0, 8)} ${JSON.stringify(line.slice(0, 60))}`); }
     }
   }

--- a/server/entry.js
+++ b/server/entry.js
@@ -4,7 +4,7 @@ const INDEX_FIELDS = [
   'id','ts','sessionId','provider','agent','model','msgCount','toolCount','toolCalls','skillCalls',
   'isSubagent','sessionInferred','cwd','isSSE','usage','cost','maxContext','responseMetadata',
   'stopReason','title','thinkingDuration','toolFail','elapsed','status','receivedAt',
-  'sysHash','toolsHash','coreHash','agentKey','agentLabel','thinkingStripped','hasCredential','toolSources',
+  'sysHash','toolsHash','coreHash','agentKey','agentLabel','convId','thinkingStripped','hasCredential','toolSources',
   'edited','editSummary',
 ];
 

--- a/server/forward.js
+++ b/server/forward.js
@@ -696,15 +696,17 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
 
     if (reqSessionId) {
       store.activeRequests[reqSessionId] = Math.max(0, (store.activeRequests[reqSessionId] || 1) - 1);
-      broadcastSessionStatus(reqSessionId);
       if (store.sessionMeta[reqSessionId]) {
         store.sessionMeta[reqSessionId].lastStopReason = stopReason || null;
         // Refresh at stream END too: lastSeenAt is otherwise stamped at request
         // arrival, so after an orchestrator turn longer than the 30s inference
         // window, a subagent spawned right after the stream closes would find
-        // no parent candidate and fall to the direct-api sentinel.
+        // no parent candidate and fall to the direct-api sentinel. Must happen
+        // before broadcastSessionStatus so the status event carries the fresh
+        // timestamp (codex R1).
         store.sessionMeta[reqSessionId].lastSeenAt = Date.now();
       }
+      broadcastSessionStatus(reqSessionId);
     }
 
     const sessionId = reqSessionId;

--- a/server/forward.js
+++ b/server/forward.js
@@ -697,7 +697,14 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
     if (reqSessionId) {
       store.activeRequests[reqSessionId] = Math.max(0, (store.activeRequests[reqSessionId] || 1) - 1);
       broadcastSessionStatus(reqSessionId);
-      if (store.sessionMeta[reqSessionId]) store.sessionMeta[reqSessionId].lastStopReason = stopReason || null;
+      if (store.sessionMeta[reqSessionId]) {
+        store.sessionMeta[reqSessionId].lastStopReason = stopReason || null;
+        // Refresh at stream END too: lastSeenAt is otherwise stamped at request
+        // arrival, so after an orchestrator turn longer than the 30s inference
+        // window, a subagent spawned right after the stream closes would find
+        // no parent candidate and fall to the direct-api sentinel.
+        store.sessionMeta[reqSessionId].lastSeenAt = Date.now();
+      }
     }
 
     const sessionId = reqSessionId;

--- a/server/sse-broadcast.js
+++ b/server/sse-broadcast.js
@@ -36,6 +36,7 @@ function summarizeEntry(entry) {
     coreHash: entry.coreHash || null,
     agentKey: entry.agentKey || null,
     agentLabel: entry.agentLabel || null,
+    convId: entry.convId || null,
     toolsHash: entry.toolsHash || null,
     thinkingStripped: entry.thinkingStripped || false,
     parentSessionId: store.sessionMeta[entry.sessionId]?.parentSessionId || null,

--- a/server/store.js
+++ b/server/store.js
@@ -178,6 +178,14 @@ function linkParentSession(sessionId, parsedBody, isSubagentHint) {
   const meta = sessionMeta[sessionId];
   if (!meta) return null;
   if (meta.parentSessionId) return meta.parentSessionId;
+  // A session that has ever shown a cwd is an established top-level session —
+  // never re-parent it. Anthropic subagent kickoffs carry the PARENT's own
+  // session_id (no cwd, ≤2 msgs), so without this guard every spawn re-qualifies
+  // the parent itself for linking and inferParentSession may pick another
+  // project's inflight session (real incident: d1997e5f → 3e419704). An explicit
+  // wire-level hint (Codex subagent header) still overrides — those child
+  // sessions never carry a cwd of their own.
+  if (!isSubagentHint && meta.cwd) return null;
   // Unlike isLikelySubagent (which screens orphan requests without session_id),
   // this handles sessions WITH their own session_id. Tools and metadata guards
   // are intentionally absent because Codex subagents may carry both.
@@ -214,8 +222,13 @@ function detectSession(req) {
   if (isLikelySubagent(req)) {
     const parent = inferParentSession();
     if (parent) return { sessionId: parent, isNewSession: false, inferred: true };
-    // No recent session → keep as-is, don't create spurious session
-    return { sessionId: currentSessionId || 'direct-api', isNewSession: false, inferred: true };
+    // No recent session → fall back to currentSessionId only if it was active
+    // within the inference window. An unbounded fallback silently glued orphans
+    // arriving hours later onto a dead session (cross-project when the user had
+    // switched). Stale → direct-api sentinel, don't create a spurious session.
+    const curMeta = currentSessionId ? sessionMeta[currentSessionId] : null;
+    const curFresh = curMeta?.lastSeenAt && Date.now() - curMeta.lastSeenAt <= 30000;
+    return { sessionId: curFresh ? currentSessionId : 'direct-api', isNewSession: false, inferred: true };
   }
 
   // Non-subagent without session_id: try parent attribution before creating a phantom

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -41,6 +41,19 @@ function detectSession(_req, _headers, parsedBody) {
   return store.detectSession(parsedBody);
 }
 
+// Conversation identity: hash of the first message's text. All turns of one
+// subagent instance share messages[0] verbatim (history only appends), while
+// parallel instances of the same agent type differ in their task prompt —
+// this is what lets the swimlane split N concurrent Explore agents into N
+// lanes (#117). Null when messages[0] has no text (never key lanes on md5('')).
+function computeConvId(parsedBody) {
+  const c = parsedBody?.messages?.[0]?.content;
+  const txt = typeof c === 'string' ? c
+    : Array.isArray(c) ? c.filter(b => b?.type === 'text' && typeof b.text === 'string').map(b => b.text).join('\n') : '';
+  if (!txt) return null;
+  return crypto.createHash('md5').update(txt).digest('hex').slice(0, 8);
+}
+
 function buildEntryFields(ctx) {
   const { parsedBody } = ctx;
   const usage = ctx.usage || extractUsage(ctx.events) || null;
@@ -70,6 +83,7 @@ function buildEntryFields(ctx) {
     coreHash: ctx.coreHash || null,
     agentKey: ctx.agentKey || null,
     agentLabel: ctx.agentLabel || null,
+    convId: computeConvId(parsedBody),
     thinkingStripped: ctx.thinkingStripped,
     sessionId: ctx.sessionId,
   };

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -242,6 +242,22 @@ describe('store', () => {
       assert.equal(r.sessionId, 'aaa-111');
     });
 
+    it('orphan does not stick to a stale currentSessionId (falls back to direct-api)', () => {
+      // currentSessionId had no time bound: an orphan arriving hours after the
+      // last session activity was silently attributed to that dead session —
+      // across projects if the user had switched. Stale fallback must go to
+      // the direct-api sentinel instead.
+      const store = require('../server/store');
+      resetSessionState(store);
+
+      store.detectSession(mainReq('dead-0a1b', 3));
+      Object.assign(store.sessionMeta['dead-0a1b'], { cwd: '/old', lastSeenAt: Date.now() - 3600000 });
+      store.activeRequests['dead-0a1b'] = 0;
+
+      const r = store.detectSession({ messages: [{ role: 'user', content: 'task' }] });
+      assert.equal(r.sessionId, 'direct-api');
+    });
+
     it('never pollutes currentSessionId from subagent path', () => {
       const store = require('../server/store');
       resetSessionState(store);
@@ -367,6 +383,31 @@ describe('store', () => {
       const parent = store.linkParentSession('normal-ddd', normalBody, false);
       assert.equal(parent, null);
       assert.equal(store.sessionMeta['normal-ddd'].parentSessionId, undefined);
+    });
+
+    it('never re-parents an established top-level session (meta.cwd set)', () => {
+      // Real incident (d1997e5f → 3e419704): a long-running project session's own
+      // subagent kickoffs carry the SAME session_id with no cwd and 1 message.
+      // After a hub restart wiped parentSessionId, one such kickoff re-qualified
+      // the whole session for linking and inferParentSession picked another
+      // project's inflight session. A session that has ever shown a cwd is
+      // top-level — it must never be re-parented.
+      const store = require('../server/store');
+      resetSessionState(store);
+
+      // Another project's session, currently inflight
+      store.detectSession(mainReq('bbb2-feed', 3));
+      store.activeRequests['bbb2-feed'] = 1;
+      Object.assign(store.sessionMeta['bbb2-feed'], { cwd: '/proj-b', lastSeenAt: Date.now() });
+
+      // Established session: cwd known (e.g. restored from index after hub restart)
+      store.sessionMeta['aaa1-feed'] = { cwd: '/proj-a', lastSeenAt: Date.now() - 10000, bannerPrinted: true };
+
+      // Its own subagent kickoff: same session_id, no cwd, 1 message
+      const kick = { metadata: { session_id: 'aaa1-feed' }, messages: [{ role: 'user', content: 'task' }] };
+      const parent = store.linkParentSession('aaa1-feed', kick, undefined);
+      assert.equal(parent, null);
+      assert.equal(store.sessionMeta['aaa1-feed'].parentSessionId, undefined);
     });
 
     it('does not link when no parent session is active', () => {

--- a/test/wire-parsers-build-entry.test.js
+++ b/test/wire-parsers-build-entry.test.js
@@ -110,6 +110,25 @@ test('anthropic Skill message → buildEntryFields → buildIndexLine persists c
   assert.deepEqual(back.skillCalls, { 'code-review': 1 });
 });
 
+test('anthropic convId: stable across turns of one conversation, distinct across instances, null for no text', () => {
+  const base = { provider: 'anthropic', transport: 'sse', proxyRes: { statusCode: 200 }, usage: { input_tokens: 1, output_tokens: 1 }, sessionId: 's1' };
+  const mk = (messages) => getParser('anthropic').buildEntryFields({ ...base, parsedBody: { model: 'claude-sonnet-4-6', messages } });
+  const kick = [{ role: 'user', content: [{ type: 'text', text: 'shared reminder' }, { type: 'text', text: 'task A' }] }];
+  const turn2 = [...kick, { role: 'assistant', content: [{ type: 'text', text: 'ok' }] }, { role: 'user', content: 'go on' }];
+  const otherKick = [{ role: 'user', content: [{ type: 'text', text: 'shared reminder' }, { type: 'text', text: 'task B' }] }];
+  const a1 = mk(kick), a2 = mk(turn2), b1 = mk(otherKick);
+  assert.ok(a1.convId && /^[0-9a-f]{8}$/.test(a1.convId));
+  assert.equal(a1.convId, a2.convId, 'same conversation keeps its convId as history grows');
+  assert.notEqual(a1.convId, b1.convId, 'different task prompts → different convId');
+  // no text in messages[0] → null (never md5(''))
+  assert.equal(mk([{ role: 'user', content: [{ type: 'tool_result', tool_use_id: 'x' }] }]).convId, null);
+  assert.equal(mk([]).convId, null);
+  // survives the INDEX_FIELDS projection
+  assert.ok(INDEX_FIELDS.includes('convId'));
+  const back = JSON.parse(buildIndexLine({ id: 'X', ts: 't', status: 200, isSSE: true, receivedAt: 1, ...a1 }));
+  assert.equal(back.convId, a1.convId);
+});
+
 test('T9: anthropic.registerPromptVersion returns coreHash', () => {
   const longB2 = 'You are Claude Code, Anthropic\'s official CLI for Claude. ' + 'x'.repeat(600);
   const parsedBody = {

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -144,6 +144,43 @@ describe('workflow-timeline data layer', () => {
     assert.equal(ctx.wfState.lanes[1].name, 'agent-explore');
   });
 
+  it('convId splits parallel same-agent instances into separate lanes (#117)', () => {
+    const ctx = loadWfModule();
+    var entries = [
+      mkEntry('t1', 's1', 'claude-fable-5', 1000, 5, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      // two parallel Explore instances, interleaved turns
+      mkEntry('e1a', 's1', 'claude-sonnet-4-6', 2000, 3, { agentKey: 'explore', agentLabel: 'Explore', convId: 'aaaa1111' }),
+      mkEntry('e2a', 's1', 'claude-sonnet-4-6', 2100, 3, { agentKey: 'explore', agentLabel: 'Explore', convId: 'bbbb2222' }),
+      mkEntry('e1b', 's1', 'claude-sonnet-4-6', 6000, 2, { agentKey: 'explore', agentLabel: 'Explore', convId: 'aaaa1111' }),
+      // legacy entry without convId keeps the shared agent lane
+      mkEntry('e3', 's1', 'claude-sonnet-4-6', 7000, 2, { agentKey: 'explore', agentLabel: 'Explore' }),
+    ];
+    var lanes = ctx.wfInferLanes(entries, []);
+    assert.equal(lanes.length, 4);
+    var names = lanes.map(function(l) { return l.name; }).sort().join(',');
+    assert.equal(names, 'agent-explore,agent-explore:aaaa1111,agent-explore:bbbb2222,main');
+    var laneA = lanes.find(function(l) { return l.name === 'agent-explore:aaaa1111'; });
+    assert.equal(laneA.turns.length, 2);
+    assert.equal(laneA.convId, 'aaaa1111');
+  });
+
+  it('wfAddEntry routes by convId lane key', () => {
+    const ctx = loadWfModule();
+    ctx.allEntries = [
+      mkEntry('t1', 's1', 'claude-fable-5', 1000, 5, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('e1a', 's1', 'claude-sonnet-4-6', 2000, 3, { agentKey: 'explore', agentLabel: 'Explore', convId: 'aaaa1111' }),
+    ];
+    ctx.wfState = ctx.wfBuildState('s1');
+    assert.equal(ctx.wfState.lanes.length, 2);
+    // same conv → same lane; new conv → new lane
+    ctx.wfAddEntry(mkEntry('e1b', 's1', 'claude-sonnet-4-6', 5000, 2, { agentKey: 'explore', agentLabel: 'Explore', convId: 'aaaa1111' }));
+    assert.equal(ctx.wfState.lanes.length, 2);
+    assert.equal(ctx.wfState.lanes[1].turns.length, 2);
+    ctx.wfAddEntry(mkEntry('e2a', 's1', 'claude-sonnet-4-6', 5100, 2, { agentKey: 'explore', agentLabel: 'Explore', convId: 'bbbb2222' }));
+    assert.equal(ctx.wfState.lanes.length, 3);
+    assert.equal(ctx.wfState.lanes[2].name, 'agent-explore:bbbb2222');
+  });
+
   it('wfBuildState computes time bounds', () => {
     const ctx = loadWfModule();
     ctx.allEntries = [


### PR DESCRIPTION
Addresses the lane-merging bullet of #117 and two session-attribution leaks found while investigating it. Groundwork for #129.

## What

**1. Parallel same-type subagents each get their own swimlane lane** (`cff661f`, `5eb19bd`)
Anthropic subagent turns land in the parent's session (kickoffs carry the parent's `metadata.session_id`) with a shared `agentKey`, so N concurrent Explore agents collapsed into one `agent-explore` lane. New `convId` = 8-hex hash of `messages[0]` text (stable across an instance's turns — history only appends; distinct across instances — task prompts differ; null when messages[0] has no text so unrelated no-text requests never share a lane). Lane key becomes `agent-<key>:<convId>`; entries without convId (legacy index lines) keep the merged lane.

**2. Cross-project attribution guards** (`3ad9a7d`)
Real incident: a long-running session from another project was re-parented onto this project's session, pulling its turns into the wrong swimlane. Two temporal-inference leaks closed:
- `linkParentSession`: a session that has ever shown a cwd is top-level — never re-parent it (explicit Codex subagent hint still overrides).
- `detectSession` orphan fallback: `currentSessionId` was unbounded-stale; now 30s-bounded with `lastSeenAt` refreshed at stream end so subagents spawned after >30s orchestrator turns still attribute correctly.

**3. Attribution invariant audit** (`6fde005`)
`node scripts/audit-attribution.mjs [--port N] [--deep]` against the live server (parent links are memory-only). Exits 1 on hard invariant violations; prints counts for every check.

## Verification (differential, red-first)

- convId tests run against pre-change `700e33a` in a throwaway worktree: **3 fail on old, pass on new** (lane split ×2, server convId).
- Both guards written red-first against reproduced incident scenarios: red on old code, green after.
- Negative cases covered: Codex hinted subagent still links; fresh-window fallback unchanged; existing linkParentSession suite green before/after.
- Full suite `CCXRAY_HOME=$(mktemp -d) npm test`: 986/988, only failure is the pre-existing codex-adapter fixture test (fails identically on main).
- Browser smoke with real session data (isolated CCXRAY_HOME, port 5602): 5 concurrent Explore instances render as 5 lanes.
- Live audit post-hub-restart: I1/I2/I4 clean.

## Known behavior change

Fresh-conversation-per-call agents (title-generator, name-generator) now get one lane per call — semantically correct; coalescing single-turn lanes is possible follow-up if it gets noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)