### PR TITLE
chore(#165): npm files whitelist — ship runtime only (11.5MB → 953KB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,13 @@
   "bugs": {
     "url": "https://github.com/lis186/ccxray/issues"
   },
+  "files": [
+    "server/",
+    "public/",
+    "shared/",
+    "README*.md",
+    "LICENSE"
+  ],
   "type": "commonjs",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
Closes #165

## What
`package.json` had no `files` field, so `npm pack` shipped screenshots (`.dogfood-backup/*.png`, `docs/*.png`), `prototype/`, and dev docs. Added a whitelist of the actual runtime.

```json
"files": ["server/", "public/", "shared/", "README*.md", "LICENSE"]
```

`shared/` is required (`server/helpers.js` → `require('../shared/injected-tags')`). `package.json` and the bin entry (`server/index.js`, under `server/`) are auto-included by npm. **No version change** (stays 1.10.0).

## Before → After (`npm pack --dry-run`)
| | package size | unpacked | files |
|---|---|---|---|
| before | 8.2 MB | 11.5 MB | 140 |
| after | **262 kB** | **953 kB** | **68** |

Bloat scan of the after list (`.png` / `prototype/` / `docs/` / `.dogfood-backup/`): **0 matches**.

## Verification (orchestrator personally re-ran)
- `npm pack --dry-run` → 262 kB / 953 kB / 68 files; runtime files present (`server/index.js`, `public/miller-columns.js`, `shared/injected-tags.js`).
- **Install-from-tarball smoke**: `npm install --prefix <tmp> ccxray-1.10.0.tgz` then ran `ccxray :5605` — `/`, `/miller-columns.js`, `/style.css`, `/app.js`, `/messages.js`, `/entry-rendering.js`, `/workflow-timeline.js` all **200**, no `MODULE_NOT_FOUND`. Proves the whitelist drops no runtime file.
- `CCXRAY_HOME=$(mktemp -d) npm test` → **1046/1046** (the `files` field can't affect test outcomes; attached for the gate).

## codex review gate
Reviewed via agmsg by `reviewer` (codex): **CLEAN**, no blocking. Independently verified `npm pack --dry-run --json`: 68 files / 261111 B / 953231 B unpacked, no docs/prototype/png, `shared/` present.