### PR TITLE
fix(test): move agent-classify-eval harness out of test/ (#134)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -79,6 +79,16 @@ process.on('exit', () => { try { fs.rmSync(FIX_HOME, { recursive: true, force: t
 
 Use `finally` instead for dirs scoped to a single test.
 
+### 5. Evaluation harnesses live in `scripts/`, not `test/`
+
+`node --test` auto-discovers every `.js` file under `test/` and tries to run
+each as a test. Scripts that intentionally scan the real `~/.ccxray` (e.g.
+`scripts/agent-classify-eval.js`) must never live in `test/` — they read live
+user data, so their runtime and result depend on whatever the machine has
+captured (issue #134: a 30s+ scan of ~100k files whose verdict drifts with the
+data). Anything in `scripts/` is a manual developer tool invoked explicitly;
+anything in `test/` must be a hygienic, self-contained test.
+
 ## Canonical pattern
 
 `test/usage.test.js` is the reference. Copy its setup:

--- a/openspec/changes/archive/2026-04-21-fix-turns-left-prediction/proposal.md
+++ b/openspec/changes/archive/2026-04-21-fix-turns-left-prediction/proposal.md
@@ -112,7 +112,7 @@ return Math.min(Math.round(remaining / stableAvg), 99);
 4. metric: median absolute percent error
 5. 目標：median 誤差 <50%，worst case 不超過 2x 高估
 
-可用 `test/agent-classify-eval.js` 同款架構寫 `test/predict-eval.js`。
+可用 `scripts/agent-classify-eval.js` 同款架構寫 `scripts/predict-eval.js`（讀真實資料的 eval harness 放 `scripts/`，不放 `test/`，見 docs/testing.md 規則 5）。
 
 ## Impact
 

--- a/scripts/agent-classify-eval.js
+++ b/scripts/agent-classify-eval.js
@@ -1,6 +1,9 @@
 'use strict';
 
 // Ground-truth evaluation harness for extractAgentType.
+// Manual tool: run with `node scripts/agent-classify-eval.js`. Lives outside
+// test/ because it scans real user data and takes ~30s+ — `node --test`
+// auto-discovers every .js under test/, so it must not sit there (issue #134).
 // Scans ~/.ccxray/logs/shared/sys_*.json (real captured prompts) and compares
 // the algorithm's prediction against a canonical prefix table.
 //


### PR DESCRIPTION
## Root cause (#134)

`test/agent-classify-eval.js` is not a test — it's a manual ground-truth eval harness (`experiment(classify)` series) that by design scans the **real** `~/.ccxray/logs/shared` (ignores `CCXRAY_HOME`). Two consequences:

1. **The ~32s "timeout" is scan time**: the shared dir has grown to ~102k `sys_*.json` files; a full scan takes 37s on this machine.
2. **The failure is data drift, not a code bug**: after scanning, `PRECISION: 0.9467 < 0.9999` → `process.exit(1)` → `node --test` reports `testCodeFailure: 'test failed'`. Newly captured prompts (e.g. Workflow-tool subagents: "You are a subagent spawned by a workflow orchestration script") aren't in its TRUTH_TABLE, so truth says `unknown` while `extractAgentType` regex-derives a specific label.

**Why "full suite" reproduced it**: `npm test` = `node --test test/*.test.js` — the glob never matched this file (which is also why CI stays green with an empty `CCXRAY_HOME`). The 991-test run in the issue came from bare `node --test`, whose auto-discovery runs **every** `.js` under `test/`.

## Fix

Move the harness to `scripts/` alongside the other manual analysis tools (`analyze-ratelimit-samples.mjs`, `audit-attribution.mjs`). No behavior change to the script itself — it remains a manual precision guard (`node scripts/agent-classify-eval.js`). Added `docs/testing.md` rule 5 so future eval harnesses don't land in `test/`.

Noted but intentionally not changed: the script reads `os.homedir()` directly rather than honoring `CCXRAY_HOME`; that's its purpose (eval against real captured data), and changing it is out of scope for this fix.

## Verification

- `CCXRAY_HOME=$(mktemp -d) npm test` × 3 (perl alarm 180s bounded): **989/989 pass, 3/3 runs**
- Bare `node --test` (the issue's discovery mode, bounded): **990/990 pass, exit 0** — eval no longer discovered
- `node scripts/agent-classify-eval.js` from new location: runs, prints `SCORE/PRECISION`, require path resolves
- `ls test/` has no stray `.js` files left

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)