### PR TITLE
fix(server): classify /v1/messages/count_tokens as noise (#146)

### DIFF
--- a/docs/wire-protocol-reference.md
+++ b/docs/wire-protocol-reference.md
@@ -27,6 +27,7 @@
 
 | Date | Agent | Version | Change |
 |------|-------|---------|--------|
+| 2026-07-06 | Claude Code | 2.1.x | Discovered: `POST /v1/messages/count_tokens` calls (token pre-counting for large content). Body is bare `{model, messages}` — no `system`, no `metadata`, no `tools`, no `max_tokens`; response is exactly `{"input_tokens": N}` (non-SSE). Satisfied every subagent heuristic and polluted sessions with fake single-turn subagent entries (#146). ccxray now classifies the path as noise (`skipEntry`), matching quota-check / codex-platform-ping handling. |
 | 2026-06-09 | Claude Code | 2.1.x | Confirmed via loopback wire capture: `anthropic-beta` carries `context-1m-2025-08-07` on **every** request when the account's 1M context is enabled — including haiku title-gen turns (it is a client/account-level capability flag, not a per-turn window declaration). ccxray now uses it as the non-lagging 1M-window signal, gated by model capability (`SUPPORTS_1M`), replacing sole reliance on the lagging system-prompt `[1m]` marker (#58). |
 | 2026-06-05 | ccxray | 1.11.x | Usage normalization: OpenAI `input_tokens` includes `cached_tokens` (subset), unlike Anthropic's disjoint fields. `normalizeUsageForProvider` now subtracts the overlap so canonical `input_tokens + cache_read + cache_creation = total context` holds for both providers. Normalized entries carry `_ccxrayUsageNormalized: true`. Historical entries normalized on restore (in-memory, index unchanged). Cache display: Codex sessions show `cache N% hit` instead of TTL countdown; topbar adapts per provider (`ephemeral-ttl` vs `server-managed`). `UPSTREAM_PROFILES` registry added to `providers.js`. |
 | 2026-06-04 | ccxray | 1.10.x | Fix: WS `stopReason` now extracts `response.status` from terminal events (`completed`/`incomplete`/`failed`/`cancelled`) instead of WS close reason. WS `title` extracts user input summary via `getOpenAIInputSummary` instead of hardcoded string. Non-terminal statuses (`in_progress`/`queued`) are ignored to prevent masking close/error reasons. |
@@ -43,7 +44,7 @@
 |--------|-------------|-------|------------|
 | Protocol | HTTP POST + SSE streaming | HTTP POST (SSE) + WebSocket upgrade | `contractual` |
 | Primary path | `POST /v1/messages` | `POST /v1/responses` (HTTP) or WS upgrade on `/v1/responses` | `contractual` |
-| Alternative paths | — | `/v1/realtime` (Realtime API, not used by Codex CLI for chat) | `contractual` |
+| Alternative paths | `POST /v1/messages/count_tokens` (token pre-counting; bare `{model, messages}` body, non-SSE `{"input_tokens": N}` response; classified as noise by ccxray, #146) | `/v1/realtime` (Realtime API, not used by Codex CLI for chat) | `contractual` |
 | WS upgrade detection | N/A | `upgrade: websocket` header on `/v1/responses` or `/v1/realtime`; ccxray also requires `upstream.provider === 'openai'` | `contractual` |
 | WS handshake header | N/A | `openai-beta: responses_websockets=2026-02-06` (observed value from Codex wire traffic; ccxray passes through without validation) | `obs-stable` codex ≥0.131 |
 | WS idle timeout (proxy) | N/A | ccxray: 60s default, configurable via `CCXRAY_WS_IDLE_TIMEOUT_MS` | `obs-stable` |

--- a/scripts/cleanup-count-tokens.js
+++ b/scripts/cleanup-count-tokens.js
@@ -42,14 +42,22 @@ function hubAlive() {
   }
 }
 
-function isCountTokensRes(id) {
-  let raw;
-  try { raw = fs.readFileSync(path.join(LOGS, id + '_res.json'), 'utf8'); } catch { return false; }
-  let res;
-  try { res = JSON.parse(raw); } catch { return false; }
+function readJson(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return null; }
+}
+
+// Both sides of the wire must agree before we remove anything:
+// res is exactly {"input_tokens": N} (the count_tokens response contract),
+// and req has no max_tokens (required on /v1/messages, absent on
+// count_tokens). Missing or unreadable files → keep the entry.
+function isCountTokens(id) {
+  const res = readJson(path.join(LOGS, id + '_res.json'));
   if (!res || typeof res !== 'object' || Array.isArray(res)) return false;
   const keys = Object.keys(res);
-  return keys.length === 1 && keys[0] === 'input_tokens' && typeof res.input_tokens === 'number';
+  if (keys.length !== 1 || keys[0] !== 'input_tokens' || typeof res.input_tokens !== 'number') return false;
+  const req = readJson(path.join(LOGS, id + '_req.json'));
+  if (!req || typeof req !== 'object' || Array.isArray(req)) return false;
+  return req.max_tokens == null && Array.isArray(req.messages);
 }
 
 function main() {
@@ -67,7 +75,7 @@ function main() {
     try { e = JSON.parse(line); } catch { keep.push(line); continue; }
     // Cheap prefilter: count_tokens entries never have usage and are never SSE.
     const candidate = e && e.id && e.usage == null && !e.isSSE;
-    if (candidate && isCountTokensRes(e.id)) {
+    if (candidate && isCountTokens(e.id)) {
       removed.push(e);
     } else {
       keep.push(line);
@@ -96,7 +104,10 @@ function main() {
 
   const backup = INDEX + '.bak-' + Date.now();
   fs.copyFileSync(INDEX, backup);
-  fs.writeFileSync(INDEX, keep.join('\n') + '\n');
+  // Atomic swap: a crash mid-write must not leave a truncated live index.
+  const tmp = INDEX + '.tmp-' + process.pid;
+  fs.writeFileSync(tmp, keep.join('\n') + '\n');
+  fs.renameSync(tmp, INDEX);
   console.log('\nremoved ' + removed.length + ' entries; backup at ' + backup);
 }
 

--- a/scripts/cleanup-count-tokens.js
+++ b/scripts/cleanup-count-tokens.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+'use strict';
+
+// Remove historical count_tokens entries from index.ndjson (#146).
+//
+// Before the isNoiseRequest fix, POST /v1/messages/count_tokens calls were
+// recorded as fake single-turn subagent entries and rendered as extra
+// swimlanes. This script identifies them precisely — the response body of a
+// count_tokens call is exactly {"input_tokens": N}, a shape no /v1/messages
+// response can produce — and drops their lines from index.ndjson.
+//
+// Log files ({id}_req.json / {id}_res.json) are left on disk; restore reads
+// only the index, so orphaned files are harmless.
+//
+// Usage:
+//   node scripts/cleanup-count-tokens.js            # dry run (default)
+//   node scripts/cleanup-count-tokens.js --apply    # rewrite index (with backup)
+//   CCXRAY_HOME=/tmp/copy node scripts/cleanup-count-tokens.js
+//
+// --apply refuses to run while a hub is alive on this home (it appends to
+// index.ndjson; a concurrent rewrite would lose entries). Stop the hub first,
+// or pass --force if you know the lockfile is stale.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const APPLY = process.argv.includes('--apply');
+const FORCE = process.argv.includes('--force');
+const HOME = process.env.CCXRAY_HOME || path.join(os.homedir(), '.ccxray');
+const LOGS = path.join(HOME, 'logs');
+const INDEX = path.join(LOGS, 'index.ndjson');
+
+function hubAlive() {
+  try {
+    const hub = JSON.parse(fs.readFileSync(path.join(HOME, 'hub.json'), 'utf8'));
+    if (!hub.pid) return false;
+    process.kill(hub.pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isCountTokensRes(id) {
+  let raw;
+  try { raw = fs.readFileSync(path.join(LOGS, id + '_res.json'), 'utf8'); } catch { return false; }
+  let res;
+  try { res = JSON.parse(raw); } catch { return false; }
+  if (!res || typeof res !== 'object' || Array.isArray(res)) return false;
+  const keys = Object.keys(res);
+  return keys.length === 1 && keys[0] === 'input_tokens' && typeof res.input_tokens === 'number';
+}
+
+function main() {
+  if (!fs.existsSync(INDEX)) {
+    console.error('index not found: ' + INDEX);
+    process.exit(1);
+  }
+
+  const lines = fs.readFileSync(INDEX, 'utf8').split('\n').filter(Boolean);
+  const keep = [];
+  const removed = [];
+
+  for (const line of lines) {
+    let e;
+    try { e = JSON.parse(line); } catch { keep.push(line); continue; }
+    // Cheap prefilter: count_tokens entries never have usage and are never SSE.
+    const candidate = e && e.id && e.usage == null && !e.isSSE;
+    if (candidate && isCountTokensRes(e.id)) {
+      removed.push(e);
+    } else {
+      keep.push(line);
+    }
+  }
+
+  console.log('index lines : ' + lines.length);
+  console.log('count_tokens: ' + removed.length);
+  for (const e of removed) {
+    console.log('  ' + e.id + '  session=' + (e.sessionId || '-') + '  model=' + (e.model || '-'));
+  }
+
+  if (!removed.length) { console.log('nothing to clean.'); return; }
+
+  if (!APPLY) {
+    console.log('\ndry run — pass --apply to rewrite ' + INDEX);
+    return;
+  }
+
+  if (hubAlive() && !FORCE) {
+    console.error('\nrefusing --apply: a hub is running on this home and appends to the');
+    console.error('index; rewriting now would lose its entries. Stop the hub first');
+    console.error('(let all ccxray clients exit) or pass --force if the lockfile is stale.');
+    process.exit(1);
+  }
+
+  const backup = INDEX + '.bak-' + Date.now();
+  fs.copyFileSync(INDEX, backup);
+  fs.writeFileSync(INDEX, keep.join('\n') + '\n');
+  console.log('\nremoved ' + removed.length + ' entries; backup at ' + backup);
+}
+
+main();

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -9,8 +9,13 @@ const { calculateCost } = require('../pricing');
 const { agentForProvider } = require('../providers');
 
 // ── isNoiseRequest ──────────────────────────────────────────
-function isNoiseRequest(_url, _headers, _parsedBody) {
-  return false;
+// count_tokens (#146): Claude Code pre-counts tokens for large content. The
+// body is bare {model, messages} — no system, no metadata, no tools — which
+// satisfies every subagent heuristic, so each call became a fake single-turn
+// subagent entry glued onto the active session (one swimlane per call).
+// Forward it, but don't record an entry.
+function isNoiseRequest(url, _headers, _parsedBody) {
+  return typeof url === 'string' && url.split('?')[0] === '/v1/messages/count_tokens';
 }
 
 // ── extractUsage ────────────────────────────────────────────

--- a/test/anthropic-count-tokens-noise.e2e.test.js
+++ b/test/anthropic-count-tokens-noise.e2e.test.js
@@ -1,0 +1,168 @@
+'use strict';
+
+// Claude Code calls POST /v1/messages/count_tokens (token pre-counting for
+// large content). The body is {model, messages} — no system prompt, no
+// metadata, no tools — which happens to satisfy every subagent heuristic
+// (isAnthropicSubagent + isLikelySubagent), so each call was recorded as a
+// fake single-turn subagent entry glued onto the active session and rendered
+// as an extra swimlane. This test fires count_tokens at a real proxy with a
+// mock upstream and asserts zero dashboard entries are created, while a real
+// /v1/messages request still records one.
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const SERVER_SCRIPT = path.join(__dirname, '..', 'server', 'index.js');
+const tmpDirs = [];
+
+function findFreePort() {
+  return new Promise(resolve => {
+    const s = http.createServer();
+    s.listen(0, () => {
+      const port = s.address().port;
+      s.close(() => resolve(port));
+    });
+  });
+}
+
+function waitForPort(port, timeoutMs = 8000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      const req = http.get(`http://localhost:${port}/_api/health`, { timeout: 1000 }, res => {
+        res.resume();
+        res.on('end', () => resolve());
+      });
+      req.on('error', () => {
+        if (Date.now() - start > timeoutMs) return reject(new Error('proxy did not start'));
+        setTimeout(check, 100);
+      });
+      req.on('timeout', () => {
+        req.destroy();
+        if (Date.now() - start > timeoutMs) return reject(new Error('proxy did not start'));
+        setTimeout(check, 100);
+      });
+    };
+    check();
+  });
+}
+
+function killAndWait(child) {
+  return new Promise(resolve => {
+    if (!child || child.exitCode !== null) return resolve();
+    child.on('exit', resolve);
+    child.kill('SIGTERM');
+    setTimeout(() => { try { child.kill('SIGKILL'); } catch {} resolve(); }, 3000);
+  });
+}
+
+// Mock upstream: count_tokens returns its real response shape; everything
+// else gets a minimal messages response.
+function makeMockUpstream() {
+  return http.createServer((req, res) => {
+    if (req.url.startsWith('/v1/messages/count_tokens')) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ input_tokens: 73081 }));
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({
+      id: 'msg_mock', type: 'message', role: 'assistant', model: 'claude-opus-4-6',
+      content: [{ type: 'text', text: 'pong' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 10, output_tokens: 2 },
+    }));
+  });
+}
+
+function fireRequest(port, urlPath, body) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      hostname: 'localhost', port, path: urlPath, method: 'POST',
+      headers: { 'x-api-key': 'sk-fake', 'content-type': 'application/json' },
+    }, res => {
+      const chunks = [];
+      res.on('data', c => chunks.push(c));
+      res.on('end', () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() }));
+    });
+    req.on('error', reject);
+    req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+function fetchEntries(port) {
+  return new Promise((resolve, reject) => {
+    http.get(`http://localhost:${port}/_api/entries`, res => {
+      const chunks = [];
+      res.on('data', c => chunks.push(c));
+      res.on('end', () => {
+        try { resolve(JSON.parse(Buffer.concat(chunks).toString())); }
+        catch (e) { reject(e); }
+      });
+    }).on('error', reject);
+  });
+}
+
+describe('anthropic count_tokens requests are suppressed from dashboard entries', () => {
+  after(() => {
+    for (const d of tmpDirs) { try { fs.rmSync(d, { recursive: true, force: true }); } catch {} }
+  });
+
+  it('proxies count_tokens (response intact) but creates zero entries', async () => {
+    const upstreamPort = await findFreePort();
+    const proxyPort = await findFreePort();
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-ct-noise-'));
+    tmpDirs.push(home);
+
+    const upstream = makeMockUpstream();
+    await new Promise(resolve => upstream.listen(upstreamPort, '127.0.0.1', resolve));
+
+    const child = spawn(process.execPath, [SERVER_SCRIPT, '--port', String(proxyPort), '--no-browser'], {
+      env: {
+        ...process.env,
+        ANTHROPIC_TEST_HOST: '127.0.0.1',
+        ANTHROPIC_TEST_PORT: String(upstreamPort),
+        ANTHROPIC_TEST_PROTOCOL: 'http',
+        CCXRAY_HOME: home,
+        BROWSER: 'none',
+        RESTORE_DAYS: '0',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    try {
+      await waitForPort(proxyPort);
+
+      // Shape captured from a real Claude Code count_tokens call: bare
+      // {model, messages} with a single large user message.
+      const out = await fireRequest(proxyPort, '/v1/messages/count_tokens', {
+        model: 'claude-opus-4-6',
+        messages: [{ role: 'user', content: 'some very large document text' }],
+      });
+      assert.equal(out.status, 200, 'count_tokens should be proxied through');
+      assert.equal(JSON.parse(out.body).input_tokens, 73081, 'upstream response must pass through intact');
+
+      await new Promise(r => setTimeout(r, 200));
+      let entries = (await fetchEntries(proxyPort)).entries || [];
+      assert.equal(entries.length, 0, `count_tokens should produce 0 entries, got ${entries.length}`);
+
+      // Positive control: a normal /v1/messages request SHOULD record.
+      await fireRequest(proxyPort, '/v1/messages', {
+        model: 'claude-opus-4-6', max_tokens: 10,
+        messages: [{ role: 'user', content: 'ping' }],
+      });
+      await new Promise(r => setTimeout(r, 200));
+      entries = (await fetchEntries(proxyPort)).entries || [];
+      assert.equal(entries.length, 1, `positive control: expected 1 entry, got ${entries.length}`);
+    } finally {
+      await killAndWait(child);
+      upstream.close();
+    }
+  });
+});

--- a/test/cleanup-count-tokens.test.js
+++ b/test/cleanup-count-tokens.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+// scripts/cleanup-count-tokens.js: removal requires BOTH the count_tokens
+// response shape ({"input_tokens": N} only) and a request without max_tokens.
+// Anything ambiguous — missing files, malformed lines, /v1/messages-shaped
+// requests — must survive the rewrite.
+
+const { describe, it, beforeEach, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'cleanup-count-tokens.js');
+const tmpDirs = [];
+
+function makeHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-ct-clean-'));
+  tmpDirs.push(home);
+  fs.mkdirSync(path.join(home, 'logs'), { recursive: true });
+  return home;
+}
+
+function writeEntry(home, id, { indexExtra = {}, req, res } = {}) {
+  const logs = path.join(home, 'logs');
+  const line = JSON.stringify({ id, sessionId: 's1', usage: null, isSSE: false, ...indexExtra });
+  fs.appendFileSync(path.join(logs, 'index.ndjson'), line + '\n');
+  if (req !== undefined) fs.writeFileSync(path.join(logs, id + '_req.json'), JSON.stringify(req));
+  if (res !== undefined) fs.writeFileSync(path.join(logs, id + '_res.json'), JSON.stringify(res));
+}
+
+function run(home, args = []) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    env: { ...process.env, CCXRAY_HOME: home },
+    encoding: 'utf8',
+  });
+}
+
+function indexLines(home) {
+  return fs.readFileSync(path.join(home, 'logs', 'index.ndjson'), 'utf8').split('\n').filter(Boolean);
+}
+
+describe('cleanup-count-tokens script', () => {
+  after(() => {
+    for (const d of tmpDirs) { try { fs.rmSync(d, { recursive: true, force: true }); } catch {} }
+  });
+
+  let home;
+  beforeEach(() => {
+    home = makeHome();
+    // A genuine count_tokens entry (shape captured from real data).
+    writeEntry(home, 'ct-1', {
+      req: { model: 'claude-opus-4-6', messages: [{ role: 'user', content: 'big doc' }] },
+      res: { input_tokens: 73081 },
+    });
+    // A real turn: usage present — never a candidate.
+    writeEntry(home, 'turn-1', {
+      indexExtra: { usage: { input_tokens: 10 }, isSSE: true },
+      req: { model: 'claude-opus-4-6', max_tokens: 8096, messages: [] },
+      res: [{ type: 'message_start' }],
+    });
+    // False-positive trap: count_tokens-shaped res but the req has
+    // max_tokens (i.e. a real /v1/messages call) — must be kept.
+    writeEntry(home, 'trap-req', {
+      req: { model: 'claude-opus-4-6', max_tokens: 8096, messages: [] },
+      res: { input_tokens: 5 },
+    });
+    // Ambiguity trap: matching res but req file missing — must be kept.
+    writeEntry(home, 'trap-noreq', { res: { input_tokens: 5 } });
+    // Malformed index line — must be preserved verbatim.
+    fs.appendFileSync(path.join(home, 'logs', 'index.ndjson'), 'not json\n');
+  });
+
+  it('dry run identifies only the real count_tokens entry and modifies nothing', () => {
+    const before = fs.readFileSync(path.join(home, 'logs', 'index.ndjson'), 'utf8');
+    const out = run(home);
+    assert.equal(out.status, 0, out.stderr);
+    assert.match(out.stdout, /count_tokens: 1\b/);
+    assert.match(out.stdout, /ct-1/);
+    assert.match(out.stdout, /dry run/);
+    assert.equal(fs.readFileSync(path.join(home, 'logs', 'index.ndjson'), 'utf8'), before);
+  });
+
+  it('--apply removes exactly the count_tokens entry, keeps traps, writes backup', () => {
+    const out = run(home, ['--apply']);
+    assert.equal(out.status, 0, out.stderr);
+
+    const lines = indexLines(home);
+    assert.equal(lines.length, 4, 'ct-1 removed, 3 entries + malformed line kept');
+    assert.ok(!lines.some(l => l.includes('ct-1')));
+    assert.ok(lines.some(l => l.includes('trap-req')));
+    assert.ok(lines.some(l => l.includes('trap-noreq')));
+    assert.ok(lines.some(l => l === 'not json'));
+
+    const backups = fs.readdirSync(path.join(home, 'logs')).filter(f => f.startsWith('index.ndjson.bak-'));
+    assert.equal(backups.length, 1);
+    const backupLines = fs.readFileSync(path.join(home, 'logs', backups[0]), 'utf8').split('\n').filter(Boolean);
+    assert.equal(backupLines.length, 5, 'backup preserves the pre-cleanup index');
+    assert.equal(fs.readdirSync(path.join(home, 'logs')).filter(f => f.includes('.tmp-')).length, 0, 'no temp file left behind');
+  });
+
+  it('--apply refuses while a hub is alive on this home', () => {
+    fs.writeFileSync(path.join(home, 'hub.json'), JSON.stringify({ pid: process.pid }));
+    const out = run(home, ['--apply']);
+    assert.notEqual(out.status, 0);
+    assert.match(out.stderr, /hub is running/);
+    assert.equal(indexLines(home).length, 5, 'index untouched');
+  });
+});

--- a/test/wire-parsers-anthropic.test.js
+++ b/test/wire-parsers-anthropic.test.js
@@ -25,8 +25,14 @@ describe('wire-parsers/index', () => {
 
 describe('wire-parsers/anthropic', () => {
   describe('isNoiseRequest', () => {
-    it('always returns false for Anthropic', () => {
+    it('classifies count_tokens as noise (#146: fake subagent lanes)', () => {
+      assert.equal(anthropic.isNoiseRequest('/v1/messages/count_tokens', {}, {}), true);
+      assert.equal(anthropic.isNoiseRequest('/v1/messages/count_tokens?beta=true', {}, {}), true);
+    });
+
+    it('keeps real conversation and other paths as entries', () => {
       assert.equal(anthropic.isNoiseRequest('/v1/messages', {}, {}), false);
+      assert.equal(anthropic.isNoiseRequest('/v1/messages?beta=true', {}, {}), false);
       assert.equal(anthropic.isNoiseRequest('/v1/plugins/list', {}, {}), false);
     });
   });


### PR DESCRIPTION
Closes #146.

## Problem

Session `8bd812ca` launched 6 subagents but the workflow swimlane rendered ~25 lanes. The 19 extras were Claude Code's `POST /v1/messages/count_tokens` calls (token pre-counting after large tool results) recorded as fake single-turn subagent entries: the bare `{model, messages}` body — no system, no metadata, no tools — satisfies every subagent heuristic (`isAnthropicSubagent`, `isLikelySubagent`), then `inferParentSession()` glues each call onto the active session, and each distinct `messages[0]` yields a distinct `convId` → one swimlane per call.

## Fix

- `server/wire-parsers/anthropic.js`: `isNoiseRequest` matches `/v1/messages/count_tokens` (query string stripped) → forward with `skipEntry`, same mechanism as quota checks and codex platform pings.
- `scripts/cleanup-count-tokens.js`: removes historical entries from `index.ndjson`. Precise identification (res body is exactly `{"input_tokens": N}` — a shape no `/v1/messages` response produces), dry-run by default, backs up on `--apply`, refuses to rewrite while a hub is alive.
- `docs/wire-protocol-reference.md`: count_tokens behavior recorded + changelog.

## Verification (old-fail / new-pass at every layer)

| Check | Old code | New code |
|---|---|---|
| Unit + e2e (synthetic request, real proxy) | 2 FAIL | PASS (incl. positive control: `/v1/messages` still records) |
| Historical cleanup on isolated index copy | 21 lane keys | 2 lane keys (real browser `wfBuildState`) |
| **Real `claude` traffic**, identical big-file task | **9 fake entries** (`/v1/messages/count_tokens?beta=true`, `isSubagent=true`) | **0 fake entries**, 8 real turns recorded, 1 lane |

Full suite: `CCXRAY_HOME=$(mktemp -d) npm test` → 1011 pass / 0 fail.

Observed live URL carries `?beta=true` — the query-string strip in the matcher is load-bearing, covered by unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)