### PR TITLE
test(#169): guard the three duplicated B2 markerDefs against drift

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -83,19 +83,21 @@ const SP_BLOCK_OWNERS = {
   autoMemory: 'user', customAgents: 'user',
 };
 
+// eslint-disable-next-line no-var -- file-scope var so vm.runInContext tests can read B2_MARKER_DEFS (a top-level const does not attach to the context global)
+var B2_MARKER_DEFS = [
+  { key: 'customSkills',   pattern: /# User'?s Current Configuration/ },
+  { key: 'customAgents',   pattern: /\*\*Available custom agents/ },
+  { key: 'mcpServersList', pattern: /\*\*Configured MCP servers/ },
+  { key: 'pluginSkills',   pattern: /\*\*Available plugin skills/ },
+  { key: 'settingsJson',   pattern: /\*\*User's settings\.json/ },
+  { key: 'envAndGit',      pattern: /# Environment\n|<env>/ },
+  { key: 'autoMemory',     pattern: /# auto memory\n|You have a persistent, file-based memory/ },
+];
+
 function splitB2IntoBlocks(b2) {
-  const markerDefs = [
-    { key: 'customSkills',   pattern: /# User'?s Current Configuration/ },
-    { key: 'customAgents',   pattern: /\*\*Available custom agents/ },
-    { key: 'mcpServersList', pattern: /\*\*Configured MCP servers/ },
-    { key: 'pluginSkills',   pattern: /\*\*Available plugin skills/ },
-    { key: 'settingsJson',   pattern: /\*\*User's settings\.json/ },
-    { key: 'envAndGit',      pattern: /# Environment\n|<env>/ },
-    { key: 'autoMemory',     pattern: /# auto memory\n|You have a persistent, file-based memory/ },
-  ];
   var positions = [];
-  for (var i = 0; i < markerDefs.length; i++) {
-    var m = markerDefs[i];
+  for (var i = 0; i < B2_MARKER_DEFS.length; i++) {
+    var m = B2_MARKER_DEFS[i];
     var match = m.pattern.exec(b2);
     if (match) positions.push({ key: m.key, index: match.index });
   }

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -25,6 +25,17 @@ function safeCountTokens(text) {
 }
 
 // ── Context Breakdown Analysis ───────────────────────────────────────
+
+const B2_MARKER_DEFS = [
+  { key: 'autoMemory',     pattern: /# auto memory\n|You have a persistent, file-based memory/ },
+  { key: 'customSkills',   pattern: /# User'?s Current Configuration/ },
+  { key: 'customAgents',   pattern: /\*\*Available custom agents/ },
+  { key: 'mcpServersList', pattern: /\*\*Configured MCP servers/ },
+  { key: 'pluginSkills',   pattern: /\*\*Available plugin skills/ },
+  { key: 'settingsJson',   pattern: /\*\*User's settings\.json/ },
+  { key: 'envAndGit',      pattern: /# Environment\n|<env>/ },
+];
+
 const TOOL_CATEGORIES = {
   core:  ['Bash','Read','Write','Edit','Glob','Grep','WebFetch','WebSearch','NotebookEdit','ToolSearch'],
   agent: ['Agent','Skill','TaskOutput','TaskStop','AskUserQuestion','EnterPlanMode','ExitPlanMode'],
@@ -47,17 +58,8 @@ function parseSystemBlocks(system) {
   const mainText = system.slice(2).map(b => b.text || '').join('\n');
   if (!mainText) return result;
 
-  const markerDefs = [
-    { key: 'autoMemory',     pattern: /# auto memory\n|You have a persistent, file-based memory/ },
-    { key: 'customSkills',   pattern: /# User'?s Current Configuration/ },
-    { key: 'customAgents',   pattern: /\*\*Available custom agents/ },
-    { key: 'mcpServersList', pattern: /\*\*Configured MCP servers/ },
-    { key: 'pluginSkills',   pattern: /\*\*Available plugin skills/ },
-    { key: 'settingsJson',   pattern: /\*\*User's settings\.json/ },
-    { key: 'envAndGit',      pattern: /# Environment\n|<env>/ },
-  ];
   const positions = [];
-  for (const m of markerDefs) {
+  for (const m of B2_MARKER_DEFS) {
     const match = m.pattern.exec(mainText);
     if (match) positions.push({ key: m.key, index: match.index });
   }
@@ -841,6 +843,7 @@ function isProtectedByStar(meta, sets) {
 }
 
 module.exports = {
+  B2_MARKER_DEFS,
   timestamp,
   taipeiTime,
   printSeparator,

--- a/server/system-prompt.js
+++ b/server/system-prompt.js
@@ -22,6 +22,16 @@ function logUnknownAgent(b2, key) {
 
 // ── System prompt diff helpers ───────────────────────────────────────
 
+const B2_MARKER_DEFS = [
+  { key: 'customSkills',   pattern: /# User'?s Current Configuration/ },
+  { key: 'customAgents',   pattern: /\*\*Available custom agents/ },
+  { key: 'mcpServersList', pattern: /\*\*Configured MCP servers/ },
+  { key: 'pluginSkills',   pattern: /\*\*Available plugin skills/ },
+  { key: 'settingsJson',   pattern: /\*\*User's settings\.json/ },
+  { key: 'envAndGit',      pattern: /# Environment\n|<env>/ },
+  { key: 'autoMemory',     pattern: /# auto memory\n|You have a persistent, file-based memory/ },
+];
+
 const BLOCK_OWNERS_SERVER = {
   billingHeader: 'anthropic', coreIdentity: 'anthropic', coreInstructions: 'anthropic',
   customSkills: 'user', pluginSkills: 'user', mcpServersList: 'user', settingsJson: 'user', envAndGit: 'user',
@@ -102,17 +112,8 @@ function extractPromptAgentType(provider, req) {
 }
 
 function splitB2IntoBlocks(b2) {
-  const markerDefs = [
-    { key: 'customSkills',   pattern: /# User'?s Current Configuration/ },
-    { key: 'customAgents',   pattern: /\*\*Available custom agents/ },
-    { key: 'mcpServersList', pattern: /\*\*Configured MCP servers/ },
-    { key: 'pluginSkills',   pattern: /\*\*Available plugin skills/ },
-    { key: 'settingsJson',   pattern: /\*\*User's settings\.json/ },
-    { key: 'envAndGit',      pattern: /# Environment\n|<env>/ },
-    { key: 'autoMemory',     pattern: /# auto memory\n|You have a persistent, file-based memory/ },
-  ];
   const positions = [];
-  for (const m of markerDefs) {
+  for (const m of B2_MARKER_DEFS) {
     const match = m.pattern.exec(b2);
     if (match) positions.push({ key: m.key, index: match.index });
   }
@@ -213,6 +214,7 @@ function computeUnifiedDiff(textA, textB, labelA, labelB) {
 }
 
 module.exports = {
+  B2_MARKER_DEFS,
   BLOCK_OWNERS_SERVER,
   extractAgentType,
   extractPromptAgentType,

--- a/test/markerdefs-consistency.test.js
+++ b/test/markerdefs-consistency.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+// #169: regression guard — three independent B2_MARKER_DEFS copies must stay
+// key+regex-identical. Array order is irrelevant (splitB2IntoBlocks sorts by
+// text index), so we normalize to sorted "key pattern.source" strings before
+// comparing. A future one-sided marker change will fail this test.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const EXPECTED_KEYS = new Set([
+  'autoMemory', 'customSkills', 'customAgents',
+  'mcpServersList', 'pluginSkills', 'settingsJson', 'envAndGit',
+]);
+
+function normalize(defs) {
+  return defs
+    .map(d => d.key + ' ' + d.pattern.source)
+    .sort()
+    .join('\n');
+}
+
+// ── Load client (miller-columns.js) in a VM, same pattern as ctx-color.test.js ──
+function loadClient() {
+  const publicDir = path.join(__dirname, '..', 'public');
+  const el = () => ({
+    style: {}, dataset: {}, innerHTML: '', textContent: '',
+    classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+    addEventListener() {}, appendChild() {}, insertBefore() {},
+    querySelector: () => el(), querySelectorAll: () => [], remove() {},
+  });
+  const context = {
+    console, window: {},
+    document: {
+      getElementById: () => el(), createElement: () => el(),
+      querySelector: () => el(), querySelectorAll: () => [],
+      addEventListener() {}, body: el(),
+    },
+    localStorage: { getItem: () => null, setItem() {} },
+    sessionStorage: { getItem: () => null, setItem() {} },
+    navigator: {}, location: { search: '', hash: '' },
+    history: { replaceState() {} },
+    URLSearchParams, setTimeout, clearTimeout,
+  };
+  vm.createContext(context);
+  vm.runInContext(`
+    function updateSysPromptBadge() {} function startQuotaTicker() {}
+    function EventSource() { this.onmessage = null; } function setInterval() { return 0; }
+    function clearInterval() {} window.ccxraySettings = { visibleProviders: [] };
+    function fetch() { return Promise.resolve({ ok: false, json() { return Promise.resolve({}); } }); }
+  `, context);
+  vm.runInContext(fs.readFileSync(path.join(publicDir, 'miller-columns.js'), 'utf8'), context);
+  return context;
+}
+
+describe('#169 B2_MARKER_DEFS consistency across all three copies', () => {
+  const helpers = require('../server/helpers');
+  const sysprompt = require('../server/system-prompt');
+  const clientCtx = loadClient();
+
+  const serverHelpersDefs  = helpers.B2_MARKER_DEFS;
+  const serverSyspromptDefs = sysprompt.B2_MARKER_DEFS;
+  const clientDefs          = clientCtx.B2_MARKER_DEFS;
+
+  it('server/helpers.js exports B2_MARKER_DEFS', () => {
+    assert.ok(Array.isArray(serverHelpersDefs), 'should be an array');
+  });
+
+  it('server/system-prompt.js exports B2_MARKER_DEFS', () => {
+    assert.ok(Array.isArray(serverSyspromptDefs), 'should be an array');
+  });
+
+  it('public/miller-columns.js exposes B2_MARKER_DEFS as VM global', () => {
+    assert.ok(Array.isArray(clientDefs), 'should be an array');
+  });
+
+  it('all three copies have exactly 7 entries', () => {
+    assert.equal(serverHelpersDefs.length,  7, 'server/helpers.js');
+    assert.equal(serverSyspromptDefs.length, 7, 'server/system-prompt.js');
+    assert.equal(clientDefs.length,          7, 'public/miller-columns.js');
+  });
+
+  it('all three copies contain the 7 expected keys', () => {
+    for (const defs of [serverHelpersDefs, serverSyspromptDefs, clientDefs]) {
+      const keys = new Set(defs.map(d => d.key));
+      for (const k of EXPECTED_KEYS) assert.ok(keys.has(k), `missing key: ${k}`);
+      assert.equal(keys.size, 7);
+    }
+  });
+
+  it('server/helpers.js and server/system-prompt.js are key+regex identical', () => {
+    assert.equal(normalize(serverHelpersDefs), normalize(serverSyspromptDefs));
+  });
+
+  it('server/helpers.js and public/miller-columns.js are key+regex identical', () => {
+    assert.equal(normalize(serverHelpersDefs), normalize(clientDefs));
+  });
+
+  it('server/system-prompt.js and public/miller-columns.js are key+regex identical', () => {
+    assert.equal(normalize(serverSyspromptDefs), normalize(clientDefs));
+  });
+});


### PR DESCRIPTION
Closes #169

## Context — the issue premise had already dissolved
Re-verification (see the issue's [corrective comment](https://github.com/lis186/ccxray/issues/169#issuecomment-4897269454)) found the described drift ("client missing `autoMemory`") **no longer exists**: all three `markerDefs` copies (`server/helpers.js`, `server/system-prompt.js`, `public/miller-columns.js`) already carry all 7 markers. They differ only in array **order**, and `splitB2IntoBlocks` sorts matches by text index — so there is **no behavioral drift** today.

Per owner decision (**option 2**), this PR adds a **regression guard** against a future one-sided change (the way `autoMemory` once drifted). Consolidating the three copies into a single source (option A/B) remains a deferred decision.

## What
- Hoist each local `markerDefs` to a named `B2_MARKER_DEFS`: server side module-scope `const` + `module.exports`; client side a **file-scope `var`** (a top-level `const` does not attach to a `vm.runInContext` global — documented with an `eslint-disable no-var`).
- New `test/markerdefs-consistency.test.js`: loads all three (server via `require`, client via the `ctx-color.test.js` VM pattern) and asserts identical `{key, pattern.source}` **sets** (order-agnostic).
- **No regex or split-algorithm change** — behavior identical.

## Verification (orchestrator personally re-ran)
- Pure-hoist confirmed: `git diff` adds no `pattern:` / `.exec` / `sort` / `slice` lines.
- Full suite (`node --test test/*.test.js`, perl-alarm bounded 300s) → **1073/1073, exit 0**.
- Guard green: **8/8**.
- **Mutation check** (effectiveness proof, in lieu of diff-check since this is a green-from-start guard, not a bug fix): dropping one marker from the client copy makes the guard **FAIL (4 pass / 4 fail)**; `git checkout` revert → **8/8** again.

## codex review gate
Reviewed via agmsg by `reviewer` (codex): **CLEAN / no findings** — scope matches, no regex/algorithm change, guard 8/8, independently confirmed all three sets match.