### PR TITLE
fix(#143): tighten wfBuildState sentinel — preserve valid tMax

### DIFF
--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -362,7 +362,7 @@ function wfBuildState(sessionId) {
     var end = ts + (parseFloat(t.elapsed) || 0) * 1000;
     if (end > tMax) tMax = end;
   }
-  if (tMin === Infinity) { tMin = 0; tMax = 1; }
+  if (tMin === Infinity) { tMin = 0; if (tMax === -Infinity) tMax = 1; }
 
   var lanes = wfInferLanes(entries, childEntries);
 

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -198,6 +198,15 @@ describe('workflow-timeline data layer', () => {
     assert.equal(state.lanes[0].turns.length, 2);
   });
 
+  it('#143: sentinel does not clobber valid tMax when receivedAt is falsy', () => {
+    const ctx = loadWfModule();
+    ctx.allEntries = [
+      mkEntry('t1', 's1', 'claude-opus-4-6', 0, 10, {}), // receivedAt = 0 (falsy)
+    ];
+    var state = ctx.wfBuildState('s1');
+    assert.equal(state.tMax, 10000); // 0 + 10*1000, NOT sentinel 1
+  });
+
   it('wfAddEntry assigns to correct lane and extends tMax', () => {
     const ctx = loadWfModule();
     ctx.allEntries = [


### PR DESCRIPTION
## 繁中摘要

`wfBuildState` 的 sentinel 在所有 entry 的 `receivedAt` 為 falsy 時，會把已正確計算的 `tMax` 砍成 1，導致 timeline 壓縮成 1ms。修正：只在真正無資料時才重設 tMax。

## Detail

One-line fix in the `wfBuildState` sentinel guard:

```diff
- if (tMin === Infinity) { tMin = 0; tMax = 1; }
+ if (tMin === Infinity) { tMin = 0; if (tMax === -Infinity) tMax = 1; }
```

The old code conflated "no data at all" (tMax stays -Infinity) with "data exists but tMin was never set" (all entries have falsy receivedAt). Only the first case should reset tMax.

Dormant today (real `receivedAt` is always epoch millis), but a real trap for any entry whose `receivedAt` is falsy.

## Verification

- ✅ `scripts/diff-check.sh` — old FAIL / new PASS confirmed
- ✅ Full suite: 1118/1118 pass, 0 fail
- ⚠️ Codex review gate skipped (same toolchain issue as #214)

## Test

```js
// receivedAt = 0 (falsy), elapsed = 10s
// expected tMax = 10000 (0 + 10*1000)
// old code: tMax = 1 (sentinel clobbered it)
```

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)