### PR TITLE
fix: improve subagent detection when session_id is inherited (#221)

### DIFF
--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -280,6 +280,9 @@ function wfInferLanes(entries, childEntries) {
   // reached main via an authoritative agentKey (WF_MAIN_AGENT_KEYS) are
   // exempt — that server-side signal already resolved them definitively.
   // INVARIANT: gate on AGENT_KEY_UNRELIABLE — see docs/decisions/0005-agent-key-unreliable-shared-contract.md
+  // Sort by receivedAt so the earliest-starting turn stays in main (codex R1:
+  // entries arrive in completion order which may differ from start order).
+  mainLane.turns.sort(function(a, b) { return (Number(a.receivedAt) || 0) - (Number(b.receivedAt) || 0); });
   for (var oi = mainLane.turns.length - 1; oi >= 1; oi--) {
     var cur = mainLane.turns[oi];
     if (cur.agentKey && !AGENT_KEY_UNRELIABLE[cur.agentKey]) continue;

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -273,6 +273,31 @@ function wfInferLanes(entries, childEntries) {
     }
   }
 
+  // Post-pass (#221): two turns in main whose time ranges overlap cannot be
+  // the same serial conversation — they must be parallel agents (e.g. a fork
+  // whose session_id matches the parent, so the agentKey signal above missed
+  // it). Split the later-starting one into its own sub-lane. Turns that
+  // reached main via an authoritative agentKey (WF_MAIN_AGENT_KEYS) are
+  // exempt — that server-side signal already resolved them definitively.
+  // INVARIANT: gate on AGENT_KEY_UNRELIABLE — see docs/decisions/0005-agent-key-unreliable-shared-contract.md
+  for (var oi = mainLane.turns.length - 1; oi >= 1; oi--) {
+    var cur = mainLane.turns[oi];
+    if (cur.agentKey && !AGENT_KEY_UNRELIABLE[cur.agentKey]) continue;
+    var curStart = Number(cur.receivedAt) || 0;
+    if (!curStart) continue;
+    for (var oj = oi - 1; oj >= 0 && oj >= oi - 5; oj--) {
+      var prev = mainLane.turns[oj];
+      var prevStart = Number(prev.receivedAt) || 0;
+      var prevEnd = prevStart + (parseFloat(prev.elapsed) || 0) * 1000;
+      if (curStart < prevEnd && prevStart > 0) {
+        var olKey = _wfSubLaneKey('parallel-' + wfShortModel(cur.model), cur);
+        _wfPushToSubLane(laneMap, olKey, cur);
+        mainLane.turns.splice(oi, 1);
+        break;
+      }
+    }
+  }
+
   // Child session entries → their own lanes
   if (childEntries.length) {
     var childBySid = new Map();
@@ -446,6 +471,25 @@ function wfAddEntry(entry) {
     var mainModel = wfState.lanes[0]?.model;
     needsSub = entry.isSubagent || (mainModel && entry.model !== mainModel);
     key = _wfSubLaneKey('subagent-' + wfShortModel(entry.model), entry);
+  }
+  // INVARIANT: gate on AGENT_KEY_UNRELIABLE — see docs/decisions/0005-agent-key-unreliable-shared-contract.md
+  if (!needsSub && !(entry.agentKey && !AGENT_KEY_UNRELIABLE[entry.agentKey])) {
+    // Temporal overlap check (#221): if this entry's time range overlaps a
+    // recent main-lane turn, it must be a parallel agent (e.g. a fork
+    // sharing the parent's session_id) — split it to a sub-lane, mirroring
+    // the wfInferLanes post-pass. Entries with an authoritative agentKey
+    // already went through the WF_MAIN_AGENT_KEYS check above — exempt.
+    var mainTurns = wfState.lanes[0]?.turns || [];
+    for (var mi = mainTurns.length - 1; mi >= 0 && mi >= mainTurns.length - 5; mi--) {
+      var mt = mainTurns[mi];
+      var mtStart = Number(mt.receivedAt) || 0;
+      var mtEnd = mtStart + (parseFloat(mt.elapsed) || 0) * 1000;
+      if (ts < mtEnd && mtStart > 0) {
+        needsSub = true;
+        key = _wfSubLaneKey('parallel-' + wfShortModel(entry.model), entry);
+        break;
+      }
+    }
   }
   if (needsSub) {
     var lane = wfState.lanes.find(function(l) { return l.key === key; });

--- a/server/store.js
+++ b/server/store.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { agentForProvider, getUpstreamProfile } = require('./providers');
+const { extractAgentType } = require('./system-prompt');
 
 // Synthetic session buckets that have no resumable rollout/session file.
 const NON_RESUMABLE_SESSIONS = new Set(['direct-api', 'codex-raw', 'unknown']);
@@ -88,8 +89,20 @@ function extractSessionId(req) {
 
 // Anthropic subagent heuristic: no cwd AND no explicit session_id.
 // Goal verifiers carry session_id but no cwd — they are NOT subagents.
+// #221: newer Claude Code builds stamp subagent requests with the parent's
+// session_id, so the "no session_id" signal alone under-detects. When cwd
+// is absent but session_id is present, fall back to agentKey — a known
+// non-main key (e.g. 'general-purpose') still means subagent.
 function isAnthropicSubagent(parsedBody) {
-  return !extractCwd(parsedBody) && !extractSessionId(parsedBody);
+  const noCwd = !extractCwd(parsedBody);
+  const noSid = !extractSessionId(parsedBody);
+  if (noCwd && noSid) return true;
+  if (noCwd) {
+    const { key } = extractAgentType(parsedBody?.system);
+    if (key !== 'orchestrator' && key !== 'sdk-agent' && key !== 'default'
+        && key !== 'unknown' && key !== 'agent') return true;
+  }
+  return false;
 }
 
 // Bare subagent requests: no session_id, no system prompt, no tools, 1-2 messages.

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -150,6 +150,48 @@ describe('store', () => {
     };
   }
 
+  // #221: newer Claude Code builds stamp subagent requests with the parent's
+  // session_id, so the old "no cwd AND no session_id" heuristic under-detects.
+  describe('isAnthropicSubagent', () => {
+    function withAgentType(b1, b2, extra) {
+      return Object.assign({ system: [{ text: 'billing' }, { text: b1 }, { text: b2 }] }, extra || {});
+    }
+
+    it('old path: no cwd, no session_id → subagent', () => {
+      const store = require('../server/store');
+      assert.equal(store.isAnthropicSubagent({}), true);
+    });
+
+    it('new path: no cwd, has session_id, agentKey general-purpose → subagent', () => {
+      const store = require('../server/store');
+      const req = withAgentType(
+        'You are Claude Code',
+        'You are an agent for Claude Code, tasked with completing a task.',
+        { metadata: { session_id: 'child-sid' } }
+      );
+      assert.equal(store.isAnthropicSubagent(req), true);
+    });
+
+    it('main orchestrator: has cwd and session_id → not a subagent', () => {
+      const store = require('../server/store');
+      const req = {
+        system: [{ text: 'Primary working directory: /home/user/project' }],
+        metadata: { session_id: 'parent-sid' },
+      };
+      assert.equal(store.isAnthropicSubagent(req), false);
+    });
+
+    it('fork (orchestrator key, no cwd, has session_id) → not a subagent (fork detection is #222)', () => {
+      const store = require('../server/store');
+      const req = withAgentType(
+        'You are Claude Code',
+        'You are an interactive agent for coding tasks.',
+        { metadata: { session_id: 'parent-sid' } }
+      );
+      assert.equal(store.isAnthropicSubagent(req), false);
+    });
+  });
+
   describe('detectSession – subagent attribution', () => {
     function bareSubagentReq() {
       return { messages: [{ role: 'user', content: 'do research' }] };

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -972,4 +972,17 @@ describe('#221 subagent lane inference when session_id no longer separates agent
     assert.equal(ctx.wfState.lanes.length, 1);
     assert.equal(ctx.wfState.lanes[0].turns.length, 2);
   });
+
+  it('completion-order mismatch: earlier-starting turn stays in main even if it finishes last (codex R1)', () => {
+    const ctx = loadWfModule();
+    // t2 completes first but started after t1 — arrival order ≠ start order
+    var entries = [
+      mkEntry('t2', 's1', 'claude-opus-4-6', 3000, 1, {}),
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, {}),
+    ];
+    var lanes = ctx.wfInferLanes(entries, []);
+    assert.equal(lanes.length, 2);
+    assert.equal(lanes[0].turns[0].id, 't1');
+    assert.equal(lanes[1].turns[0].id, 't2');
+  });
 });

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -263,13 +263,13 @@ describe('workflow-timeline data layer', () => {
     const ctx = loadWfModule();
     ctx.allEntries = [
       mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, { cost: 0.01 }),
-      mkEntry('t2', 's1', 'claude-opus-4-6', 3000, 5, { cost: 0.05 }),
-      mkEntry('t3', 's1', 'claude-opus-4-6', 5000, 5, { cost: 0.09 }),
+      mkEntry('t2', 's1', 'claude-opus-4-6', 7000, 5, { cost: 0.05 }),
+      mkEntry('t3', 's1', 'claude-opus-4-6', 13000, 5, { cost: 0.09 }),
     ];
     ctx.wfState = ctx.wfBuildState('s1');
     var lane = ctx.wfState.lanes[0];
     assert.equal(ctx.wfLaneCostMedian(lane), 0.05);
-    ctx.wfAddEntry(mkEntry('t4', 's1', 'claude-opus-4-6', 7000, 5, { cost: 0.2 }));
+    ctx.wfAddEntry(mkEntry('t4', 's1', 'claude-opus-4-6', 19000, 5, { cost: 0.2 }));
     assert.equal(lane._costMedian, null);
     assert.equal(ctx.wfLaneCostMedian(lane), 0.09);
   });
@@ -336,8 +336,8 @@ describe('workflow-timeline data layer', () => {
     const ctx = loadWfModule();
     // t2 starts while t1 is still running — spans overlap; later bar draws on top
     ctx.allEntries = [
-      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 100, {}),
-      mkEntry('t2', 's1', 'claude-opus-4-6', 51000, 100, {}),
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 100, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('t2', 's1', 'claude-opus-4-6', 51000, 100, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
     ];
     ctx.wfState = ctx.wfBuildState('s1');
     ctx.wfState.viewT0 = ctx.wfState.tMin;
@@ -897,5 +897,79 @@ describe('#142 wfCtxZoneColor band boundaries', () => {
   it('39% -> green', () => {
     const ctx = loadWfModule();
     assert.equal(ctx.wfCtxZoneColor(t(39)), '#3fb950');
+  });
+});
+
+// ── #221: subagents carrying the parent's session_id ─────────────────────────
+describe('#221 subagent lane inference when session_id no longer separates agents', () => {
+  it('agentKey-identified subagent lanes by agentKey regardless of isSubagent flag', () => {
+    const ctx = loadWfModule();
+    var entries = [
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      // server now sets agentKey from the B2 prompt even though session_id
+      // matches the parent (isSubagent stays false) — agentKey must still win
+      mkEntry('t2', 's1', 'claude-sonnet-4-6', 7000, 3, { agentKey: 'general-purpose', agentLabel: 'General Purpose', isSubagent: false }),
+    ];
+    var lanes = ctx.wfInferLanes(entries, []);
+    assert.equal(lanes.length, 2);
+    assert.equal(lanes[0].name, 'main');
+    assert.equal(lanes[0].turns.length, 1);
+    assert.equal(lanes[1].name, 'agent-general-purpose');
+    assert.equal(lanes[1].turns.length, 1);
+  });
+
+  it('wfInferLanes post-pass splits temporally overlapping main-lane turns into a parallel lane', () => {
+    const ctx = loadWfModule();
+    var entries = [
+      // t1 runs 1000..6000
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, {}),
+      // t2 starts at 3000, while t1 is still running — no agentKey, so only
+      // the temporal-overlap post-pass can catch this
+      mkEntry('t2', 's1', 'claude-opus-4-6', 3000, 4, {}),
+    ];
+    var lanes = ctx.wfInferLanes(entries, []);
+    assert.equal(lanes.length, 2);
+    assert.equal(lanes[0].name, 'main');
+    assert.equal(lanes[0].turns.length, 1);
+    assert.equal(lanes[0].turns[0].id, 't1');
+    assert.equal(lanes[1].name, 'parallel-opus-4-6');
+    assert.equal(lanes[1].turns.length, 1);
+    assert.equal(lanes[1].turns[0].id, 't2');
+  });
+
+  it('wfAddEntry splits a temporally overlapping incremental entry into a parallel lane', () => {
+    const ctx = loadWfModule();
+    ctx.allEntries = [
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, {}), // runs 1000..6000
+    ];
+    ctx.wfState = ctx.wfBuildState('s1');
+    assert.equal(ctx.wfState.lanes.length, 1);
+    // arrives at 3000, overlapping t1's 1000..6000 span
+    var result = ctx.wfAddEntry(mkEntry('t2', 's1', 'claude-opus-4-6', 3000, 4, {}));
+    assert.equal(result.lanesChanged, true);
+    assert.equal(ctx.wfState.lanes.length, 2);
+    assert.equal(ctx.wfState.lanes[0].turns.length, 1);
+    assert.equal(ctx.wfState.lanes[1].name, 'parallel-opus-4-6');
+    assert.equal(ctx.wfState.lanes[1].turns.length, 1);
+    assert.equal(ctx.wfState.lanes[1].turns[0].id, 't2');
+  });
+
+  it('non-overlapping same-model turns stay in main (no false positive)', () => {
+    const ctx = loadWfModule();
+    var entries = [
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, {}),   // ends at 6000
+      mkEntry('t2', 's1', 'claude-opus-4-6', 7000, 3, {}),   // starts after t1 ends
+    ];
+    var lanes = ctx.wfInferLanes(entries, []);
+    assert.equal(lanes.length, 1);
+    assert.equal(lanes[0].name, 'main');
+    assert.equal(lanes[0].turns.length, 2);
+
+    ctx.allEntries = entries.slice(0, 1);
+    ctx.wfState = ctx.wfBuildState('s1');
+    var result = ctx.wfAddEntry(entries[1]);
+    assert.equal(result.lanesChanged, false);
+    assert.equal(ctx.wfState.lanes.length, 1);
+    assert.equal(ctx.wfState.lanes[0].turns.length, 2);
   });
 });


### PR DESCRIPTION
## 摘要

修復 Anthropic subagent 因繼承 parent session_id 而被 `isAnthropicSubagent()` 漏判的問題，導致所有 subagent turns 被吸進 main swimlane lane。

- **Server-side**: `isAnthropicSubagent` 新增 agentKey fallback — 當 cwd 缺失但 session_id 存在時，用 `extractAgentType` 判斷已知的 non-main agent type
- **Client-side**: `wfInferLanes` 新增 temporal overlap post-pass — 同一 session 中時間區間重疊的 main-lane turns 必定是平行 agent，拆到 parallel lane
- **Codex R1 fix**: 拆分前先按 `receivedAt` 排序，避免 completion order ≠ start order 導致拆錯方向

## 驗證證據

- diff-check: `old FAIL (3 failures) / new PASS` — 新測試在舊碼 fail、新碼 pass
- 全測試套件: 1187 pass, 0 fail
- Smoke: 隔離 port 5604 + CCXRAY_HOME 啟動正常
- Codex review: P2-1 (sort order) 已修; P2-2 (turn-list classification consistency) 為 #222 scope — temporal overlap 只影響無 reliable agentKey 的 fork subagent，entry-rendering.js 對有 agentKey 的 subagent 已正確分類

## 未驗證

- 需真實 subagent 流量的 browser 視覺驗證（無法自動產生 Agent subagent 請求）
- Fork subagent 的 turn-list counter 一致性（scope: #222）
- 30s inference window / cwd-linked session edge cases（scope: #223）

## Test plan

- [x] diff-check old-fail/new-pass
- [x] Full test suite 1187 pass
- [x] Smoke test isolated server
- [x] Codex review findings addressed (R1: sort order fix)
- [ ] Browser verification with real subagent session (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)