### PR TITLE
chore: add scripts/boot-smoke.sh — bounded boot smoke with evidence output

### DIFF
--- a/scripts/boot-smoke.sh
+++ b/scripts/boot-smoke.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Bounded boot smoke: start the server against an isolated CCXRAY_HOME, wait
+# for the dashboard to answer HTTP 200, print the boot signal, exit 0/1.
+# Never touches the real ~/.ccxray or the hub port.
+#
+# Usage: scripts/boot-smoke.sh [port]        (default 5642)
+#   CCXRAY_HOME override respected; otherwise a throwaway mktemp dir.
+#
+# Evidence contract (pipeline runbook step 6): stdout carries the "listening"
+# line + HTTP code; exit code is the verdict. Keep both in the PR evidence.
+set -u
+
+PORT="${1:-5642}"
+HOME_DIR="${CCXRAY_HOME:-$(mktemp -d)}"
+LOG="$(mktemp)"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# ANTHROPIC_BASE_URL inherited from a ccxray-proxied shell would trip the
+# upstream-loop guard (42c80fb) or point upstream at the local hub — boot
+# smoke must test default upstream config.
+env -u ANTHROPIC_BASE_URL CCXRAY_HOME="$HOME_DIR" PROXY_PORT="$PORT" \
+  node "$ROOT/server/index.js" >"$LOG" 2>&1 &
+PID=$!
+trap 'kill "$PID" 2>/dev/null; wait "$PID" 2>/dev/null' EXIT
+
+for _ in $(seq 1 30); do  # ponytail: 15s hard bound, raise if slow machines ever miss it
+  code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/" 2>/dev/null || true)
+  if [ "$code" = "200" ]; then
+    grep -m1 "listening" "$LOG" || true
+    echo "BOOT OK: dashboard HTTP 200 on :$PORT"
+    exit 0
+  fi
+  kill -0 "$PID" 2>/dev/null || break   # server died — stop waiting, dump log
+  sleep 0.5
+done
+
+echo "BOOT FAIL: no dashboard HTTP 200 on :$PORT within bound" >&2
+tail -20 "$LOG" >&2
+exit 1


### PR DESCRIPTION
## 摘要

依 2026-07-11 Batch 11 事故 retro（handoff step 3）新增 `scripts/boot-smoke.sh`：隔離 `CCXRAY_HOME`、有界（15s）啟動驗證，stdout 留 boot 訊號證據、exit code 為判定。runbook step 6 的隔離 smoke 從散文步驟變成可稽核的 script。

## Details

- Isolated `CCXRAY_HOME` (mktemp unless caller overrides), custom port (default 5642) — never touches real `~/.ccxray` or the hub port.
- Strips inherited `ANTHROPIC_BASE_URL`: a ccxray-proxied shell would otherwise trip the upstream-loop hard-fail (`42c80fb`) — the exact symptom behind the 7/11 "server won't start" incident report.
- Evidence contract: prints the `listening` line + `BOOT OK: dashboard HTTP 200`; exit 0/1.
- Fast-fails when the server process dies before answering (no 15s wait on a crashed boot).

## Verification

- PASS direction: clean tree → prints listening line, `BOOT OK`, exit 0.
- FAIL direction: stub tree whose `server/index.js` throws at startup → `BOOT FAIL`, log tail to stderr, exit 1 (immediate, via process-death break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)