### PR TITLE
fix(#184): replace blank/Loading/$0.00 with skeleton loading states

### DIFF
--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -43,7 +43,7 @@ function renderCostSkeletons() {
   if (right) {
     let html = '';
     // Monthly skeleton
-    html += '<div class="cost-card" style="margin-bottom:12px">';
+    html += '<div id="cp-monthly" class="cost-card" style="margin-bottom:12px">';
     html += '<div class="cost-card-label">Monthly</div>';
     html += '<div style="display:flex;flex-direction:column;gap:6px">';
     for (let i = 0; i < 4; i++) {
@@ -56,7 +56,7 @@ function renderCostSkeletons() {
     html += '</div></div>';
 
     // Daily heatmap skeleton
-    html += '<div class="cost-card">';
+    html += '<div id="cp-daily" class="cost-card">';
     html += '<div class="cost-card-label">Daily Cost</div>';
     html += '<div style="display:flex;flex-direction:column;gap:2px">';
     for (let i = 0; i < 10; i++) {

--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -11,7 +11,70 @@ function hideCostPage() {
   switchTab('dashboard');
 }
 
+function renderCostSkeletons() {
+  // Left panel: account card skeleton
+  const left = document.getElementById('cp-left');
+  if (left) {
+    const acctCard = document.getElementById('cp-accounts');
+    if (acctCard) {
+      acctCard.style.display = '';
+      const content = document.getElementById('cp-accounts-content');
+      if (content) {
+        content.innerHTML =
+          '<div style="margin-bottom:8px"><span class="skeleton skeleton-text" style="width:60px"></span></div>' +
+          '<div style="display:flex;gap:10px">' +
+            '<div style="flex:1;background:var(--surface);border-radius:6px;padding:10px 12px">' +
+              '<div class="skeleton skeleton-block" style="width:40px;height:10px;margin-bottom:6px"></div>' +
+              '<div class="skeleton skeleton-block" style="width:70px;height:18px;margin-bottom:8px"></div>' +
+              '<div class="skeleton skeleton-block" style="height:5px;border-radius:3px"></div>' +
+            '</div>' +
+            '<div style="flex:1;background:var(--surface);border-radius:6px;padding:10px 12px">' +
+              '<div class="skeleton skeleton-block" style="width:40px;height:10px;margin-bottom:6px"></div>' +
+              '<div class="skeleton skeleton-block" style="width:70px;height:18px;margin-bottom:8px"></div>' +
+              '<div class="skeleton skeleton-block" style="height:5px;border-radius:3px"></div>' +
+            '</div>' +
+          '</div>';
+      }
+    }
+  }
+
+  // Right panel: monthly + daily skeletons
+  const right = document.getElementById('cp-right');
+  if (right) {
+    let html = '';
+    // Monthly skeleton
+    html += '<div class="cost-card" style="margin-bottom:12px">';
+    html += '<div class="cost-card-label">Monthly</div>';
+    html += '<div style="display:flex;flex-direction:column;gap:6px">';
+    for (let i = 0; i < 4; i++) {
+      html += '<div style="display:flex;align-items:center;gap:8px">' +
+        '<span class="skeleton skeleton-text" style="width:28px;height:11px"></span>' +
+        '<div class="skeleton skeleton-block" style="flex:1;height:14px;border-radius:3px;margin-bottom:0"></div>' +
+        '<span class="skeleton skeleton-text" style="width:44px;height:11px"></span>' +
+      '</div>';
+    }
+    html += '</div></div>';
+
+    // Daily heatmap skeleton
+    html += '<div class="cost-card">';
+    html += '<div class="cost-card-label">Daily Cost</div>';
+    html += '<div style="display:flex;flex-direction:column;gap:2px">';
+    for (let i = 0; i < 10; i++) {
+      html += '<div style="display:flex;align-items:center;gap:8px;height:16px">' +
+        '<span class="skeleton skeleton-text" style="width:56px;height:10px"></span>' +
+        '<div class="skeleton skeleton-block" style="flex:1;height:10px;border-radius:3px;margin-bottom:0"></div>' +
+        '<span class="skeleton skeleton-text" style="width:40px;height:10px"></span>' +
+      '</div>';
+    }
+    html += '</div></div>';
+
+    right.innerHTML = html;
+  }
+}
+
 async function loadCostPage() {
+  renderCostSkeletons();
+
   async function fetchWithRetry(url, fallback, maxRetries = 20) {
     for (let i = 0; i < maxRetries; i++) {
       try {

--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -132,6 +132,7 @@ function renderAccounts(blockData) {
   const configured = blockData.claudeStatuslineConfigured;
 
   if (accounts.length === 0 && configured !== false) {
+    el.innerHTML = '';
     card.style.display = 'none';
     return;
   }

--- a/public/style.css
+++ b/public/style.css
@@ -728,3 +728,21 @@
   #wf-resize { height: 16px; }
   #wf-resize::after { content: ''; display: block; width: 24px; height: 3px; background: var(--dim); border-radius: 2px; margin: 6px auto; }
 }
+
+/* ── Skeleton Loading States (#184) ── */
+.skeleton {
+  background: linear-gradient(90deg, #2a2a2a 25%, #333 50%, #2a2a2a 75%);
+  background-size: 200% 100%;
+  animation: skeleton-pulse 1.5s ease-in-out infinite;
+  border-radius: 4px;
+}
+[data-theme="light"] .skeleton {
+  background: linear-gradient(90deg, #e5e7eb 25%, #f3f4f6 50%, #e5e7eb 75%);
+  background-size: 200% 100%;
+}
+@keyframes skeleton-pulse {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+.skeleton-text { display: inline-block; height: 12px; width: 80px; vertical-align: middle; }
+.skeleton-block { display: block; width: 100%; height: 14px; margin-bottom: 4px; }

--- a/public/system-prompt-ui.js
+++ b/public/system-prompt-ui.js
@@ -175,6 +175,7 @@ async function openSystemPromptPanel(forceDiff) {
   }
 
   if (!spAgents.length) {
+    const panel = document.getElementById('diff-text-panel');
     if (panel) panel.innerHTML = '<div style="color:var(--dim);font-size:11px">No versions found.</div>';
     return;
   }

--- a/public/system-prompt-ui.js
+++ b/public/system-prompt-ui.js
@@ -177,6 +177,10 @@ async function openSystemPromptPanel(forceDiff) {
   if (!spAgents.length) {
     const panel = document.getElementById('diff-text-panel');
     if (panel) panel.innerHTML = '<div style="color:var(--dim);font-size:11px">No versions found.</div>';
+    const agentList = document.getElementById('sp-agent-list');
+    if (agentList) agentList.innerHTML = '<div class="sp-version-list-title">Agents</div>';
+    const versionList = document.getElementById('sp-version-list');
+    if (versionList) versionList.innerHTML = '<div class="sp-version-list-title">Versions</div>';
     return;
   }
 

--- a/public/system-prompt-ui.js
+++ b/public/system-prompt-ui.js
@@ -100,6 +100,60 @@ function updateSysPromptBadge() {
   }).catch(() => {});
 }
 
+function renderSyspromptSkeletons() {
+  // Agent list skeleton
+  const agentList = document.getElementById('sp-agent-list');
+  if (agentList) {
+    let html = '<div class="sp-version-list-title">Agents</div>';
+    html += '<div class="agent-group-header">── Claude Code ──</div>';
+    for (let i = 0; i < 5; i++) {
+      const w = [90, 70, 110, 60, 80][i];
+      html += '<div class="sp-agent-item" style="pointer-events:none">' +
+        '<div class="sp-agent-label"><span class="skeleton skeleton-text" style="width:' + w + 'px"></span></div>' +
+        '<div class="sp-agent-meta"><span class="skeleton skeleton-text" style="width:50px;height:9px"></span></div>' +
+      '</div>';
+    }
+    agentList.innerHTML = html;
+  }
+
+  // Version list skeleton
+  const versionList = document.getElementById('sp-version-list');
+  if (versionList) {
+    let html = '<div class="sp-version-list-title">Versions</div>';
+    for (let i = 0; i < 8; i++) {
+      html += '<div class="sp-version-item" style="pointer-events:none">' +
+        '<span class="skeleton skeleton-text" style="width:32px;height:11px"></span>' +
+        '<span class="skeleton skeleton-text" style="width:' + (80 + (i % 3) * 20) + 'px;height:11px"></span>' +
+        '<span class="skeleton skeleton-text sp-size-col" style="width:28px;height:11px"></span>' +
+        '<span class="skeleton skeleton-text sp-delta-col" style="width:32px;height:11px"></span>' +
+      '</div>';
+    }
+    versionList.innerHTML = html;
+  }
+
+  // Content area skeleton
+  const panel = document.getElementById('diff-text-panel');
+  if (panel) {
+    let html = '<div style="padding:4px 0">';
+    for (let i = 0; i < 12; i++) {
+      const w = [100, 85, 95, 60, 90, 75, 100, 80, 70, 95, 55, 88][i];
+      html += '<div class="skeleton skeleton-block" style="width:' + w + '%;height:12px;margin-bottom:6px"></div>';
+    }
+    html += '</div>';
+    panel.innerHTML = html;
+  }
+}
+
+function _spContentSkeleton() {
+  const widths = [100, 85, 95, 60, 90, 75, 100, 80];
+  let html = '<div style="padding:4px 0">';
+  for (let i = 0; i < widths.length; i++) {
+    html += '<div class="skeleton skeleton-block" style="width:' + widths[i] + '%;height:12px;margin-bottom:6px"></div>';
+  }
+  html += '</div>';
+  return html;
+}
+
 async function openSystemPromptPanel(forceDiff) {
   // If called from outside tab system, redirect to tab
   if (typeof activeTab !== 'undefined' && activeTab !== 'sysprompt') {
@@ -110,8 +164,7 @@ async function openSystemPromptPanel(forceDiff) {
   const hasBadge = forceDiff || (badge && badge.style.display !== 'none');
 
   document.getElementById('diff-overlay').classList.add('open');
-  const panel = document.getElementById('diff-text-panel');
-  if (panel) panel.innerHTML = '<div style="color:var(--dim);font-size:11px">Loading...</div>';
+  renderSyspromptSkeletons();
 
   const data = await fetch('/_api/sysprompt/versions').then(r => r.json());
   spAllVersions = data.versions || [];
@@ -276,7 +329,7 @@ async function loadContentForVersion(v) {
   const summary = document.getElementById('diff-summary');
   if (summary) summary.textContent = v.version;
   updateModeIndicator();
-  if (panel) panel.innerHTML = '<div style="color:var(--dim);font-size:11px">Loading...</div>';
+  if (panel) panel.innerHTML = _spContentSkeleton();
   try {
     const data = await fetch(`/_api/sysprompt/diff?a=${encodeURIComponent(v.coreHash)}&b=${encodeURIComponent(v.coreHash)}&agent=${encodeURIComponent(spSelectedAgent)}`).then(r => r.json());
     const block = (data.blockDiff || []).find(b => b.block === 'coreInstructions');
@@ -304,7 +357,7 @@ async function loadDiffForVersion(v) {
   }
   const prev = spVersions[prevIdx];
   if (summary) summary.textContent = `${prev.version} → ${v.version}`;
-  if (panel) panel.innerHTML = '<div style="color:var(--dim);font-size:11px">Loading...</div>';
+  if (panel) panel.innerHTML = _spContentSkeleton();
   try {
     const data = await fetch(`/_api/sysprompt/diff?a=${encodeURIComponent(prev.coreHash)}&b=${encodeURIComponent(v.coreHash)}&agent=${encodeURIComponent(spSelectedAgent)}`).then(r => r.json());
     const block = (data.blockDiff || []).find(b => b.block === 'coreInstructions');


### PR DESCRIPTION
## Summary
- Add `.skeleton` / `.skeleton-text` / `.skeleton-block` CSS with pulse animation (dark + light theme)
- Usage page: render skeleton placeholders (account cards, monthly bars, daily heatmap) during loading instead of blank space
- System Prompt page: skeleton placeholders in agent list, version list, and content panel instead of "Loading..." text
- Layout stability: column frames preserved during loading (no layout shift)

Closes #184

## Test plan
- [x] `CCXRAY_HOME=$(mktemp -d) npm test` — 1076 tests, 0 fail
- [ ] Browser smoke: loading state shows skeleton, completion shows real data, no layout shift
- [ ] agmsg code review CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)