### PR TITLE
fix(#191): block path traversal in local-usage-reader

### DIFF
--- a/server/local-usage-reader.js
+++ b/server/local-usage-reader.js
@@ -32,8 +32,11 @@ function readAllAccounts(statusDir) {
 
   for (const name of entries) {
     if (!name.endsWith('.json')) continue;
+    const filePath = path.resolve(statusDir, name);
+    if (!filePath.startsWith(path.resolve(statusDir) + path.sep) && filePath !== path.resolve(statusDir)) continue;
+    try { if (fs.lstatSync(filePath).isSymbolicLink()) continue; } catch { continue; }
     try {
-      const raw = fs.readFileSync(path.join(statusDir, name), 'utf8');
+      const raw = fs.readFileSync(filePath, 'utf8');
       const snap = JSON.parse(raw);
       if (!snap.id || !snap.fiveHour) continue;
 

--- a/test/local-usage-reader.test.js
+++ b/test/local-usage-reader.test.js
@@ -92,6 +92,25 @@ describe('local-usage-reader', () => {
     }
   });
 
+  it('skips symlinks pointing outside statusDir', () => {
+    const dir = makeTmpDir();
+    const outside = makeTmpDir();
+    try {
+      fs.writeFileSync(path.join(outside, 'secret.json'), JSON.stringify({
+        id: 'stolen', label: 'Stolen', provider: 'openai', planType: 'plus',
+        fiveHour: { usedPct: 99, resetsAt: 1780000000 }, sevenDay: null,
+        updatedAt: Math.floor(Date.now() / 1000),
+      }));
+      fs.symlinkSync(path.join(outside, 'secret.json'), path.join(dir, 'evil.json'));
+
+      const accounts = readAllAccounts(dir);
+      assert.equal(accounts.length, 0, 'symlink should be skipped');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
   it('skips malformed JSON files', () => {
     const dir = makeTmpDir();
     try {


### PR DESCRIPTION
## Summary

- `path.resolve` guard ensures joined path stays within `statusDir` boundary
- `lstatSync` rejects symlinks before `readFileSync` can follow them outside
- Regression test with cross-directory symlink

Closes #191

## Test plan

- [x] `npm test` — 1077 tests pass (including new symlink test)
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)