### PR TITLE
fix(#151): block path traversal in /_api/tools-diff shared-file reads

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -96,7 +96,8 @@ function handleApiRoutes(clientReq, clientRes) {
   if (clientReq.url.startsWith('/_api/tools-diff')) {
     const params = new URLSearchParams(clientReq.url.split('?')[1] || '');
     const hashA = params.get('a'), hashB = params.get('b');
-    if (!hashA || !hashB) {
+    const HASH_RE = /^[0-9a-f]{12}$/i;
+    if (!hashA || !hashB || !HASH_RE.test(hashA) || !HASH_RE.test(hashB)) {
       clientRes.writeHead(400, { 'Content-Type': 'application/json' });
       clientRes.end(JSON.stringify({ error: 'missing a or b param' }));
       return true;

--- a/server/storage/local.js
+++ b/server/storage/local.js
@@ -14,6 +14,15 @@ const path = require('path');
  *   local adapter, so non-local backends (e.g. S3) never touch the local FS.
  * @returns {import('./interface').StorageAdapter}
  */
+function safeJoin(base, filename) {
+  if (filename.includes('\0')) throw new Error(`unsafe filename: NUL byte`);
+  const resolved = path.resolve(base, filename);
+  if (!resolved.startsWith(path.resolve(base) + path.sep) && resolved !== path.resolve(base)) {
+    throw new Error(`unsafe filename: traversal detected`);
+  }
+  return resolved;
+}
+
 function createLocalStorage(logsDir, opts = {}) {
   const sharedDir = path.join(logsDir, 'shared');
   const indexPath = path.join(logsDir, 'index.ndjson');
@@ -94,7 +103,7 @@ function createLocalStorage(logsDir, opts = {}) {
     // ── Shared content-addressed storage (shared/) ───────────────────
 
     async writeSharedIfAbsent(filename, data) {
-      const p = path.join(sharedDir, filename);
+      const p = safeJoin(sharedDir, filename);
       try {
         await fsp.writeFile(p, data, { flag: 'wx' });
       } catch (e) {
@@ -103,12 +112,12 @@ function createLocalStorage(logsDir, opts = {}) {
     },
 
     async readShared(filename) {
-      return fsp.readFile(path.join(sharedDir, filename), 'utf8');
+      return fsp.readFile(safeJoin(sharedDir, filename), 'utf8');
     },
 
     async statShared(filename) {
       try {
-        return await fsp.stat(path.join(sharedDir, filename));
+        return await fsp.stat(safeJoin(sharedDir, filename));
       } catch { return null; }
     },
 

--- a/test/path-traversal.test.js
+++ b/test/path-traversal.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+// ── A: API layer — tools-diff input whitelist ──────────────────────────────
+
+describe('path-traversal #151', () => {
+
+  describe('/_api/tools-diff input whitelist', () => {
+    const { handleApiRoutes } = require('../server/routes/api');
+
+    function callToolsDiff(url) {
+      return new Promise((resolve) => {
+        const clientReq = { url, method: 'GET' };
+        let statusCode;
+        const clientRes = {
+          writeHead: (code) => { statusCode = code; },
+          end: (data) => { resolve({ statusCode, body: JSON.parse(data) }); },
+        };
+        handleApiRoutes(clientReq, clientRes);
+      });
+    }
+
+    it('rejects traversal in a param → 400', async () => {
+      // ../x is not 12 hex chars → whitelist blocks it
+      const result = await callToolsDiff('/_api/tools-diff?a=../x&b=0123456789ab');
+      assert.equal(result.statusCode, 400, 'traversal in a must return 400');
+    });
+
+    it('rejects traversal in b param → 400', async () => {
+      const result = await callToolsDiff('/_api/tools-diff?a=0123456789ab&b=../../etc/x');
+      assert.equal(result.statusCode, 400, 'traversal in b must return 400');
+    });
+
+    it('rejects non-hex a param → 400', async () => {
+      const result = await callToolsDiff('/_api/tools-diff?a=gggggggggggg&b=0123456789ab');
+      assert.equal(result.statusCode, 400, 'non-hex a must return 400');
+    });
+
+    it('valid 12-hex hashes pass the format gate — not 400', async () => {
+      // Both hashes are valid format. The shared files won't exist, so we may
+      // get 404 or 500, but NOT 400 (which would mean the format check rejected them).
+      const result = await callToolsDiff('/_api/tools-diff?a=0123456789ab&b=abcdef012345');
+      assert.notEqual(result.statusCode, 400, 'valid hashes must not be rejected with 400');
+    });
+  });
+
+  // ── B: Storage layer — safeJoin traversal guard ────────────────────────
+
+  describe('local storage safeJoin', () => {
+    // Build a temporary sharedDir so we can exercise the real adapter
+    const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-test-'));
+    const { createLocalStorage } = require('../server/storage/local');
+    const storage = createLocalStorage(tmpBase);
+
+    // init() creates logsDir/shared
+    before(async () => { await storage.init(); });
+
+    it('readShared with .. component throws traversal error', async () => {
+      await assert.rejects(
+        () => storage.readShared('../escape.json'),
+        /traversal/,
+        'should throw traversal error for ../escape.json'
+      );
+    });
+
+    it('readShared with nested traversal throws traversal error', async () => {
+      // 'subdir/../../../escape.json' — descends into subdir then escapes above sharedDir
+      await assert.rejects(
+        () => storage.readShared('subdir/../../../escape.json'),
+        /traversal/,
+        'should throw traversal error for subdir/../../../escape.json'
+      );
+    });
+
+    it('readShared with absolute path throws traversal error', async () => {
+      await assert.rejects(
+        () => storage.readShared('/etc/hosts'),
+        /traversal/,
+        'should throw traversal error for absolute path'
+      );
+    });
+
+    it('readShared with NUL byte throws', async () => {
+      await assert.rejects(
+        () => storage.readShared('tools_0123456789ab\0.json'),
+        /NUL byte/,
+        'should throw for NUL byte in filename'
+      );
+    });
+
+    it('readShared with legit filename resolves within sharedDir (ENOENT, not traversal)', async () => {
+      // File doesn't exist, but should reach the filesystem — not be blocked by safeJoin
+      try {
+        await storage.readShared('tools_0123456789ab.json');
+        assert.fail('should have thrown (file does not exist)');
+      } catch (e) {
+        assert.ok(
+          e.code === 'ENOENT',
+          `expected ENOENT for missing file, got: ${e.message}`
+        );
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #151

## What
`/_api/tools-diff` `a`/`b` params (client-controlled) were interpolated into shared filenames with no validation, and `local.js` shared reads used `path.join(sharedDir, filename)` with no traversal guard. Defense in depth:
- **A — input whitelist** (`server/routes/api.js`): validate `a`/`b` against `/^[0-9a-f]{12}$/i` (exactly sha12) at the handler entry; malformed → **400** before any read.
- **B — storage safeJoin** (`server/storage/local.js`): new `safeJoin()` (NUL-byte reject + `path.resolve` within-base boundary using `resolvedBase + path.sep`); routes `readShared` / `writeSharedIfAbsent` / `statShared` through it, so a future caller can't traverse even without A.

## Scope corrections (documented in the issue's corrective comment)
- `server/storage/s3.js` is an **unimplemented skeleton** (the storage factory throws on `STORAGE_BACKEND=s3`) → out of scope, not touched.
- The system-prompt diff route uses a `versionIndex` lookup, **not** a raw query param → not vulnerable, not touched.

## Verification (orchestrator personally re-ran)
- **diff-check** `origin/main test/path-traversal.test.js -- node --test` → **exit 0** (NEW 9 pass / OLD 7 fail): old-fail/new-pass proven.
- `CCXRAY_HOME=$(mktemp -d) npm test` → **1055/1055**.
- **Live smoke** (worktree ccxray :5606): `?a=../x&b=<12hex>` → **400**; `a=<12hex>&b=<12hex>` (valid) → **404** (passes the format gate, file just absent); `a=../../../../../../etc/hosts` → **400**; URL-encoded `b=%2e%2e%2fx` → **400**; server no crash; no traversal read in log.

## codex review gate
Reviewed via agmsg by `reviewer` (codex): **CLEAN**, no blocking. Independently confirmed `safeJoin` rejects sibling-prefix escapes (`../shared2/secret.json`) and HASH_RE bounds, 9/9 tests pass.