### PR TITLE
perf(#167): add dirty-check + rAF batching to renderProjectsCol

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1559,8 +1559,9 @@ function renderProjectsCol() {
   for (const [name, proj] of projectsMap) {
     const statusClass = getProjectStatusClass(proj);
     const starred = isStarredOrDerived('project', name) ? '1' : '0';
+    const idleBucket = proj.lastSeenAt ? String(Math.floor((Date.now() - proj.lastSeenAt) / 60000)) : '';
     sigParts.push(name, String(proj.totalCost), String(proj.sessionIds.size),
-      proj.firstId || '', proj.lastId || '', statusClass, starred);
+      proj.firstId || '', proj.lastId || '', statusClass, starred, idleBucket);
   }
   const sig = sigParts.join('\x00');
   if (sig === _lastProjectsSignature) return;

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1540,7 +1540,43 @@ function renderSessionItem(sess, sid) {
     '</div>';
 }
 
+const _raf = typeof requestAnimationFrame === 'function' ? requestAnimationFrame : fn => fn();
+let _projectsRafPending = false;
+let _lastProjectsSignature = '';
+let _projectsRenderCount = 0;
+if (typeof window !== 'undefined') {
+  if (!window.__ccxrayDebug) window.__ccxrayDebug = {};
+  window.__ccxrayDebug.projectsRenderCount = 0;
+}
+
 function renderProjectsCol() {
+  const sigParts = [
+    projectFilterMode,
+    selectedProjectName || '',
+    window._entriesLoading ? '1' : '0',
+    window._entriesLoadingText || '',
+  ];
+  for (const [name, proj] of projectsMap) {
+    const statusClass = getProjectStatusClass(proj);
+    const starred = isStarredOrDerived('project', name) ? '1' : '0';
+    sigParts.push(name, String(proj.totalCost), String(proj.sessionIds.size),
+      proj.firstId || '', proj.lastId || '', statusClass, starred);
+  }
+  const sig = sigParts.join('\x00');
+  if (sig === _lastProjectsSignature) return;
+  _lastProjectsSignature = sig;
+
+  if (_projectsRafPending) return;
+  _projectsRafPending = true;
+  _raf(() => {
+    _projectsRafPending = false;
+    _projectsRenderCount++;
+    if (typeof window !== 'undefined' && window.__ccxrayDebug) window.__ccxrayDebug.projectsRenderCount = _projectsRenderCount;
+    _renderProjectsColInner();
+  });
+}
+
+function _renderProjectsColInner() {
   let html = '<div class="col-title" style="display:flex;align-items:center;gap:6px">Projects' +
     '<select id="proj-filter-select" onchange="setProjectFilter(this.value)" style="background:var(--surface);color:var(--dim);border:1px solid var(--border);border-radius:3px;font-size:10px;padding:1px 4px;cursor:pointer">' +
     '<option value="streaming"' + (projectFilterMode === 'streaming' ? ' selected' : '') + ' title="Only projects with in-flight API calls">Streaming</option>' +

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1558,10 +1558,11 @@ function renderProjectsCol() {
   ];
   for (const [name, proj] of projectsMap) {
     const statusClass = getProjectStatusClass(proj);
-    const starred = isStarredOrDerived('project', name) ? '1' : '0';
+    const starCount = String(countDescendantStars('project', name));
+    const directStar = isStarredAt('project', name) ? '1' : '0';
     const idleBucket = proj.lastSeenAt ? String(Math.floor((Date.now() - proj.lastSeenAt) / 60000)) : '';
     sigParts.push(name, String(proj.totalCost), String(proj.sessionIds.size),
-      proj.firstId || '', proj.lastId || '', statusClass, starred, idleBucket);
+      proj.firstId || '', proj.lastId || '', statusClass, directStar, starCount, idleBucket);
   }
   const sig = sigParts.join('\x00');
   if (sig === _lastProjectsSignature) return;


### PR DESCRIPTION
## Summary

Re-opened as new PR — #188 was incorrectly auto-closed by GitHub when #187 merged (both pointed at the same commit due to a branch mis-push).

- Add signature-based dirty check to `renderProjectsCol` — skips DOM rebuild when project state hasn't changed
- Batch renders via `requestAnimationFrame` to avoid redundant paints during rapid SSE updates
- Include `lastSeenAt` idle-minute bucket in signature so stale idle tooltips update correctly

## Commits
- `a5859de` perf(#167): add dirty-check signature + rAF batching to renderProjectsCol
- `71483ab` fix(#167): include lastSeenAt idle bucket in dirty-check signature

Closes #167

## Test plan
- [ ] Verify projects column updates when new sessions arrive
- [ ] Verify idle time tooltips update correctly
- [ ] Verify no duplicate/stale renders during rapid activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)