### PR TITLE
fix(#198): remove @anthropic-ai/tokenizer WASM dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/tokenizer": "^0.0.4",
         "ws": "^8.19.0"
       },
       "bin": {
@@ -22,16 +21,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@anthropic-ai/tokenizer": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/tokenizer/-/tokenizer-0.0.4.tgz",
-      "integrity": "sha512-EHRKbxlxlc8W4KCBEseByJ7YwyYCmgu9OyN59H9+IYIGPoKv8tXyQXinkeGDI+cI8Tiuz9wk2jZb/kK7AyvL7g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "tiktoken": "^1.0.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -540,7 +529,9 @@
       "version": "18.19.130",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2162,12 +2153,6 @@
         "b4a": "^1.6.4"
       }
     },
-    "node_modules/tiktoken": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/tiktoken/-/tiktoken-1.0.22.tgz",
-      "integrity": "sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA==",
-      "license": "MIT"
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2199,7 +2184,9 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@anthropic-ai/tokenizer": "^0.0.4",
     "ws": "^8.19.0"
   },
   "devDependencies": {

--- a/server/forward.js
+++ b/server/forward.js
@@ -729,7 +729,7 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
       elapsed, status: proxyRes.statusCode, isSSE: true,
       receivedAt: startTime,
       edited: ctx.edited, editSummary: ctx.editSummary,
-      tokens: helpers.tokenizeRequest(parsedBody),
+      tokens: null,
       duplicateToolCalls: helpers.extractDuplicateToolCalls(parsedBody?.messages),
       ...getParser('anthropic').buildEntryFields({
         provider: 'anthropic', transport: 'sse', parsedBody, events, usage,
@@ -831,7 +831,7 @@ function handleOpenAISSE(ctx, proxyRes, clientRes) {
       req: parsedBody, res: events,
       elapsed, status: proxyRes.statusCode, isSSE: true,
       receivedAt: startTime,
-      tokens: helpers.tokenizeRequest(parsedBody),
+      tokens: null,
       duplicateToolCalls: null,
       ...getParser('openai').buildEntryFields({
         provider: 'openai', transport: 'sse', parsedBody, events, proxyRes,
@@ -924,7 +924,7 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
         req: parsedBody, res: resData,
         elapsed, status: proxyRes.statusCode, isSSE: !!openAIEvents,
         receivedAt: startTime,
-        tokens: helpers.tokenizeRequest(parsedBody),
+        tokens: null,
         duplicateToolCalls: null,
         ...getParser('openai').buildEntryFields({
           provider: 'openai', transport: openAIEvents ? 'sse' : 'http',
@@ -955,7 +955,7 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
         elapsed, status: proxyRes.statusCode, isSSE: false,
         receivedAt: startTime,
         edited: ctx.edited, editSummary: ctx.editSummary,
-        tokens: helpers.tokenizeRequest(parsedBody),
+        tokens: null,
         duplicateToolCalls: helpers.extractDuplicateToolCalls(parsedBody?.messages),
         ...getParser('anthropic').buildEntryFields({
           provider: 'anthropic', transport: 'http', parsedBody,

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { countTokens } = require('@anthropic-ai/tokenizer');
 const { isInjectedText } = require('../shared/injected-tags');
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -19,9 +18,10 @@ function printSeparator() {
   console.log('\x1b[33m' + '═'.repeat(60) + '\x1b[0m');
 }
 
+// ponytail: char/4 estimate replaces WASM tokenizer (#198); upgrade to tiktoken if drift matters
 function safeCountTokens(text) {
   if (!text) return 0;
-  try { return countTokens(text); } catch { return 0; }
+  return Math.ceil(text.length / 4);
 }
 
 // ── Context Breakdown Analysis ───────────────────────────────────────

--- a/server/ws-proxy.js
+++ b/server/ws-proxy.js
@@ -334,7 +334,7 @@ async function recordWebSocketEntry(ctx, result, turn = null) {
     status: result.status,
     isSSE: false,
     receivedAt: t.startTime || ctx.startTime,
-    tokens: cr ? helpers.tokenizeRequest(reqLog) : null,
+    tokens: null,
     duplicateToolCalls: null,
     ...getParser('openai').buildEntryFields({
       provider: 'openai', transport: 'websocket',


### PR DESCRIPTION
## Summary
- Remove `@anthropic-ai/tokenizer` WASM — inaccurate for Claude 3+ (Anthropic advisory) and blocks event loop on large payloads (#122)
- Hot-path token counts (turn list ctx bar, cache%, cost) all come from API `usage` — unaffected
- `safeCountTokens` → `Math.ceil(text.length / 4)` heuristic for detail breakdown (same proportional distribution)
- `forward.js` / `ws-proxy.js`: entry `tokens` field set to `null` at creation (lazy endpoint `/_api/tokens/:id` still computes on demand)

## Test plan
- [x] `CCXRAY_HOME=$(mktemp -d) npm test` — 0 new failures vs main
- [ ] Smoke: verify dashboard turn list / detail view / cost page render correctly

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)