### PR TITLE
docs(issue-authoring): §1 對齊 runbook — Blocked-by hard / Blocks advisory

### DIFF
--- a/docs/issue-authoring.md
+++ b/docs/issue-authoring.md
@@ -15,6 +15,8 @@ Blocks: #NNN（或「無」）
 Related: #NNN（可省略）
 ```
 
+**Hard gate 僅 `Blocked-by:`**——它是 dependency resolver 的唯一輸入，缺它 pre-flight lint 即判 `pipeline:needs-owner`。`Blocks:` 為 **advisory**（建議填、pre-flight 提示但不擋）：它是同一條相依邊的反向宣告、可從其他 issue 的 `Blocked-by:` 反推，雙向宣告也無從機械驗一致性。`Related:` 可省略。此與 `docs/issue-pipeline-runbook.md` step 0 及 `scripts/pipeline/issue-lint.sh` 的實際 gate 行為一致。
+
 ### 2. 驗收 schema
 
 驗收段必須包含：


### PR DESCRIPTION
## 為什麼

`docs/issue-authoring.md` §1 把 `Blocked-by:` 與 `Blocks:` 都列在 **Hard gates** 區塊下（缺任一 → needs-owner），但 runbook step 0 與 `scripts/pipeline/issue-lint.sh`（PR #185）的實際 gate 行為是：

- **`Blocked-by:` = 唯一 hard gate** — 它是 dependency resolver 的唯一輸入。
- **`Blocks:` = advisory** — 同一條相依邊的反向宣告，可從其他 issue 的 `Blocked-by:` 反推；雙向宣告也無從機械驗一致性。升為 hard 只多一個誤殺點。

這是 Fable 二次判斷 + codex 二審過程中點出的**文件互相打架**。本 PR 補一段說明消除分歧。

## 範圍

- 純文件（`docs/issue-authoring.md` §1 加一段），**不改任何 gate 行為**。
- 措辭寫成自足政策，不論先 merge 本 PR 或 #185，main 上都自洽。
- 治理文件，依 automation-plan 永久排除 auto-merge → 人工 merge。

## 關聯

- 與 PR #185（Phase 0.5 狀態機 + issue-lint.sh）配套；順序無關（互不依賴）。