### PR TITLE
docs(pipeline): add autonomy principle — pause only when human input is truly needed

### DIFF
--- a/.claude/skills/issue-pipeline/SKILL.md
+++ b/.claude/skills/issue-pipeline/SKILL.md
@@ -10,4 +10,4 @@ description: >
 
 完整 runbook 以 **`docs/issue-pipeline-runbook.md`** 為準（已進版控）——先完整讀取它，照章執行。本檔只是本機入口捷徑，不放內容：兩份若有出入，一律以 docs 那份為準（`.claude/skills/` 被 repo .gitignore 排除，屬既定政策，所以內容不能只放這裡）。
 
-執行摘要：你是 orchestrator，不親自寫碼。GitHub 是唯一真相（開場重讀 issue/PR/git 實況）。批內序列派工：Explore 重驗 → worktree 開發 subagent → fresh 驗證 subagent（`docs/verification-principles.md` + `scripts/diff-check.sh`）→ orchestrator 親自重跑 exit code → gates（隔離 npm test、隔離 smoke、codex 二審）→ PR 附證據。兩次失敗即 blocked。絕不碰 5577 與真實 `~/.ccxray`，絕不直接動 main。結尾輸出：待 merge／blocked／待決策三欄。
+執行摘要：你是 orchestrator，不親自寫碼。GitHub 是唯一真相（開場重讀 issue/PR/git 實況）。批內序列派工：Explore 重驗 → worktree 開發 subagent → fresh 驗證 subagent（`docs/verification-principles.md` + `scripts/diff-check.sh`）→ orchestrator 親自重跑 exit code → gates（隔離 npm test、隔離 smoke、codex 二審）→ PR 附證據。兩次失敗即 blocked。絕不碰 5577 與真實 `~/.ccxray`，絕不直接動 main。結尾輸出：待 merge／blocked／待決策三欄。**自主推進：只在破壞性/不可逆操作、真正範圍變更、或只有 owner 能給的資訊/決策時暫停；其餘可逆且範圍內的步驟直接做完再報告，不要中途問「要不要…？」。**

--- a/docs/issue-pipeline-runbook.md
+++ b/docs/issue-pipeline-runbook.md
@@ -2,6 +2,15 @@
 
 你是 orchestrator：**不親自寫碼**。派工、核實、裁決、記錄。開發與驗證交給 subagent。目標是把人的介入收斂到三點：merge、被點名的決策題、blocked 清單。
 
+## 自主推進原則
+
+只在工作真正需要人介入時暫停：**破壞性或不可逆的操作**、**真正的範圍變更**、**只有 owner 能提供的資訊或決策**。其餘一律繼續推進，完成後才報告——不要為可逆、範圍內、有合理預設的步驟停下來問「要不要…？」。
+
+判斷準則：
+- **停**：merge（見 base branch protection 一節）、刪 remote branch、關 issue、改 issue body、跨 issue 的範圍擴張、A/B 設計題（#157/#169-A/B 之類）、兩次失敗的 blocked。
+- **不停、直接做**：開分支/worktree、commit、開 PR、跑測試與 smoke、重驗證據、修 review findings、留 issue/PR comment、批內序列推進下一張。
+- 不確定屬於哪類時，看「錯了能不能廉價回滾」——能就做、做完報告；不能就停。
+
 ## 真相來源：GitHub，不是 session 記憶
 
 - 每批開始先 `gh issue list --state open` + `gh pr list` 重讀實況；**同時 `git log --oneline -5` + `git status` 重驗 git 狀態**（session 快照與記憶都會過時；本機有自動 sync 會推 main，分支可能已被 rebase/merge）。


### PR DESCRIPTION
## 摘要

在 issue-pipeline runbook 加入「自主推進原則」：orchestrator 只在真正需要人介入時暫停——破壞性/不可逆操作、真正的範圍變更、或只有 owner 能提供的資訊/決策；其餘可逆且範圍內的步驟繼續推進，完成後才報告。附停/不停的具體判斷清單與「錯了能否廉價回滾」的兜底規則。runbook 正典與 `/issue-pipeline` skill 薄殼同步。

## Details

**What**

- `docs/issue-pipeline-runbook.md`: new "自主推進原則" section right under the orchestrator role definition, refining the existing "three human touchpoints" into an actionable pause/proceed rule.
  - **Pause**: merge, delete remote branch, close/edit issue, cross-issue scope expansion, A/B design decisions (e.g. #157/#169-A/B), 2-strike blocked.
  - **Proceed without asking**: create branch/worktree, commit, open PR, run tests/smoke, re-verify evidence, fix review findings, leave issue/PR comments, advance to the next issue in-batch.
  - **Tiebreaker**: if unsure, ask "can this be cheaply rolled back if wrong?" — if yes, do it and report after; if no, pause.
- `.claude/skills/issue-pipeline/SKILL.md`: one-line sync of the same principle in the execution summary.

**Why**

The runbook already aimed to collapse human involvement to three touchpoints, but didn't state the general decision rule for everything else. Without it an autonomous orchestrator tends to over-pause ("要不要…？") on reversible, in-scope steps, defeating the point. This encodes the owner's stated preference: proceed on the reversible, stop only on the irreversible / scope-changing / owner-only.

**Verification**

Docs-only; no runtime code touched. Consistent with the file's own base-branch-protection note (merge remains an explicit pause point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
