### PR TITLE
docs: issue-pipeline runbook + tracked /issue-pipeline skill entry

### DIFF
--- a/.claude/skills/issue-pipeline/SKILL.md
+++ b/.claude/skills/issue-pipeline/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: issue-pipeline
+description: >
+  Orchestrate the ccxray GitHub issue backlog in dependency order with subagents —
+  re-verify, develop in worktrees, verify with diff-check evidence, gate, PR.
+  Use when asked to 處理 issue、跑 issue pipeline、continue the backlog、process batch N.
+---
+
+# Issue Pipeline
+
+完整 runbook 以 **`docs/issue-pipeline-runbook.md`** 為準（已進版控）——先完整讀取它，照章執行。本檔只是本機入口捷徑，不放內容：兩份若有出入，一律以 docs 那份為準（`.claude/skills/` 被 repo .gitignore 排除，屬既定政策，所以內容不能只放這裡）。
+
+執行摘要：你是 orchestrator，不親自寫碼。GitHub 是唯一真相（開場重讀 issue/PR/git 實況）。批內序列派工：Explore 重驗 → worktree 開發 subagent → fresh 驗證 subagent（verifying-improvements skill + `docs/verification-principles.md`）→ orchestrator 親自重跑 exit code → gates（隔離 npm test、隔離 smoke、codex 二審）→ PR 附證據。兩次失敗即 blocked。絕不碰 5577 與真實 `~/.ccxray`，絕不直接動 main。結尾輸出：待 merge／blocked／待決策三欄。

--- a/.claude/skills/issue-pipeline/SKILL.md
+++ b/.claude/skills/issue-pipeline/SKILL.md
@@ -10,4 +10,4 @@ description: >
 
 完整 runbook 以 **`docs/issue-pipeline-runbook.md`** 為準（已進版控）——先完整讀取它，照章執行。本檔只是本機入口捷徑，不放內容：兩份若有出入，一律以 docs 那份為準（`.claude/skills/` 被 repo .gitignore 排除，屬既定政策，所以內容不能只放這裡）。
 
-執行摘要：你是 orchestrator，不親自寫碼。GitHub 是唯一真相（開場重讀 issue/PR/git 實況）。批內序列派工：Explore 重驗 → worktree 開發 subagent → fresh 驗證 subagent（verifying-improvements skill + `docs/verification-principles.md`）→ orchestrator 親自重跑 exit code → gates（隔離 npm test、隔離 smoke、codex 二審）→ PR 附證據。兩次失敗即 blocked。絕不碰 5577 與真實 `~/.ccxray`，絕不直接動 main。結尾輸出：待 merge／blocked／待決策三欄。
+執行摘要：你是 orchestrator，不親自寫碼。GitHub 是唯一真相（開場重讀 issue/PR/git 實況）。批內序列派工：Explore 重驗 → worktree 開發 subagent → fresh 驗證 subagent（`docs/verification-principles.md` + `scripts/diff-check.sh`）→ orchestrator 親自重跑 exit code → gates（隔離 npm test、隔離 smoke、codex 二審）→ PR 附證據。兩次失敗即 blocked。絕不碰 5577 與真實 `~/.ccxray`，絕不直接動 main。結尾輸出：待 merge／blocked／待決策三欄。

--- a/docs/issue-pipeline-runbook.md
+++ b/docs/issue-pipeline-runbook.md
@@ -1,0 +1,45 @@
+# Issue Pipeline Runbook
+
+你是 orchestrator：**不親自寫碼**。派工、核實、裁決、記錄。開發與驗證交給 subagent。目標是把人的介入收斂到三點：merge、被點名的決策題、blocked 清單。
+
+## 真相來源：GitHub，不是 session 記憶
+
+- 每批開始先 `gh issue list --state open` + `gh pr list` 重讀實況；**同時 `git log --oneline -5` + `git status` 重驗 git 狀態**（session 快照與記憶都會過時；本機有自動 sync 會推 main，分支可能已被 rebase/merge）。
+- 下方批次表是 2026-07-06 制定的快照。**與 GitHub 實況衝突時以 GitHub 為準，並更新本檔**（改表提交進 PR 或獨立 docs commit）。
+- 每張 issue 完成或 blocked，當下就留 issue comment——進度不留在對話裡。
+
+## 批次順序（批內序列執行，不平行——同檔互撞）
+
+**Batch 0 — 安全快修（獨立小張）**：#163（ws CVE + CI audit gate；WS smoke 需真實 codex 流量，做不到就標註邊界升級給人）→ #164 → #150 → #151 → #165（⚠️ merge 影響已發佈產物，PR 必附 `npm pack --dry-run` 清單）→ #169 第一步（client 補 autoMemory，先寫一致性測試看它紅）。
+
+**Batch 2 — quick win**（Batch 1 收 wf-color 分支已於 2026-07-06 完成）：#156（吸收 #150 的 escapeHtml 搬家，若其已先修則只搬）→ #166 → #167 → #168 → #170。
+
+**Batch 3 — 結構重構（嚴格串行、每批 ≤5 檔、人審每階段）**：#158 → #159 → #160 →（量測 index.js 殘餘後在 #161 留數據，建議關閉或動工）。#157 獨立軌：**動工前升級給人**排 #112/#115/#116/#117 相依。
+
+**Batch 4 — 中期安全**：#152 → #153（⚠️ 長 SSE 誤殺風險，驗收含長串流實測）→ #154 → #155 → #169 結構解（A/B 是 owner 決策題）。
+
+**不派工**：feature backlog（#30/#64/#76/#78）、品味題（#144 殘餘決策、#169 A/B、#157 設計）——列入升級清單等 owner。
+
+## 每張 issue 的標準流程
+
+1. **重驗**：Explore subagent 重驗 issue 內 file:line 證據（都是快照，repo 變動快）。證據失效 → 更新 issue body 再動工；問題已不存在 → 留證據關閉。
+2. **隔離**：獨立 git worktree ＋ branch `fix/NNN-slug`。**絕不在 main 上直接改**（本機自動 sync 會立刻推出去）。
+3. **開發 subagent**：issue body 即規格。硬規則寫進派工 prompt：不順手重構、不碰無關檔案；遇 A/B 設計題**停下標 blocked-on-owner，不猜**。
+4. **驗證（fresh subagent，不共開發者 context）**：載入 `verifying-improvements` skill，按 `docs/verification-principles.md` 的「改動類型→驗證方式」表執行：
+   - bug 類（#150/#151/#164/#169）：`diff-check.sh` old-fail/new-pass
+   - 重構類（#156/#158/#159/#160）：rg 結構指標＋確認沒有 fail-on-old 測試混入
+   - 效能類（#166/#167）：同條件 before/after ≥5 次中位數
+5. **Orchestrator 親自重跑**：只採信自己重跑的 exit code 與數字，不採信任何 subagent 的文字轉述。
+6. **Gates**（全過才開 PR）：`CCXRAY_HOME=$(mktemp -d) npm test` 全綠 → 隔離 smoke（`CCXRAY_HOME=/tmp/ccxray-smoke-$$ ccxray --port 5602 --no-browser`；UI 改動用 browser-harness/CDP）→ codex review gate（codex CLI 二審 clean）。
+7. **PR**：附證據（diff-check 輸出、基準數字、rg 計數、pack 清單），link issue，明說驗了什麼、**沒**驗什麼。
+8. **失敗預算**：同一 issue 兩次修不動 → 留下已試路徑與驗證輸出的 comment、標 blocked → 跳下一張。不硬試第三次。
+
+## 環境安全（硬規則）
+
+- 絕不碰 port 5577、絕不讀寫真實 `~/.ccxray`（使用者的活 hub 正在監控）。
+- 只在 feature branch 工作；不 commit/push main。
+- 刪檔/覆寫前先 `git status` 看該路徑的追蹤狀態——session 快照不可信。
+
+## 升級給人的固定格式
+
+批次結束輸出三欄：**待 merge 的 PR**（各附證據層級：爬到可信度階梯第幾層）／**blocked 清單**（含已試路徑）／**待決策題**（一句話講清 A/B 與你的建議）。

--- a/docs/issue-pipeline-runbook.md
+++ b/docs/issue-pipeline-runbook.md
@@ -28,7 +28,7 @@
 2. **隔離**：獨立 git worktree ＋ branch `fix/NNN-slug`。**絕不在 main 上直接改**（本機自動 sync 會立刻推出去）。
 3. **開發 subagent**：issue body 即規格。硬規則寫進派工 prompt：不順手重構、不碰無關檔案；遇 A/B 設計題**停下標 blocked-on-owner，不猜**。
 4. **驗證（fresh subagent，不共開發者 context）**：按 `docs/verification-principles.md` 的「改動類型→驗證方式」表執行（本機若有 `verifying-improvements` skill 可載入輔助，沒有不影響——所需工具都在 repo 內）：
-   - bug 類（#150/#151/#164/#169）：`scripts/diff-check.sh <base-ref> <test-file...> -- <test-cmd...>` 產出 old-fail/new-pass 證明（exit 0=成立、1=新碼沒過、2=測試分辨不出新舊）；腳本不可用時照 `docs/verification-principles.md` 末段的 worktree fallback 手動執行
+   - bug 類（#150/#151/#164/#169）：`scripts/diff-check.sh <base-ref> <test-file...> -- <test-cmd...>` 產出 old-fail/new-pass 證明（exit 0=成立、1=新碼沒過、2=測試分辨不出新舊、3=用法/設定錯誤——不具證據語意，修正呼叫後重跑）；腳本不可用時照 `docs/verification-principles.md` 末段的 worktree fallback 手動執行
    - 重構類（#156/#158/#159/#160）：rg 結構指標＋確認沒有 fail-on-old 測試混入
    - 效能類（#166/#167）：同條件 before/after ≥5 次中位數
 5. **Orchestrator 親自重跑**：只採信自己重跑的 exit code 與數字，不採信任何 subagent 的文字轉述。

--- a/docs/issue-pipeline-runbook.md
+++ b/docs/issue-pipeline-runbook.md
@@ -10,6 +10,8 @@
 
 ## 批次順序（批內序列執行，不平行——同檔互撞）
 
+**相依分支規則**：有前置相依的 issue（例：#156 依 #150 的 escapeHtml 搬家）必須等前置 PR **merge 進 main 後**、從最新 main 開分支才動工；**絕不 stack PR**（不以另一個未 merge 的 branch 為 base）。等待前置 merge 期間，可以先做同批內無相依的下一張。
+
 **Batch 0 — 安全快修（獨立小張）**：#163（ws CVE + CI audit gate；WS smoke 需真實 codex 流量，做不到就標註邊界升級給人）→ #164 → #150 → #151 → #165（⚠️ merge 影響已發佈產物，PR 必附 `npm pack --dry-run` 清單）→ #169 第一步（client 補 autoMemory，先寫一致性測試看它紅）。
 
 **Batch 2 — quick win**（Batch 1 收 wf-color 分支已於 2026-07-06 完成）：#156（吸收 #150 的 escapeHtml 搬家，若其已先修則只搬）→ #166 → #167 → #168 → #170。
@@ -22,11 +24,11 @@
 
 ## 每張 issue 的標準流程
 
-1. **重驗**：Explore subagent 重驗 issue 內 file:line 證據（都是快照，repo 變動快）。證據失效 → 更新 issue body 再動工；問題已不存在 → 留證據關閉。
+1. **重驗**：Explore subagent 重驗 issue 內 file:line 證據（都是快照，repo 變動快）。證據失效 → **留 corrective comment**（新舊 file:line 對照）再動工，issue body 非經 owner 同意不改；問題已不存在 → 留證據 comment 並升級給 owner 決定關閉。
 2. **隔離**：獨立 git worktree ＋ branch `fix/NNN-slug`。**絕不在 main 上直接改**（本機自動 sync 會立刻推出去）。
 3. **開發 subagent**：issue body 即規格。硬規則寫進派工 prompt：不順手重構、不碰無關檔案；遇 A/B 設計題**停下標 blocked-on-owner，不猜**。
-4. **驗證（fresh subagent，不共開發者 context）**：載入 `verifying-improvements` skill，按 `docs/verification-principles.md` 的「改動類型→驗證方式」表執行：
-   - bug 類（#150/#151/#164/#169）：`diff-check.sh` old-fail/new-pass
+4. **驗證（fresh subagent，不共開發者 context）**：按 `docs/verification-principles.md` 的「改動類型→驗證方式」表執行（本機若有 `verifying-improvements` skill 可載入輔助，沒有不影響——所需工具都在 repo 內）：
+   - bug 類（#150/#151/#164/#169）：`scripts/diff-check.sh <base-ref> <test-file...> -- <test-cmd...>` 產出 old-fail/new-pass 證明（exit 0=成立、1=新碼沒過、2=測試分辨不出新舊）；腳本不可用時照 `docs/verification-principles.md` 末段的 worktree fallback 手動執行
    - 重構類（#156/#158/#159/#160）：rg 結構指標＋確認沒有 fail-on-old 測試混入
    - 效能類（#166/#167）：同條件 before/after ≥5 次中位數
 5. **Orchestrator 親自重跑**：只採信自己重跑的 exit code 與數字，不採信任何 subagent 的文字轉述。

--- a/scripts/diff-check.sh
+++ b/scripts/diff-check.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# 差異檢查：同一測試在舊碼必須 FAIL、新碼必須 PASS。
+# 用法: diff-check.sh <base-ref> <test-file...> -- <test-cmd...>
+# 例:   diff-check.sh main test/escape.test.js -- node --test test/escape.test.js
+# Exit: 0 = old FAIL / new PASS  1 = 新碼失敗  2 = 舊碼也 PASS(測試分辨不出新舊)
+set -euo pipefail
+
+base="$1"; shift
+tests=()
+while [[ "$1" != "--" ]]; do tests+=("$1"); shift; done
+shift
+cmd=("$@")
+
+root=$(git rev-parse --show-toplevel)
+wt=$(mktemp -d)/before
+git -C "$root" worktree add --force --detach "$wt" "$base" >/dev/null 2>&1
+trap 'git -C "$root" worktree remove --force "$wt" >/dev/null 2>&1 || true' EXIT
+
+# 新測試複製進舊碼；deps 用 symlink 共享，避免舊碼因缺 node_modules 假失敗
+for t in "${tests[@]}"; do
+  mkdir -p "$wt/$(dirname "$t")"
+  cp "$root/$t" "$wt/$t"
+done
+[[ -d "$root/node_modules" && ! -e "$wt/node_modules" ]] && ln -s "$root/node_modules" "$wt/node_modules"
+
+echo "== NEW code: expect PASS =="
+if ! (cd "$root" && "${cmd[@]}"); then
+  echo "❌ 新碼失敗 — 先讓它綠再來證明差異"; exit 1
+fi
+
+echo "== OLD code ($base): expect FAIL =="
+if (cd "$wt" && "${cmd[@]}"); then
+  echo "⚠️  舊碼也 PASS — 這個測試分辨不出新舊，證明不了「更好」"; exit 2
+fi
+
+echo "✅ old FAIL / new PASS — 差異檢查成立"

--- a/scripts/diff-check.sh
+++ b/scripts/diff-check.sh
@@ -2,24 +2,44 @@
 # 差異檢查：同一測試在舊碼必須 FAIL、新碼必須 PASS。
 # 用法: diff-check.sh <base-ref> <test-file...> -- <test-cmd...>
 # 例:   diff-check.sh main test/escape.test.js -- node --test test/escape.test.js
-# Exit: 0 = old FAIL / new PASS  1 = 新碼失敗  2 = 舊碼也 PASS(測試分辨不出新舊)
+# Exit: 0 = old FAIL / new PASS   1 = 新碼失敗   2 = 舊碼也 PASS(測試分辨不出新舊)
+#       3 = 用法/設定錯誤(不具證據語意 — 修正呼叫方式後重跑)
 set -euo pipefail
 
+die() { echo "❌ usage/config: $*" >&2; exit 3; }
+
+[[ $# -ge 1 ]] || die "缺 base-ref。用法: diff-check.sh <base-ref> <test-file...> -- <test-cmd...>"
 base="$1"; shift
+
+# 解析 test-files 直到 '--'；缺 '--' 或無 test-file 都是設定錯誤，不可當證據
 tests=()
-while [[ "$1" != "--" ]]; do tests+=("$1"); shift; done
-shift
+found_sep=0
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--" ]]; then found_sep=1; shift; break; fi
+  tests+=("$1"); shift
+done
+[[ $found_sep -eq 1 ]] || die "缺 '--' 分隔符，無法區分 test-file 與 test-cmd"
+[[ ${#tests[@]} -ge 1 ]] || die "'--' 前至少要有一個 test-file（否則差異證明無測試可帶進舊碼）"
 cmd=("$@")
+[[ ${#cmd[@]} -ge 1 ]] || die "'--' 後缺 test-cmd"
 
 root=$(git rev-parse --show-toplevel)
+
+# 每個 test-file 必須在新碼存在，否則無從複製進舊碼、證據無效
+for t in "${tests[@]}"; do
+  [[ -f "$root/$t" ]] || die "test-file 不存在於當前工作樹: $t"
+done
+
 wt=$(mktemp -d)/before
-git -C "$root" worktree add --force --detach "$wt" "$base" >/dev/null 2>&1
+git -C "$root" worktree add --force --detach "$wt" "$base" >/dev/null 2>&1 \
+  || die "無法在 $base 建立 worktree（ref 不存在？）"
 trap 'git -C "$root" worktree remove --force "$wt" >/dev/null 2>&1 || true' EXIT
 
-# 新測試複製進舊碼；deps 用 symlink 共享，避免舊碼因缺 node_modules 假失敗
+# 新測試複製進舊碼並確認落地；deps 用 symlink 共享，避免舊碼因缺 node_modules 假失敗
 for t in "${tests[@]}"; do
   mkdir -p "$wt/$(dirname "$t")"
   cp "$root/$t" "$wt/$t"
+  [[ -f "$wt/$t" ]] || die "測試檔複製進舊 worktree 失敗: $t"
 done
 [[ -d "$root/node_modules" && ! -e "$wt/node_modules" ]] && ln -s "$root/node_modules" "$wt/node_modules"
 


### PR DESCRIPTION
## 摘要

把 issue backlog 的處理方式制度化：新增 orchestrator runbook（`docs/issue-pipeline-runbook.md`），定義批次順序（Batch 0 安全快修 → 2 quick win → 3 結構重構 → 4 中期安全）、每張 issue 的八步標準流程（重驗 → worktree 開發 → fresh 驗證 → orchestrator 親自重跑 → 三道 gate → PR 附證據 → 兩次失敗即 blocked）、環境安全硬規則（不碰 5577／真實 `~/.ccxray`／main），以及升級給人的固定輸出格式。另將 `/issue-pipeline` skill 薄殼入口以 `-f` 納入版控（`.claude/skills/` 的 gitignore 規則不變），clone 即可用。驗證紀律依 `docs/verification-principles.md`（差異檢查 old-fail/new-pass）。

## Details

**What**

- `docs/issue-pipeline-runbook.md` — the single source of truth for orchestrated backlog processing:
  - Batch order derived from the dependency analysis across #150–#170 (security harvest, architecture deepening, external-audit findings), with per-issue caveats (e.g. #165 touches the published artifact, #153 must not kill long SSE streams).
  - An 8-step per-issue protocol: re-verify file:line evidence (issue bodies are dated snapshots) → isolated worktree + `fix/NNN-slug` branch → dev subagent with hard no-scope-creep rules → fresh-context verification subagent applying `docs/verification-principles.md` (diff-check for bug fixes, structural `rg` metrics for refactors, ≥5-run median benchmarks for perf) → orchestrator re-runs evidence itself (exit codes over narration) → gates (isolated `npm test`, isolated smoke on port 5602, codex review) → PR with attached evidence → 2-strike failure budget.
  - GitHub as the only source of truth: state is re-read at batch start and recorded back as issue comments, never kept in session memory.
- `.claude/skills/issue-pipeline/SKILL.md` — thin entry shell so any clone gets `/issue-pipeline`; force-added as a single tracked exception while `.claude/skills/` stays gitignored for local skills.

**Why**

Recent sessions produced 18 self-contained issues designed for autonomous processing. This runbook is the missing piece that lets a fresh orchestrator session execute them in order with minimal human involvement (human touchpoints reduced to: merges, named design decisions, blocked list), while structurally preventing the known failure modes: fake completion (old-fail/new-pass evidence re-run by the orchestrator), stale-snapshot edits (mandatory git/GitHub re-verification), and environment damage (isolation rules).

**Verification**

Docs-only change; no runtime code touched. Runbook cross-references verified against open issues #150–#170 and `docs/verification-principles.md` (both on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
