### PR TITLE
docs: 3-layer ADR trigger pattern for batch #182 invariants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,14 @@ npm test                                         # Run tests
 
 No build step. No linting. Restart to apply changes.
 
+## Invariants
+
+These constraints have guard comments at their mutation sites. Read the linked ADR before modifying the affected code.
+
+- **entryIndex must mirror entries[]** at all push/trim sites (forward.js, ws-proxy.js, restore.js, store.js) — @docs/decisions/0003-entry-index-map.md
+- **renderProjectsCol signature must include every field that affects rendered output** — adding a rendered field without updating `sigParts` = silent stale render — @docs/decisions/0002-dirty-check-signature.md
+- **Skeleton early-return must clear innerHTML** before returning; skeleton containers must have the same `id` as the render function's `getElementById` target — @docs/decisions/0004-skeleton-lifecycle.md
+
 ## Smoke Testing
 
 UI or server changes must be verified in a real browser, not just unit tests. Unit tests verify logic; they don't catch lazy-load, SSE, or render pipeline failures.

--- a/docs/decisions/0002-dirty-check-signature.md
+++ b/docs/decisions/0002-dirty-check-signature.md
@@ -1,0 +1,49 @@
+# 0002 — Signature-based dirty check for renderProjectsCol
+
+- Status: Accepted (stop-gap; superseded when #157 lands)
+- Date: 2026-07-08
+- Related: #167 / PR #192, #157
+
+## Context
+
+Every SSE entry arrival calls `renderProjectsCol()`. On main before this
+change, each call walks `projectsMap`, sorts, and does a full `innerHTML`
+rebuild of the Projects column. During active sessions this means ~100 full
+DOM rebuilds per 100 entries, most of which produce identical output.
+
+#157 (subscription-based rendering) is the structural fix, but it's a large
+refactor. #167 is a stop-gap.
+
+## Decision
+
+Guard `renderProjectsCol` with a **signature string** — a `\x00`-joined
+concatenation of every field that affects the rendered output. If the
+signature equals the previous one, skip. If changed, schedule the real
+render via `requestAnimationFrame` to coalesce multiple changes per frame.
+
+Signature fields (as of PR #192):
+
+```
+projectFilterMode, selectedProjectName, _entriesLoading, _entriesLoadingText,
+[per project]: name, totalCost, sessionIds.size, firstId, lastId,
+               statusClass, directStar, starCount, idleBucket
+```
+
+## Consequences
+
+**Good**: 99% reduction in DOM rebuilds (100 → 1 per 100 SSE entries).
+
+**Bad — manual maintenance**: any new field that affects the rendered project
+row must be added to `sigParts`. Forgetting a field = stale render that only
+surfaces when that field changes in isolation. There is no compile-time or
+test-time guard — only code review catches omissions.
+
+**Mitigation**: Layer 1 guard comment at the signature site in
+`miller-columns.js` names this ADR. Reviewers adding rendered fields should
+grep for `sigParts`.
+
+## Exit condition
+
+When #157 (subscription-based rendering) lands and replaces the signature
+mechanism, delete the dirty-check code, remove the guard comments, and mark
+this ADR as Superseded.

--- a/docs/decisions/0003-entry-index-map.md
+++ b/docs/decisions/0003-entry-index-map.md
@@ -1,0 +1,46 @@
+# 0003 — Parallel entryIndex Map for O(1) lookups
+
+- Status: Accepted
+- Date: 2026-07-08
+- Related: #166 / PR #187
+
+## Context
+
+`store.entries[]` is the canonical ordered list of proxy entries, capped at
+`MAX_ENTRIES`. Delta-chain reconstruction (`loadEntryReqRes`) and the API
+query endpoint both need to find an entry by `id`. Before this change, both
+used `entries.find()` — O(n) per lookup, which compounds along delta chains
+(O(n·k) for a k-hop chain in an n-entry store).
+
+## Decision
+
+Add `store.entryIndex = new Map()` as a parallel index keyed by `entry.id`.
+Every site that mutates `entries[]` must keep `entryIndex` in sync:
+
+| Mutation | File | Operation |
+|----------|------|-----------|
+| Live push (HTTP) | `server/forward.js` (×3 sites) | `.set(entry.id, entry)` |
+| Live push (WS) | `server/ws-proxy.js` (×1 site) | `.set(entry.id, entry)` |
+| Restore on startup | `server/restore.js` | `.set(entry.id, entry)` |
+| Trim (eviction) | `server/store.js` `trimEntries()` | `.delete(entry.id)` |
+| API read | `server/routes/api.js` | `.get(id)` (read-only) |
+
+## Consequences
+
+**Good**: delta-chain lookup is O(1) regardless of store size.
+
+**Bad — consistency contract**: adding a new push site (e.g., a future
+provider transport) without a corresponding `.set()` silently degrades to
+the fallback `entries.find()` path, hiding the O(n) regression until the
+store is large enough to notice.
+
+**Mitigation**: Layer 1 guard comments at every push/trim site name this
+ADR. `getEntryById()` in `store.js` has a fallback `.find()` — if
+the fallback path ever fires in production, a push site was missed.
+
+## Alternatives considered
+
+**Replace `entries[]` with a Map entirely**: rejected because insertion
+order matters (the array is the timeline), and many consumers iterate
+sequentially. A Map preserves insertion order but loses array methods
+(`slice`, `splice`, index access) used throughout the codebase.

--- a/docs/decisions/0004-skeleton-lifecycle.md
+++ b/docs/decisions/0004-skeleton-lifecycle.md
@@ -1,0 +1,62 @@
+# 0004 — Skeleton loading lifecycle: ID matching + early-return contract
+
+- Status: Accepted
+- Date: 2026-07-08
+- Related: #184 / PR #189
+
+## Context
+
+Usage, System Prompt, and the main dashboard show skeleton placeholders
+during data loading. The original implementation had two failure modes:
+
+1. **Orphaned skeletons**: skeleton `<div>`s had no `id`, so render
+   functions couldn't find them via `getElementById`. They created new
+   elements and appended them — leaving skeletons permanently in the DOM.
+
+2. **Early-return leaks**: render functions that received empty data (e.g.,
+   `accounts.length === 0`) returned early without clearing the skeleton
+   content inside the container.
+
+Both violate the #184 guard: after data loads, `document.querySelectorAll('.skeleton').length` must be 0.
+
+## Decision
+
+Two rules for any skeleton → real-content handoff:
+
+**Rule 1 — ID matching**: skeleton containers must carry the same `id` that
+the render function looks up via `getElementById`. This way the render
+function finds the existing skeleton div and overwrites its `innerHTML`
+in place, rather than appending a sibling.
+
+Current ID mappings:
+
+| Skeleton | Render function | ID |
+|----------|----------------|-----|
+| Monthly cost | `renderMonthlySummary` | `cp-monthly` |
+| Daily heatmap | `renderDailyHeatmap` | `cp-daily` |
+| Account card | `renderAccounts` | `cp-accounts-content` |
+
+**Rule 2 — Early-return must clear**: every code path in a render function
+that returns without writing real content must first set
+`container.innerHTML = ''` (or equivalent). This includes empty-data
+branches, error branches, and hide-card branches.
+
+## Consequences
+
+**Good**: skeletons reliably disappear after data loads; no layout shift
+between loading and loaded states.
+
+**Bad — implicit contract**: there is no compile-time or test-time
+enforcement. A new render function that skips clearing on early-return will
+silently leave skeleton nodes. The Puppeteer verification script
+(`/tmp/verify-184-skeleton.js` pattern) is not yet in CI.
+
+**Mitigation**: Layer 1 guard comments at `renderCostSkeletons` and each
+render function's early-return path name this ADR. Future skeleton pages
+should follow the same pattern.
+
+## Affected tabs
+
+- **Usage** (`cost-budget-ui.js`): accounts, monthly, daily
+- **System Prompt** (`system-prompt-ui.js`): agent list, version list, content panel
+- **Dashboard** (`miller-columns.js`): no skeletons currently; if added, follow Rule 1 + 2

--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -11,6 +11,7 @@ function hideCostPage() {
   switchTab('dashboard');
 }
 
+// INVARIANT: skeleton IDs must match render function lookups — see docs/decisions/0004-skeleton-lifecycle.md
 function renderCostSkeletons() {
   // Left panel: account card skeleton
   const left = document.getElementById('cp-left');
@@ -131,6 +132,7 @@ function renderAccounts(blockData) {
   const accounts = blockData.accounts || [];
   const configured = blockData.claudeStatuslineConfigured;
 
+  // INVARIANT: early-return must clear innerHTML — see docs/decisions/0004-skeleton-lifecycle.md
   if (accounts.length === 0 && configured !== false) {
     el.innerHTML = '';
     card.style.display = 'none';

--- a/public/cost-budget-ui.js
+++ b/public/cost-budget-ui.js
@@ -423,6 +423,7 @@ function renderMonthlySummary(monthlyResp) {
   }
 
   const allMonths = monthlyResp.monthly || [];
+  // INVARIANT: early-return must clear innerHTML — see docs/decisions/0004-skeleton-lifecycle.md
   if (!allMonths.length) { container.innerHTML = ''; return; }
   const accounts = collectAccounts(_costPageCache?.dailyData || []);
 

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1550,6 +1550,7 @@ if (typeof window !== 'undefined') {
 }
 
 function renderProjectsCol() {
+  // INVARIANT: sigParts must include every rendered field — see docs/decisions/0002-dirty-check-signature.md
   const sigParts = [
     projectFilterMode,
     selectedProjectName || '',

--- a/public/system-prompt-ui.js
+++ b/public/system-prompt-ui.js
@@ -100,6 +100,7 @@ function updateSysPromptBadge() {
   }).catch(() => {});
 }
 
+// INVARIANT: skeleton IDs must match render function lookups — see docs/decisions/0004-skeleton-lifecycle.md
 function renderSyspromptSkeletons() {
   // Agent list skeleton
   const agentList = document.getElementById('sp-agent-list');
@@ -174,6 +175,7 @@ async function openSystemPromptPanel(forceDiff) {
     (data.versions || []).forEach(v => { if (v.coreHash) _hashAgentMap[v.coreHash] = { label: v.agentLabel || v.agentKey, key: v.agentKey }; });
   }
 
+  // INVARIANT: no-data branch must clear skeleton content — see docs/decisions/0004-skeleton-lifecycle.md
   if (!spAgents.length) {
     const panel = document.getElementById('diff-text-panel');
     if (panel) panel.innerHTML = '<div style="color:var(--dim);font-size:11px">No versions found.</div>';

--- a/server/forward.js
+++ b/server/forward.js
@@ -744,6 +744,7 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
     entry.hasCredential = helpers.entryHasCredential(entry) || undefined;
     entry.toolSources = helpers.buildToolSources(entry) || undefined;
     entry._writePromise = Promise.all([ctx.reqWritePromise, resWritePromise].filter(Boolean));
+    // INVARIANT: push + entryIndex.set must pair — see docs/decisions/0003-entry-index-map.md
     store.entries.push(entry);
     store.entryIndex.set(entry.id, entry);
     store.trimEntries();
@@ -843,6 +844,7 @@ function handleOpenAISSE(ctx, proxyRes, clientRes) {
     entry.hasCredential = helpers.entryHasCredential(entry) || undefined;
     entry.toolSources = helpers.buildToolSources(entry) || undefined;
     entry._writePromise = Promise.all([ctx.reqWritePromise, resWritePromise].filter(Boolean));
+    // INVARIANT: push + entryIndex.set must pair — see docs/decisions/0003-entry-index-map.md
     store.entries.push(entry);
     store.entryIndex.set(entry.id, entry);
     store.trimEntries();
@@ -970,6 +972,7 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
     entry.hasCredential = helpers.entryHasCredential(entry) || undefined;
     entry.toolSources = helpers.buildToolSources(entry) || undefined;
     entry._writePromise = Promise.all([ctx.reqWritePromise, resWritePromise].filter(Boolean));
+    // INVARIANT: push + entryIndex.set must pair — see docs/decisions/0003-entry-index-map.md
     store.entries.push(entry);
     store.entryIndex.set(entry.id, entry);
     store.trimEntries();

--- a/server/restore.js
+++ b/server/restore.js
@@ -182,6 +182,7 @@ async function restoreFromLogs() {
     }
 
     const restoredEntry = { ...meta, req: null, res: null, _loaded: false };
+    // INVARIANT: push + entryIndex.set must pair — see docs/decisions/0003-entry-index-map.md
     store.entries.push(restoredEntry);
     store.entryIndex.set(meta.id, restoredEntry);
 

--- a/server/store.js
+++ b/server/store.js
@@ -8,7 +8,8 @@ const NON_RESUMABLE_SESSIONS = new Set(['direct-api', 'codex-raw', 'unknown']);
 // ── In-memory store & SSE clients ───────────────────────────────────
 const MAX_ENTRIES = parseInt(process.env.CCXRAY_MAX_ENTRIES || '5000', 10);
 const entries = [];
-const entryIndex = new Map(); // id → entry for O(1) delta chain lookup
+// INVARIANT: entryIndex must mirror entries[] — see docs/decisions/0003-entry-index-map.md
+const entryIndex = new Map();
 const sseClients = [];
 const restoreState = {
   phase: 'idle',
@@ -20,6 +21,7 @@ const restoreState = {
   entryCount: 0,
 };
 
+// INVARIANT: trim must delete from entryIndex — see docs/decisions/0003-entry-index-map.md
 function trimEntries() {
   if (entries.length > MAX_ENTRIES) {
     const removed = entries.splice(0, entries.length - MAX_ENTRIES);

--- a/server/ws-proxy.js
+++ b/server/ws-proxy.js
@@ -352,6 +352,7 @@ async function recordWebSocketEntry(ctx, result, turn = null) {
   entry.hasCredential = helpers.entryHasCredential(entry) || undefined;
   entry.toolSources = helpers.buildToolSources(entry) || undefined;
   entry._writePromise = Promise.all([reqWritePromise, resWritePromise]);
+  // INVARIANT: push + entryIndex.set must pair — see docs/decisions/0003-entry-index-map.md
   store.entries.push(entry);
   store.entryIndex.set(entry.id, entry);
   store.trimEntries();


### PR DESCRIPTION
## Summary

- **3 ADR files**: `docs/decisions/0002` (dirty-check signature), `0003` (entryIndex Map), `0004` (skeleton lifecycle)
- **12 INVARIANT guard comments** at mutation sites across 7 files (forward.js ×3, store.js ×2, ws-proxy.js ×1, restore.js ×1, miller-columns.js ×1, cost-budget-ui.js ×2, system-prompt-ui.js ×2)
- **CLAUDE.md `## Invariants` section** with 3 rules + `@docs/decisions/` references

Implements the 3-layer trigger pattern so agents discover constraints at edit time:
1. Layer 1 — code guard comments at mutation sites (visible when editing)
2. Layer 2 — CLAUDE.md rules loaded every session
3. Layer 3 — full ADR files referenced by Layer 1+2

## Test plan

- [x] `CCXRAY_HOME=$(mktemp -d) npm test` — 1162/1162 pass
- [ ] Verify guard comments appear at correct sites (review diff)
- [ ] Verify ADR file content matches PR descriptions in #187, #192, #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)