### PR TITLE
perf(#166): replace O(n) entries.find with Map index for delta chain

### DIFF
--- a/server/forward.js
+++ b/server/forward.js
@@ -745,6 +745,7 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
     entry.toolSources = helpers.buildToolSources(entry) || undefined;
     entry._writePromise = Promise.all([ctx.reqWritePromise, resWritePromise].filter(Boolean));
     store.entries.push(entry);
+    store.entryIndex.set(entry.id, entry);
     store.trimEntries();
     store.propagateLoadedSkills(entry, sessionId);
     broadcast(entry);
@@ -843,6 +844,7 @@ function handleOpenAISSE(ctx, proxyRes, clientRes) {
     entry.toolSources = helpers.buildToolSources(entry) || undefined;
     entry._writePromise = Promise.all([ctx.reqWritePromise, resWritePromise].filter(Boolean));
     store.entries.push(entry);
+    store.entryIndex.set(entry.id, entry);
     store.trimEntries();
     broadcast(entry);
 
@@ -969,6 +971,7 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
     entry.toolSources = helpers.buildToolSources(entry) || undefined;
     entry._writePromise = Promise.all([ctx.reqWritePromise, resWritePromise].filter(Boolean));
     store.entries.push(entry);
+    store.entryIndex.set(entry.id, entry);
     store.trimEntries();
     store.propagateLoadedSkills(entry, sessionId);
     broadcast(entry);

--- a/server/restore.js
+++ b/server/restore.js
@@ -45,7 +45,7 @@ function loadEntryReqRes(entry) {
         // gracefully — the delta portion is returned as-is.
         let messages = stripped.messages || [];
         if (stripped.prevId != null && stripped.msgOffset != null) {
-          const prevEntry = store.entries.find(e => e.id === stripped.prevId);
+          const prevEntry = store.getEntryById(stripped.prevId);
           if (prevEntry) {
             await loadEntryReqRes(prevEntry);
             if (Array.isArray(prevEntry.req?.messages)) {
@@ -181,7 +181,9 @@ async function restoreFromLogs() {
       }
     }
 
-    store.entries.push({ ...meta, req: null, res: null, _loaded: false });
+    const restoredEntry = { ...meta, req: null, res: null, _loaded: false };
+    store.entries.push(restoredEntry);
+    store.entryIndex.set(meta.id, restoredEntry);
 
     // Track earliest timestamp per sysHash for version dating
     if (meta.sysHash && meta.id) {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -171,7 +171,7 @@ function handleApiRoutes(clientReq, clientRes) {
   const entryMatch = pathname.match(/^\/_api\/entry\/(.+)$/);
   if (entryMatch) {
     const id = decodeURIComponent(entryMatch[1]);
-    const entry = store.entries.find(e => e.id === id);
+    const entry = store.getEntryById(id);
     if (!entry) { clientRes.writeHead(404); clientRes.end('Not found'); return true; }
     (async () => {
       await loadEntryReqRes(entry);
@@ -190,7 +190,7 @@ function handleApiRoutes(clientReq, clientRes) {
   const tokMatch = pathname.match(/^\/_api\/tokens\/(.+)$/);
   if (tokMatch) {
     const id = decodeURIComponent(tokMatch[1]);
-    const entry = store.entries.find(e => e.id === id);
+    const entry = store.getEntryById(id);
     if (!entry) { clientRes.writeHead(404); clientRes.end('Not found'); return true; }
     (async () => {
       if (!entry.tokens) {

--- a/server/store.js
+++ b/server/store.js
@@ -8,6 +8,7 @@ const NON_RESUMABLE_SESSIONS = new Set(['direct-api', 'codex-raw', 'unknown']);
 // ── In-memory store & SSE clients ───────────────────────────────────
 const MAX_ENTRIES = parseInt(process.env.CCXRAY_MAX_ENTRIES || '5000', 10);
 const entries = [];
+const entryIndex = new Map(); // id → entry for O(1) delta chain lookup
 const sseClients = [];
 const restoreState = {
   phase: 'idle',
@@ -21,8 +22,13 @@ const restoreState = {
 
 function trimEntries() {
   if (entries.length > MAX_ENTRIES) {
-    entries.splice(0, entries.length - MAX_ENTRIES);
+    const removed = entries.splice(0, entries.length - MAX_ENTRIES);
+    for (const e of removed) entryIndex.delete(e.id);
   }
+}
+
+function getEntryById(id) {
+  return entryIndex.get(id) || entries.find(e => e.id === id) || null;
 }
 
 // ── Rate limit state (from Anthropic response headers) ──────────────
@@ -360,7 +366,9 @@ function computeSessionResume(sessionId, provider) {
 module.exports = {
   MAX_ENTRIES,
   entries,
+  entryIndex,
   trimEntries,
+  getEntryById,
   sseClients,
   restoreState,
   setRestoreState,

--- a/server/ws-proxy.js
+++ b/server/ws-proxy.js
@@ -353,6 +353,7 @@ async function recordWebSocketEntry(ctx, result, turn = null) {
   entry.toolSources = helpers.buildToolSources(entry) || undefined;
   entry._writePromise = Promise.all([reqWritePromise, resWritePromise]);
   store.entries.push(entry);
+  store.entryIndex.set(entry.id, entry);
   store.trimEntries();
   broadcast(entry);
 


### PR DESCRIPTION
## Summary
- Add `entryIndex` Map in `server/store.js` for O(1) id→entry lookup
- Replace `store.entries.find(e => e.id === ...)` with `store.getEntryById(id)` in `restore.js`, `routes/api.js`
- Map maintained on `trimEntries()` (delete evicted) and `restoreFromLogs()` (index restored entries)
- Live entries from `forward.js`/`ws-proxy.js` covered by fallback to `entries.find`

Closes #166

## Test plan
- [x] `CCXRAY_HOME=$(mktemp -d) npm test` — 1076 tests, 0 fail
- [ ] Perf measurement: before/after median ≥5 runs with `scripts/perf/measure.js` (sequentialized, not parallel with other tasks)
- [ ] agmsg code review CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)