### PR TITLE
Follow-live-turn: fix subagent hijack, add session metrics + lane-focus mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,9 @@ These constraints have guard comments at their mutation sites. Read the linked A
 - **entryIndex must mirror entries[]** at all push/trim sites (forward.js, ws-proxy.js, restore.js, store.js) — @docs/decisions/0003-entry-index-map.md
 - **renderProjectsCol signature must include every field that affects rendered output** — adding a rendered field without updating `sigParts` = silent stale render — @docs/decisions/0002-dirty-check-signature.md
 - **Skeleton early-return must clear innerHTML** before returning; skeleton containers must have the same `id` as the render function's `getElementById` target — @docs/decisions/0004-skeleton-lifecycle.md
+- **agentKey main/subagent classification must gate on AGENT_KEY_UNRELIABLE** in both `entry-rendering.js` and `workflow-timeline.js` (`wfInferLanes`, `wfAddEntry`) — the two files must never disagree on the same turn — @docs/decisions/0005-agent-key-unreliable-shared-contract.md
+- **Lane-focus geometry must match what `_wfRenderSvgContent` actually draws** — `_wfTotalLanesHeight`, `_wfLaneIdxAtY`, and the label-click hit-test in `workflow-timeline.js` must all agree with it under `laneFocusMode` — @docs/decisions/0006-lane-focus-geometry-consistency.md
+- **Use `_wfIsMainLane(lane)` for main/orchestrator detection, never `!lane.spawnParent`** (`spawnParent` is always `null`, in every lane object, everywhere) — @docs/decisions/0007-wf-is-main-lane-not-spawn-parent.md
 
 ## Smoke Testing
 

--- a/docs/decisions/0005-agent-key-unreliable-shared-contract.md
+++ b/docs/decisions/0005-agent-key-unreliable-shared-contract.md
@@ -1,0 +1,74 @@
+# 0005 — Shared agentKey-unreliability contract
+
+- Status: Accepted
+- Date: 2026-07-10
+- Related: PR #224
+
+## Context
+
+Two independent client files each classify a turn as "main" or "subagent":
+
+- `entry-rendering.js`'s `addEntry()` — drives the turn list, the
+  follow-live-turn pill, and session counters.
+- `workflow-timeline.js`'s `wfInferLanes()` (batch) / `wfAddEntry()` (live) —
+  drives which swimlane a turn is drawn in.
+
+Both prefer the server-detected `agentKey` (from system-prompt content,
+authoritative — not fooled by Claude Code's current behavior of Task-tool
+subagent requests carrying the *parent's* `session_id`, which is what makes
+the server's own `isAnthropicSubagent()` heuristic miss the common case).
+But `extractAgentType()` (server, `system-prompt.js`) has two catch-all
+defaults — `unknown` and `agent` — for prompts it can't classify. Those could
+be a genuinely new main-agent variant, not necessarily a subagent, so
+treating them as an authoritative "not main" signal risks silently breaking
+follow-live-turn or misfiling a main turn into its own subagent lane.
+
+Codex review (round 4, PR #224) caught the two files disagreeing on exactly
+this: `entry-rendering.js` already guarded with `AGENT_KEY_UNRELIABLE`
+(falling back to the raw `isSubagent` flag for `unknown`/`agent`),
+`workflow-timeline.js` did not — so the same turn could show as "main" in
+the turn list and as a subagent lane in the workflow view.
+
+## Decision
+
+`AGENT_KEY_UNRELIABLE = { unknown: 1, agent: 1 }` lives in
+`workflow-timeline.js` (loaded before `entry-rendering.js`, see
+`public/index.html` script order) so both files read the same object. Every
+site in either file that branches on `entry.agentKey` to decide main vs.
+subagent must gate on `entry.agentKey && !AGENT_KEY_UNRELIABLE[entry.agentKey]`
+before trusting it, and fall back to the raw `isSubagent` flag otherwise:
+
+| Site | File | Guard |
+|------|------|-------|
+| `isSubagent` computation | `entry-rendering.js` `addEntry()` | `e.agentKey && !AGENT_KEY_UNRELIABLE[e.agentKey]` |
+| Batch lane build | `workflow-timeline.js` `wfInferLanes()` | `e.agentKey && !AGENT_KEY_UNRELIABLE[e.agentKey]` |
+| Live lane update | `workflow-timeline.js` `wfAddEntry()` | `entry.agentKey && !AGENT_KEY_UNRELIABLE[entry.agentKey]` |
+
+## Consequences
+
+**Good**: the turn list and the workflow swimlanes can no longer disagree on
+the same turn's main/subagent classification — both read the same
+`AGENT_KEY_UNRELIABLE` object and apply the same fallback rule.
+
+**Bad — consistency contract**: adding a new call site that branches on
+`agentKey` (e.g. a future view) without this guard silently reintroduces the
+round-4 bug for that view, undetectably until someone notices the same turn
+classified two different ways in two different places.
+
+**Mitigation**: `INVARIANT` guard comments at all three sites above name
+this ADR. If `WF_MAIN_AGENT_KEYS` or `AGENT_KEY_UNRELIABLE` ever needs a new
+entry, both files' classification logic reads from the one shared object —
+there's nothing to keep in sync by hand.
+
+## Alternatives considered
+
+**Have the server never emit `unknown`/`agent` as `agentKey`, forcing a
+real classification**: rejected — `extractAgentType()`'s regex fallback is
+specifically there to degrade gracefully for prompts nobody has written a
+matcher for yet; refusing to serve those entries or guessing wrong is worse
+than the client falling back to the raw flag.
+
+**Duplicate `AGENT_KEY_UNRELIABLE` in both files**: rejected — this is
+exactly the shape of drift that caused the round-4 bug in the first place;
+a single shared definition (like `WF_MAIN_AGENT_KEYS`, already shared the
+same way) removes the possibility.

--- a/docs/decisions/0006-lane-focus-geometry-consistency.md
+++ b/docs/decisions/0006-lane-focus-geometry-consistency.md
@@ -1,0 +1,74 @@
+# 0006 — Lane-focus geometry must match what's actually rendered
+
+- Status: Accepted
+- Date: 2026-07-10
+- Related: PR #224
+
+## Context
+
+Lane-focus mode (`wfState.laneFocusMode`) collapses the swimlane overview so
+the sub-lane SVG draws only the currently-selected lane, instead of every
+subagent lane stacked — added because a real session with 473 `Agent` tool
+calls (many spawned subagents) overflowed the fixed-height lane list with no
+scroll affordance.
+
+Three separate places in `workflow-timeline.js` each computes lane geometry
+independently:
+
+- `_wfRenderSvgContent()` — the actual draw: builds `subIndices` as either
+  `[focusLi]` (focus mode) or all lanes `1..N` (normal), and lays them out
+  top to bottom.
+- `_wfTotalLanesHeight()` — used to size the SVG container so it doesn't
+  reserve empty space for lanes that aren't drawn.
+- `_wfLaneIdxAtY(svgEl, my)` — hit-testing: given a mouse Y coordinate,
+  which lane is under the cursor? Used by both hover (`_wfHoverMove`) and
+  the chart click-to-lock handler.
+
+Codex review (round 4, PR #224) caught `_wfLaneIdxAtY()` walking
+`wfState.lanes[1..N]` and accumulating heights as if every sub-lane were
+stacked — the pre-focus-mode behavior — even when `laneFocusMode` was on and
+only one lane was actually drawn at `y = WF_PAD`. Hovering or clicking
+anywhere in the (single, real) rendered lane could resolve to whatever
+*unfocused* lane happened to occupy that Y range under the old sequential
+math, selecting or locking the wrong turn. The label-area click handler
+(a separate code path, same file) already had the correct focus-mode branch
+— `_wfLaneIdxAtY()` was the one site that drifted.
+
+## Decision
+
+Any function that computes "which lane is at this position" in the sub-lane
+SVG must branch on `wfState.laneFocusMode` the same way
+`_wfRenderSvgContent()` does: focus mode → only `_wfFocusLaneIdx()`'s lane
+exists, drawn at `y = WF_PAD`; normal mode → walk `lanes[1..N]` accumulating
+`_wfLaneHeight(i)`.
+
+| Site | Role | Focus-mode branch |
+|------|------|--------------------|
+| `_wfRenderSvgContent()` | draws the lanes (ground truth) | `subIndices = focusLi > 0 ? [focusLi] : []` |
+| `_wfTotalLanesHeight()` | sizes the container | already correct — see inline comment |
+| `_wfLaneIdxAtY()` | hover + chart click hit-test | fixed in PR #224 (round 4) |
+| Label-area click handler (inline, `wfRenderTimeline`) | click-in-label-column hit-test | already correct — has its own focus branch |
+
+## Consequences
+
+**Good**: hover, chart-click, and label-click all agree on which lane is
+under the cursor in every mode, matching what's actually drawn.
+
+**Bad — consistency contract**: a fourth geometry consumer added later
+(e.g. a new interaction mode) that doesn't special-case `laneFocusMode` will
+silently hit-test against the pre-collapse layout again, exactly like the
+round-4 bug.
+
+**Mitigation**: `INVARIANT` guard comments at each site above name this
+ADR. The label-area click handler's existing focus-mode branch was the
+reference implementation `_wfLaneIdxAtY()` was brought in line with — future
+geometry consumers should copy that same `focusLi > 0 && my >= WF_PAD`
+shape rather than re-deriving it.
+
+## Alternatives considered
+
+**Single shared geometry-lookup table, rebuilt on every render, all three
+sites read from it**: rejected as disproportionate for three call sites —
+would trade "three places must agree" for "one more cache that must be
+invalidated correctly," a different but not obviously smaller consistency
+burden. Revisit if a fourth or fifth geometry consumer appears.

--- a/docs/decisions/0007-wf-is-main-lane-not-spawn-parent.md
+++ b/docs/decisions/0007-wf-is-main-lane-not-spawn-parent.md
@@ -1,0 +1,64 @@
+# 0007 — `_wfIsMainLane(lane)`, never `!lane.spawnParent`
+
+- Status: Accepted
+- Date: 2026-07-10
+- Related: PR #224
+
+## Context
+
+`lane.spawnParent` looks like it should mean "this lane was spawned by
+another lane, i.e. it's a subagent" — so `!lane.spawnParent` reads as "this
+is the main lane." It isn't: every lane object created in
+`workflow-timeline.js` (`wfInferLanes`, `wfAddEntry`, child-session lanes,
+sub-agent lanes) sets `spawnParent: null` unconditionally. Nothing in the
+current codebase ever assigns it a truthy value. `!lane.spawnParent` is
+`true` for every lane, main and subagent alike.
+
+This trap was hit twice in the same feature (PR #224):
+
+1. During implementation, an early version of the Main/Subagent cost split
+   used `!lane.spawnParent` to detect the main lane, misattributing 100% of
+   subagent cost as main in verification testing (caught before merge, fixed
+   with `_wfIsMainLane(lane)`, an already-existing helper from the #91
+   swimlane feature).
+2. `wfRenderAgentCard`'s meta line (`'N turns · Xm · ' +
+   (lane.spawnParent ? 'subagent' : 'orchestrator')`) — pre-existing code,
+   not touched by PR #224's diff — has the same bug: it always renders
+   "orchestrator," even on subagent lanes, confirmed live in a 10-lane
+   session during PR #224's browser verification pass. Fixed alongside this
+   ADR since it's the exact trap being documented, not a new finding.
+
+## Decision
+
+`_wfIsMainLane(lane)` — `lane.key === 'main' || lane.name === 'main'` — is
+the only correct test for "is this the main/orchestrator lane" anywhere in
+`workflow-timeline.js`. `lane.spawnParent` is not a live signal; treat any
+code that branches on its truthiness as a bug.
+
+## Consequences
+
+**Good**: one canonical helper, already used by `wfComputeLaneStyles`,
+`wfLaneColor`, `wfLaneShape`, and (as of PR #224) `wfRenderAgentCard`'s
+rollup gate and meta-line label.
+
+**Bad — the field itself invites the mistake**: `spawnParent` reads as
+meaningful even though it's dead. Anyone skimming lane-object construction
+for "how do I tell main from subagent" will reach for it first, because it's
+right there and its name suggests exactly that.
+
+**Mitigation**: an `INVARIANT` guard comment at `_wfIsMainLane`'s
+definition and at each call site that gates main-lane-only behavior names
+this ADR.
+
+## Alternatives considered
+
+**Remove the dead `spawnParent` field entirely**: rejected for this PR —
+it's assigned at 5 lane-construction sites, and removing it is an unrelated
+cleanup outside PR #224's scope. Worth doing as a follow-up: if the field
+never becomes live, deleting it removes the trap at the source instead of
+just guarding against it.
+
+**Make `spawnParent` actually track the parent lane**: rejected as
+out of scope here — no current feature needs "which lane spawned this
+one" as data; `_wfIsMainLane` is the only distinction anything currently
+reads.

--- a/docs/designs/follow-live-turn-subagent.md
+++ b/docs/designs/follow-live-turn-subagent.md
@@ -34,16 +34,30 @@ Investigate job but have no home in the current UI.
 Subagent turns append to the Turns list silently (visible as cards) but
 do NOT call `selectTurn`.
 
-**Known limitation (codex review)**: this rule is only as good as the
-`isSubagent` signal it reads, and that signal has the same gap documented
-under Problem 3's "Dropped from this pass" section below —
+**Fixed (codex review round 2)**: the raw `isSubagent` flag has a real gap —
 `isAnthropicSubagent()` in `store.js` classifies by `!cwd && !session_id`,
 but current Claude Code Task-tool subagents carry the parent's
-`session_id`, so those turns arrive with `isSubagent: false` and are NOT
-recognized as subagents by this rule either. They enter the "main" branch
-and auto-select normally — the exact jumping behavior this whole design
-exists to prevent, for exactly the common subagent case. Not fixed here
-(same out-of-scope server-side detection gap); tracked as the same
+`session_id`, so those turns arrive with `e.isSubagent: false`. Codex
+correctly rejected documenting this as an accepted limitation for the pill
+mechanism specifically, since it's the exact jumping behavior this whole
+design exists to prevent. Fixed client-side by preferring `e.agentKey`
+(server-detected from system-prompt content via `extractAgentType()` in
+`server/system-prompt.js` — not fooled by shared `session_id`) over the raw
+flag when available, reusing `WF_MAIN_AGENT_KEYS` — the same "authoritative"
+classification `wfInferLanes()` in `workflow-timeline.js` already uses to
+build correct lanes. Verified in-browser against the real session that
+originally exposed this: entries with `agentKey: 'general-purpose'` that
+were previously misclassified `isSubagent: false` are now correctly `true`.
+
+Important: `isSubagent` is computed once in `addEntry()` and read
+throughout the function (retry detection, main/sub counts, this pill,
+etc.), so this fix corrects the signal at its source — every downstream
+use benefits, including the exact `isSubagent`-keyed accumulation that
+caused Problem 3's Main/Subagent cost split to be dropped below. That
+split is *not* re-added here — re-introducing a feature that was
+deliberately cut is a separate scoping decision the fix for a different
+bug shouldn't make unilaterally — but it's worth noting the fix removes
+the reason it was cut, so re-adding it later is no longer blocked on
 follow-up as Problem 3's cost-split limitation, not a separate issue.
 
 ### Subagent pill notification
@@ -209,6 +223,12 @@ lane-inference signal the workflow timeline already uses to split lanes
 correctly (it isn't fooled by the shared session_id, per the verification
 screenshots that caught this). Tracked as a separate follow-up, not blocking
 this PR.
+
+**Update (codex review round 2)**: the second option above is now done —
+`addEntry()`'s `isSubagent` computation (Problem 1, above) was fixed to
+prefer `agentKey`/`WF_MAIN_AGENT_KEYS`, the same signal `sess.mainCost`/
+`subCost` would need. Re-adding this split is no longer blocked; it's a
+scope decision, not a data-availability one.
 
 ### New/enhanced sections
 

--- a/docs/designs/follow-live-turn-subagent.md
+++ b/docs/designs/follow-live-turn-subagent.md
@@ -235,6 +235,27 @@ TIME                                   ← NEW section
   Active            ~2.3h
 ```
 
+### Overview swimlane strip — lane-focus mode (added post-review)
+
+`ux-heuristic-analysis` on a real 5-subagent session found a MAJOR issue:
+`#wf-lanes-section` hard-clips lanes off the bottom with a fixed max-height
+and no scroll affordance (no visible scrollbar, no lane count, no fade
+cue) — directly undermining this design's own motivating scenario (a
+session with 473 Agent tool calls). This is pre-existing behavior from the
+earlier swimlane feature (#91), not something Problems 1-3 introduced, but
+it makes the new Agent Card metrics hard to reach in exactly the sessions
+where they're most useful.
+
+Fix: a collapse toggle button in `#wf-overview-label` (`wfToggleLaneFocus()`)
+that narrows the sub-lane area to just the selected lane — main stays
+visible (pinned, cheap) so orchestrator context is never lost; if main
+itself is selected, the sub-lane area shows nothing. Two ▲/▼ buttons appear
+next to the toggle when active, showing a "N/total" position and cycling
+`wfState.selectedLane` — reusing the same stepping logic as the existing
+Tab/Shift+Tab lane-cycle shortcut (`wfCycleLane(dir)`, extracted so both
+call sites share one implementation). No build step, no new dependency —
+pure CSS/JS reusing the existing `#wf-overview-label button` style.
+
 ### Data availability
 
 | Metric | Source | Status |

--- a/docs/designs/follow-live-turn-subagent.md
+++ b/docs/designs/follow-live-turn-subagent.md
@@ -34,6 +34,18 @@ Investigate job but have no home in the current UI.
 Subagent turns append to the Turns list silently (visible as cards) but
 do NOT call `selectTurn`.
 
+**Known limitation (codex review)**: this rule is only as good as the
+`isSubagent` signal it reads, and that signal has the same gap documented
+under Problem 3's "Dropped from this pass" section below —
+`isAnthropicSubagent()` in `store.js` classifies by `!cwd && !session_id`,
+but current Claude Code Task-tool subagents carry the parent's
+`session_id`, so those turns arrive with `isSubagent: false` and are NOT
+recognized as subagents by this rule either. They enter the "main" branch
+and auto-select normally — the exact jumping behavior this whole design
+exists to prevent, for exactly the common subagent case. Not fixed here
+(same out-of-scope server-side detection gap); tracked as the same
+follow-up as Problem 3's cost-split limitation, not a separate issue.
+
 ### Subagent pill notification
 
 When subagent turns arrive while the user is on the main live edge, a
@@ -227,7 +239,8 @@ TOOLS
   Bash              6758
   Agent             473
   Read              396
-  Failure rate      2.3%               ← NEW: tool failure rate
+  Turn failure rate 2.3%               ← NEW: turns with 1+ failed tool result
+                                          (turn-level, not per-call — codex review)
 
 TIME                                   ← NEW section
   Started           Jul 10 04:30

--- a/docs/designs/follow-live-turn-subagent.md
+++ b/docs/designs/follow-live-turn-subagent.md
@@ -1,0 +1,285 @@
+# Design: Session UX — Follow-Live-Turn + Session Card + Overview Panel
+
+- Status: Draft (pending sign-off)
+- Date: 2026-07-10
+- Expert panel: Endsley (SA), Wickens (MRT), Czerwinski (Interruption), Tufte (Information Design)
+- Autoresearch: 3 sub-problems, all ≥9/10
+
+## Problem 1: Follow-live-turn jumps on subagent activity
+
+When `followLiveTurn` is ON and a session has heavy subagent activity
+(e.g., 473 Agent tool calls), every subagent turn auto-selects in the
+Turns column, causing the detail panel to jump between main and subagent
+content every few seconds. This destroys comprehension of the main
+orchestrator's reasoning.
+
+## Problem 2: Session card information gaps
+
+The session card lacks duration, context window size, and temporal
+anchors needed for the three user goals: cost control, better results,
+less human intervention. The card serves Find/Triage/Compare jobs and
+must be scannable in <0.5s.
+
+## Problem 3: Overview panel depth metrics
+
+When drilling into a session, deeper metrics (cost breakdown, token
+analysis, autonomy indicators, tool failure rate) are needed for the
+Investigate job but have no home in the current UI.
+
+## Design
+
+### Core rule: Follow main only
+
+`followLiveTurn` auto-selects only `!isSubagent && !isRetry` turns.
+Subagent turns append to the Turns list silently (visible as cards) but
+do NOT call `selectTurn`.
+
+### Subagent pill notification
+
+When subagent turns arrive while the user is on the main live edge, a
+pill appears at the bottom of the Turns column (same position as the
+existing `showNewTurnPill`).
+
+#### Pill text format (SP1 — 9.0/10)
+
+| State              | Text                  | Color                                      |
+|--------------------|-----------------------|--------------------------------------------|
+| Normal (no errors) | `+3 sub`              | all `var(--dim)`                            |
+| With errors        | `+5 sub · 1 err`      | all `var(--red)` (see SP3)                  |
+| High count         | `+47 sub`             | all `var(--dim)`                            |
+| High count + errors| `+47 sub · 2 err`     | all `var(--red)`                            |
+| No errors          | no `· N err` suffix   | absence = normalcy                          |
+
+- `sub` not `subagent` — 3 chars, peripheral/preattentive context
+- `err` not `e` — 5-char red target for peripheral detection
+- No count cap — the number itself carries magnitude information
+- Tooltip: `"N subagent turns (M errors) since main #X"` — L2 bridge
+
+**Symmetry**: When user manually clicks a subagent turn (off main live
+edge), the existing `showNewTurnPill` shows `+N main` for subsequent
+main turns.
+
+#### Pill click behavior (SP2 — 9.0/10)
+
+**Peek, not select.** Clicking the pill:
+1. Scrolls the Turns column to reveal subagent turn cards
+2. Resets pill count to 0, hides pill
+3. Does NOT change `selectedTurnIdx` or detail panel content
+
+The user can then optionally click a specific subagent turn card to
+inspect it — that's a deliberate context switch.
+
+**Scenarios:**
+
+1. *User on main #121, clicks `+5 sub` pill* → Turns scrolls to show
+   subagent cards. Detail stays on main #121. Pill disappears.
+
+2. *After peek, main #122 arrives* → Auto-follows #122 normally (user
+   was still on main live edge since `selectedTurnIdx === latestMainTurnIdx`).
+
+3. *User clicks subagent card s47, then main #122 arrives* → User is
+   off main live edge. Existing pill shows `+1`. User clicks pill to
+   return to #122.
+
+4. *User peeks, doesn't care* → Nothing to undo. Detail panel never
+   changed.
+
+**Implementation notes:**
+- Track `latestMainTurnIdx` separately (init to `null`)
+- Live-edge check: `latestMainTurnIdx !== null && selectedTurnIdx === latestMainTurnIdx`
+- Pill only appears when `followLiveTurn === true`
+- Retries excluded from auto-follow: `!isSubagent && !isRetry`
+
+#### Error visual (SP3 — 9.2/10)
+
+| State         | Color                      | Background | Animation |
+|---------------|----------------------------|------------|-----------|
+| Normal pill   | `var(--dim)` all           | none       | none      |
+| Error pill    | `var(--red)` **all** text   | none       | none      |
+| Error cleared | back to `var(--dim)`       | none       | none      |
+| Dismissed     | removed                    | —          | —         |
+
+- On error: **entire pill** turns red (not just the error token)
+- ~15 chars of red monospace ≈ ~20mm — reliable peripheral detection
+- No animation (HELD badge retains animation monopoly)
+- No background (text-only, matches cache row pattern)
+- Color onset (dim → red in one repaint) is the preattentive signal
+- CSS: `.sub-pill.has-errors { color: var(--red); }`
+
+### Salience hierarchy
+
+| Level | Element    | Treatment                                | When      |
+|-------|------------|------------------------------------------|-----------|
+| 1     | HELD badge | Red bg + white text + pulse + container  | Intercept |
+| 2     | Error pill | Red text, no bg, no animation            | Sub error |
+| 3     | Normal pill| Dim grey text                            | Sub turns |
+
+---
+
+## Design: Session Card (L1)
+
+### Information hierarchy
+
+```
+Tier 1 — Must have          Tier 2 — High value         Tier 3 — Useful
+① Status dot                ⑤ Model                     ⑨ Duration
+② Title                     ⑥ Relative time             ⑩ Preview text
+③ Cost                      ⑦ Turn count
+④ Context % + window size   ⑧ Cache TTL
+```
+
+### Card layout
+
+```
+● 95f7a15a  ⤻                                    ☆
+查詢需記錄為 ADR 的項目
+opus-4-6 · 396t · 9.5h
+$25.92
+████████░░░░░░░░░░░░░░░░░░░ 24% of 1M
+Local main synced — `df5b925...
+25m ago                              cache 34m left
+```
+
+Changes from current:
+- **Model line**: add duration — `opus-4-6 · 396t · 9.5h`
+- **Context bar**: add window size — `24% of 1M`
+- Duration format: `<1h` → minutes (`8m`), `≥1h` → hours (`9.5h`), `≥24h` → days (`2.3d`)
+- All other elements unchanged
+
+### Tooltip (L2 — desktop shortcut, iPad skips to L3)
+
+```
+Started Jul 10 04:30
+Last activity 25m ago
+3 cache breaks
+```
+
+Tooltip is a convenience for desktop hover. No information is exclusive
+to tooltip — everything appears in fuller form in the Overview panel.
+iPad users tap the card to go directly to L3.
+
+```
+Desktop:  L1 Card → L2 Tooltip (hover) → L3 Overview (click)
+iPad:     L1 Card → L3 Overview (tap)
+```
+
+---
+
+## Design: Overview Panel (L3)
+
+**Placement correction (post-implementation)**: the "session selected, no
+turn drilled into" state described below does not exist in the current UI
+— selecting a session always auto-selects a turn and a lane. The closest
+existing panel is `wfRenderAgentCard(lane)` in `workflow-timeline.js`, but
+it's per-lane (one agent thread), not session-wide — a lane has no view of
+"the other lanes," so a Main/Subagent cost split can't be lane-local data.
+
+Decided placement: extend `wfRenderAgentCard` so the session-wide rollup
+sections below appear only when the selected lane is the true main lane
+(`_wfIsMainLane(lane)` — do **not** use `!lane.spawnParent`; that's also
+null for non-main lanes such as Task-tool subagents whose requests carry
+the parent's session_id, which `isAnthropicSubagent()` in `store.js`
+doesn't detect as a subagent — this caused an earlier version of the
+Main/Subagent cost split below to misattribute subagent cost as "main" in
+verification testing). Subagent lanes keep showing exactly what they showed
+before this change.
+
+**Dropped from this pass — Main/Subagent cost split**: because
+`isAnthropicSubagent()` classifies by `!cwd && !session_id`, and current
+Claude Code subagent requests carry the parent's `session_id`, subagent
+turns that share the session_id are misclassified as main turns
+server-side. A cost split built on that signal would silently show
+subagent activity as 100% main cost for exactly this common case, so it
+was cut from the shipped Cost section (Total only, unchanged from before
+this design). Re-add once subagent detection is fixed — either the
+server-side `isAnthropicSubagent()` heuristic, or reuse the client-side
+lane-inference signal the workflow timeline already uses to split lanes
+correctly (it isn't fooled by the shared session_id, per the verification
+screenshots that caught this). Tracked as a separate follow-up, not blocking
+this PR.
+
+### New/enhanced sections
+
+```
+CONTEXT
+  Peak              24.0%
+  Window            1000K
+  Compacts          3                  ← NEW: autocompact count
+
+CACHE
+  Hit rate          98.4%
+  Breaks            3                  ← NEW: cache invalidation boundaries
+
+COST
+  Total             $25.92                (lane-scoped, pre-existing row)
+  # Main/Subagent split dropped — see "Dropped from this pass" above
+
+TOKENS                                 ← NEW section
+  Input             2.4M
+  Output            186K
+  I/O ratio         12.9:1
+
+AUTONOMY                               ← NEW section
+  Turns/intervene   38
+  Retries           12
+
+TOOLS
+  Bash              6758
+  Agent             473
+  Read              396
+  Failure rate      2.3%               ← NEW: tool failure rate
+
+TIME                                   ← NEW section
+  Started           Jul 10 04:30
+  Duration          9.5h
+  Active            ~2.3h
+```
+
+### Data availability
+
+| Metric | Source | Status |
+|--------|--------|--------|
+| Duration | `lastId - firstId` timestamp diff | ✅ Client can compute |
+| Window size | `e.maxContext` from entry | ✅ Already in entries |
+| Compacts | Count context % resets (sawtooth drops) | ⚠️ Need to track |
+| Cache breaks | Count gaps > cache TTL between turns | ⚠️ Need to track |
+| Cost main/sub split | Sum `turnCost` by `isSubagent` flag | ⚠️ Need to accumulate |
+| Token I/O | Sum `input_tokens` / `output_tokens` | ⚠️ Need to accumulate |
+| I/O ratio | Computed from above | ✅ Derived |
+| Turns/intervene | Detect user turns vs auto-approved | ⚠️ Complex — may defer |
+| Tool failure rate | Count error tool results / total | ⚠️ Need to track |
+| Active time | Duration minus gaps > cache TTL | ⚠️ Derived from breaks |
+
+---
+
+## What this does NOT change
+
+- Session card ordering in the Sessions column (separate issue)
+- Existing `followLiveTurn` ON/OFF toggle behavior
+- Turn card rendering for subagent turns (they still appear in the list)
+- The existing `showNewTurnPill` mechanism (reused for `+N main`)
+
+## Code locations
+
+### Follow-live-turn pill
+
+| File | Change |
+|------|--------|
+| `public/entry-rendering.js:565-577` | Add `!isSubagent && !isRetry` guard to `wasOnLiveEdge` auto-follow |
+| `public/entry-rendering.js` | Track `latestMainTurnIdx`, increment `subPillCount` for subagent turns |
+| `public/miller-columns.js` | Add `showSubagentPill(count, errCount)` — reuses pill DOM pattern |
+| `public/style.css` | `.sub-pill` + `.sub-pill.has-errors` styles |
+
+### Session card
+
+| File | Change |
+|------|--------|
+| `public/miller-columns.js` `renderSessionItem()` | Add duration to model line, window size to ctx bar |
+| `public/miller-columns.js` `renderSessionItem()` | Add tooltip with start time + cache breaks |
+
+### Overview panel
+
+| File | Change |
+|------|--------|
+| `public/entry-rendering.js` | Accumulate new session fields: `mainCost`, `subCost`, `inputTokens`, `outputTokens`, `compactCount`, `cacheBreaks` |
+| `public/miller-columns.js` | Render new sections in overview detail panel |

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -14,14 +14,14 @@ function cleanTitle(raw) {
 function showNewTurnPill(count) {
   const existing = document.getElementById('new-turn-pill');
   if (existing) {
-    existing.textContent = '↓ ' + count + ' new';
+    existing.textContent = '+' + count + ' main';
     return;
   }
 
   const pill = document.createElement('div');
   pill.id = 'new-turn-pill';
   pill.className = 'new-turn-pill';
-  pill.textContent = '↓ ' + count + ' new';
+  pill.textContent = '+' + count + ' main';
   pill.onclick = function() {
     selectTurn(allEntries.length - 1);
     scrollTurnsToBottom();
@@ -33,6 +33,40 @@ function hideNewTurnPill() {
   const pill = document.getElementById('new-turn-pill');
   if (pill) pill.remove();
   newTurnCount = 0;
+}
+
+// Peek-only pill for subagent turns arriving while the user is on the main
+// live edge (docs/designs/follow-live-turn-subagent.md Problem 1). Never
+// calls selectTurn — clicking it only scrolls to reveal the subagent cards.
+function showSubagentPill(count, errCount, sinceNum) {
+  const hasErrors = errCount > 0;
+  const text = '+' + count + ' sub' + (hasErrors ? ' · ' + errCount + ' err' : '');
+  const title = count + ' subagent turns (' + errCount + ' errors)' + (sinceNum != null ? ' since main #' + sinceNum : '');
+  const existing = document.getElementById('sub-turn-pill');
+  if (existing) {
+    existing.textContent = text;
+    existing.title = title;
+    existing.classList.toggle('has-errors', hasErrors);
+    return;
+  }
+
+  const pill = document.createElement('div');
+  pill.id = 'sub-turn-pill';
+  pill.className = 'sub-pill' + (hasErrors ? ' has-errors' : '');
+  pill.textContent = text;
+  pill.title = title;
+  pill.onclick = function() {
+    scrollTurnsToBottom();
+    const s = sessionsMap.get(selectedSessionId);
+    if (s) { s.subPillCount = 0; s.subPillErrCount = 0; }
+    hideSubagentPill();
+  };
+  colTurns.appendChild(pill);
+}
+
+function hideSubagentPill() {
+  const pill = document.getElementById('sub-turn-pill');
+  if (pill) pill.remove();
 }
 
 function renderMessages(messages, perMessage) {
@@ -557,15 +591,34 @@ function addEntry(e) {
   if (!_loading && selectedSessionId === sid) {
     // Only auto-follow if toggle is on AND user is currently on the live edge
     // Never interrupt focused mode (drill-down); workflow split view is the default
-    // state and must keep following live turns
-    const wasOnLiveEdge = followLiveTurn && !isFocusedMode &&
-      (selectedTurnIdx === -1 || selectedTurnIdx === idx - 1);
-    if (wasOnLiveEdge) {
-      selectTurn(idx);
-      scrollTurnsToBottom();
-    } else if (followLiveTurn) {
-      newTurnCount++;
-      showNewTurnPill(newTurnCount);
+    // state and must keep following live turns.
+    // Subagent turns never auto-select (docs/designs/follow-live-turn-subagent.md
+    // Problem 1) — heavy subagent activity would otherwise yank the detail panel
+    // away from the main thread on every turn. They bump a peek-only "+N sub"
+    // pill instead, tracked on sess so switching sessions needs no manual reset.
+    if (isSubagent) {
+      const wasOnMainLiveEdge = followLiveTurn && !isFocusedMode &&
+        (selectedTurnIdx === -1 || selectedTurnIdx === sess.latestMainTurnIdx);
+      if (wasOnMainLiveEdge) {
+        sess.subPillCount = (sess.subPillCount || 0) + 1;
+        if (!isHttpStatusOk(e.status)) sess.subPillErrCount = (sess.subPillErrCount || 0) + 1;
+        showSubagentPill(sess.subPillCount, sess.subPillErrCount || 0, allEntries[sess.latestMainTurnIdx]?.displayNum);
+      }
+      // Off the main live edge: subagent turns append silently, no pill bump.
+    } else {
+      const wasOnLiveEdge = followLiveTurn && !isFocusedMode &&
+        (selectedTurnIdx === -1 || selectedTurnIdx === sess.latestMainTurnIdx);
+      sess.latestMainTurnIdx = idx;
+      if (wasOnLiveEdge) {
+        selectTurn(idx);
+        scrollTurnsToBottom();
+        sess.subPillCount = 0;
+        sess.subPillErrCount = 0;
+        hideSubagentPill();
+      } else if (followLiveTurn) {
+        newTurnCount++;
+        showNewTurnPill(newTurnCount);
+      }
     }
   }
 }

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -332,6 +332,7 @@ function addEntry(e) {
   // a future main-agent variant could hit it too, and forcing it to subagent
   // would silently break auto-follow for legitimate main content (codex
   // review round 3). For those, fall back to the raw flag as before.
+  // INVARIANT: gate on AGENT_KEY_UNRELIABLE — see docs/decisions/0005-agent-key-unreliable-shared-contract.md
   const isSubagent = e.agentKey && !AGENT_KEY_UNRELIABLE[e.agentKey]
     ? (typeof WF_MAIN_AGENT_KEYS !== 'undefined' ? !WF_MAIN_AGENT_KEYS[e.agentKey] : !!e.isSubagent)
     : (e.isSubagent || false);

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -353,6 +353,7 @@ function addEntry(e) {
     sess.latestMainCtxPct = Math.min(100, ctxUsed / (e.maxContext || DEFAULT_MAX_CTX) * 100);
     sess.latestCacheReadTokens = ctxCacheRead;
     sess.latestCacheHitRatio = ctxUsed > 0 ? ctxCacheRead / ctxUsed : 0;
+    sess.latestMaxContext = e.maxContext || DEFAULT_MAX_CTX;
     const sessElCtx = document.getElementById('sess-' + sid.slice(0, 8));
     if (sessElCtx) sessElCtx.innerHTML = renderSessionItem(sess, sid);
   }
@@ -373,6 +374,7 @@ function addEntry(e) {
       gapTitle = cacheMode === 'ephemeral-ttl'
         ? (gapMs < 5 * 60000 ? 'Cache likely warm (< 5m)' : gapMs < 60 * 60000 ? 'Default cache expired (5m–1h)' : 'All cache expired (> 1h)')
         : 'Cached automatically';
+      if (window.ccxraySettings?.cacheTtlMs && gapMs > window.ccxraySettings.cacheTtlMs) sess.cacheBreaks = (sess.cacheBreaks || 0) + 1;
     }
   }
 

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -23,7 +23,13 @@ function showNewTurnPill(count) {
   pill.className = 'new-turn-pill';
   pill.textContent = '+' + count + ' main';
   pill.onclick = function() {
-    selectTurn(allEntries.length - 1);
+    // Go to the latest MAIN turn, not literally the last entry — a subagent
+    // turn can append after the last main turn while off-edge (codex review:
+    // allEntries.length - 1 would silently select that subagent turn instead
+    // of what this "+N main" pill advertises).
+    const s = sessionsMap.get(selectedSessionId);
+    const targetIdx = (s && s.latestMainTurnIdx != null) ? s.latestMainTurnIdx : allEntries.length - 1;
+    selectTurn(targetIdx);
     scrollTurnsToBottom();
   };
   colTurns.appendChild(pill);
@@ -603,6 +609,13 @@ function addEntry(e) {
   colTurns.appendChild(el);
 
   if (selectedSessionId === sid) renderSessionSparkline(sid);
+  // Track unconditionally (not gated by !_loading) — codex review: this was
+  // previously only set while live, so a session restored from history had
+  // it unset until the first live main turn, meaning that very first live
+  // turn was never recognized as "on the live edge" even though a user
+  // viewing the just-loaded latest turn genuinely is on it.
+  const prevMainIdx = sess.latestMainTurnIdx;
+  if (!isSubagent) sess.latestMainTurnIdx = idx;
   if (!_loading && selectedSessionId === sid) {
     // Only auto-follow if toggle is on AND user is currently on the live edge
     // Never interrupt focused mode (drill-down); workflow split view is the default
@@ -622,8 +635,7 @@ function addEntry(e) {
       // Off the main live edge: subagent turns append silently, no pill bump.
     } else {
       const wasOnLiveEdge = followLiveTurn && !isFocusedMode &&
-        (selectedTurnIdx === -1 || selectedTurnIdx === sess.latestMainTurnIdx);
-      sess.latestMainTurnIdx = idx;
+        (selectedTurnIdx === -1 || selectedTurnIdx === prevMainIdx);
       if (wasOnLiveEdge) {
         selectTurn(idx);
         scrollTurnsToBottom();

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -307,7 +307,16 @@ function addEntry(e) {
   if (model && model !== '?') sess.model = model;
   sess.lastId = entryId;
   if (e.receivedAt) sess.lastReceivedAt = Number(e.receivedAt);
-  const isSubagent = e.isSubagent || false;
+  // Prefer the server-detected agent identity (from system-prompt content,
+  // via agentKey) over the raw isSubagent flag when available — codex review:
+  // isAnthropicSubagent() in store.js classifies by !cwd && !session_id, but
+  // current Claude Code Task-tool subagents carry the parent's session_id, so
+  // isSubagent is false for exactly the common subagent case. agentKey isn't
+  // fooled by that (same authoritative signal wfInferLanes already uses in
+  // workflow-timeline.js, loaded before this file — WF_MAIN_AGENT_KEYS).
+  const isSubagent = e.agentKey
+    ? (typeof WF_MAIN_AGENT_KEYS !== 'undefined' ? !WF_MAIN_AGENT_KEYS[e.agentKey] : !!e.isSubagent)
+    : (e.isSubagent || false);
   const isRetry = !isSubagent && !isHttpStatusOk(e.status) && !(usage && usage.output_tokens > 0);
   sess.count++;
   if (isRetry) { sess.retryCount = (sess.retryCount || 0) + 1; }

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -1,10 +1,7 @@
 // ── Entry rendering ──
 let newTurnCount = 0;
-// agentKey values that don't reliably mean "not main" — both are catch-all
-// defaults from extractAgentType()'s regex fallback for unrecognized prompts
-// (server/system-prompt.js), which could be a genuinely new main-agent
-// variant, not necessarily a subagent (codex review round 3).
-const AGENT_KEY_UNRELIABLE = { unknown: 1, agent: 1 };
+// AGENT_KEY_UNRELIABLE lives in workflow-timeline.js (loaded before this
+// file) so both files agree on which agentKey values are untrustworthy.
 
 function cleanTitle(raw) {
   if (!raw) return null;
@@ -293,7 +290,7 @@ function addEntry(e) {
     sessEl.dataset.sessionId = sid;
     sessEl.id = 'sess-' + shortSid;
     sessEl.onclick = () => selectSession(sid);
-    sessEl.innerHTML = renderSessionItem(sessionsMap.get(sid), sid);
+    sessEl.innerHTML = renderSessionItem(sessionsMap.get(sid), sid, sessEl);
     // Insert at top (after col-title) — newest sessions first
     const firstSession = colSessions.querySelector('.session-item');
     if (firstSession) colSessions.insertBefore(sessEl, firstSession);
@@ -361,7 +358,7 @@ function addEntry(e) {
   if (!_loading) {
     const sessEl = document.getElementById('sess-' + sid.slice(0, 8));
     if (sessEl) {
-      sessEl.innerHTML = renderSessionItem(sess, sid);
+      sessEl.innerHTML = renderSessionItem(sess, sid, sessEl);
       const firstSession = colSessions.querySelector('.session-item');
       if (firstSession && firstSession !== sessEl) colSessions.insertBefore(sessEl, firstSession);
     }
@@ -398,7 +395,7 @@ function addEntry(e) {
     sess.latestCacheHitRatio = ctxUsed > 0 ? ctxCacheRead / ctxUsed : 0;
     sess.latestMaxContext = e.maxContext || DEFAULT_MAX_CTX;
     const sessElCtx = document.getElementById('sess-' + sid.slice(0, 8));
-    if (sessElCtx) sessElCtx.innerHTML = renderSessionItem(sess, sid);
+    if (sessElCtx) sessElCtx.innerHTML = renderSessionItem(sess, sid, sessElCtx);
   }
 
   // Gap timing: idle time from end of previous turn to start of this turn
@@ -695,7 +692,7 @@ evtSource.onmessage = (ev) => {
       const sid = data.sessionId;
       const sessEl = document.getElementById('sess-' + sid.slice(0, 8));
       const sess = sessionsMap.get(sid);
-      if (sessEl && sess) sessEl.innerHTML = renderSessionItem(sess, sid);
+      if (sessEl && sess) sessEl.innerHTML = renderSessionItem(sess, sid, sessEl);
       renderProjectsCol();
       applySessionFilter();
       updateTopbarStatus();
@@ -707,7 +704,7 @@ evtSource.onmessage = (ev) => {
         sess.title = data.title;
         sess.titleReqTs = nextTs;
         const sessEl = document.getElementById('sess-' + sid.slice(0, 8));
-        if (sessEl) sessEl.innerHTML = renderSessionItem(sess, sid);
+        if (sessEl) sessEl.innerHTML = renderSessionItem(sess, sid, sessEl);
         if (typeof renderBreadcrumb === 'function') renderBreadcrumb();
       }
     } else {
@@ -721,7 +718,7 @@ setInterval(() => {
   colSessions.querySelectorAll('.session-item').forEach(el => {
     const sid = el.dataset.sessionId;
     const sess = sessionsMap.get(sid);
-    if (sess) el.innerHTML = renderSessionItem(sess, sid);
+    if (sess) el.innerHTML = renderSessionItem(sess, sid, el);
   });
   renderProjectsCol();
   updateTopbarStatus();
@@ -996,7 +993,7 @@ Promise.all([_entriesReady, _starsReady]).then(async ([data]) => {
     for (const sid of sortedSids) {
       const el = document.getElementById('sess-' + sid.slice(0, 8));
       if (!el) continue;
-      el.innerHTML = renderSessionItem(sessionsMap.get(sid), sid);
+      el.innerHTML = renderSessionItem(sessionsMap.get(sid), sid, el);
       colSessEl.appendChild(el); // appendChild in desc order → most-recent rises to top
     }
   }

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -311,11 +311,7 @@ function addEntry(e) {
   if (entryId && window.entryById) {
     window.entryById.set(entryId, { id: entryId, sessionId: sid, cwd: entryCwd, receivedAt: e.receivedAt || null, displayNum });
   }
-  if (turnCost != null) {
-    sess.totalCost += turnCost;
-    if (isSubagent) sess.subCost = (sess.subCost || 0) + turnCost;
-    else sess.mainCost = (sess.mainCost || 0) + turnCost;
-  }
+  if (turnCost != null) sess.totalCost += turnCost;
   if (!isSubagent && e.title) { const t = cleanTitle(e.title); if (t) sess.lastAssistantText = t; }
   if (!sess.toolCalls) sess.toolCalls = {};
   Object.entries(e.toolCalls || {}).forEach(([name, cnt]) => {

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -1,5 +1,10 @@
 // ── Entry rendering ──
 let newTurnCount = 0;
+// agentKey values that don't reliably mean "not main" — both are catch-all
+// defaults from extractAgentType()'s regex fallback for unrecognized prompts
+// (server/system-prompt.js), which could be a genuinely new main-agent
+// variant, not necessarily a subagent (codex review round 3).
+const AGENT_KEY_UNRELIABLE = { unknown: 1, agent: 1 };
 
 function cleanTitle(raw) {
   if (!raw) return null;
@@ -63,16 +68,23 @@ function showSubagentPill(count, errCount, sinceNum) {
   pill.title = title;
   pill.onclick = function() {
     scrollTurnsToBottom();
-    const s = sessionsMap.get(selectedSessionId);
-    if (s) { s.subPillCount = 0; s.subPillErrCount = 0; }
     hideSubagentPill();
   };
   colTurns.appendChild(pill);
 }
 
-function hideSubagentPill() {
+// sid defaults to selectedSessionId, but callers leaving a session (e.g.
+// selectSession switching to a different one) must pass the OLD id
+// explicitly — by the time they call this, selectedSessionId may already
+// point at the new session. Without resetting the counters (not just
+// removing the DOM node), the next qualifying subagent arrival on the
+// abandoned session recreates the pill with the stale prior count/errors
+// (codex review round 3).
+function hideSubagentPill(sid) {
   const pill = document.getElementById('sub-turn-pill');
   if (pill) pill.remove();
+  const s = sessionsMap.get(sid || selectedSessionId);
+  if (s) { s.subPillCount = 0; s.subPillErrCount = 0; }
 }
 
 function renderMessages(messages, perMessage) {
@@ -314,7 +326,16 @@ function addEntry(e) {
   // isSubagent is false for exactly the common subagent case. agentKey isn't
   // fooled by that (same authoritative signal wfInferLanes already uses in
   // workflow-timeline.js, loaded before this file — WF_MAIN_AGENT_KEYS).
-  const isSubagent = e.agentKey
+  //
+  // Only trust agentKey to force isSubagent=true for keys we're actually
+  // confident are non-main — never for AGENT_KEY_UNRELIABLE ('unknown', the
+  // extractAgentType() catch-all default; 'agent', its regex-fallback default
+  // when role extraction fails). Those come from the SAME regex fallback that
+  // handles genuinely new/unrecognized prompts (server/system-prompt.js) —
+  // a future main-agent variant could hit it too, and forcing it to subagent
+  // would silently break auto-follow for legitimate main content (codex
+  // review round 3). For those, fall back to the raw flag as before.
+  const isSubagent = e.agentKey && !AGENT_KEY_UNRELIABLE[e.agentKey]
     ? (typeof WF_MAIN_AGENT_KEYS !== 'undefined' ? !WF_MAIN_AGENT_KEYS[e.agentKey] : !!e.isSubagent)
     : (e.isSubagent || false);
   const isRetry = !isSubagent && !isHttpStatusOk(e.status) && !(usage && usage.output_tokens > 0);

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -385,7 +385,6 @@ function addEntry(e) {
       gapTitle = cacheMode === 'ephemeral-ttl'
         ? (gapMs < 5 * 60000 ? 'Cache likely warm (< 5m)' : gapMs < 60 * 60000 ? 'Default cache expired (5m–1h)' : 'All cache expired (> 1h)')
         : 'Cached automatically';
-      if (window.ccxraySettings?.cacheTtlMs && gapMs > window.ccxraySettings.cacheTtlMs) sess.cacheBreaks = (sess.cacheBreaks || 0) + 1;
     }
   }
 

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -311,12 +311,20 @@ function addEntry(e) {
   if (entryId && window.entryById) {
     window.entryById.set(entryId, { id: entryId, sessionId: sid, cwd: entryCwd, receivedAt: e.receivedAt || null, displayNum });
   }
-  if (turnCost != null) sess.totalCost += turnCost;
+  if (turnCost != null) {
+    sess.totalCost += turnCost;
+    if (isSubagent) sess.subCost = (sess.subCost || 0) + turnCost;
+    else sess.mainCost = (sess.mainCost || 0) + turnCost;
+  }
   if (!isSubagent && e.title) { const t = cleanTitle(e.title); if (t) sess.lastAssistantText = t; }
   if (!sess.toolCalls) sess.toolCalls = {};
   Object.entries(e.toolCalls || {}).forEach(([name, cnt]) => {
     sess.toolCalls[name] = (sess.toolCalls[name] || 0) + cnt;
   });
+  if (Object.keys(e.toolCalls || {}).length > 0) {
+    sess.toolCallTurns = (sess.toolCallTurns || 0) + 1;
+    if (e.toolFail) sess.toolFailTurns = (sess.toolFailTurns || 0) + 1;
+  }
   // During batch load, suppress per-entry DOM rerenders (post-batch does one final pass).
   if (!_loading) {
     const sessEl = document.getElementById('sess-' + sid.slice(0, 8));
@@ -348,6 +356,9 @@ function addEntry(e) {
   const ctxInput       = usage ? (usage.input_tokens || 0) : 0;
   const ctxUsed = ctxCacheCreate + ctxCacheRead + ctxInput;
 
+  sess.inputTokens = (sess.inputTokens || 0) + (usage ? (usage.input_tokens || 0) : 0);
+  sess.outputTokens = (sess.outputTokens || 0) + (usage ? (usage.output_tokens || 0) : 0);
+
   // Update session context alert badge + cache stats for main turns
   if (!isSubagent && ctxUsed > 0) {
     sess.latestMainCtxPct = Math.min(100, ctxUsed / (e.maxContext || DEFAULT_MAX_CTX) * 100);
@@ -378,6 +389,12 @@ function addEntry(e) {
     }
   }
 
+  const cacheTtlMs = window.ccxraySettings?.cacheTtlMs;
+  if (gapMs !== null && cacheTtlMs && gapMs > cacheTtlMs) {
+    sess.cacheBreaks = (sess.cacheBreaks || 0) + 1;
+    sess.idleMs = (sess.idleMs || 0) + gapMs;
+  }
+
   // Compression detection: compare message count AND context tokens vs previous main turn.
   // True compaction = msgCount drops significantly (messages got summarized/removed).
   // Token-only drops can happen from cache eviction or normal conversation flow.
@@ -394,6 +411,7 @@ function addEntry(e) {
       }
     }
   }
+  if (isCompacted) sess.compactCount = (sess.compactCount || 0) + 1;
 
   allEntries.push({
     tokens: tok, usage, ts: e.ts, model, maxContext: e.maxContext, cost: turnCost, sessionId: sid,

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2090,6 +2090,7 @@ function selectSession(id) {
   if (id === selectedSessionId) return;
   selectedSessionId = id;
   if (typeof hideNewTurnPill === 'function') hideNewTurnPill();
+  if (typeof hideSubagentPill === 'function') hideSubagentPill();
   selectedTurnIdx = -1;
   selectedSection = null;
   clearSelectedStepSelection();

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1399,6 +1399,48 @@ function renderSessionItem(sess, sid) {
   const shortModelStr = shortModel(sess.model);
   const costStr = sess.totalCost > 0 ? '$' + sess.totalCost.toFixed(2) : '—';
   const dateStr = sess.lastId ? formatRelativeTime(sess.lastId) : (sess.firstId ? formatEntryDate(sess.firstId) : escapeHtml(sess.firstTs || ''));
+
+  // Duration: from firstId to lastReceivedAt (or now if ongoing)
+  let durationStr = '';
+  if (sess.firstId && sess.firstId.length >= 19) {
+    const startTs = new Date(sess.firstId.slice(0, 10) + 'T' + sess.firstId.slice(11, 19).replace(/-/g, ':')).getTime();
+    if (!isNaN(startTs)) {
+      const endTs = sess.lastReceivedAt ? Number(sess.lastReceivedAt) : Date.now();
+      const durationMs = endTs - startTs;
+      if (durationMs >= 86400000) { // >= 24h
+        durationStr = (durationMs / 86400000).toFixed(1) + 'd';
+      } else if (durationMs >= 3600000) { // >= 1h
+        durationStr = (durationMs / 3600000).toFixed(1) + 'h';
+      } else if (durationMs >= 60000) { // >= 1m
+        durationStr = Math.floor(durationMs / 60000) + 'm';
+      }
+    }
+  }
+
+  // Context window size formatting (e.g., "1M", "200K")
+  let windowSizeStr = '';
+  if (sess.latestMaxContext) {
+    const w = sess.latestMaxContext;
+    if (w >= 1000000) {
+      windowSizeStr = Math.round(w / 1000000) + 'M';
+    } else if (w >= 1000) {
+      windowSizeStr = Math.round(w / 1000) + 'K';
+    } else {
+      windowSizeStr = String(w);
+    }
+  }
+
+  // Session tooltip: started, last activity, cache breaks
+  let sessionCardTooltip = '';
+  if (sess.firstId) {
+    const startDate = formatEntryDate(sess.firstId);
+    const lastActivityStr = sess.lastId ? formatRelativeTime(sess.lastId) : '';
+    sessionCardTooltip = 'Started ' + startDate + '\n' + 'Last activity ' + lastActivityStr;
+    if (sess.cacheBreaks > 0) {
+      sessionCardTooltip += '\n' + sess.cacheBreaks + ' cache break' + (sess.cacheBreaks === 1 ? '' : 's');
+    }
+  }
+
   const previewText = sess.lastAssistantText
     ? sess.lastAssistantText.slice(0, 60) + (sess.lastAssistantText.length > 60 ? '…' : '')
     : null;
@@ -1420,7 +1462,9 @@ function renderSessionItem(sess, sid) {
                                        : 'ctx-alert-dim';
   }
   const ctxAlertHtml = ctxPct > 0
-    ? '<span class="ctx-alert ' + ctxPctClass + '">' + Math.round(ctxPct) + '%</span>'
+    ? '<span class="ctx-alert ' + ctxPctClass + '">' + Math.round(ctxPct) + '%' +
+      (windowSizeStr ? ' <span style="color:var(--dim)">' + 'of ' + windowSizeStr + '</span>' : '') +
+      '</span>'
     : '';
   // Thin ctx bar with auto-compact reference line; shown only once session has real context.
   const ctxBarInner = ctxPct > 0
@@ -1473,7 +1517,7 @@ function renderSessionItem(sess, sid) {
   const copyBtn = resumeCmd
     ? '<button class="launch-btn" data-resume="' + escapeHtml(resumeCmd) + '" onclick="event.stopPropagation();copySessionContinue(this.dataset.resume,this)" title="Copy: ' + escapeHtml(resumeCmd) + '">&#10697;</button>'
     : '';
-  return '<div class="si-row1">' +
+  return '<div class="si-row1"' + (sessionCardTooltip ? ' title="' + escapeHtml(sessionCardTooltip) + '"' : '') + '>' +
     '<button class="' + sdotClasses + '"' + (sdotTitle ? ' title="' + sdotTitle + '"' : '') + sdotDataSid + (sdotOnclick ? ' onclick="' + sdotOnclick + '"' : '') + ' tabindex="-1"></button>' +
     '<span class="sid" title="' + escapeHtml(tooltip) + '">' + escapeHtml(shortSid) + '</span>' +
     copyBtn +
@@ -1482,7 +1526,7 @@ function renderSessionItem(sess, sid) {
     pinBtn +
     '</div>' +
   titleRow +
-    '<div class="si-row2"><span class="turn-model">' + escapeHtml(shortModelStr) + '</span> · ' + (sess.count - (sess.retryCount || 0)) + 't' + (sess.retryCount ? ' <span class="retry-count" title="' + sess.retryCount + ' failed retries (hidden from turn list)">' + sess.retryCount + 'r</span>' : '') + '</div>' +
+    '<div class="si-row2"><span class="turn-model">' + escapeHtml(shortModelStr) + '</span> · ' + (sess.count - (sess.retryCount || 0)) + 't' + (sess.retryCount ? ' <span class="retry-count" title="' + sess.retryCount + ' failed retries (hidden from turn list)">' + sess.retryCount + 'r</span>' : '') + (durationStr ? ' · ' + durationStr : '') + '</div>' +
     '<div class="si-cost-row"><span class="si-cost">' + escapeHtml(costStr) + '</span></div>' +
     ctxBarHtml +
     previewRow +

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1013,7 +1013,7 @@ function rerenderColumnsAfterStar() {
   // Sessions column: re-render every visible session card so derived counts update.
   for (const [sid, sess] of sessionsMap) {
     const sessEl = document.getElementById('sess-' + sid.slice(0, 8));
-    if (sessEl && sess) sessEl.innerHTML = renderSessionItem(sess, sid);
+    if (sessEl && sess) sessEl.innerHTML = renderSessionItem(sess, sid, sessEl);
   }
   applySessionFilter();
   // Turn cards: only the directly affected turn changes glyph; cheap to redraw all
@@ -1393,7 +1393,7 @@ function clearAll() { // kept for console use if needed
   renderBreadcrumb();
 }
 
-function renderSessionItem(sess, sid) {
+function renderSessionItem(sess, sid, sessEl) {
   const shortSid = formatSessionIdLabel(sid);
   const tooltip = formatSessionTooltip(null, sid);
   const shortModelStr = shortModel(sess.model);
@@ -1440,6 +1440,12 @@ function renderSessionItem(sess, sid) {
       sessionCardTooltip += '\n' + sess.cacheBreaks + ' cache break' + (sess.cacheBreaks === 1 ? '' : 's');
     }
   }
+  // Card-level tooltip (codex review: was only on .si-row1, so hovering the
+  // title/model/cost/context/preview rows showed nothing) — set on the outer
+  // card element itself; title-less descendants inherit it on hover, while
+  // elements with their own more specific title (sid, status dot, cache row)
+  // keep taking precedence per normal HTML tooltip nesting.
+  if (sessEl) sessEl.title = sessionCardTooltip;
 
   const previewText = sess.lastAssistantText
     ? sess.lastAssistantText.slice(0, 60) + (sess.lastAssistantText.length > 60 ? '…' : '')
@@ -1517,7 +1523,7 @@ function renderSessionItem(sess, sid) {
   const copyBtn = resumeCmd
     ? '<button class="launch-btn" data-resume="' + escapeHtml(resumeCmd) + '" onclick="event.stopPropagation();copySessionContinue(this.dataset.resume,this)" title="Copy: ' + escapeHtml(resumeCmd) + '">&#10697;</button>'
     : '';
-  return '<div class="si-row1"' + (sessionCardTooltip ? ' title="' + escapeHtml(sessionCardTooltip) + '"' : '') + '>' +
+  return '<div class="si-row1">' +
     '<button class="' + sdotClasses + '"' + (sdotTitle ? ' title="' + sdotTitle + '"' : '') + sdotDataSid + (sdotOnclick ? ' onclick="' + sdotOnclick + '"' : '') + ' tabindex="-1"></button>' +
     '<span class="sid" title="' + escapeHtml(tooltip) + '">' + escapeHtml(shortSid) + '</span>' +
     copyBtn +

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1694,6 +1694,7 @@ function selectProject(name) {
   if (name !== null && name === selectedProjectName) return;
   selectedProjectName = name;
   if (typeof hideNewTurnPill === 'function') hideNewTurnPill();
+  if (typeof hideSubagentPill === 'function') hideSubagentPill();
   renderProjectsCol();
   applySessionFilter();
 
@@ -2237,6 +2238,7 @@ function _smoothScrollBy(el, deltaY, durationMs) {
 function selectTurn(idx, opts) {
   if (idx < 0 || idx >= allEntries.length) return;
   if (typeof hideNewTurnPill === 'function') hideNewTurnPill();
+  if (typeof hideSubagentPill === 'function') hideSubagentPill();
   // Exit focused mode when switching turns — user is browsing, not drilling into timeline
   // In workflow mode, keep focused mode (timeline stays in split-pane view)
   if (isFocusedMode && !(typeof wfState !== 'undefined' && wfState)) {

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2133,9 +2133,13 @@ function formatCurrentStepBreadcrumb() {
 function selectSession(id) {
   setFocus('sessions');
   if (id === selectedSessionId) return;
+  const prevSessionId = selectedSessionId;
   selectedSessionId = id;
   if (typeof hideNewTurnPill === 'function') hideNewTurnPill();
-  if (typeof hideSubagentPill === 'function') hideSubagentPill();
+  // Pass the OLD session id — selectedSessionId already points at the new
+  // one above, but the pill/counters being cleared belong to the session
+  // being left (codex review round 3).
+  if (typeof hideSubagentPill === 'function') hideSubagentPill(prevSessionId);
   selectedTurnIdx = -1;
   selectedSection = null;
   clearSelectedStepSelection();

--- a/public/style.css
+++ b/public/style.css
@@ -682,6 +682,8 @@
 #wf-overview-label { width: 240px; flex-shrink: 0; padding: 0 10px; font-size: 10px; color: var(--dim); text-transform: uppercase; letter-spacing: 0.5px; display: flex; align-items: center; gap: 4px; }
 #wf-overview-label button { background: transparent; border: 1px solid var(--border); color: var(--dim); width: 18px; height: 18px; font-size: 12px; cursor: pointer; border-radius: 2px; display: flex; align-items: center; justify-content: center; padding: 0; }
 #wf-overview-label button:hover { color: var(--text); border-color: var(--dim); }
+#wf-overview-label button.active { color: var(--accent); border-color: var(--accent); }
+#wf-overview-label .wf-lane-pos { font-size: 10px; color: var(--dim); white-space: nowrap; }
 /* height set by JS: wfOverviewHeight(laneCount), 28-48px */
 #wf-minimap-canvas { flex: 1; min-width: 0; height: 28px; cursor: pointer; display: block; margin: 2px 8px 2px 0; }
 #wf-lanes-section { position: relative; flex-shrink: 0; overflow-y: auto; overflow-x: hidden; transition: max-height 200ms ease; }

--- a/public/style.css
+++ b/public/style.css
@@ -681,10 +681,13 @@
 #wf-overview { flex-shrink: 0; border-bottom: 1px solid var(--border); position: relative; display: flex; align-items: center; }
 #wf-overview-label { width: 240px; flex-shrink: 0; padding: 4px 10px; font-size: 10px; color: var(--dim); text-transform: uppercase; letter-spacing: 0.5px; display: flex; flex-direction: column; gap: 3px; }
 #wf-overview-label .wf-ol-row { display: flex; align-items: center; gap: 4px; }
-/* Lane pager (row 2) — right-aligned, own row so it never shares the 4px
-   gap with the focus-mode toggle button (nine-gate: that adjacency risked
-   the same misclick shape as the original show-all-agents collision). */
-#wf-overview-label .wf-ol-row-pager { justify-content: flex-end; }
+/* Row 2 always renders (toggle button never disappears) so the label's
+   height and every button's position stay fixed whether focus mode is on
+   or off — only the pager fades in on the right, filling otherwise-empty
+   space instead of the row itself appearing/disappearing. Toggle stays far
+   left, pager far right — more separation than the flagged 4px gap, so
+   they don't read as one adjacent control pair. */
+#wf-overview-label .wf-ol-row-mode { justify-content: space-between; }
 #wf-overview-label button { background: transparent; border: 1px solid var(--border); color: var(--dim); width: 18px; height: 18px; font-size: 12px; cursor: pointer; border-radius: 2px; display: flex; align-items: center; justify-content: center; padding: 0; }
 #wf-overview-label button:hover { color: var(--text); border-color: var(--dim); }
 #wf-overview-label button.active { color: var(--accent); border-color: var(--accent); }

--- a/public/style.css
+++ b/public/style.css
@@ -679,7 +679,12 @@
 #columns.wf-active #col-turns .col-sticky-header { display: none; }
 #wf-timeline { display: flex; flex-direction: column; flex: 1; min-height: 0; overflow: hidden; }
 #wf-overview { flex-shrink: 0; border-bottom: 1px solid var(--border); position: relative; display: flex; align-items: center; }
-#wf-overview-label { width: 240px; flex-shrink: 0; padding: 0 10px; font-size: 10px; color: var(--dim); text-transform: uppercase; letter-spacing: 0.5px; display: flex; align-items: center; gap: 4px; }
+#wf-overview-label { width: 240px; flex-shrink: 0; padding: 4px 10px; font-size: 10px; color: var(--dim); text-transform: uppercase; letter-spacing: 0.5px; display: flex; flex-direction: column; gap: 3px; }
+#wf-overview-label .wf-ol-row { display: flex; align-items: center; gap: 4px; }
+/* Lane pager (row 2) — right-aligned, own row so it never shares the 4px
+   gap with the focus-mode toggle button (nine-gate: that adjacency risked
+   the same misclick shape as the original show-all-agents collision). */
+#wf-overview-label .wf-ol-row-pager { justify-content: flex-end; }
 #wf-overview-label button { background: transparent; border: 1px solid var(--border); color: var(--dim); width: 18px; height: 18px; font-size: 12px; cursor: pointer; border-radius: 2px; display: flex; align-items: center; justify-content: center; padding: 0; }
 #wf-overview-label button:hover { color: var(--text); border-color: var(--dim); }
 #wf-overview-label button.active { color: var(--accent); border-color: var(--accent); }

--- a/public/style.css
+++ b/public/style.css
@@ -416,26 +416,38 @@
 
   /* ── Detail column ── */
   #col-detail { display: flex; flex-direction: column; overflow: hidden; transition: opacity 0.15s ease; }
-  .new-turn-pill {
+  .new-turn-pill, .sub-pill {
     position: sticky;
     bottom: 12px;
     align-self: center;
     margin: 0 auto;
     display: block;
     width: fit-content;
-    background: var(--accent);
-    color: var(--bg);
     padding: 3px 12px;
     border-radius: 12px;
     font-size: 11px;
     cursor: pointer;
     box-shadow: 0 2px 8px rgba(0,0,0,0.3);
     z-index: 10;
+  }
+  .new-turn-pill {
+    background: var(--accent);
+    color: var(--bg);
     animation: slideUp 0.3s ease;
   }
   @keyframes slideUp {
     from { transform: translateX(-50%) translateY(10px); opacity: 0; }
     to { transform: translateX(-50%) translateY(0); opacity: 1; }
+  }
+  /* Peek-only pill for subagent turns — no animation (HELD badge retains
+     animation monopoly, see docs/designs/follow-live-turn-subagent.md SP3) */
+  .sub-pill {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--dim);
+  }
+  .sub-pill.has-errors {
+    color: var(--red);
   }
   .ctx-sticky { position: sticky; top: 0; background: var(--surface); border-bottom: 2px solid var(--border); padding: 10px 12px; z-index: 2; flex-shrink: 0; }
   .ctx-sticky-title { font-size: 11px; color: var(--dim); margin-bottom: 6px; }

--- a/public/style.css
+++ b/public/style.css
@@ -693,10 +693,16 @@
 #wf-sub-scroll::-webkit-scrollbar { width: 4px; }
 #wf-sub-scroll::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
 #wf-sub-svg { display: block; }
-#wf-resize { height: 8px; cursor: row-resize; background: var(--bg); flex-shrink: 0; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); transition: background 0.15s; display: flex; align-items: center; justify-content: center; }
+#wf-resize { height: 8px; cursor: row-resize; background: var(--bg); flex-shrink: 0; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); transition: background 0.15s, height 0.15s; display: flex; align-items: center; justify-content: center; }
 #wf-resize::after { content: ''; width: 32px; height: 3px; border-radius: 2px; background: var(--border); }
 #wf-resize:hover { background: rgba(88,166,255,0.2); }
 #wf-resize:hover::after { background: var(--dim); }
+/* Lane-focus mode locks the strip's height (nothing left to drag), so this
+   same spot becomes a click target back to the normal draggable state
+   instead of a grip handle that silently stops responding at the floor. */
+#wf-resize.wf-resize-expand { height: 15px; cursor: pointer; }
+#wf-resize.wf-resize-expand::after { content: '▾ show all agents'; width: auto; height: auto; border-radius: 0; background: none; color: var(--dim); font-size: 10px; letter-spacing: 0.2px; }
+#wf-resize.wf-resize-expand:hover::after { color: var(--text); }
 #wf-detail-area { flex: 1; display: flex; min-height: 0; overflow: hidden; }
 #wf-agent-card-panel { width: 240px; flex-shrink: 0; overflow-y: auto; border-right: 1px solid var(--border); background: var(--surface); }
 #wf-steps-panel { flex: 1; overflow-y: auto; min-width: 0; }

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -830,20 +830,30 @@ function _wfRenderSvgContent(mainSvg, subSvg, canvas) {
 // #wf-lanes-section clips lanes off the bottom with no scroll affordance).
 // Focused mode narrows the sub-lane area to just the selected lane; main
 // stays visible (pinned/cheap) so orchestrator context is never lost.
+// Two rows: zoom/focus-toggle controls stay together (row 1, unchanged
+// position), the lane pager gets its own row (row 2, right-aligned) instead
+// of sharing row 1's 4px gap with the toggle button — nine-gate review found
+// that adjacency put a functionally-opposite control (toggle exits focus
+// entirely) right next to "next lane," the same misclick shape this whole
+// redesign exists to avoid. Row 2 renders empty/collapsed outside focus mode.
 function _wfOverviewLabelHtml() {
   var focusLi = _wfFocusLaneIdx();
-  var navHtml = wfState.laneFocusMode
-    ? '<button onclick="wfCycleLane(-1)" title="Previous agent">▲</button>' +
-      '<span class="wf-lane-pos">' + (focusLi + 1) + '/' + wfState.lanes.length + '</span>' +
-      '<button onclick="wfCycleLane(1)" title="Next agent">▼</button>'
-    : '';
-  return '<span>Overview</span>' +
+  var row1 = '<div class="wf-ol-row">' +
+    '<span>Overview</span>' +
     '<button onclick="wfZoomBy(0.5)">+</button>' +
     '<button onclick="wfZoomBy(2)">−</button>' +
     '<button onclick="wfState.viewT0=wfState.tMin;wfState.viewT1=wfState.tMax;wfDeferRender()">⟲</button>' +
     '<button onclick="wfToggleLaneFocus()" title="' + (wfState.laneFocusMode ? 'Show all agents' : 'Focus selected agent') +
       '" class="' + (wfState.laneFocusMode ? 'active' : '') + '">' + (wfState.laneFocusMode ? '▤' : '▥') + '</button>' +
-    navHtml;
+    '</div>';
+  var row2 = wfState.laneFocusMode
+    ? '<div class="wf-ol-row wf-ol-row-pager">' +
+        '<button onclick="wfCycleLane(-1)" title="Previous agent">▲</button>' +
+        '<span class="wf-lane-pos">' + (focusLi + 1) + '/' + wfState.lanes.length + '</span>' +
+        '<button onclick="wfCycleLane(1)" title="Next agent">▼</button>' +
+      '</div>'
+    : '';
+  return row1 + row2;
 }
 
 function _wfRefreshLaneFocusUI() {

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -139,6 +139,9 @@ function wfComputeLaneColors(lanes) {
   for (var entry of styles) map.set(entry[0], entry[1].color);
   return map;
 }
+// INVARIANT: this is the only correct way to test "is this the main/orchestrator
+// lane" — never !lane.spawnParent, which is null for every lane (see
+// docs/decisions/0007-wf-is-main-lane-not-spawn-parent.md).
 function _wfIsMainLane(lane) { return lane && (lane.key === 'main' || lane.name === 'main'); }
 function wfLaneColor(lane) {
   if (!lane) return WF_LANE_COLORS.main;
@@ -210,9 +213,10 @@ var WF_MAIN_AGENT_KEYS = { 'orchestrator': 1, 'sdk-agent': 1, 'default': 1 };
 // agentKey values that don't reliably mean "not main" — both are catch-all
 // defaults from extractAgentType()'s regex fallback for unrecognized prompts
 // (server/system-prompt.js), which could be a genuinely new main-agent
-// variant, not necessarily a subagent (codex review round 3). Shared with
-// entry-rendering.js (loaded after this file) so both files agree on when
-// agentKey is trustworthy enough to override the raw isSubagent flag.
+// variant, not necessarily a subagent (codex review round 3).
+// INVARIANT: every agentKey-based main/subagent classification site in this
+// file AND entry-rendering.js must gate on this — see
+// docs/decisions/0005-agent-key-unreliable-shared-contract.md
 var AGENT_KEY_UNRELIABLE = { unknown: 1, agent: 1 };
 
 function _wfPushToSubLane(laneMap, key, entry) {
@@ -239,6 +243,7 @@ function wfInferLanes(entries, childEntries) {
     var e = entries[i];
     var sub = false;
 
+    // INVARIANT: gate on AGENT_KEY_UNRELIABLE — see docs/decisions/0005-agent-key-unreliable-shared-contract.md
     if (e.agentKey && !AGENT_KEY_UNRELIABLE[e.agentKey]) {
       // Agent-identity classification (server-detected, authoritative):
       // main-agent keys → main lane regardless of model or isSubagent flag
@@ -433,6 +438,7 @@ function wfAddEntry(entry) {
   }
 
   var needsSub, key;
+  // INVARIANT: gate on AGENT_KEY_UNRELIABLE — see docs/decisions/0005-agent-key-unreliable-shared-contract.md
   if (entry.agentKey && !AGENT_KEY_UNRELIABLE[entry.agentKey]) {
     needsSub = !WF_MAIN_AGENT_KEYS[entry.agentKey];
     key = _wfSubLaneKey('agent-' + entry.agentKey, entry);
@@ -486,6 +492,8 @@ function _wfLaneHeight(laneIdx) {
   if (!wfState || laneIdx >= wfState.lanes.length) return WF_LANE_H;
   return wfState.selectedLane?.key === wfState.lanes[laneIdx].key ? WF_LANE_H_SEL : WF_LANE_H;
 }
+// INVARIANT: must match what _wfRenderSvgContent actually draws in
+// laneFocusMode — see docs/decisions/0006-lane-focus-geometry-consistency.md
 function _wfTotalLanesHeight() {
   if (!wfState) return 0;
   // Focus mode: only main (index 0) + the selected lane (if not main) take
@@ -794,6 +802,9 @@ function _wfRenderSvgContent(mainSvg, subSvg, canvas) {
   // (collapse toggle) narrows this to just the selected lane (or none, if
   // main is selected) so a session with many subagents can't overflow the
   // fixed-height overview area.
+  // INVARIANT: this is ground truth for lane geometry — _wfTotalLanesHeight
+  // and _wfLaneIdxAtY must match it — see
+  // docs/decisions/0006-lane-focus-geometry-consistency.md
   var subIndices;
   if (wfState.laneFocusMode) {
     subIndices = focusLi > 0 ? [focusLi] : [];
@@ -966,6 +977,8 @@ function _wfApplyLockVisuals() {
   if (g) _wfApplySpotlight(g, lock.lane, lock.tidx);
 }
 
+// INVARIANT: must match what _wfRenderSvgContent actually draws in
+// laneFocusMode — see docs/decisions/0006-lane-focus-geometry-consistency.md
 function _wfLaneIdxAtY(svgEl, my) {
   if (!wfState) return -1;
   if (svgEl.id === 'wf-main-svg') return my >= WF_PAD + WF_AXIS_H ? 0 : -1;
@@ -1288,6 +1301,7 @@ function wfSetupInteractions(mainSvg, subSvg) {
         } else if (wfState.laneFocusMode) {
           // Focus mode: sub SVG draws only the focused lane (see _wfRenderSvgContent) —
           // walking 1..lanes.length would hit-test against a layout that isn't rendered.
+          // INVARIANT: see docs/decisions/0006-lane-focus-geometry-consistency.md
           var focusLiClick = _wfFocusLaneIdx();
           if (focusLiClick > 0 && my >= WF_PAD) li = focusLiClick;
         } else {
@@ -1613,9 +1627,8 @@ function wfRenderAgentCard(lane) {
   var color = wfLaneColor(lane);
 
   // Orchestrator lane only: session-wide rollup (see comment above wfRenderAgentCard).
-  // _wfIsMainLane, not !lane.spawnParent — other non-subagent-flagged lanes (e.g.
-  // Task-tool subagents whose requests carry the parent's session_id, which the
-  // server's isAnthropicSubagent() heuristic doesn't detect) also have spawnParent: null.
+  // INVARIANT: _wfIsMainLane, not !lane.spawnParent — see
+  // docs/decisions/0007-wf-is-main-lane-not-spawn-parent.md
   var isOrchestrator = _wfIsMainLane(lane);
   var sess = (isOrchestrator && wfState && typeof sessionsMap !== 'undefined')
     ? sessionsMap.get(wfState.sessionId) : null;
@@ -1635,7 +1648,9 @@ function wfRenderAgentCard(lane) {
 
   var html = '<div class="wf-agent-card" style="border-left:2px solid ' + color + '">';
   html += '<div class="wf-ac-name">' + wfGlyphHtml(wfLaneShape(lane), 10, color) + ' ' + wfEsc(lane.name) + ' <span class="wf-ac-model" style="background:' + color + '22;color:' + color + '">' + wfEsc(wfShortModel(lane.model)) + '</span></div>';
-  html += '<div class="wf-ac-meta">' + summary.turnCount + ' turns · ' + wfFmtDur(summary.duration) + ' · ' + (lane.spawnParent ? 'subagent' : 'orchestrator') + '</div>';
+  // INVARIANT: main/subagent label must use _wfIsMainLane, not lane.spawnParent
+  // — see docs/decisions/0007-wf-is-main-lane-not-spawn-parent.md
+  html += '<div class="wf-ac-meta">' + summary.turnCount + ' turns · ' + wfFmtDur(summary.duration) + ' · ' + (isOrchestrator ? 'orchestrator' : 'subagent') + '</div>';
 
   html += '<div class="wf-ac-section"><div class="wf-ac-section-title">Context</div>';
   html += '<div class="wf-ac-row"><span>Peak</span><span class="wf-ac-val">' + summary.peakCtx.toFixed(1) + '%</span></div>';

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -1649,8 +1649,12 @@ function wfRenderAgentCard(lane) {
       html += '<div class="wf-ac-row"><span class="wf-ac-tool">' + wfEsc(topTools[ti][0]) + '</span><span class="wf-ac-tool-count">' + topTools[ti][1] + '</span></div>';
     }
     if (sess && (sess.toolCallTurns || 0) > 0) {
+      // Turn-level, not call-level: a turn with 1 failed call among many still
+      // counts as fully failed (toolFail is a turn boolean, not a per-call
+      // count — codex review flagged the old "Failure rate" label as implying
+      // more precision than this data actually has).
       var failRate = (sess.toolFailTurns || 0) / sess.toolCallTurns * 100;
-      html += '<div class="wf-ac-row"><span>Failure rate</span><span class="wf-ac-val">' + failRate.toFixed(1) + '%</span></div>';
+      html += '<div class="wf-ac-row"><span title="Turns with 1+ failed tool result, not individual call failures">Turn failure rate</span><span class="wf-ac-val">' + failRate.toFixed(1) + '%</span></div>';
     }
     html += '</div>';
   }

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -836,6 +836,10 @@ function _wfRenderSvgContent(mainSvg, subSvg, canvas) {
 // that adjacency put a functionally-opposite control (toggle exits focus
 // entirely) right next to "next lane," the same misclick shape this whole
 // redesign exists to avoid. Row 2 renders empty/collapsed outside focus mode.
+// Row 1 (zoom) and row 2 (mode) both always render, so #wf-overview-label's
+// height never changes when focus mode toggles — only the pager fades in on
+// row 2's right side, filling space that's otherwise just empty. Keeps the
+// zoom buttons' and toggle button's positions stable regardless of state.
 function _wfOverviewLabelHtml() {
   var focusLi = _wfFocusLaneIdx();
   var row1 = '<div class="wf-ol-row">' +
@@ -843,16 +847,17 @@ function _wfOverviewLabelHtml() {
     '<button onclick="wfZoomBy(0.5)">+</button>' +
     '<button onclick="wfZoomBy(2)">−</button>' +
     '<button onclick="wfState.viewT0=wfState.tMin;wfState.viewT1=wfState.tMax;wfDeferRender()">⟲</button>' +
+    '</div>';
+  var pagerHtml = wfState.laneFocusMode
+    ? '<button onclick="wfCycleLane(-1)" title="Previous agent">▲</button>' +
+      '<span class="wf-lane-pos">' + (focusLi + 1) + '/' + wfState.lanes.length + '</span>' +
+      '<button onclick="wfCycleLane(1)" title="Next agent">▼</button>'
+    : '';
+  var row2 = '<div class="wf-ol-row wf-ol-row-mode">' +
     '<button onclick="wfToggleLaneFocus()" title="' + (wfState.laneFocusMode ? 'Show all agents' : 'Focus selected agent') +
       '" class="' + (wfState.laneFocusMode ? 'active' : '') + '">' + (wfState.laneFocusMode ? '▤' : '▥') + '</button>' +
+    pagerHtml +
     '</div>';
-  var row2 = wfState.laneFocusMode
-    ? '<div class="wf-ol-row wf-ol-row-pager">' +
-        '<button onclick="wfCycleLane(-1)" title="Previous agent">▲</button>' +
-        '<span class="wf-lane-pos">' + (focusLi + 1) + '/' + wfState.lanes.length + '</span>' +
-        '<button onclick="wfCycleLane(1)" title="Next agent">▼</button>' +
-      '</div>'
-    : '';
   return row1 + row2;
 }
 

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -207,6 +207,13 @@ function _wfBarSpan(t) {
 // Agent keys whose turns belong to the main lane — model switches within the
 // main conversation stay in main (the dashed model-switch line marks them)
 var WF_MAIN_AGENT_KEYS = { 'orchestrator': 1, 'sdk-agent': 1, 'default': 1 };
+// agentKey values that don't reliably mean "not main" — both are catch-all
+// defaults from extractAgentType()'s regex fallback for unrecognized prompts
+// (server/system-prompt.js), which could be a genuinely new main-agent
+// variant, not necessarily a subagent (codex review round 3). Shared with
+// entry-rendering.js (loaded after this file) so both files agree on when
+// agentKey is trustworthy enough to override the raw isSubagent flag.
+var AGENT_KEY_UNRELIABLE = { unknown: 1, agent: 1 };
 
 function _wfPushToSubLane(laneMap, key, entry) {
   if (!laneMap.has(key)) laneMap.set(key, { name: key, key: key, turns: [], model: entry.model, ctxWindow: entry.maxContext || 0, spawnParent: null, agentKey: entry.agentKey || null, agentLabel: entry.agentLabel || null, convId: entry.convId || null });
@@ -232,7 +239,7 @@ function wfInferLanes(entries, childEntries) {
     var e = entries[i];
     var sub = false;
 
-    if (e.agentKey) {
+    if (e.agentKey && !AGENT_KEY_UNRELIABLE[e.agentKey]) {
       // Agent-identity classification (server-detected, authoritative):
       // main-agent keys → main lane regardless of model or isSubagent flag
       if (!WF_MAIN_AGENT_KEYS[e.agentKey]) {
@@ -426,7 +433,7 @@ function wfAddEntry(entry) {
   }
 
   var needsSub, key;
-  if (entry.agentKey) {
+  if (entry.agentKey && !AGENT_KEY_UNRELIABLE[entry.agentKey]) {
     needsSub = !WF_MAIN_AGENT_KEYS[entry.agentKey];
     key = _wfSubLaneKey('agent-' + entry.agentKey, entry);
   } else {
@@ -962,6 +969,12 @@ function _wfApplyLockVisuals() {
 function _wfLaneIdxAtY(svgEl, my) {
   if (!wfState) return -1;
   if (svgEl.id === 'wf-main-svg') return my >= WF_PAD + WF_AXIS_H ? 0 : -1;
+  if (wfState.laneFocusMode) {
+    // Focus mode: sub SVG draws only the focused lane (see _wfRenderSvgContent) —
+    // walking 1..lanes.length would hit-test against a layout that isn't rendered.
+    var focusLi = _wfFocusLaneIdx();
+    return (focusLi > 0 && my >= WF_PAD) ? focusLi : -1;
+  }
   var accY = WF_PAD;
   for (var i = 1; i < wfState.lanes.length; i++) {
     var lh = _wfLaneHeight(i);
@@ -1599,13 +1612,6 @@ function wfRenderAgentCard(lane) {
   var summary = wfLaneSummary(lane);
   var color = wfLaneColor(lane);
 
-  var toolTotals = {};
-  for (var i = 0; i < lane.turns.length; i++) {
-    var tc = lane.turns[i].toolCalls || {};
-    for (var k in tc) toolTotals[k] = (toolTotals[k] || 0) + tc[k];
-  }
-  var topTools = Object.entries(toolTotals).sort(function(a, b) { return b[1] - a[1]; }).slice(0, 6);
-
   // Orchestrator lane only: session-wide rollup (see comment above wfRenderAgentCard).
   // _wfIsMainLane, not !lane.spawnParent — other non-subagent-flagged lanes (e.g.
   // Task-tool subagents whose requests carry the parent's session_id, which the
@@ -1613,6 +1619,19 @@ function wfRenderAgentCard(lane) {
   var isOrchestrator = _wfIsMainLane(lane);
   var sess = (isOrchestrator && wfState && typeof sessionsMap !== 'undefined')
     ? sessionsMap.get(wfState.sessionId) : null;
+
+  // Session-wide on the main lane (matches Context/Cache/Tokens below — a lane
+  // has no view of "the other lanes," so main's tool rollup must read sess.toolCalls,
+  // not just this lane's own turns, or counts like a 473-call Agent/Task tool
+  // total would be undercounted to whatever subset the orchestrator itself called).
+  var toolTotals = (isOrchestrator && sess && sess.toolCalls) ? sess.toolCalls : {};
+  if (!isOrchestrator || !sess || !sess.toolCalls) {
+    for (var i = 0; i < lane.turns.length; i++) {
+      var tc = lane.turns[i].toolCalls || {};
+      for (var k in tc) toolTotals[k] = (toolTotals[k] || 0) + tc[k];
+    }
+  }
+  var topTools = Object.entries(toolTotals).sort(function(a, b) { return b[1] - a[1]; }).slice(0, 6);
 
   var html = '<div class="wf-agent-card" style="border-left:2px solid ' + color + '">';
   html += '<div class="wf-ac-name">' + wfGlyphHtml(wfLaneShape(lane), 10, color) + ' ' + wfEsc(lane.name) + ' <span class="wf-ac-model" style="background:' + color + '22;color:' + color + '">' + wfEsc(wfShortModel(lane.model)) + '</span></div>';
@@ -1640,6 +1659,15 @@ function wfRenderAgentCard(lane) {
     html += '<div class="wf-ac-row"><span>Input</span><span class="wf-ac-val">' + _wfFmtSessTok(inTok) + '</span></div>';
     html += '<div class="wf-ac-row"><span>Output</span><span class="wf-ac-val">' + _wfFmtSessTok(outTok) + '</span></div>';
     html += '<div class="wf-ac-row"><span>I/O ratio</span><span class="wf-ac-val">' + ioRatio + '</span></div>';
+    html += '</div>';
+  }
+
+  // Turns/intervene dropped — design doc's own data-availability table marks
+  // it "Complex — may defer" (no signal yet for user-turn vs auto-approved).
+  // Retries is available (sess.retryCount, tracked in entry-rendering.js).
+  if (sess && sess.retryCount) {
+    html += '<div class="wf-ac-section"><div class="wf-ac-section-title">Autonomy</div>';
+    html += '<div class="wf-ac-row"><span>Retries</span><span class="wf-ac-val">' + sess.retryCount + '</span></div>';
     html += '</div>';
   }
 

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -363,6 +363,7 @@ function wfBuildState(sessionId) {
     selectedLane: lanes[0] || null,
     selectedTurnId: null,
     selectedSection: 'timeline',
+    laneFocusMode: false,
   };
 }
 
@@ -479,6 +480,13 @@ function _wfLaneHeight(laneIdx) {
 }
 function _wfTotalLanesHeight() {
   if (!wfState) return 0;
+  // Focus mode: only main (index 0) + the selected lane (if not main) take
+  // height — matches what _wfRenderSvgContent actually draws, so the
+  // container doesn't reserve empty space for lanes that are hidden.
+  if (wfState.laneFocusMode) {
+    var focusLi = _wfFocusLaneIdx();
+    return _wfLaneHeight(0) + (focusLi > 0 ? _wfLaneHeight(focusLi) : 0);
+  }
   var h = 0;
   for (var i = 0; i < wfState.lanes.length; i++) h += _wfLaneHeight(i);
   return h;
@@ -673,7 +681,7 @@ function wfRenderTimeline() {
   overviewDiv.id = 'wf-overview';
   var overviewLabel = document.createElement('div');
   overviewLabel.id = 'wf-overview-label';
-  overviewLabel.innerHTML = '<span>Overview</span><button onclick="wfZoomBy(0.5)">+</button><button onclick="wfZoomBy(2)">−</button><button onclick="wfState.viewT0=wfState.tMin;wfState.viewT1=wfState.tMax;wfDeferRender()">⟲</button>';
+  overviewLabel.innerHTML = _wfOverviewLabelHtml();
   overviewDiv.appendChild(overviewLabel);
   var canvas = document.createElement('canvas');
   canvas.id = 'wf-minimap-canvas';
@@ -773,20 +781,29 @@ function _wfRenderSvgContent(mainSvg, subSvg, canvas) {
   ms += '<g class="' + laneCls(0) + '" data-lane="0" transform="translate(0,' + mainLaneY + ')">' + wfRenderLaneSvg(lanes[0], 0, W, xFn) + '</g>';
   mainSvg.innerHTML = ms;
 
-  // Sub SVG: remaining lanes (dynamic height per lane)
-  var subLanes = lanes.slice(1);
-  if (subLanes.length) {
+  // Sub SVG: remaining lanes (dynamic height per lane). Lane-focus mode
+  // (collapse toggle) narrows this to just the selected lane (or none, if
+  // main is selected) so a session with many subagents can't overflow the
+  // fixed-height overview area.
+  var subIndices;
+  if (wfState.laneFocusMode) {
+    subIndices = focusLi > 0 ? [focusLi] : [];
+  } else {
+    subIndices = lanes.slice(1).map(function(_, i) { return i + 1; });
+  }
+  if (subIndices.length) {
     var subTotalH = 0;
-    for (var sh = 0; sh < subLanes.length; sh++) subTotalH += _wfLaneHeight(sh + 1);
+    for (var sh = 0; sh < subIndices.length; sh++) subTotalH += _wfLaneHeight(subIndices[sh]);
     var subH = WF_PAD + subTotalH + WF_PAD;
     subSvg.setAttribute('width', W);
     subSvg.setAttribute('height', subH);
     subSvg.setAttribute('viewBox', '0 0 ' + W + ' ' + subH);
     var ss = '';
     var subY = WF_PAD;
-    for (var si = 0; si < subLanes.length; si++) {
-      ss += '<g class="' + laneCls(si + 1) + '" data-lane="' + (si + 1) + '" transform="translate(0,' + subY + ')">' + wfRenderLaneSvg(subLanes[si], si + 1, W, xFn) + '</g>';
-      subY += _wfLaneHeight(si + 1);
+    for (var si = 0; si < subIndices.length; si++) {
+      var li = subIndices[si];
+      ss += '<g class="' + laneCls(li) + '" data-lane="' + li + '" transform="translate(0,' + subY + ')">' + wfRenderLaneSvg(lanes[li], li, W, xFn) + '</g>';
+      subY += _wfLaneHeight(li);
     }
     subSvg.innerHTML = ss;
     subSvg.parentElement.style.display = '';
@@ -804,6 +821,58 @@ function _wfRenderSvgContent(mainSvg, subSvg, canvas) {
   // ponytail: charts now inline in selected lane SVG, no separate header
   var stepsEl = document.getElementById('wf-steps-content');
   if (stepsEl) _wfSyncStepsHighlight(stepsEl);
+}
+
+// ── Lane focus mode ────────────────────────────────────────────────────────
+// Collapse toggle for sessions with many subagent lanes (heuristic finding:
+// #wf-lanes-section clips lanes off the bottom with no scroll affordance).
+// Focused mode narrows the sub-lane area to just the selected lane; main
+// stays visible (pinned/cheap) so orchestrator context is never lost.
+function _wfOverviewLabelHtml() {
+  var focusLi = _wfFocusLaneIdx();
+  var navHtml = wfState.laneFocusMode
+    ? '<button onclick="wfCycleLane(-1)" title="Previous agent">▲</button>' +
+      '<span class="wf-lane-pos">' + (focusLi + 1) + '/' + wfState.lanes.length + '</span>' +
+      '<button onclick="wfCycleLane(1)" title="Next agent">▼</button>'
+    : '';
+  return '<span>Overview</span>' +
+    '<button onclick="wfZoomBy(0.5)">+</button>' +
+    '<button onclick="wfZoomBy(2)">−</button>' +
+    '<button onclick="wfState.viewT0=wfState.tMin;wfState.viewT1=wfState.tMax;wfDeferRender()">⟲</button>' +
+    '<button onclick="wfToggleLaneFocus()" title="' + (wfState.laneFocusMode ? 'Show all agents' : 'Focus selected agent') +
+      '" class="' + (wfState.laneFocusMode ? 'active' : '') + '">' + (wfState.laneFocusMode ? '▤' : '▥') + '</button>' +
+    navHtml;
+}
+
+function _wfRefreshLaneFocusUI() {
+  var overviewLabel = document.getElementById('wf-overview-label');
+  if (overviewLabel) overviewLabel.innerHTML = _wfOverviewLabelHtml();
+  var lanesSection = document.getElementById('wf-lanes-section');
+  if (lanesSection) {
+    var contentH = WF_PAD + WF_AXIS_H + _wfTotalLanesHeight() + WF_PAD;
+    var maxH = window.innerHeight * 0.45;
+    lanesSection.style.maxHeight = Math.min(contentH, maxH) + 'px';
+  }
+  wfDeferRender();
+}
+
+function wfToggleLaneFocus() {
+  if (!wfState) return;
+  wfState.laneFocusMode = !wfState.laneFocusMode;
+  _wfRefreshLaneFocusUI();
+}
+
+// Shared by the ▲/▼ buttons and the Tab/Shift+Tab keyboard shortcut.
+function wfCycleLane(dir) {
+  if (!wfState || !wfState.lanes.length) return;
+  var lanes = wfState.lanes;
+  var curLi = lanes.indexOf(wfState.selectedLane);
+  var nextLi = (curLi + dir + lanes.length) % lanes.length;
+  wfState.selectedLane = lanes[nextLi];
+  wfState.selectedTurnId = null;
+  _wfRefreshLaneFocusUI();
+  wfRenderAgentCard(lanes[nextLi]);
+  wfRenderCurrentSection();
 }
 
 // ── v8 spotlight / lock visuals ───────────────────────────────────────────
@@ -1181,6 +1250,11 @@ function wfSetupInteractions(mainSvg, subSvg) {
         if (svgEl.id === 'wf-main-svg') {
           // Main SVG: one lane at y = WF_PAD + WF_AXIS_H
           if (my >= WF_PAD + WF_AXIS_H) li = 0;
+        } else if (wfState.laneFocusMode) {
+          // Focus mode: sub SVG draws only the focused lane (see _wfRenderSvgContent) —
+          // walking 1..lanes.length would hit-test against a layout that isn't rendered.
+          var focusLiClick = _wfFocusLaneIdx();
+          if (focusLiClick > 0 && my >= WF_PAD) li = focusLiClick;
         } else {
           // Sub SVG: lanes have variable height, walk to find index
           var accY = WF_PAD;
@@ -1193,7 +1267,7 @@ function wfSetupInteractions(mainSvg, subSvg) {
         if (li >= 0 && li < wfState.lanes.length) {
           wfState.selectedLane = wfState.lanes[li];
           wfState.selectedTurnId = null;
-          wfDeferRender();
+          _wfRefreshLaneFocusUI();
           wfRenderAgentCard(wfState.lanes[li]);
           wfRenderCurrentSection();
         }
@@ -1628,7 +1702,7 @@ function wfLockTurn(turnId) {
   if (!hit) return; // unknown turn → no phantom lock (leave selection untouched)
   wfState.selectedTurnId = turnId;
   wfState.selectedLane = wfState.lanes[hit.laneIdx];
-  wfDeferRender();
+  _wfRefreshLaneFocusUI();
   for (var k = 0; k < allEntries.length; k++) {
     if (allEntries[k].id === turnId) { selectTurn(k); break; }
   }
@@ -1788,17 +1862,10 @@ function wfKeyHandler(key, e) {
     return true;
   }
 
-  // Tab / Shift+Tab: cycle lanes
+  // Tab / Shift+Tab: cycle lanes (same stepping logic as the ▲/▼ overview buttons)
   if (key === 'Tab') {
     e.preventDefault();
-    var lanes = wfState.lanes;
-    var curLi = lanes.indexOf(lane);
-    var nextLi = e.shiftKey ? (curLi - 1 + lanes.length) % lanes.length : (curLi + 1) % lanes.length;
-    wfState.selectedLane = lanes[nextLi];
-    wfState.selectedTurnId = null;
-    wfDeferRender();
-    wfRenderAgentCard(lanes[nextLi]);
-    wfRenderCurrentSection();
+    wfCycleLane(e.shiftKey ? -1 : 1);
     return true;
   }
 
@@ -1818,7 +1885,7 @@ function wfKeyHandler(key, e) {
     if (lane.name !== 'main') {
       wfState.selectedLane = wfState.lanes[0];
       wfState.selectedTurnId = null;
-      wfDeferRender();
+      _wfRefreshLaneFocusUI();
       wfRenderAgentCard(wfState.lanes[0]);
       return true;
     }

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -1456,11 +1456,15 @@ function _wfDrawOverviewCursor(canvas) {
 }
 
 // ── Agent Card ────────────────────────────────────────────────────────────
-// Session-wide rollup fields (mainCost/subCost/inputTokens/outputTokens/compactCount/
-// cacheBreaks/idleMs/toolFailTurns/toolCallTurns) live on the sessionsMap session object,
+// Session-wide rollup fields (inputTokens/outputTokens/compactCount/cacheBreaks/
+// idleMs/toolFailTurns/toolCallTurns) live on the sessionsMap session object,
 // accumulated per-entry in entry-rendering.js addEntry(). Only meaningful for the
 // orchestrator lane — a single lane has no view of "other lanes" so these are session,
 // not lane, aggregates. See docs/designs/follow-live-turn-subagent.md "Overview Panel (L3)".
+// No main/subagent cost split here — isAnthropicSubagent() in store.js can't
+// tell them apart when the subagent request carries the parent's session_id
+// (current Claude Code behavior), so the split would silently misattribute
+// subagent spend as main. Tracked separately; add back once that's fixed.
 function _wfFmtSessTok(n) {
   n = n || 0;
   if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
@@ -1520,14 +1524,6 @@ function wfRenderAgentCard(lane) {
 
   html += '<div class="wf-ac-section"><div class="wf-ac-section-title">Cost</div>';
   html += '<div class="wf-ac-row"><span>Total</span><span class="wf-ac-val">$' + summary.totalCost.toFixed(4) + '</span></div>';
-  if (sess) {
-    var sessTotalCost = sess.totalCost || 0;
-    var mainCost = sess.mainCost || 0, subCost = sess.subCost || 0;
-    var mainPct = sessTotalCost > 0 ? (mainCost / sessTotalCost * 100).toFixed(0) : '0';
-    var subPct = sessTotalCost > 0 ? (subCost / sessTotalCost * 100).toFixed(0) : '0';
-    html += '<div class="wf-ac-row"><span>Main</span><span class="wf-ac-val">$' + mainCost.toFixed(4) + ' (' + mainPct + '%)</span></div>';
-    html += '<div class="wf-ac-row"><span>Subagent</span><span class="wf-ac-val">$' + subCost.toFixed(4) + ' (' + subPct + '%)</span></div>';
-  }
   html += '</div>';
 
   if (sess && (sess.inputTokens || sess.outputTokens)) {

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -364,7 +364,6 @@ function wfBuildState(sessionId) {
     selectedTurnId: null,
     selectedSection: 'timeline',
     laneFocusMode: false,
-    laneHeightManual: false,
   };
 }
 
@@ -735,6 +734,7 @@ function wfRenderTimeline() {
   _wfRenderSvgContent(mainSvg, subSvg, canvas);
   wfSetupInteractions(mainSvg, subSvg);
   wfInitResize(lanesSection, resizeHandle);
+  resizeHandle.classList.toggle('wf-resize-expand', !!wfState.laneFocusMode);
   wfRenderAgentCard(wfState.selectedLane);
   // ponytail: charts now inline in selected lane SVG, no separate header
   wfRenderCurrentSection();
@@ -848,15 +848,14 @@ function _wfOverviewLabelHtml() {
 function _wfRefreshLaneFocusUI() {
   var overviewLabel = document.getElementById('wf-overview-label');
   if (overviewLabel) overviewLabel.innerHTML = _wfOverviewLabelHtml();
-  // Respect a manual drag-resize (wfInitResize) — don't silently overwrite
-  // it on the next toggle/cycle/click, or the resize handle would appear
-  // broken (ux-heuristic-analysis: drags that don't stick read as a bug).
   var lanesSection = document.getElementById('wf-lanes-section');
-  if (lanesSection && !(wfState && wfState.laneHeightManual)) {
+  if (lanesSection) {
     var contentH = WF_PAD + WF_AXIS_H + _wfTotalLanesHeight() + WF_PAD;
     var maxH = window.innerHeight * 0.45;
     lanesSection.style.maxHeight = Math.min(contentH, maxH) + 'px';
   }
+  var resizeHandle = document.getElementById('wf-resize');
+  if (resizeHandle) resizeHandle.classList.toggle('wf-resize-expand', !!(wfState && wfState.laneFocusMode));
   wfDeferRender();
 }
 
@@ -1430,13 +1429,13 @@ function _wfHideTooltip() {
 // ── Resize Handle ─────────────────────────────────────────────────────────
 function wfInitResize(subScroll, handle) {
   handle.onmousedown = function(e) {
+    // Lane-focus mode drives the height from content, not the user — there's
+    // nothing to drag (see wf-resize-expand in style.css). A plain click still
+    // fires below and exits focus mode instead.
+    if (wfState && wfState.laneFocusMode) return;
     e.preventDefault();
     var startY = e.clientY;
     var startH = subScroll.offsetHeight;
-    // Once the user drags, stop auto-computing maxHeight on lane-select
-    // (_wfRefreshLaneFocusUI) — otherwise the next toggle/cycle/click
-    // silently overwrites their resize with no feedback (ux-heuristic-analysis).
-    if (wfState) wfState.laneHeightManual = true;
     var onMove = function(ev) {
       var delta = ev.clientY - startY;
       var newH = Math.max(60, startH + delta);
@@ -1448,6 +1447,9 @@ function wfInitResize(subScroll, handle) {
     };
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);
+  };
+  handle.onclick = function() {
+    if (wfState && wfState.laneFocusMode) wfToggleLaneFocus();
   };
 }
 

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -364,6 +364,7 @@ function wfBuildState(sessionId) {
     selectedTurnId: null,
     selectedSection: 'timeline',
     laneFocusMode: false,
+    laneHeightManual: false,
   };
 }
 
@@ -848,8 +849,11 @@ function _wfOverviewLabelHtml() {
 function _wfRefreshLaneFocusUI() {
   var overviewLabel = document.getElementById('wf-overview-label');
   if (overviewLabel) overviewLabel.innerHTML = _wfOverviewLabelHtml();
+  // Respect a manual drag-resize (wfInitResize) — don't silently overwrite
+  // it on the next toggle/cycle/click, or the resize handle would appear
+  // broken (ux-heuristic-analysis: drags that don't stick read as a bug).
   var lanesSection = document.getElementById('wf-lanes-section');
-  if (lanesSection) {
+  if (lanesSection && !(wfState && wfState.laneHeightManual)) {
     var contentH = WF_PAD + WF_AXIS_H + _wfTotalLanesHeight() + WF_PAD;
     var maxH = window.innerHeight * 0.45;
     lanesSection.style.maxHeight = Math.min(contentH, maxH) + 'px';
@@ -1436,6 +1440,10 @@ function wfInitResize(subScroll, handle) {
     e.preventDefault();
     var startY = e.clientY;
     var startH = subScroll.offsetHeight;
+    // Once the user drags, stop auto-computing maxHeight on lane-select
+    // (_wfRefreshLaneFocusUI) — otherwise the next toggle/cycle/click
+    // silently overwrites their resize with no feedback (ux-heuristic-analysis).
+    if (wfState) wfState.laneHeightManual = true;
     var onMove = function(ev) {
       var delta = ev.clientY - startY;
       var newH = Math.max(60, startH + delta);

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -1496,7 +1496,10 @@ function wfRenderAgentCard(lane) {
   var topTools = Object.entries(toolTotals).sort(function(a, b) { return b[1] - a[1]; }).slice(0, 6);
 
   // Orchestrator lane only: session-wide rollup (see comment above wfRenderAgentCard).
-  var isOrchestrator = !lane.spawnParent;
+  // _wfIsMainLane, not !lane.spawnParent — other non-subagent-flagged lanes (e.g.
+  // Task-tool subagents whose requests carry the parent's session_id, which the
+  // server's isAnthropicSubagent() heuristic doesn't detect) also have spawnParent: null.
+  var isOrchestrator = _wfIsMainLane(lane);
   var sess = (isOrchestrator && wfState && typeof sessionsMap !== 'undefined')
     ? sessionsMap.get(wfState.sessionId) : null;
 

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -364,6 +364,7 @@ function wfBuildState(sessionId) {
     selectedTurnId: null,
     selectedSection: 'timeline',
     laneFocusMode: false,
+    laneHeightManual: false,
   };
 }
 
@@ -847,8 +848,11 @@ function _wfOverviewLabelHtml() {
 function _wfRefreshLaneFocusUI() {
   var overviewLabel = document.getElementById('wf-overview-label');
   if (overviewLabel) overviewLabel.innerHTML = _wfOverviewLabelHtml();
+  // Respect a manual drag-resize (wfInitResize) — don't silently overwrite
+  // it on the next toggle/cycle/click, or the resize handle would appear
+  // broken (ux-heuristic-analysis: drags that don't stick read as a bug).
   var lanesSection = document.getElementById('wf-lanes-section');
-  if (lanesSection) {
+  if (lanesSection && !(wfState && wfState.laneHeightManual)) {
     var contentH = WF_PAD + WF_AXIS_H + _wfTotalLanesHeight() + WF_PAD;
     var maxH = window.innerHeight * 0.45;
     lanesSection.style.maxHeight = Math.min(contentH, maxH) + 'px';
@@ -1429,6 +1433,10 @@ function wfInitResize(subScroll, handle) {
     e.preventDefault();
     var startY = e.clientY;
     var startH = subScroll.offsetHeight;
+    // Once the user drags, stop auto-computing maxHeight on lane-select
+    // (_wfRefreshLaneFocusUI) — otherwise the next toggle/cycle/click
+    // silently overwrites their resize with no feedback (ux-heuristic-analysis).
+    if (wfState) wfState.laneHeightManual = true;
     var onMove = function(ev) {
       var delta = ev.clientY - startY;
       var newH = Math.max(60, startH + delta);

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -1456,6 +1456,32 @@ function _wfDrawOverviewCursor(canvas) {
 }
 
 // ── Agent Card ────────────────────────────────────────────────────────────
+// Session-wide rollup fields (mainCost/subCost/inputTokens/outputTokens/compactCount/
+// cacheBreaks/idleMs/toolFailTurns/toolCallTurns) live on the sessionsMap session object,
+// accumulated per-entry in entry-rendering.js addEntry(). Only meaningful for the
+// orchestrator lane — a single lane has no view of "other lanes" so these are session,
+// not lane, aggregates. See docs/designs/follow-live-turn-subagent.md "Overview Panel (L3)".
+function _wfFmtSessTok(n) {
+  n = n || 0;
+  if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+  if (n >= 1000) return (n / 1000).toFixed(0) + 'K';
+  return String(n);
+}
+function _wfFmtSessDur(ms) {
+  if (ms == null || !isFinite(ms) || ms < 0) return '-';
+  if (ms < 3600000) return Math.round(ms / 60000) + 'm';
+  if (ms < 86400000) return (ms / 3600000).toFixed(1) + 'h';
+  return (ms / 86400000).toFixed(1) + 'd';
+}
+// Parse an entry-id timestamp ("2026-03-08T17-47-13-000") to epoch ms.
+// Same 4-line parse as formatRelativeTime in miller-columns.js — not reused
+// directly since that helper returns a formatted string, not raw ms.
+function _wfParseIdMs(id) {
+  if (!id || id.length < 19) return null;
+  var ts = new Date(id.slice(0, 10) + 'T' + id.slice(11, 19).replace(/-/g, ':')).getTime();
+  return isFinite(ts) ? ts : null;
+}
+
 function wfRenderAgentCard(lane) {
     var agentPanel = document.getElementById('wf-agent-card-panel');
   if (!lane || !agentPanel) return;
@@ -1469,25 +1495,68 @@ function wfRenderAgentCard(lane) {
   }
   var topTools = Object.entries(toolTotals).sort(function(a, b) { return b[1] - a[1]; }).slice(0, 6);
 
+  // Orchestrator lane only: session-wide rollup (see comment above wfRenderAgentCard).
+  var isOrchestrator = !lane.spawnParent;
+  var sess = (isOrchestrator && wfState && typeof sessionsMap !== 'undefined')
+    ? sessionsMap.get(wfState.sessionId) : null;
+
   var html = '<div class="wf-agent-card" style="border-left:2px solid ' + color + '">';
   html += '<div class="wf-ac-name">' + wfGlyphHtml(wfLaneShape(lane), 10, color) + ' ' + wfEsc(lane.name) + ' <span class="wf-ac-model" style="background:' + color + '22;color:' + color + '">' + wfEsc(wfShortModel(lane.model)) + '</span></div>';
   html += '<div class="wf-ac-meta">' + summary.turnCount + ' turns · ' + wfFmtDur(summary.duration) + ' · ' + (lane.spawnParent ? 'subagent' : 'orchestrator') + '</div>';
 
   html += '<div class="wf-ac-section"><div class="wf-ac-section-title">Context</div>';
   html += '<div class="wf-ac-row"><span>Peak</span><span class="wf-ac-val">' + summary.peakCtx.toFixed(1) + '%</span></div>';
-  html += '<div class="wf-ac-row"><span>Window</span><span class="wf-ac-val">' + Math.round((lane.ctxWindow || 0) / 1000) + 'K</span></div></div>';
+  html += '<div class="wf-ac-row"><span>Window</span><span class="wf-ac-val">' + Math.round((lane.ctxWindow || 0) / 1000) + 'K</span></div>';
+  if (sess) html += '<div class="wf-ac-row"><span>Compacts</span><span class="wf-ac-val">' + (sess.compactCount || 0) + '</span></div>';
+  html += '</div>';
 
   html += '<div class="wf-ac-section"><div class="wf-ac-section-title">Cache</div>';
-  html += '<div class="wf-ac-row"><span>Hit rate</span><span class="wf-ac-val">' + summary.avgCache.toFixed(1) + '%</span></div></div>';
+  html += '<div class="wf-ac-row"><span>Hit rate</span><span class="wf-ac-val">' + summary.avgCache.toFixed(1) + '%</span></div>';
+  if (sess) html += '<div class="wf-ac-row"><span>Breaks</span><span class="wf-ac-val">' + (sess.cacheBreaks || 0) + '</span></div>';
+  html += '</div>';
 
   html += '<div class="wf-ac-section"><div class="wf-ac-section-title">Cost</div>';
-  html += '<div class="wf-ac-row"><span>Total</span><span class="wf-ac-val">$' + summary.totalCost.toFixed(4) + '</span></div></div>';
+  html += '<div class="wf-ac-row"><span>Total</span><span class="wf-ac-val">$' + summary.totalCost.toFixed(4) + '</span></div>';
+  if (sess) {
+    var sessTotalCost = sess.totalCost || 0;
+    var mainCost = sess.mainCost || 0, subCost = sess.subCost || 0;
+    var mainPct = sessTotalCost > 0 ? (mainCost / sessTotalCost * 100).toFixed(0) : '0';
+    var subPct = sessTotalCost > 0 ? (subCost / sessTotalCost * 100).toFixed(0) : '0';
+    html += '<div class="wf-ac-row"><span>Main</span><span class="wf-ac-val">$' + mainCost.toFixed(4) + ' (' + mainPct + '%)</span></div>';
+    html += '<div class="wf-ac-row"><span>Subagent</span><span class="wf-ac-val">$' + subCost.toFixed(4) + ' (' + subPct + '%)</span></div>';
+  }
+  html += '</div>';
+
+  if (sess && (sess.inputTokens || sess.outputTokens)) {
+    var inTok = sess.inputTokens || 0, outTok = sess.outputTokens || 0;
+    var ioRatio = outTok > 0 ? (inTok / outTok).toFixed(1) + ':1' : '-';
+    html += '<div class="wf-ac-section"><div class="wf-ac-section-title">Tokens</div>';
+    html += '<div class="wf-ac-row"><span>Input</span><span class="wf-ac-val">' + _wfFmtSessTok(inTok) + '</span></div>';
+    html += '<div class="wf-ac-row"><span>Output</span><span class="wf-ac-val">' + _wfFmtSessTok(outTok) + '</span></div>';
+    html += '<div class="wf-ac-row"><span>I/O ratio</span><span class="wf-ac-val">' + ioRatio + '</span></div>';
+    html += '</div>';
+  }
 
   if (topTools.length) {
     html += '<div class="wf-ac-section"><div class="wf-ac-section-title">Tools</div>';
     for (var ti = 0; ti < topTools.length; ti++) {
       html += '<div class="wf-ac-row"><span class="wf-ac-tool">' + wfEsc(topTools[ti][0]) + '</span><span class="wf-ac-tool-count">' + topTools[ti][1] + '</span></div>';
     }
+    if (sess && (sess.toolCallTurns || 0) > 0) {
+      var failRate = (sess.toolFailTurns || 0) / sess.toolCallTurns * 100;
+      html += '<div class="wf-ac-row"><span>Failure rate</span><span class="wf-ac-val">' + failRate.toFixed(1) + '%</span></div>';
+    }
+    html += '</div>';
+  }
+
+  if (sess) {
+    var startMs = _wfParseIdMs(sess.firstId);
+    var durationMs = (startMs != null && sess.lastReceivedAt) ? (sess.lastReceivedAt - startMs) : null;
+    var activeMs = durationMs != null ? Math.max(0, durationMs - (sess.idleMs || 0)) : null;
+    html += '<div class="wf-ac-section"><div class="wf-ac-section-title">Time</div>';
+    html += '<div class="wf-ac-row"><span>Started</span><span class="wf-ac-val">' + (sess.firstId ? wfEsc(formatEntryDate(sess.firstId)) : '-') + '</span></div>';
+    html += '<div class="wf-ac-row"><span>Duration</span><span class="wf-ac-val">' + _wfFmtSessDur(durationMs) + '</span></div>';
+    html += '<div class="wf-ac-row"><span>Active</span><span class="wf-ac-val">' + _wfFmtSessDur(activeMs) + '</span></div>';
     html += '</div>';
   }
 

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -638,6 +638,65 @@ describe('workflow-timeline focus dim follows selectedLane', () => {
   });
 });
 
+describe('workflow-timeline lane-focus hit-testing (codex round 4)', () => {
+  function threeLanes(ctx) {
+    ctx.allEntries = [
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('e1', 's1', 'claude-sonnet-4-6', 2000, 3, { agentKey: 'explore', agentLabel: 'Explore' }),
+      mkEntry('g1', 's1', 'claude-sonnet-4-6', 2500, 3, { agentKey: 'general-purpose', agentLabel: 'General' }),
+    ];
+    ctx.wfState = ctx.wfBuildState('s1');
+  }
+
+  // Focus mode draws only the selected sub-lane (see _wfRenderSvgContent), at
+  // y=WF_PAD — walking 1..lanes.length as if all sub-lanes are stacked (the old
+  // behavior) hit-tests against a layout that isn't actually on screen.
+  it('_wfLaneIdxAtY returns the focused lane, not whatever unfocused lane occupies that y-slot', () => {
+    const ctx = loadWfModule();
+    threeLanes(ctx);
+    assert.equal(ctx.wfState.lanes.length, 3); // main + explore + general-purpose
+    ctx.wfState.laneFocusMode = true;
+    ctx.wfState.selectedLane = ctx.wfState.lanes[2]; // focus the 3rd lane (general-purpose)
+    var my = 9; // WF_PAD(4) + 5 — inside lane[1]'s slot under the old sequential walk
+    assert.equal(ctx._wfLaneIdxAtY({ id: 'wf-sub-svg' }, my), 2); // RED before fix: 1
+    // main SVG hit-testing is untouched by focus mode
+    assert.equal(ctx._wfLaneIdxAtY({ id: 'wf-main-svg' }, 30), 0);
+    // focus on main itself → sub SVG has nothing to hit-test
+    ctx.wfState.selectedLane = ctx.wfState.lanes[0];
+    assert.equal(ctx._wfLaneIdxAtY({ id: 'wf-sub-svg' }, my), -1);
+  });
+});
+
+describe('workflow-timeline agentKey classification agrees with entry-rendering.js (codex round 4)', () => {
+  // 'unknown'/'agent' are extractAgentType()'s catch-all defaults — could be a
+  // genuinely new main-agent variant, not necessarily a subagent. Both the batch
+  // build (wfInferLanes) and the live-update path (wfAddEntry) must fall back to
+  // the raw isSubagent flag for these, matching AGENT_KEY_UNRELIABLE in
+  // entry-rendering.js — otherwise the same turn classifies differently in the
+  // turn list (main) vs the workflow lanes (subagent).
+  it('wfInferLanes keeps an unreliable-agentKey, non-subagent turn in main', () => {
+    const ctx = loadWfModule();
+    var entries = [
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, { agentKey: 'orchestrator' }),
+      mkEntry('t2', 's1', 'claude-opus-4-6', 6000, 3, { agentKey: 'unknown', isSubagent: false }),
+    ];
+    var lanes = ctx.wfInferLanes(entries, []);
+    assert.equal(lanes.length, 1); // RED before fix: 2 (t2 split into its own 'agent-unknown' lane)
+    assert.equal(lanes[0].turns.length, 2);
+  });
+
+  it('wfAddEntry (live update) keeps an unreliable-agentKey, non-subagent turn in main', () => {
+    const ctx = loadWfModule();
+    ctx.allEntries = [mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, { agentKey: 'orchestrator' })];
+    ctx.wfState = ctx.wfBuildState('s1');
+    assert.equal(ctx.wfState.lanes.length, 1);
+    var t2 = mkEntry('t2', 's1', 'claude-opus-4-6', 6000, 3, { agentKey: 'unknown', isSubagent: false });
+    ctx.wfAddEntry(t2);
+    assert.equal(ctx.wfState.lanes.length, 1); // RED before fix: 2 (routed into an 'agent-unknown' sub-lane)
+    assert.equal(ctx.wfState.lanes[0].turns.length, 2);
+  });
+});
+
 describe('workflow-timeline tail-follow sliding window (#138 Fix B)', () => {
   it('slides a fixed-span window instead of expanding while following the tail', () => {
     const ctx = loadWfModule();


### PR DESCRIPTION
## 摘要

實作 `docs/designs/follow-live-turn-subagent.md` 三個 UX 問題的修正：

- **Subagent 劫持 follow-live-turn**：subagent 的 turn 送達時會把主線的「跟隨最新 turn」選取狀態搶走，使用者盯著 orchestrator 的輸出時畫面會突然跳走。改成 subagent turn 只顯示一個 peek pill（`+N sub`），不搶選取；主線 turn 才會真正推進 live edge。
- **Session 卡片資訊不足**：sidebar 的 session 卡片加上 duration、context window 大小、hover tooltip（開始時間/最後活動/cache breaks）。
- **Orchestrator lane 缺少 session 全局指標**：workflow timeline 的 agent card 在 orchestrator lane 上新增 Context/Cache/Tokens/Autonomy/Tools/Time 的 session-wide rollup 區塊，並加上一個 lane-focus 收合模式（`▥`/`▤` 切換鈕），解決多 subagent（例如 473 次 Agent tool call）時 lane 列表把畫面撐爆、看不清哪個被選取的問題。

nine-gate 專家評估流程（Endsley/SA、Wickens/MRT、Czerwinski/interruption、Tufte 四位視角）跑了多輪迭代 lane-focus 的 pager 控制項擺放位置，最高分方案 6.75/10 未達 9 分門檻；使用者最終選擇最高分且安全的方案出貨，而非無限迭代。

codex 二審跑了 4 輪，逐輪修正，詳見下方 Detail。

## Detail

Three worktree-parallel implementations converged onto this branch, then iterated through UX heuristic analysis, a nine-gate expert-panel design pass, and four rounds of codex adversarial review.

### Problem 1 — subagent turns hijacking follow-live-turn

**Root cause**: entries arrive interleaved (main + subagent turns share the same SSE stream), and the original "select whatever entry just arrived" logic didn't distinguish them — a subagent turn landing mid-conversation would yank the user's view away from the orchestrator turn they were reading.

**Design tradeoff**: considered auto-navigating only within the same lane vs. a non-intrusive peek indicator. Chose a peek pill (`+N sub`, click-through to view) over auto-navigation — it surfaces that something happened without moving the user's reading position, and a locked/manual selection is never silently overridden.

**Architecture decision**: the natural signal for "is this a subagent turn" is the server's `isAnthropicSubagent()`, but it classifies by `!cwd && !session_id` — current Claude Code Task-tool subagents carry the *parent's* session_id, so this heuristic misses the common case entirely (returns `false` for real subagents). The fix threads through the client-side `agentKey` (derived from system-prompt content server-side, in `system-prompt.js` — not fooled by shared session_id) as the primary signal, with a fallback to the raw flag only when `agentKey` is one of the extractor's own catch-all defaults (`unknown`/`agent`) — those could plausibly be a genuinely new main-agent variant, not a subagent, so forcing them to "subagent" risked silently breaking auto-follow for legitimate main content. This `AGENT_KEY_UNRELIABLE` guard is now shared between `entry-rendering.js` (turn list) and `workflow-timeline.js` (swimlanes) so the two views can't disagree on the same turn (codex round 4 finding — they did disagree before this PR).

### Problem 2 — session card metrics

Straightforward addition: duration (computed from `firstId`/`lastReceivedAt`), context window size, and a hover tooltip. No architecture changes.

### Problem 3 — orchestrator lane session-wide rollup + lane-focus mode

**Placement correction (post-implementation)**: the design doc originally assumed a "session selected, no turn drilled into" empty state to host these metrics — that state doesn't exist in the current UI (selecting a session always auto-selects a turn/lane). Landed instead by extending the existing `wfRenderAgentCard(lane)`, gated on `_wfIsMainLane(lane)` rather than `!lane.spawnParent` (the latter is also null for non-main lanes like Task-tool subagents, which would have misattributed subagent data as the main rollup — caught in verification testing before merge).

**Dropped from this pass — Main/Subagent cost split**: originally blocked because `isAnthropicSubagent()`'s session_id-sharing gap (see Problem 1) would have silently shown subagent spend as 100% main cost. Problem 1's `agentKey`-based fix removes that data-availability blocker, but re-adding the split was kept out of scope for this PR — it's a UI decision now, not a data problem, and tracked separately so this PR stays focused.

**Lane-focus mode (added post-review)**: `ux-heuristic-analysis` against a real 5-subagent session found a MAJOR issue — the swimlane list has a fixed max-height with no scroll affordance, silently clipping lanes off the bottom in exactly the sessions this feature targets (a session with 473 `Agent` tool calls, i.e. many spawned subagents). Added a collapse toggle that narrows the sub-lane area to just the selected lane, keeping main pinned/always-visible. The toggle button and pager control placement went through a full nine-gate pass (4 independent expert personas — situation awareness, mental resource theory, interruption-cost, information-design — each scoring candidate layouts against a pre-committed rubric); no candidate reached the ≥9/10 acceptance bar (best was 6.75/10 for a two-row header split that keeps zoom controls and the focus toggle/pager on separate rows so they're never adjacent misclick targets). Rather than iterate indefinitely against a bar nothing was clearing, the user made the pragmatic call to ship the highest-scoring, safest layout.

### Codex adversarial review (4 rounds)

- **Round 1**: `latestMainTurnIdx` left unset after a batch restore (stale pill click target).
- **Round 2**: `isSubagent` detection was fixed in the design doc's prose but not in the actual code — round 2 forced the real `agentKey`-based fix described in Problem 1.
- **Round 3**: narrowed the `agentKey` override to exclude `unknown`/`agent` (the `AGENT_KEY_UNRELIABLE` guard); reset pill counters on dismiss.
- **Round 4** (this PR's final state): `_wfLaneIdxAtY()` wasn't focus-mode-aware, so hover/click could hit-test against a lane layout that wasn't actually rendered once lane-focus collapsed the view; `workflow-timeline.js` and `entry-rendering.js` disagreed on which `agentKey` values are trustworthy (the exact gap Problem 1's guard was meant to close, just not shared between the two files yet); the design doc's committed AUTONOMY section (Retries) was missing from the render; the Tools rollup read lane-local data instead of session-wide `sess.toolCalls` (undercounting, and hiding the failure-rate row whenever the orchestrator made no direct tool calls itself); the session card tooltip was only wired to `.si-row1`, not the card container.

All 4 rounds' findings were accepted and fixed — none rejected. No blockers remain.

### ADRs 0005–0007

Three round-4 findings (and the debugging behind them) are the same shape as this repo's existing ADRs — an invariant that's easy to silently break, protected by a guard comment at every site that must respect it. Added:

- **[0005](docs/decisions/0005-agent-key-unreliable-shared-contract.md)** — `AGENT_KEY_UNRELIABLE` must be shared between `entry-rendering.js` and `workflow-timeline.js`; round 4 caught them disagreeing on the same turn's classification.
- **[0006](docs/decisions/0006-lane-focus-geometry-consistency.md)** — lane-focus geometry (`_wfTotalLanesHeight`, `_wfLaneIdxAtY`, the label-click hit-test) must all agree with what `_wfRenderSvgContent` actually draws; round 4's HIGH finding was exactly one of these three drifting from the other two.
- **[0007](docs/decisions/0007-wf-is-main-lane-not-spawn-parent.md)** — `_wfIsMainLane(lane)`, never `!lane.spawnParent` (the latter is `null` at every lane-construction site in the file, so it's always `true`). Hit twice in this same feature: once in an early cost-split draft (caught pre-merge), and in `wfRenderAgentCard`'s pre-existing meta-line label — which always rendered "orchestrator" even for subagent lanes, confirmed live in a 10-lane session during this PR's own browser verification. Fixed alongside the ADR since it's the exact trap being documented (pre-existing bug, not introduced by this PR's diff).

`CLAUDE.md`'s invariants table and `INVARIANT` guard comments at every affected site were updated to match.

## Test plan

- [x] `CCXRAY_HOME=$(mktemp -d) npm test` — 1178/1178 passing (re-run after the ADR commit)
- [x] Regression tests for both codex round-4 HIGH findings, verified RED on pre-fix code / GREEN on fixed code (`test/workflow-timeline.test.js`)
- [x] Real-browser smoke test against an isolated copy of production log data (never touching `~/.ccxray`): 10-lane session, lane-focus toggle via genuine DOM click, hover verified via dispatched `mousemove` on the actual focused sub-lane SVG, AUTONOMY/Tools/tooltip sections visually confirmed
- [x] e2e recording of the live subagent-pill + lane-focus flow against real streaming session data
- [x] `_wfIsMainLane` fix (0007): confirmed statically — `grep` shows `spawnParent` is assigned `null` at all 5 construction sites and never reassigned — plus the live screenshot from the smoke test above that shows the old, wrong "orchestrator" label on an actual subagent lane. A second live re-check after the fix stalled on an unrelated smoke-server restore issue (isolated env, not this code path) rather than confirming green in-browser; the fix is a direct swap to the already browser-verified `isOrchestrator`/`_wfIsMainLane` value, so this is a lower-confidence leg than the others above and called out as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
