### PR TITLE
fix(#153): add HTTP timeouts + SSE per-IP connection cap

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -187,6 +187,7 @@ function joinUpstreamPath(upstream, requestUrl) {
 }
 const LOGS_DIR = resolveLogsDir();
 const LOG_RETENTION_DAYS = parseInt(process.env.LOG_RETENTION_DAYS || '14', 10);
+const MAX_SSE_PER_IP = parseInt(process.env.CCXRAY_SSE_MAX_PER_IP || '20', 10);
 // ponytail: aligned with LOG_RETENTION_DAYS so the index is a cache, not a sole record
 const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || String(LOG_RETENTION_DAYS), 10);
 // 0 = only session-start anchor; N>0 = force full snapshot every N delta writes
@@ -321,6 +322,7 @@ module.exports = {
   RESTORE_DAYS,
   LOG_RETENTION_DAYS,
   DELTA_SNAPSHOT_N,
+  MAX_SSE_PER_IP,
   REWRITE_MODEL_PREFIX,
   storage,
   MODEL_CONTEXT_FALLBACK,

--- a/server/index.js
+++ b/server/index.js
@@ -467,6 +467,11 @@ const server = http.createServer((clientReq, clientRes) => {
   });
 });
 
+server.headersTimeout = 60_000;    // 60s — only header phase, safe
+server.keepAliveTimeout = 5_000;   // 5s — idle keep-alive connections
+// ponytail: requestTimeout=0 — proxy SSE streams can last minutes; a non-zero value kills long thinking/output turns. Revisit if slowloris via request body becomes a concern (body size cap in #152 mitigates the OOM vector).
+server.requestTimeout = 0;         // disabled — see comment above
+
 server.on('upgrade', (req, socket, head) => {
   handleWebSocketUpgrade(req, socket, head);
 });

--- a/server/index.js
+++ b/server/index.js
@@ -469,8 +469,8 @@ const server = http.createServer((clientReq, clientRes) => {
 
 server.headersTimeout = 60_000;    // 60s — only header phase, safe
 server.keepAliveTimeout = 5_000;   // 5s — idle keep-alive connections
-// ponytail: requestTimeout=0 — proxy SSE streams can last minutes; a non-zero value kills long thinking/output turns. Revisit if slowloris via request body becomes a concern (body size cap in #152 mitigates the OOM vector).
-server.requestTimeout = 0;         // disabled — see comment above
+// ponytail: requestTimeout covers receiving the client request (headers+body), not response streaming — safe for long SSE responses
+server.requestTimeout = 300_000;   // 5min — matches Node default; slow POST body = slowloris, body size cap (#152) handles OOM
 
 server.on('upgrade', (req, socket, head) => {
   handleWebSocketUpgrade(req, socket, head);

--- a/server/routes/sse.js
+++ b/server/routes/sse.js
@@ -1,10 +1,26 @@
 'use strict';
 
 const store = require('../store');
+const { MAX_SSE_PER_IP } = require('../config');
+
+function normalizeIp(raw) {
+  if (!raw) return '';
+  if (raw === '::1' || raw === '::ffff:127.0.0.1') return '127.0.0.1';
+  if (raw.startsWith('::ffff:')) return raw.slice(7);
+  return raw;
+}
 
 function handleSSERoute(clientReq, clientRes) {
   const pathname = clientReq.url.split('?')[0];
   if (pathname !== '/_events') return false;
+
+  const ip = normalizeIp(clientReq.socket.remoteAddress);
+  const count = store.sseClients.filter(c => normalizeIp(c.socket && c.socket.remoteAddress) === ip).length;
+  if (count >= MAX_SSE_PER_IP) {
+    clientRes.writeHead(429, { 'Content-Type': 'application/json' });
+    clientRes.end(JSON.stringify({ error: 'SSE connection limit per IP exceeded' }));
+    return true;
+  }
 
   clientRes.writeHead(200, {
     'Content-Type': 'text/event-stream',
@@ -42,4 +58,4 @@ function handleSSERoute(clientReq, clientRes) {
   return true;
 }
 
-module.exports = { handleSSERoute };
+module.exports = { handleSSERoute, normalizeIp };

--- a/test/timeouts-sse.test.js
+++ b/test/timeouts-sse.test.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('http');
+const { handleSSERoute, normalizeIp } = require('../server/routes/sse');
+const store = require('../server/store');
+const { MAX_SSE_PER_IP } = require('../server/config');
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+// Build a fake SSE client already in store.sseClients so we can simulate
+// hitting the per-IP cap without actually opening real connections.
+function fakeClient(ip) {
+  return { socket: { remoteAddress: ip } };
+}
+
+function fakeReqRes(ip = '127.0.0.1', url = '/_events') {
+  const socket = { remoteAddress: ip };
+  const listeners = {};
+  const req = {
+    url,
+    socket,
+    on(event, cb) { listeners[event] = cb; return this; },
+  };
+  let status = null;
+  let ended = null;
+  const written = [];
+  const res = {
+    socket, // same socket as req — mirrors real Node.js behavior
+    _status: () => status,
+    _ended: () => ended,
+    _written: () => written,
+    writeHead(s) { status = s; },
+    write(chunk) { written.push(chunk); },
+    end(data) { ended = data || true; },
+  };
+  return { req, res };
+}
+
+// ── normalizeIp ──────────────────────────────────────────────────────
+
+describe('normalizeIp', () => {
+  it('passes through a plain IPv4', () => {
+    assert.equal(normalizeIp('1.2.3.4'), '1.2.3.4');
+  });
+
+  it('normalizes ::1 to 127.0.0.1', () => {
+    assert.equal(normalizeIp('::1'), '127.0.0.1');
+  });
+
+  it('normalizes ::ffff:127.0.0.1 to 127.0.0.1', () => {
+    assert.equal(normalizeIp('::ffff:127.0.0.1'), '127.0.0.1');
+  });
+
+  it('strips ::ffff: prefix from any mapped IPv4', () => {
+    assert.equal(normalizeIp('::ffff:192.168.1.1'), '192.168.1.1');
+  });
+
+  it('handles null/undefined gracefully', () => {
+    assert.equal(normalizeIp(null), '');
+    assert.equal(normalizeIp(undefined), '');
+  });
+});
+
+// ── SSE per-IP cap (unit — no real TCP) ──────────────────────────────
+
+describe('SSE per-IP cap', () => {
+  beforeEach(() => {
+    store.sseClients.length = 0;
+  });
+
+  afterEach(() => {
+    store.sseClients.length = 0;
+  });
+
+  it('accepts first connection (store empty)', () => {
+    const { req, res } = fakeReqRes('10.0.0.1');
+    const handled = handleSSERoute(req, res);
+    assert.equal(handled, true);
+    assert.equal(res._status(), 200);
+  });
+
+  it('rejects when per-IP count reaches MAX_SSE_PER_IP', () => {
+    const ip = '10.0.0.2';
+    // Pre-populate store with MAX_SSE_PER_IP fake clients from the same IP.
+    for (let i = 0; i < MAX_SSE_PER_IP; i++) {
+      store.sseClients.push(fakeClient(ip));
+    }
+
+    const { req, res } = fakeReqRes(ip);
+    handleSSERoute(req, res);
+    assert.equal(res._status(), 429);
+    const body = JSON.parse(res._ended());
+    assert.equal(body.error, 'SSE connection limit per IP exceeded');
+  });
+
+  it('allows connection from a different IP even when one IP is at cap', () => {
+    const ip = '10.0.0.3';
+    for (let i = 0; i < MAX_SSE_PER_IP; i++) {
+      store.sseClients.push(fakeClient(ip));
+    }
+
+    const { req, res } = fakeReqRes('10.0.0.99'); // different IP
+    handleSSERoute(req, res);
+    assert.equal(res._status(), 200, 'different IP should not be blocked');
+  });
+
+  it('count drops after a client closes, allowing new connection', () => {
+    const ip = '10.0.0.4';
+    // Fill to (cap - 1)
+    for (let i = 0; i < MAX_SSE_PER_IP - 1; i++) {
+      store.sseClients.push(fakeClient(ip));
+    }
+
+    // Open one more via handleSSERoute (takes us to cap)
+    const { req: req1, res: res1 } = fakeReqRes(ip);
+    handleSSERoute(req1, res1);
+    assert.equal(res1._status(), 200, 'should accept up to cap');
+    assert.equal(store.sseClients.length, MAX_SSE_PER_IP);
+
+    // Now we are at cap — next should be rejected
+    const { req: req2, res: res2 } = fakeReqRes(ip);
+    handleSSERoute(req2, res2);
+    assert.equal(res2._status(), 429);
+
+    // Simulate the first real connection closing by removing it from the store
+    // (mimics the 'close' event handler in sse.js)
+    const idx = store.sseClients.indexOf(res1);
+    if (idx >= 0) store.sseClients.splice(idx, 1);
+
+    // Now a new connection should be accepted
+    const { req: req3, res: res3 } = fakeReqRes(ip);
+    handleSSERoute(req3, res3);
+    assert.equal(res3._status(), 200, 'should accept after one closed');
+  });
+
+  it('non-/_events path is not handled', () => {
+    const { req, res } = fakeReqRes('10.0.0.5', '/_api/entries');
+    const handled = handleSSERoute(req, res);
+    assert.equal(handled, false);
+    assert.equal(res._status(), null);
+  });
+});
+
+// ── HTTP server timeout values ────────────────────────────────────────
+
+describe('HTTP server timeout assignments', () => {
+  it('headersTimeout=60000, keepAliveTimeout=5000, requestTimeout=0', () => {
+    // Mirror the assignments from server/index.js to confirm the values compile
+    // and are what the spec calls for.
+    const srv = http.createServer(() => {});
+    srv.headersTimeout = 60_000;
+    srv.keepAliveTimeout = 5_000;
+    srv.requestTimeout = 0;
+
+    assert.equal(srv.headersTimeout, 60_000);
+    assert.equal(srv.keepAliveTimeout, 5_000);
+    assert.equal(srv.requestTimeout, 0);
+  });
+});

--- a/test/timeouts-sse.test.js
+++ b/test/timeouts-sse.test.js
@@ -146,16 +146,14 @@ describe('SSE per-IP cap', () => {
 // ── HTTP server timeout values ────────────────────────────────────────
 
 describe('HTTP server timeout assignments', () => {
-  it('headersTimeout=60000, keepAliveTimeout=5000, requestTimeout=0', () => {
-    // Mirror the assignments from server/index.js to confirm the values compile
-    // and are what the spec calls for.
+  it('headersTimeout=60000, keepAliveTimeout=5000, requestTimeout=300000', () => {
     const srv = http.createServer(() => {});
     srv.headersTimeout = 60_000;
     srv.keepAliveTimeout = 5_000;
-    srv.requestTimeout = 0;
+    srv.requestTimeout = 300_000;
 
     assert.equal(srv.headersTimeout, 60_000);
     assert.equal(srv.keepAliveTimeout, 5_000);
-    assert.equal(srv.requestTimeout, 0);
+    assert.equal(srv.requestTimeout, 300_000);
   });
 });


### PR DESCRIPTION
## 繁中摘要

防禦 slowloris 攻擊與 SSE 連線耗盡：設定 HTTP timeout（headersTimeout=60s、keepAliveTimeout=5s、requestTimeout=300s）並加入 SSE 每 IP 連線上限（CCXRAY_SSE_MAX_PER_IP，預設 20）。

## Changes

- `server/index.js`: set `headersTimeout=60s`, `keepAliveTimeout=5s`, `requestTimeout=300s` (5min, Node default — covers slow POST body without affecting SSE response streaming)
- `server/config.js`: add `MAX_SSE_PER_IP` from `CCXRAY_SSE_MAX_PER_IP` env var (default 20)
- `server/routes/sse.js`: add `normalizeIp()` helper + per-IP SSE connection counting; returns 429 when cap reached
- `test/timeouts-sse.test.js`: 11 tests — normalizeIp unit tests (5), SSE per-IP cap (5 with store injection), timeout value assertions (1)

## Evidence

**Gate 1 — Full test suite**: 1088 tests, 0 fail, exit 0

**Gate 2 — Smoke test**: `CCXRAY_SSE_MAX_PER_IP=1` → 2nd SSE connection → 429 with correct error JSON; dashboard GET → 200

**Gate 3 — Codex review**: P1 finding fixed (requestTimeout changed from 0 to 300s per review — only covers request receiving phase, safe for SSE response streaming); P2 noted (test mirrors logic, follows project test patterns)

## Design decisions

- `requestTimeout=300s` (not 0): codex review correctly identified that requestTimeout only covers receiving the client request, not response streaming — disabling it removed slow-POST protection without protecting SSE. 300s is Node's own default.
- SSE cap 20 (not 8): dashboard uses 1 SSE connection per tab; 20 allows many tabs + headroom without loopback exemption complexity.
- No loopback exemption: high default covers normal use; exemption adds an unmonitored code path.

## Not verified

- Long SSE stream survival under requestTimeout=300s (Node docs confirm requestTimeout only covers request receipt, not response streaming; live testing deferred to #153's smoke requirement in the issue body — would need a multi-minute thinking turn)

Closes #153
