### PR TITLE
fix(#155): misc hardening — JSON config, file perms 0600, control-char strip, hub validation

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,5 +1,6 @@
 // ── Global Config ────────────────────────────────────────────────────
-const DEFAULT_MAX_CTX = window.__PROXY_CONFIG__?.DEFAULT_CONTEXT || 200000;
+const __PROXY_CONFIG__ = JSON.parse(document.getElementById('proxy-config').textContent);
+const DEFAULT_MAX_CTX = __PROXY_CONFIG__?.DEFAULT_CONTEXT || 200000;
 
 // ── Active Tab State ─────────────────────────────────────────────────
 let activeTab = 'dashboard';

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1292,7 +1292,8 @@ function scrollTurnsToBottom() {
 }
 
 // ── Status line injection state ──
-let statusLineEnabled = window.__PROXY_CONFIG__?.statusLine !== false;
+// eslint-disable-next-line no-undef
+let statusLineEnabled = (typeof __PROXY_CONFIG__ !== 'undefined' ? __PROXY_CONFIG__ : {})?.statusLine !== false;
 
 function toggleStatusLine() {
   statusLineEnabled = !statusLineEnabled;

--- a/server/forward.js
+++ b/server/forward.js
@@ -12,7 +12,7 @@ const helpers = require('./helpers');
 const { broadcast, broadcastSessionStatus, broadcastSessionTitleUpdate } = require('./sse-broadcast');
 const { appendSample, collectRatelimitHeaders } = require('./ratelimit-log');
 const hub = require('./hub');
-const { stripAuthParams } = require('./url-sanitize');
+const { stripAuthParams, stripControlChars } = require('./url-sanitize');
 const { getParser } = require('./wire-parsers');
 const { agentForProvider } = require('./providers');
 const { buildIndexLine } = require('./entry');
@@ -446,7 +446,7 @@ function forwardRequest(ctx) {
       reqId: id,
     });
     helpers.printSeparator();
-    console.log(`\x1b[36m📤 [${ts}]  ${ctx.attribPrefix}  ${clientReq.method} ${stripAuthParams(clientReq.url)}\x1b[0m`);
+    console.log(`\x1b[36m📤 [${ts}]  ${ctx.attribPrefix}  ${stripControlChars(clientReq.method)} ${stripControlChars(stripAuthParams(clientReq.url))}\x1b[0m`);
     console.log(helpers.summarizeRequest(parsedBody));
   }
 

--- a/server/hub.js
+++ b/server/hub.js
@@ -23,7 +23,7 @@ const HUB_LOG_KEEP_BYTES = 100 * 1024;     // 100 KB
 // ── Lockfile operations ─────────────────────────────────────────────
 
 function ensureHubDir() {
-  if (!fs.existsSync(HUB_DIR)) fs.mkdirSync(HUB_DIR, { recursive: true });
+  if (!fs.existsSync(HUB_DIR)) fs.mkdirSync(HUB_DIR, { recursive: true, mode: 0o700 });
 }
 
 function readHubLock() {
@@ -39,7 +39,7 @@ function writeHubLock(port, pid, versionOverride, sockPath) {
   const version = versionOverride || require('../package.json').version;
   const data = { port, pid, version, startedAt: new Date().toISOString() };
   if (sockPath) data.sockPath = sockPath;
-  fs.writeFileSync(HUB_LOCK_PATH, JSON.stringify(data));
+  fs.writeFileSync(HUB_LOCK_PATH, JSON.stringify(data), { mode: 0o600 });
   return data;
 }
 
@@ -334,6 +334,8 @@ function handleSocketCommand(msg, socket) {
       socket.write(JSON.stringify({ ok: true }) + '\n');
       break;
     case 'register': {
+      if (typeof msg.pid !== 'number' || msg.pid <= 0 || msg.pid > 4194304 || !Number.isInteger(msg.pid)) return;
+      if (typeof msg.cwd !== 'string' || msg.cwd.length > 4096) return;
       const wasEmpty = clients.size === 0;
       addClient(msg.pid, msg.cwd);
       socket.write(JSON.stringify({ ok: true, firstClient: wasEmpty }) + '\n');
@@ -449,7 +451,7 @@ function truncateHubLog() {
       // Find first newline to avoid partial line
       const nl = buf.indexOf(0x0a);
       const clean = nl >= 0 ? buf.subarray(nl + 1) : buf;
-      fs.writeFileSync(HUB_LOG_PATH, clean);
+      fs.writeFileSync(HUB_LOG_PATH, clean, { mode: 0o600 });
     }
   } catch {}
 }

--- a/server/hub.js
+++ b/server/hub.js
@@ -228,7 +228,7 @@ function forkHub(port, opts = {}) {
   ensureHubDir();
   truncateHubLog();
 
-  const fd = fs.openSync(HUB_LOG_PATH, 'a');
+  const fd = fs.openSync(HUB_LOG_PATH, 'a', 0o600);
   const hubScript = path.resolve(__dirname, 'index.js');
   const args = ['--port', String(port), '--hub-mode'];
   const env = { ...process.env };

--- a/server/index.js
+++ b/server/index.js
@@ -147,7 +147,7 @@ function rebuildIndexHTML(port) { serverPort = port; }
 function serveStatic(url, clientRes) {
   const pathname = url.split('?')[0];
   if (pathname === '/' || pathname === '/index.html') {
-    const script = `<script>window.__PROXY_CONFIG__=${JSON.stringify({ DEFAULT_CONTEXT: config.DEFAULT_CONTEXT, PORT: serverPort, statusLine: getStatusLineEnabled(), APP_NAME: DISPLAY_NAME })}</script>`;
+    const script = `<script type="application/json" id="proxy-config">${JSON.stringify({ DEFAULT_CONTEXT: config.DEFAULT_CONTEXT, PORT: serverPort, statusLine: getStatusLineEnabled(), APP_NAME: DISPLAY_NAME })}</script>`;
     const html = rawIndexHTML ? rawIndexHTML.replace('<!--__PROXY_CONFIG__-->', script) : '<html><body>Error loading dashboard</body></html>';
     clientRes.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' });
     clientRes.end(html);

--- a/server/index.js
+++ b/server/index.js
@@ -147,7 +147,8 @@ function rebuildIndexHTML(port) { serverPort = port; }
 function serveStatic(url, clientRes) {
   const pathname = url.split('?')[0];
   if (pathname === '/' || pathname === '/index.html') {
-    const script = `<script type="application/json" id="proxy-config">${JSON.stringify({ DEFAULT_CONTEXT: config.DEFAULT_CONTEXT, PORT: serverPort, statusLine: getStatusLineEnabled(), APP_NAME: DISPLAY_NAME })}</script>`;
+    const configJson = JSON.stringify({ DEFAULT_CONTEXT: config.DEFAULT_CONTEXT, PORT: serverPort, statusLine: getStatusLineEnabled(), APP_NAME: DISPLAY_NAME }).replace(/</g, '\\u003c');
+    const script = `<script type="application/json" id="proxy-config">${configJson}</script>`;
     const html = rawIndexHTML ? rawIndexHTML.replace('<!--__PROXY_CONFIG__-->', script) : '<html><body>Error loading dashboard</body></html>';
     clientRes.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' });
     clientRes.end(html);

--- a/server/storage/local.js
+++ b/server/storage/local.js
@@ -56,13 +56,13 @@ function createLocalStorage(logsDir, opts = {}) {
       // dir — mirrors the original `if (!fs.existsSync(LOGS_DIR))` guard and
       // never clobbers a populated logs dir.
       const logsDirExisted = fs.existsSync(logsDir);
-      await fsp.mkdir(logsDir, { recursive: true });
-      await fsp.mkdir(sharedDir, { recursive: true });
+      await fsp.mkdir(logsDir, { recursive: true, mode: 0o700 });
+      await fsp.mkdir(sharedDir, { recursive: true, mode: 0o700 });
       if (!logsDirExisted) await migrateLegacyLogs();
     },
 
     async write(id, suffix, data) {
-      await fsp.writeFile(path.join(logsDir, id + suffix), data);
+      await fsp.writeFile(path.join(logsDir, id + suffix), data, { mode: 0o600 });
     },
 
     async read(id, suffix) {
@@ -88,7 +88,7 @@ function createLocalStorage(logsDir, opts = {}) {
     // ── Index (index.ndjson) ──────────────────────────────────────────
 
     async appendIndex(line) {
-      await fsp.appendFile(indexPath, line);
+      await fsp.appendFile(indexPath, line, { mode: 0o600 });
     },
 
     async readIndex() {
@@ -105,7 +105,7 @@ function createLocalStorage(logsDir, opts = {}) {
     async writeSharedIfAbsent(filename, data) {
       const p = safeJoin(sharedDir, filename);
       try {
-        await fsp.writeFile(p, data, { flag: 'wx' });
+        await fsp.writeFile(p, data, { flag: 'wx', mode: 0o600 });
       } catch (e) {
         if (e.code !== 'EEXIST') throw e;
       }

--- a/server/url-sanitize.js
+++ b/server/url-sanitize.js
@@ -44,4 +44,8 @@ function stripAuthParams(url) {
   return remaining ? pathname + '?' + remaining : pathname;
 }
 
-module.exports = { stripAuthParams, AUTH_QUERY_PARAMS };
+function stripControlChars(str) {
+  return typeof str === 'string' ? str.replace(/[\x00-\x1f\x7f]/g, '') : str;
+}
+
+module.exports = { stripAuthParams, AUTH_QUERY_PARAMS, stripControlChars };

--- a/test/auth-dashboard-shell.e2e.test.js
+++ b/test/auth-dashboard-shell.e2e.test.js
@@ -79,7 +79,7 @@ describe('Dashboard shell stays reachable under enforcement (2.3)', () => {
     const root = await get(proxyPort, '/');
     assert.equal(root.statusCode, 200, 'GET / should serve the shell without a cookie');
     assert.match(root.headers['content-type'] || '', /text\/html/);
-    assert.match(root.body, /__PROXY_CONFIG__/);
+    assert.match(root.body, /id="proxy-config"/);
 
     const css = await get(proxyPort, '/style.css');
     assert.equal(css.statusCode, 200, 'GET /style.css should serve without a cookie');

--- a/test/hardening.test.js
+++ b/test/hardening.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { stripControlChars } = require('../server/url-sanitize');
+
+// ── A. Config injection ───────────────────────────────────────────────────────
+
+describe('proxy-config JSON pattern (item A)', () => {
+  it('JSON.parse round-trips the config object', () => {
+    const config = { DEFAULT_CONTEXT: 200000, PORT: 5577, statusLine: true, APP_NAME: 'ccxray' };
+    const serialized = JSON.stringify(config);
+    const parsed = JSON.parse(serialized);
+    assert.deepEqual(parsed, config);
+  });
+
+  it('config with special chars round-trips via JSON.parse correctly', () => {
+    const config = { APP_NAME: '</script><script>alert(1)', PORT: 5577 };
+    const serialized = JSON.stringify(config);
+    // The safety model: type="application/json" blocks are never executed as JS
+    // regardless of their textContent — JSON.parse on the client side is safe.
+    const parsed = JSON.parse(serialized);
+    assert.deepEqual(parsed, config);
+  });
+});
+
+// ── B. File permissions 0600 ──────────────────────────────────────────────────
+
+describe('file permissions 0600 (item B)', () => {
+  it('writeFile with mode 0o600 produces a 0600 file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-hardening-'));
+    const p = path.join(dir, 'test.json');
+    try {
+      fs.writeFileSync(p, '{}', { mode: 0o600 });
+      const mode = fs.statSync(p).mode & 0o777;
+      assert.equal(mode, 0o600, `expected 0600, got 0${mode.toString(8)}`);
+    } finally {
+      try { fs.rmSync(dir, { recursive: true }); } catch {}
+    }
+  });
+
+  it('mkdirSync with mode 0o700 produces a 0700 directory', () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-hardening-'));
+    const dir = path.join(parent, 'sub');
+    try {
+      fs.mkdirSync(dir, { mode: 0o700 });
+      const mode = fs.statSync(dir).mode & 0o777;
+      assert.equal(mode, 0o700, `expected 0700, got 0${mode.toString(8)}`);
+    } finally {
+      try { fs.rmSync(parent, { recursive: true }); } catch {}
+    }
+  });
+});
+
+// ── C. Control character stripping ───────────────────────────────────────────
+
+describe('stripControlChars (item C)', () => {
+  it('strips ESC and other control chars from a string', () => {
+    assert.equal(stripControlChars('hello\x1bworld'), 'helloworld');
+    assert.equal(stripControlChars('ab\x00cd'), 'abcd');
+    assert.equal(stripControlChars('line\x0abreak'), 'linebreak');
+    assert.equal(stripControlChars('tab\x09here'), 'tabhere');
+    assert.equal(stripControlChars('del\x7fchar'), 'delchar');
+  });
+
+  it('returns non-string inputs unchanged', () => {
+    assert.equal(stripControlChars(null), null);
+    assert.equal(stripControlChars(undefined), undefined);
+    assert.equal(stripControlChars(42), 42);
+  });
+
+  it('returns a clean string unchanged', () => {
+    assert.equal(stripControlChars('hello world'), 'hello world');
+    assert.equal(stripControlChars('/v1/messages'), '/v1/messages');
+  });
+});
+
+// ── D. Hub register validation ────────────────────────────────────────────────
+
+describe('hub register validation (item D)', () => {
+  // Test the validation logic directly (extracted as a pure function for testability)
+  function isValidRegisterMsg(msg) {
+    if (typeof msg.pid !== 'number' || msg.pid <= 0 || msg.pid > 4194304 || !Number.isInteger(msg.pid)) return false;
+    if (typeof msg.cwd !== 'string' || msg.cwd.length > 4096) return false;
+    return true;
+  }
+
+  it('accepts a valid pid and cwd', () => {
+    assert.ok(isValidRegisterMsg({ pid: 1234, cwd: '/home/user/project' }));
+    assert.ok(isValidRegisterMsg({ pid: 1, cwd: '/' }));
+    assert.ok(isValidRegisterMsg({ pid: 4194304, cwd: '/tmp' }));
+  });
+
+  it('rejects non-integer pid', () => {
+    assert.ok(!isValidRegisterMsg({ pid: 1.5, cwd: '/tmp' }));
+    assert.ok(!isValidRegisterMsg({ pid: NaN, cwd: '/tmp' }));
+    assert.ok(!isValidRegisterMsg({ pid: Infinity, cwd: '/tmp' }));
+  });
+
+  it('rejects out-of-range pid', () => {
+    assert.ok(!isValidRegisterMsg({ pid: 0, cwd: '/tmp' }));
+    assert.ok(!isValidRegisterMsg({ pid: -1, cwd: '/tmp' }));
+    assert.ok(!isValidRegisterMsg({ pid: 4194305, cwd: '/tmp' }));
+  });
+
+  it('rejects non-string cwd', () => {
+    assert.ok(!isValidRegisterMsg({ pid: 1234, cwd: null }));
+    assert.ok(!isValidRegisterMsg({ pid: 1234, cwd: 123 }));
+    assert.ok(!isValidRegisterMsg({ pid: 1234, cwd: undefined }));
+  });
+
+  it('rejects cwd exceeding 4096 bytes', () => {
+    assert.ok(!isValidRegisterMsg({ pid: 1234, cwd: 'a'.repeat(4097) }));
+    assert.ok(isValidRegisterMsg({ pid: 1234, cwd: 'a'.repeat(4096) }));
+  });
+});


### PR DESCRIPTION
## 繁中摘要

四項低優先安全衛生合併：(A) config 注入改 `type="application/json"` + `</script>` 轉義、(B) 檔案權限 0600/0700、(C) log 控制字元清洗、(D) hub register 輸入驗證。

## Changes (4 independent items)

**A. Config injection** (`server/index.js`, `public/app.js`, `public/miller-columns.js`):
- `<script>window.__PROXY_CONFIG__=...` → `<script type="application/json" id="proxy-config">` (non-executable)
- Client reads via `JSON.parse(getElementById('proxy-config').textContent)`
- `</script>` escaped via `<` replacement (codex review P2.1 fix)

**B. File permissions** (`server/storage/local.js`, `server/hub.js`):
- Directories: `mode: 0o700`; files: `mode: 0o600`
- Hub log initial creation now gets 0600 (codex review P2.3 fix — `openSync('a', 0o600)`)

**C. Control char stripping** (`server/url-sanitize.js`, `server/forward.js`):
- `stripControlChars()` strips `\x00–\x1f` and `\x7f` from method + URL in console log

**D. Hub register validation** (`server/hub.js`):
- pid: positive integer ≤ 2^22; cwd: string ≤ 4096 chars

## Evidence

**Gate 1 — Full test suite**: 1089 tests, 0 fail, exit 0

**Gate 2 — Smoke test**: Config renders as `type="application/json"` with `id="proxy-config"`; dashboard loads (200); directory permissions 0700

**Gate 3 — Codex review**: 4 P2 findings — 2 fixed (script tag escape, hub.log initial mode), 2 noted as scope expansion (full log line sanitize covers more fields than issue spec; existing path chmod is upgrade migration concern)

## Codex review findings (disposition)

- [P2.1] ✅ Fixed — `</script>` in config JSON escaped via `<` replacement
- [P2.2] Noted — `attribPrefix` and `summarizeRequest` not sanitized; issue scopes to method+URL only
- [P2.3] ✅ Fixed — `fs.openSync(HUB_LOG_PATH, 'a', 0o600)` covers initial creation
- [P2.4] Noted — existing directories/files from older installs keep their permissions; migration chmod is out of scope

Closes #155
