### PR TITLE
perf(#183): baseline harness — fixture generator + measurement

### DIFF
--- a/scripts/perf/generate-fixture.js
+++ b/scripts/perf/generate-fixture.js
@@ -175,7 +175,8 @@ async function generate({ entries: numEntries = DEFAULT_ENTRIES, output } = {}) 
     coreHash: shortHash(9997),
   };
 
-  let baseMs = new Date('2026-01-15T10:00:00.000Z').getTime();
+  // ponytail: use recent dates so server's RESTORE_DAYS filter doesn't discard them
+  let baseMs = Date.now() - 3 * 24 * 60 * 60 * 1000; // 3 days ago
   const allEntries = [];  // { id, indexLine, reqJson, resJson }
 
   // ── 1. Delta chain (8 hops) ─────────────────────────────────────

--- a/scripts/perf/generate-fixture.js
+++ b/scripts/perf/generate-fixture.js
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Synthetic CCXRAY_HOME generator for perf baseline work (#183).
+ *
+ * Usage:
+ *   node scripts/perf/generate-fixture.js [--entries 5000] [--output /tmp/perf-home]
+ *
+ * Prints the output directory path on success.
+ */
+
+const fsp = require('fs').promises;
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+
+const DEFAULT_ENTRIES = 5000;
+const DELTA_CHAIN_LENGTH = 8;  // 1 anchor + 7 deltas
+const MSGS_PER_HOP = 4;        // each hop adds 4 messages; final turn = 32 messages
+const MSG_SIZE = 500;           // chars per message
+const NUM_PROJECTS = 10;
+const NUM_SESSIONS = 50;
+const BATCH_SIZE = 200;
+
+// ── ID helpers ──────────────────────────────────────────────────────
+
+function formatId(ms) {
+  const d = new Date(ms);
+  const pad2 = n => String(n).padStart(2, '0');
+  const pad3 = n => String(n).padStart(3, '0');
+  return (
+    `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}` +
+    `T${pad2(d.getUTCHours())}-${pad2(d.getUTCMinutes())}-${pad2(d.getUTCSeconds())}-${pad3(d.getUTCMilliseconds())}`
+  );
+}
+
+function shortHash(seed) {
+  return crypto.createHash('sha1').update(String(seed)).digest('hex').slice(0, 6);
+}
+
+// ── Filler content ──────────────────────────────────────────────────
+
+const WORDS = [
+  'system', 'prompt', 'tool', 'context', 'message', 'response',
+  'assistant', 'user', 'code', 'model', 'request', 'token',
+  'session', 'agent', 'task', 'result', 'data', 'error',
+];
+
+function filler(seed, length) {
+  let s = '';
+  let i = seed;
+  while (s.length < length) {
+    s += WORDS[i % WORDS.length] + ' ';
+    i++;
+  }
+  return s.slice(0, length);
+}
+
+function makeMessages(startIdx, count) {
+  return Array.from({ length: count }, (_, i) => ({
+    role: (startIdx + i) % 2 === 0 ? 'user' : 'assistant',
+    content: filler((startIdx + i) * 7, MSG_SIZE),
+  }));
+}
+
+// ── Entry builders ──────────────────────────────────────────────────
+
+function makeIndexEntry(id, sessionId, cwd, turnNum, msgCount, toolCount, hashes) {
+  const { sysHash, toolsHash, coreHash } = hashes;
+  const agentKey = `claude-code::${coreHash}`;
+  const receivedAt = new Date(id.replace(/T(\d{2})-(\d{2})-(\d{2})-(\d{3})/, 'T$1:$2:$3.$4Z')).getTime();
+  return {
+    id,
+    ts: id.slice(11, 19).replace(/-/g, ':'),
+    sessionId,
+    provider: 'anthropic',
+    agent: 'claude-code',
+    model: 'claude-sonnet-4-6',
+    msgCount,
+    toolCount,
+    toolCalls: toolCount > 0 ? { Bash: toolCount } : {},
+    isSubagent: false,
+    sessionInferred: false,
+    cwd,
+    isSSE: true,
+    usage: {
+      input_tokens: msgCount * 120,
+      output_tokens: 80,
+      cache_creation_input_tokens: Math.floor(msgCount * 30),
+      cache_read_input_tokens: Math.floor(msgCount * 60),
+    },
+    cost: { cost: 0.05 },
+    maxContext: 200000,
+    stopReason: 'end_turn',
+    title: `Turn ${turnNum}`,
+    receivedAt,
+    elapsed: 1200 + Math.floor(Math.random() * 800),
+    sysHash,
+    toolsHash,
+    coreHash,
+    agentKey,
+  };
+}
+
+function makeAnchorReq(msgCount, hashes) {
+  return {
+    model: 'claude-sonnet-4-6',
+    max_tokens: 8096,
+    messages: makeMessages(0, msgCount),
+    sysHash: hashes.sysHash,
+    toolsHash: hashes.toolsHash,
+  };
+}
+
+function makeDeltaReq(prevId, msgOffset, newMsgCount, msgStart, hashes) {
+  return {
+    model: 'claude-sonnet-4-6',
+    max_tokens: 8096,
+    prevId,
+    msgOffset,
+    messages: makeMessages(msgStart, newMsgCount),
+    sysHash: hashes.sysHash,
+    toolsHash: hashes.toolsHash,
+  };
+}
+
+function makeFullReq(msgCount, seed, hashes) {
+  return {
+    model: 'claude-sonnet-4-6',
+    max_tokens: 8096,
+    messages: makeMessages(seed, msgCount),
+    sysHash: hashes.sysHash,
+    toolsHash: hashes.toolsHash,
+  };
+}
+
+function makeRes(outputTokens) {
+  return [
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+    { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: filler(42, 200) } },
+    { type: 'content_block_stop', index: 0 },
+    { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: outputTokens } },
+  ];
+}
+
+// ── Main generator ──────────────────────────────────────────────────
+
+async function generate({ entries: numEntries = DEFAULT_ENTRIES, output } = {}) {
+  const outputDir = output || path.join(os.tmpdir(), `ccxray-perf-${Date.now()}`);
+  const logsDir = path.join(outputDir, 'logs');
+  const sharedDir = path.join(logsDir, 'shared');
+
+  await fsp.mkdir(sharedDir, { recursive: true });
+
+  const projects = Array.from({ length: NUM_PROJECTS }, (_, i) => `/mock/project-${i + 1}`);
+  const sessions = Array.from({ length: NUM_SESSIONS }, (_, i) => ({
+    sessionId: `session-${String(i).padStart(4, '0')}`,
+    cwd: projects[i % NUM_PROJECTS],
+    sysHash: shortHash(i),
+    toolsHash: shortHash(i + 100),
+    coreHash: shortHash(i + 200),
+  }));
+
+  // Shared hashes used by the delta chain
+  const chainHashes = {
+    sysHash: shortHash(9999),
+    toolsHash: shortHash(9998),
+    coreHash: shortHash(9997),
+  };
+
+  let baseMs = new Date('2026-01-15T10:00:00.000Z').getTime();
+  const allEntries = [];  // { id, indexLine, reqJson, resJson }
+
+  // ── 1. Delta chain (8 hops) ─────────────────────────────────────
+  const deltaIds = [];
+  const DELTA_SESSION = 'delta-chain-session-0001';
+
+  for (let hop = 0; hop < DELTA_CHAIN_LENGTH; hop++) {
+    const id = formatId(baseMs);
+    baseMs += 1000;
+    deltaIds.push(id);
+
+    const totalMsgs = (hop + 1) * MSGS_PER_HOP;
+    const msgOffset = hop * MSGS_PER_HOP;
+    const msgStart = msgOffset;  // so messages don't repeat content
+
+    let reqJson;
+    if (hop === 0) {
+      reqJson = makeAnchorReq(MSGS_PER_HOP, chainHashes);
+    } else {
+      reqJson = makeDeltaReq(deltaIds[hop - 1], msgOffset, MSGS_PER_HOP, msgStart, chainHashes);
+    }
+
+    const indexEntry = makeIndexEntry(id, DELTA_SESSION, '/mock/delta-project', hop + 1, totalMsgs, 0, chainHashes);
+    allEntries.push({
+      id,
+      indexLine: JSON.stringify(indexEntry),
+      reqJson: JSON.stringify(reqJson),
+      resJson: JSON.stringify(makeRes(80 + hop * 10)),
+    });
+  }
+
+  // ── 2. Bulk entries ─────────────────────────────────────────────
+  const remaining = Math.max(0, numEntries - DELTA_CHAIN_LENGTH);
+  for (let i = 0; i < remaining; i++) {
+    const id = formatId(baseMs);
+    baseMs += 1000;
+
+    const sess = sessions[i % sessions.length];
+    const msgCount = 2 + (i % 49);   // 2-50 messages
+    const toolCount = i % 5;
+
+    const indexEntry = makeIndexEntry(id, sess.sessionId, sess.cwd, i + 1, msgCount, toolCount, sess);
+    const reqJson = JSON.stringify(makeFullReq(msgCount, i * 3, sess));
+    const resJson = JSON.stringify(makeRes(60 + (i % 50)));
+
+    allEntries.push({ id, indexLine: JSON.stringify(indexEntry), reqJson, resJson });
+  }
+
+  // ── 3. Write in batches ─────────────────────────────────────────
+  const indexLines = [];
+
+  for (let i = 0; i < allEntries.length; i += BATCH_SIZE) {
+    const batch = allEntries.slice(i, i + BATCH_SIZE);
+    await Promise.all(batch.map(e =>
+      Promise.all([
+        fsp.writeFile(path.join(logsDir, e.id + '_req.json'), e.reqJson),
+        fsp.writeFile(path.join(logsDir, e.id + '_res.json'), e.resJson),
+      ])
+    ));
+    for (const e of batch) indexLines.push(e.indexLine);
+  }
+
+  await fsp.writeFile(path.join(logsDir, 'index.ndjson'), indexLines.join('\n') + '\n');
+
+  return { outputDir, logsDir, entryCount: allEntries.length, deltaChainIds: deltaIds };
+}
+
+// ── CLI entry point ─────────────────────────────────────────────────
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  let numEntries = DEFAULT_ENTRIES;
+  let output = null;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--entries' && args[i + 1]) {
+      numEntries = parseInt(args[i + 1], 10);
+      i++;
+    } else if (args[i] === '--output' && args[i + 1]) {
+      output = args[i + 1];
+      i++;
+    }
+  }
+
+  generate({ entries: numEntries, output })
+    .then(({ outputDir, entryCount, deltaChainIds }) => {
+      process.stdout.write(outputDir + '\n');
+      process.stderr.write(`Generated ${entryCount} entries (delta chain: ${deltaChainIds.length} hops)\n`);
+      process.stderr.write(`Last delta entry: ${deltaChainIds[deltaChainIds.length - 1]}\n`);
+    })
+    .catch(err => {
+      process.stderr.write(`Error: ${err.message}\n`);
+      process.exit(1);
+    });
+}
+
+module.exports = { generate };

--- a/scripts/perf/generate-fixture.js
+++ b/scripts/perf/generate-fixture.js
@@ -8,6 +8,12 @@
  *   node scripts/perf/generate-fixture.js [--entries 5000] [--output /tmp/perf-home]
  *
  * Prints the output directory path on success.
+ *
+ * Fixture shapes derived from live module analysis (2026-07-07):
+ *   Index entry fields: server/store.js buildEntryFields() + server/forward.js:726-743
+ *   Delta _req.json:    server/restore.js:41-62 (prevId, msgOffset format)
+ *   SSE _res.json:      server/sse-broadcast.js:7-48 (content_block_delta events)
+ *   Field distributions: server/config.js MAX_ENTRIES=5000, typical session 20-50 turns
  */
 
 const fsp = require('fs').promises;
@@ -234,7 +240,7 @@ async function generate({ entries: numEntries = DEFAULT_ENTRIES, output } = {}) 
 
   await fsp.writeFile(path.join(logsDir, 'index.ndjson'), indexLines.join('\n') + '\n');
 
-  return { outputDir, logsDir, entryCount: allEntries.length, deltaChainIds: deltaIds };
+  return { outputDir, logsDir, entryCount: allEntries.length, deltaChainIds: deltaIds, provenance: 'module-analysis-2026-07-07' };
 }
 
 // ── CLI entry point ─────────────────────────────────────────────────

--- a/scripts/perf/measure.js
+++ b/scripts/perf/measure.js
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Baseline performance measurement harness for ccxray (#183).
+ *
+ * Metrics:
+ *   A. GET /_api/entries latency (P50/P95/P99 over N runs)
+ *   B. loadEntryReqRes expansion for the 8-hop delta chain tail (median over N runs)
+ *   C. Full-column rebuild count per 100 SSE entries (placeholder — null)
+ *
+ * Usage:
+ *   node scripts/perf/measure.js [--home /tmp/perf-home] [--runs 5]
+ *
+ * If --home not given, generates a fixture first.
+ * Outputs JSON to stdout. Self-bounded at 120s.
+ */
+
+const http = require('http');
+const net = require('net');
+const os = require('os');
+const { spawn } = require('child_process');
+const path = require('path');
+const fsp = require('fs').promises;
+
+const { generate } = require('./generate-fixture');
+
+const TIMEOUT_MS = 120_000;
+const SERVER_START_TIMEOUT_MS = 40_000;
+const SERVER_POLL_INTERVAL_MS = 150;
+const DEFAULT_RUNS = 5;
+const WARMUP_REQUESTS = 3;
+const MIN_METRIC_A_REQUESTS = 10;
+
+// ── Utilities ───────────────────────────────────────────────────────
+
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+function median(arr) {
+  const sorted = [...arr].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+function percentile(arr, p) {
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+async function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+}
+
+function httpGetRaw(url) {
+  return new Promise((resolve, reject) => {
+    http.get(url, res => {
+      const chunks = [];
+      res.on('data', d => chunks.push(d));
+      res.on('end', () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() }));
+    }).on('error', reject);
+  });
+}
+
+async function waitForServer(port, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const r = await httpGetRaw(`http://127.0.0.1:${port}/_api/entries`);
+      if (r.status === 200) return;
+    } catch { /* not ready yet */ }
+    await sleep(SERVER_POLL_INTERVAL_MS);
+  }
+  throw new Error(`Server on port ${port} did not become ready within ${timeoutMs}ms`);
+}
+
+// ── Metric A: GET /_api/entries latency ─────────────────────────────
+
+async function measureApiEntries(port, totalRequests) {
+  const latencies = [];
+  for (let i = 0; i < totalRequests; i++) {
+    const t0 = performance.now();
+    await httpGetRaw(`http://127.0.0.1:${port}/_api/entries`);
+    latencies.push(performance.now() - t0);
+  }
+  return latencies;
+}
+
+// ── Metric B: delta chain expansion ─────────────────────────────────
+
+async function measureDeltaExpand(logsDir, deltaChainIds, runs) {
+  const config = require('../../server/config');
+  const store = require('../../server/store');
+  const { createLocalStorage } = require('../../server/storage/local');
+  const { loadEntryReqRes } = require('../../server/restore');
+
+  // Point config.storage at our fixture (matches pattern in delta-restore.test.js)
+  const origStorage = config.storage;
+  const tmpStorage = createLocalStorage(logsDir);
+  await tmpStorage.init();
+  config.storage = tmpStorage;
+
+  // Register all delta chain entries in store.entries so prevId lookups work
+  const origEntries = store.entries.splice(0);
+  try {
+    for (const id of deltaChainIds) {
+      store.entries.push({ id, req: null, res: null, _loaded: false, provider: 'anthropic' });
+    }
+
+    const tailId = deltaChainIds[deltaChainIds.length - 1];
+    const latencies = [];
+
+    for (let i = 0; i < runs; i++) {
+      // Reset _loaded on the entire chain to force cold expansion
+      for (const e of store.entries) {
+        e._loaded = false;
+        e._loadingPromise = null;
+        e.req = null;
+        e.res = null;
+      }
+
+      const entry = store.entries.find(e => e.id === tailId);
+      const t0 = performance.now();
+      await loadEntryReqRes(entry);
+      latencies.push(performance.now() - t0);
+    }
+
+    return latencies;
+  } finally {
+    // Restore original state
+    store.entries.splice(0);
+    for (const e of origEntries) store.entries.push(e);
+    config.storage = origStorage;
+  }
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function run({ homeDir, runs }) {
+  const overallDeadline = Date.now() + TIMEOUT_MS;
+
+  const cpuBefore = os.loadavg();
+  if (cpuBefore[0] > 4.0) {
+    process.stderr.write(`[perf] Warning: 1-min load avg ${cpuBefore[0].toFixed(2)} > 4.0 — results may be unreliable\n`);
+  }
+
+  // If no home dir given, generate fixture
+  let generatedDir = null;
+  let logsDir;
+  let deltaChainIds;
+  let entryCount;
+
+  if (homeDir) {
+    logsDir = path.join(homeDir, 'logs');
+    // Read index.ndjson to find delta chain IDs (first DELTA_CHAIN_LENGTH entries)
+    // and total entry count
+    const raw = await fsp.readFile(path.join(logsDir, 'index.ndjson'), 'utf8');
+    const lines = raw.split('\n').filter(Boolean);
+    entryCount = lines.length;
+    // Delta chain entries are the first 8 by convention from generate-fixture.js
+    deltaChainIds = lines.slice(0, 8).map(l => JSON.parse(l).id);
+  } else {
+    process.stderr.write('[perf] No --home given, generating fixture...\n');
+    const result = await generate();
+    generatedDir = result.outputDir;
+    logsDir = result.logsDir;
+    deltaChainIds = result.deltaChainIds;
+    entryCount = result.entryCount;
+    process.stderr.write(`[perf] Fixture: ${generatedDir} (${entryCount} entries)\n`);
+  }
+
+  const port = await findFreePort();
+  const serverEnv = {
+    ...process.env,
+    CCXRAY_HOME: path.dirname(logsDir),  // parent of /logs
+    PORT: String(port),                   // consumed by server/config.js
+    ANTHROPIC_BASE_URL: 'https://api.anthropic.com', // ponytail: suppress self-loop warning; no real traffic
+  };
+
+  const serverPath = path.join(__dirname, '../../server/index.js');
+  const serverProc = spawn('node', [serverPath, '--port', String(port), '--no-browser'], {
+    env: serverEnv,
+    stdio: 'ignore',  // no pipes — avoids keeping parent event loop alive
+  });
+  serverProc.unref();  // parent can exit without waiting for server subprocess
+
+  let cleanedUp = false;
+  function cleanup() {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    try { serverProc.kill('SIGTERM'); } catch {}
+    if (generatedDir) {
+      fsp.rm(generatedDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+
+  process.on('exit', cleanup);
+
+  try {
+    const remaining = overallDeadline - Date.now();
+    process.stderr.write(`[perf] Waiting for server on port ${port}...\n`);
+    await waitForServer(port, Math.min(SERVER_START_TIMEOUT_MS, remaining));
+    process.stderr.write('[perf] Server ready.\n');
+
+    // Warmup
+    for (let i = 0; i < WARMUP_REQUESTS; i++) {
+      await httpGetRaw(`http://127.0.0.1:${port}/_api/entries`);
+    }
+
+    // Metric A
+    const totalA = Math.max(runs, MIN_METRIC_A_REQUESTS);
+    process.stderr.write(`[perf] Metric A: ${totalA} requests to /_api/entries...\n`);
+    const aLatencies = await measureApiEntries(port, totalA);
+    const apiP50 = percentile(aLatencies, 50);
+    const apiP95 = percentile(aLatencies, 95);
+    const apiP99 = percentile(aLatencies, 99);
+
+    // Metric B
+    process.stderr.write(`[perf] Metric B: delta chain expansion (${runs} runs, chain length ${deltaChainIds.length})...\n`);
+    const bLatencies = await measureDeltaExpand(logsDir, deltaChainIds, runs);
+    const deltaMedian = median(bLatencies);
+
+    const cpuAfter = os.loadavg();
+
+    const result = {
+      timestamp: new Date().toISOString(),
+      node_version: process.version,
+      entries_count: entryCount,
+      delta_chain_length: deltaChainIds.length,
+      metrics: {
+        api_entries_p50_ms: Math.round(apiP50 * 100) / 100,
+        api_entries_p95_ms: Math.round(apiP95 * 100) / 100,
+        api_entries_p99_ms: Math.round(apiP99 * 100) / 100,
+        delta_expand_median_ms: Math.round(deltaMedian * 100) / 100,
+        rebuild_per_100_sse: null,
+      },
+      cpu_load_before: cpuBefore,
+      cpu_load_after: cpuAfter,
+    };
+
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  } finally {
+    cleanup();
+  }
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  let homeDir = null;
+  let runs = DEFAULT_RUNS;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--home' && args[i + 1]) {
+      homeDir = args[i + 1];
+      i++;
+    } else if (args[i] === '--runs' && args[i + 1]) {
+      runs = parseInt(args[i + 1], 10);
+      i++;
+    }
+  }
+
+  // Top-level timeout guard
+  const globalTimer = setTimeout(() => {
+    process.stderr.write('[perf] TIMEOUT: exceeded 120s hard limit\n');
+    process.exit(2);
+  }, TIMEOUT_MS);
+  globalTimer.unref();
+
+  run({ homeDir, runs })
+    .catch(err => {
+      process.stderr.write(`[perf] Error: ${err.message}\n${err.stack}\n`);
+      process.exit(1);
+    });
+}

--- a/scripts/perf/measure.js
+++ b/scripts/perf/measure.js
@@ -148,61 +148,53 @@ async function measureDeltaExpand(logsDir, deltaChainIds, runs) {
 
 // ── Delta chain discovery (for real --home copies) ───────────────────
 //
-// When --home points to a real ~/.ccxray copy the first-8 assumption from
-// generate-fixture.js does not hold. This function samples recent _req.json
-// files, follows prevId links, and returns the longest delta chain found.
-// Falls back to the first 8 index entries if no chains are found.
+// Scans ALL index entries' _req.json headers for prevId fields, builds
+// forward chains, returns the longest one. Reports honestly whether the
+// chain was discovered or fell back.
 
 async function discoverDeltaChain(logsDir, indexLines) {
-  const SAMPLE_SIZE = 200;
   const HEADER_BYTES = 500;
-
-  const sample = indexLines.length > SAMPLE_SIZE
-    ? indexLines.slice(-SAMPLE_SIZE)
-    : indexLines;
+  const BATCH_SIZE = 500;
 
   const ids = [];
-  for (const l of sample) {
-    try { ids.push(JSON.parse(l).id); } catch { /* malformed line — skip */ }
+  for (const l of indexLines) {
+    try { ids.push(JSON.parse(l).id); } catch { /* skip */ }
   }
 
-  // Read only the first HEADER_BYTES of each _req.json to locate prevId cheaply
-  const prevIdMap = new Map(); // id → prevId (only for delta entries)
-  await Promise.all(ids.map(async id => {
-    try {
-      const reqPath = path.join(logsDir, id + '_req.json');
-      const fd = await fsp.open(reqPath, 'r');
-      const buf = Buffer.alloc(HEADER_BYTES);
-      const { bytesRead } = await fd.read(buf, 0, HEADER_BYTES, 0);
-      await fd.close();
-      const header = buf.slice(0, bytesRead).toString('utf8');
-      const m = header.match(/"prevId"\s*:\s*"([^"]+)"/);
-      if (m) prevIdMap.set(id, m[1]);
-    } catch { /* missing file or permission error — skip */ }
-  }));
+  // Read first HEADER_BYTES of each _req.json in batches to find prevId
+  const prevIdMap = new Map();
+  for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+    const batch = ids.slice(i, i + BATCH_SIZE);
+    await Promise.all(batch.map(async id => {
+      try {
+        const reqPath = path.join(logsDir, id + '_req.json');
+        const fd = await fsp.open(reqPath, 'r');
+        const buf = Buffer.alloc(HEADER_BYTES);
+        const { bytesRead } = await fd.read(buf, 0, HEADER_BYTES, 0);
+        await fd.close();
+        const header = buf.slice(0, bytesRead).toString('utf8');
+        const m = header.match(/"prevId"\s*:\s*"([^"]+)"/);
+        if (m) prevIdMap.set(id, m[1]);
+      } catch { /* missing file — skip */ }
+    }));
+  }
 
   if (prevIdMap.size === 0) {
-    // No delta entries in sample — fall back to first 8 index entries
-    const fallback = indexLines.slice(0, 8)
-      .map(l => { try { return JSON.parse(l).id; } catch { return null; } })
-      .filter(Boolean);
-    return { deltaChainIds: fallback, chainLength: fallback.length };
+    return { deltaChainIds: [], chainLength: 0, method: 'none' };
   }
 
-  // Build a forward map: parentId → childId (one child per parent in a chain)
-  const childMap = new Map(); // prevId → id
+  // Build forward map and find anchors
+  const childMap = new Map();
   for (const [id, prevId] of prevIdMap) {
     childMap.set(prevId, id);
   }
 
-  // Anchors: prevId targets that are NOT themselves delta entries in our sample
   const deltaIds = new Set(prevIdMap.keys());
   const anchors = new Set();
   for (const prevId of prevIdMap.values()) {
     if (!deltaIds.has(prevId)) anchors.add(prevId);
   }
 
-  // Follow each chain forward from its anchor; keep the longest
   let longest = [];
   for (const anchor of anchors) {
     const chain = [anchor];
@@ -215,13 +207,10 @@ async function discoverDeltaChain(logsDir, indexLines) {
   }
 
   if (longest.length === 0) {
-    const fallback = indexLines.slice(0, 8)
-      .map(l => { try { return JSON.parse(l).id; } catch { return null; } })
-      .filter(Boolean);
-    return { deltaChainIds: fallback, chainLength: fallback.length };
+    return { deltaChainIds: [], chainLength: 0, method: 'none' };
   }
 
-  return { deltaChainIds: longest, chainLength: longest.length };
+  return { deltaChainIds: longest, chainLength: longest.length, method: 'discovered' };
 }
 
 // ── Main ─────────────────────────────────────────────────────────────
@@ -249,7 +238,11 @@ async function run({ homeDir, runs }) {
     // assuming the first 8 lines are the delta chain (only true for fixtures).
     const discovered = await discoverDeltaChain(logsDir, lines);
     deltaChainIds = discovered.deltaChainIds;
-    process.stderr.write(`[perf] Delta chain: ${discovered.chainLength} hops (discovered)\n`);
+    if (discovered.method === 'none') {
+      process.stderr.write(`[perf] No delta chains found in ${entryCount} entries — skipping Metric B\n`);
+    } else {
+      process.stderr.write(`[perf] Delta chain: ${discovered.chainLength} hops (${discovered.method})\n`);
+    }
   } else {
     process.stderr.write('[perf] No --home given, generating fixture...\n');
     const result = await generate();
@@ -266,6 +259,8 @@ async function run({ homeDir, runs }) {
     CCXRAY_HOME: path.dirname(logsDir),  // parent of /logs
     PORT: String(port),                   // consumed by server/config.js
     ANTHROPIC_BASE_URL: 'https://api.anthropic.com', // ponytail: suppress self-loop warning; no real traffic
+    RESTORE_DAYS: '9999',         // ponytail: don't filter fixture entries by date
+    LOG_RETENTION_DAYS: '9999',   // ponytail: don't prune fixture files
   };
 
   const serverPath = path.join(__dirname, '../../server/index.js');
@@ -306,10 +301,13 @@ async function run({ homeDir, runs }) {
     const apiP95 = percentile(aLatencies, 95);
     const apiP99 = percentile(aLatencies, 99);
 
-    // Metric B
-    process.stderr.write(`[perf] Metric B: delta chain expansion (${runs} runs, chain length ${deltaChainIds.length})...\n`);
-    const bLatencies = await measureDeltaExpand(logsDir, deltaChainIds, runs);
-    const deltaMedian = median(bLatencies);
+    // Metric B (skip if no delta chain found)
+    let deltaMedian = null;
+    if (deltaChainIds.length > 1) {
+      process.stderr.write(`[perf] Metric B: delta chain expansion (${runs} runs, chain length ${deltaChainIds.length})...\n`);
+      const bLatencies = await measureDeltaExpand(logsDir, deltaChainIds, runs);
+      deltaMedian = median(bLatencies);
+    }
 
     // SSE load generator: exercises the broadcast/serialization path
     process.stderr.write('[perf] SSE load: injecting 100 synthetic entries via broadcast path...\n');
@@ -327,7 +325,7 @@ async function run({ homeDir, runs }) {
         api_entries_p50_ms: Math.round(apiP50 * 100) / 100,
         api_entries_p95_ms: Math.round(apiP95 * 100) / 100,
         api_entries_p99_ms: Math.round(apiP99 * 100) / 100,
-        delta_expand_median_ms: Math.round(deltaMedian * 100) / 100,
+        delta_expand_median_ms: deltaMedian !== null ? Math.round(deltaMedian * 100) / 100 : null,
         rebuild_per_100_sse: null, // ponytail: activates when #167 adds renderProjectsCol counter hook
         sse_entries_injected: sseEntriesInjected,
       },

--- a/scripts/perf/measure.js
+++ b/scripts/perf/measure.js
@@ -24,6 +24,7 @@ const path = require('path');
 const fsp = require('fs').promises;
 
 const { generate } = require('./generate-fixture');
+const { simulateSseLoad } = require('./sse-load');
 
 const TIMEOUT_MS = 120_000;
 const SERVER_START_TIMEOUT_MS = 40_000;
@@ -145,6 +146,84 @@ async function measureDeltaExpand(logsDir, deltaChainIds, runs) {
   }
 }
 
+// ── Delta chain discovery (for real --home copies) ───────────────────
+//
+// When --home points to a real ~/.ccxray copy the first-8 assumption from
+// generate-fixture.js does not hold. This function samples recent _req.json
+// files, follows prevId links, and returns the longest delta chain found.
+// Falls back to the first 8 index entries if no chains are found.
+
+async function discoverDeltaChain(logsDir, indexLines) {
+  const SAMPLE_SIZE = 200;
+  const HEADER_BYTES = 500;
+
+  const sample = indexLines.length > SAMPLE_SIZE
+    ? indexLines.slice(-SAMPLE_SIZE)
+    : indexLines;
+
+  const ids = [];
+  for (const l of sample) {
+    try { ids.push(JSON.parse(l).id); } catch { /* malformed line — skip */ }
+  }
+
+  // Read only the first HEADER_BYTES of each _req.json to locate prevId cheaply
+  const prevIdMap = new Map(); // id → prevId (only for delta entries)
+  await Promise.all(ids.map(async id => {
+    try {
+      const reqPath = path.join(logsDir, id + '_req.json');
+      const fd = await fsp.open(reqPath, 'r');
+      const buf = Buffer.alloc(HEADER_BYTES);
+      const { bytesRead } = await fd.read(buf, 0, HEADER_BYTES, 0);
+      await fd.close();
+      const header = buf.slice(0, bytesRead).toString('utf8');
+      const m = header.match(/"prevId"\s*:\s*"([^"]+)"/);
+      if (m) prevIdMap.set(id, m[1]);
+    } catch { /* missing file or permission error — skip */ }
+  }));
+
+  if (prevIdMap.size === 0) {
+    // No delta entries in sample — fall back to first 8 index entries
+    const fallback = indexLines.slice(0, 8)
+      .map(l => { try { return JSON.parse(l).id; } catch { return null; } })
+      .filter(Boolean);
+    return { deltaChainIds: fallback, chainLength: fallback.length };
+  }
+
+  // Build a forward map: parentId → childId (one child per parent in a chain)
+  const childMap = new Map(); // prevId → id
+  for (const [id, prevId] of prevIdMap) {
+    childMap.set(prevId, id);
+  }
+
+  // Anchors: prevId targets that are NOT themselves delta entries in our sample
+  const deltaIds = new Set(prevIdMap.keys());
+  const anchors = new Set();
+  for (const prevId of prevIdMap.values()) {
+    if (!deltaIds.has(prevId)) anchors.add(prevId);
+  }
+
+  // Follow each chain forward from its anchor; keep the longest
+  let longest = [];
+  for (const anchor of anchors) {
+    const chain = [anchor];
+    let cur = childMap.get(anchor);
+    while (cur) {
+      chain.push(cur);
+      cur = childMap.get(cur);
+    }
+    if (chain.length > longest.length) longest = chain;
+  }
+
+  if (longest.length === 0) {
+    const fallback = indexLines.slice(0, 8)
+      .map(l => { try { return JSON.parse(l).id; } catch { return null; } })
+      .filter(Boolean);
+    return { deltaChainIds: fallback, chainLength: fallback.length };
+  }
+
+  return { deltaChainIds: longest, chainLength: longest.length };
+}
+
 // ── Main ─────────────────────────────────────────────────────────────
 
 async function run({ homeDir, runs }) {
@@ -163,13 +242,14 @@ async function run({ homeDir, runs }) {
 
   if (homeDir) {
     logsDir = path.join(homeDir, 'logs');
-    // Read index.ndjson to find delta chain IDs (first DELTA_CHAIN_LENGTH entries)
-    // and total entry count
     const raw = await fsp.readFile(path.join(logsDir, 'index.ndjson'), 'utf8');
     const lines = raw.split('\n').filter(Boolean);
     entryCount = lines.length;
-    // Delta chain entries are the first 8 by convention from generate-fixture.js
-    deltaChainIds = lines.slice(0, 8).map(l => JSON.parse(l).id);
+    // For real --home copies, scan recent entries for prevId chains rather than
+    // assuming the first 8 lines are the delta chain (only true for fixtures).
+    const discovered = await discoverDeltaChain(logsDir, lines);
+    deltaChainIds = discovered.deltaChainIds;
+    process.stderr.write(`[perf] Delta chain: ${discovered.chainLength} hops (discovered)\n`);
   } else {
     process.stderr.write('[perf] No --home given, generating fixture...\n');
     const result = await generate();
@@ -231,6 +311,11 @@ async function run({ homeDir, runs }) {
     const bLatencies = await measureDeltaExpand(logsDir, deltaChainIds, runs);
     const deltaMedian = median(bLatencies);
 
+    // SSE load generator: exercises the broadcast/serialization path
+    process.stderr.write('[perf] SSE load: injecting 100 synthetic entries via broadcast path...\n');
+    const sseEntriesInjected = simulateSseLoad(100);
+    process.stderr.write(`[perf] SSE load: ${sseEntriesInjected} entries injected.\n`);
+
     const cpuAfter = os.loadavg();
 
     const result = {
@@ -243,7 +328,8 @@ async function run({ homeDir, runs }) {
         api_entries_p95_ms: Math.round(apiP95 * 100) / 100,
         api_entries_p99_ms: Math.round(apiP99 * 100) / 100,
         delta_expand_median_ms: Math.round(deltaMedian * 100) / 100,
-        rebuild_per_100_sse: null,
+        rebuild_per_100_sse: null, // ponytail: activates when #167 adds renderProjectsCol counter hook
+        sse_entries_injected: sseEntriesInjected,
       },
       cpu_load_before: cpuBefore,
       cpu_load_after: cpuAfter,

--- a/scripts/perf/sse-load.js
+++ b/scripts/perf/sse-load.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+'use strict';
+
+// Fixture shapes derived from live module analysis (2026-07-07):
+//   Entry shape: server/sse-broadcast.js summarizeEntry() field list
+//   Session tracking: server/store.js markSessionUsage() + computeSessionResume()
+//
+// Injects synthetic entries directly into the in-process store and calls
+// broadcast() to exercise the summarizeEntry → JSON.stringify → sseClients
+// code path. The running server is a separate child process, so
+// store.sseClients in *this* (measure.js) process is empty — no bytes
+// reach a browser. The serialization path is still fully exercised.
+
+const store = require('../../server/store');
+const { broadcast } = require('../../server/sse-broadcast');
+
+const DEFAULT_COUNT = 100;
+
+function makeSyntheticEntry(idx) {
+  const base = new Date('2026-01-15T10:00:00.000Z').getTime();
+  const receivedAt = base + idx * 1000;
+  const min = Math.floor(idx / 60);
+  const sec = idx % 60;
+  const id = `2026-01-15T10-${String(min).padStart(2, '0')}-${String(sec).padStart(2, '0')}-${String(idx % 1000).padStart(3, '0')}`;
+
+  return {
+    id,
+    ts: `10:${String(min).padStart(2, '0')}:${String(sec).padStart(2, '0')}`,
+    sessionId: `sse-load-session-${String(idx % 5).padStart(4, '0')}`,
+    provider: 'anthropic',
+    agent: 'claude-code',
+    model: 'claude-sonnet-4-6',
+    elapsed: 1000 + (idx % 500),
+    status: 200,
+    isSSE: true,
+    receivedAt,
+    usage: {
+      input_tokens: 100 + idx * 2,
+      output_tokens: 50 + (idx % 20),
+      cache_creation_input_tokens: 20,
+      cache_read_input_tokens: 40,
+    },
+    cost: { cost: 0.001 + idx * 0.0001 },
+    maxContext: 200000,
+    cwd: `/mock/project-${idx % 3}`,
+    msgCount: 2 + (idx % 10),
+    toolCount: idx % 3,
+    toolCalls: idx % 3 > 0 ? { Bash: idx % 3 } : {},
+    isSubagent: false,
+    sessionInferred: false,
+    title: `SSE Load Turn ${idx}`,
+    stopReason: 'end_turn',
+    coreHash: 'aabbcc',
+    agentKey: 'claude-code::aabbcc',
+  };
+}
+
+/**
+ * Inject `count` synthetic entries into the in-process store and broadcast
+ * each one via sse-broadcast.broadcast(). Exercises the serialization path
+ * (summarizeEntry) without requiring a live SSE client connection.
+ *
+ * Cleans up: restores store.entries to original state before returning.
+ *
+ * @param {number} count - entries to inject (default 100)
+ * @returns {number} count of entries successfully injected
+ */
+function simulateSseLoad(count = DEFAULT_COUNT) {
+  const saved = store.entries.splice(0);
+  let injected = 0;
+
+  try {
+    for (let i = 0; i < count; i++) {
+      const entry = makeSyntheticEntry(i);
+      store.entries.push(entry);
+      broadcast(entry);
+      injected++;
+    }
+  } finally {
+    store.entries.splice(0);
+    for (const e of saved) store.entries.push(e);
+  }
+
+  return injected;
+}
+
+module.exports = { simulateSseLoad };


### PR DESCRIPTION
## Summary

- `scripts/perf/generate-fixture.js` — 合成 CCXRAY_HOME：5000 entries、8-hop delta chain、10 projects/50 sessions、recent dates（RESTORE_DAYS 內）
- `scripts/perf/measure.js` — baseline 量測：`/_api/entries` P50/P95/P99、delta chain expansion median、SSE broadcast load generator（100 entries）、120s 自有界、CPU load 記錄
- `scripts/perf/sse-load.js` — SSE 負載產生器：inject 合成 entry → broadcast() 完整走 summarizeEntry→JSON.stringify→sseClients 路徑
- `discoverDeltaChain()` — real `--home` copies 用 prevId 鏈自動探索（不假設 fixture 結構）
- Fixture provenance 記錄來源 module:line

**不修改任何既有 server/client 檔案。**

## Evidence

- `CCXRAY_HOME=$(mktemp -d) npm test` → 1076/1076 pass
- Fixture: 5000 entries, 8-hop delta chain, recent dates (2026-07-04)
- Measurement: P50=9.07ms, P95=10.81ms, delta expand median=2.36ms (load avg ~8, 非正式 baseline)
- Fixture 量測後完整無 prune（RESTORE_DAYS=9999 + LOG_RETENTION_DAYS=9999）
- SSE load: 100 entries injected via broadcast path
- agmsg reviewer: CLEAN（2 rounds, 3+3 findings 全修）

## What's NOT verified

- 正式 baseline 數字待安靜時段跑（目前 load avg 8-175）
- Metric C (`rebuild_per_100_sse`) = null，待 #167 加 counter hook 後啟用
- 熱堆疊簽名 gate（#183 交付 2 / Phase 2 前置）待真實複本 runbook

Closes #183