### PR TITLE
fix: temporal overlap overrides authoritative agentKey in lane placement (#221 #222)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ docs/src/
 handoff.md
 .antigravitycli/
 .codex/
+
+# Visual-review acceptance reports (untracked evidence bundles, see ops runbook UI track)
+.visual-review/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ These constraints have guard comments at their mutation sites. Read the linked A
 - **agentKey main/subagent classification must gate on AGENT_KEY_UNRELIABLE** in both `entry-rendering.js` and `workflow-timeline.js` (`wfInferLanes`, `wfAddEntry`) — the two files must never disagree on the same turn — @docs/decisions/0005-agent-key-unreliable-shared-contract.md
 - **Lane-focus geometry must match what `_wfRenderSvgContent` actually draws** — `_wfTotalLanesHeight`, `_wfLaneIdxAtY`, and the label-click hit-test in `workflow-timeline.js` must all agree with it under `laneFocusMode` — @docs/decisions/0006-lane-focus-geometry-consistency.md
 - **Use `_wfIsMainLane(lane)` for main/orchestrator detection, never `!lane.spawnParent`** (`spawnParent` is always `null`, in every lane object, everywhere) — @docs/decisions/0007-wf-is-main-lane-not-spawn-parent.md
+- **Temporal overlap overrides agentKey for lane placement** — no lane may hold two temporally-overlapping turns; never exempt a turn from the overlap split because its agentKey looks authoritative (forks carry the parent's `orchestrator` key) — @docs/decisions/0008-temporal-overlap-overrides-agent-key.md
 
 ## Smoke Testing
 

--- a/docs/decisions/0008-temporal-overlap-overrides-agent-key.md
+++ b/docs/decisions/0008-temporal-overlap-overrides-agent-key.md
@@ -1,0 +1,78 @@
+# 0008 — Temporal overlap overrides agentKey for lane placement
+
+- Status: Accepted
+- Date: 2026-07-11
+- Related: #221 / #222 / Batch 11 redo (verification-failed evidence on both issues, 2026-07-11)
+
+## Context
+
+`agentKey` is extracted from system-prompt content (`extractAgentType`,
+server-side). It is authoritative about **what prompt an agent runs** — but
+not about **which agent instance sent the request**. A fork subagent
+inherits the parent's full system prompt, session_id, cwd, model, and
+conversation prefix, so its requests carry the parent's authoritative
+`orchestrator` agentKey on the wire. No request field distinguishes a fork
+from its parent (#222's core finding).
+
+The one signal that cannot lie is physics: two turns of the same session
+whose time ranges overlap cannot be one serial conversation — a client's
+main loop runs one request at a time, so genuine concurrency (two sockets
+open simultaneously) proves a parallel agent is in flight.
+
+Batch 11's first attempt (PR #225/#226, merged 2026-07-10) added exactly
+this temporal-overlap split, but **exempted turns with an authoritative
+agentKey** ("that server-side signal already resolved them definitively").
+Forks carry the authoritative `orchestrator` key, so the exemption excluded
+precisely the case the fix was written for. Owner acceptance failed;
+re-verification on main@9a784dd against real data found 547 overlapping
+turn pairs still rendered inside main lanes across 15 sessions (up to 8
+concurrent turns drawn as one serial lane).
+
+## Decision
+
+In lane placement, **physical overlap outranks agentKey**. Any turn whose
+start falls strictly inside the previous main-chain turn's `(start, end)`
+is moved to a parallel lane, regardless of its agentKey. `wfInferLanes`
+(batch) rebuilds main as a serial chain via a sorted sweep; overflow turns
+go to numbered parallel lanes (`parallel-<model>:<convId>`, `…#2`, `…#3`)
+by best-fit (latest-ending lane that stays serial), so a fork's own serial
+turns tend to reconstruct as one lane and lane count is bounded by the
+session's true max concurrency. `wfAddEntry` (live) mirrors this with the
+same predicate and best-fit selection.
+
+The overlap predicate — start **strictly** inside `(start, end)`; equal
+starts count as sequential — matches `entry-rendering.js`'s existing
+`_recentMainSpans` check, keeping the ADR 0005 contract (turn list and
+swimlane must not disagree) intact. ADR 0005's gate still governs where
+agentKey itself is trusted for main/subagent classification; this ADR adds
+that the overlap check sits **above** that signal and is never gated by it.
+
+## Consequences
+
+**Good**: no lane can contain two temporally-overlapping turns — a
+machine-checkable invariant (asserted in `test/workflow-timeline.test.js`)
+that cannot green-light the Batch 11 failure mode again. Real-data
+re-audit: 547 → 0 overlap findings.
+
+**Bad — identity remains inferred**: without a wire-level identity signal
+(#222's upstream ask), numbered parallel lanes are *concurrency tracks*,
+not verified per-instance identities. Interleaved fork/parent turns that
+never overlap are indistinguishable and stay in main; best-fit can in
+principle interleave two forks' turns across lanes. The invariant we
+guarantee is "no intra-lane overlap," not "one lane per fork."
+
+**Bad — hung-stream edge**: a stalled stream held open past its client's
+retry produces genuine socket concurrency for one logical agent; such a
+retry renders as a parallel lane. Accepted as rare and visually honest
+(two requests really were in flight).
+
+## Alternatives considered
+
+**Keep the exemption, special-case forks by fan-out signature (same convId
++ same msgCount + near-simultaneous starts)**: rejected — narrower, more
+parameters to tune, and misses parallel patterns that don't match the
+signature. Overlap is the strictly stronger signal.
+
+**One shared parallel lane per model+convId (the #226 shape)**: rejected —
+concurrent forks share model AND convId, so they pile into one lane that
+overlaps internally, recreating the bug one level down.

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -634,13 +634,18 @@ function wfRenderLaneSvg(lane, laneIdx, W, xFn) {
   // Label block: agent name / model·ctx window / sysprompt version chips
   var prefix = isSel ? '▶ ' : '';
   var ctxK = Math.round((lane.ctxWindow || 0) / 1000);
-  // Numbered parallel-lane instances (ADR 0008) share agentLabel AND convId
-  // (forks inherit both) — surface the #k ordinal so 7 fork lanes don't all
-  // read as the same "Orchestrator 5212".
+  // Parallel-lane instances (ADR 0008) share agentLabel AND convId (forks
+  // inherit both), so they'd all read as the same "Orchestrator 5212" —
+  // semantically wrong too: one session has one orchestrator. Label them
+  // "Fork <conv> #k" instead (owner decision, PR #232 acceptance).
   var laneOrd = /#(\d+)$/.exec(lane.key || '');
+  var isParallelLane = (lane.key || '').indexOf('parallel-') === 0;
   var dispName = lane.childSessionId
     ? (lane.agentLabel || wfShortModel(lane.model)) + ' ' + lane.childSessionId.slice(0, 8)
-    : (laneIdx === 0 ? lane.name : (lane.agentLabel || lane.name) + (lane.convId ? ' ' + lane.convId.slice(0, 4) : '') + (laneOrd ? ' #' + laneOrd[1] : ''));
+    : (laneIdx === 0 ? lane.name
+      : isParallelLane
+        ? 'Fork' + (lane.convId ? ' ' + lane.convId.slice(0, 4) : '') + ' #' + (laneOrd ? laneOrd[1] : '1')
+        : (lane.agentLabel || lane.name) + (lane.convId ? ' ' + lane.convId.slice(0, 4) : ''));
   var fullTitle = wfEsc(lane.name + ' · ' + (lane.agentLabel || '?') + ' · ' + (lane.model || '?') + ' · ' + ctxK + 'K');
   svg += '<text x="8" y="12" fill="var(--text)" style="font-size:11px;font-family:' + WF_MONO + '"><title>' + fullTitle + '</title>' + wfEsc(prefix + dispName) + '</text>';
   svg += wfGlyphSvg(wfLaneShape(lane), 14, 23, 6, wfLaneColor(lane));

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -273,31 +273,56 @@ function wfInferLanes(entries, childEntries) {
     }
   }
 
-  // Post-pass (#221): two turns in main whose time ranges overlap cannot be
-  // the same serial conversation — they must be parallel agents (e.g. a fork
-  // whose session_id matches the parent, so the agentKey signal above missed
-  // it). Split the later-starting one into its own sub-lane. Turns that
-  // reached main via an authoritative agentKey (WF_MAIN_AGENT_KEYS) are
-  // exempt — that server-side signal already resolved them definitively.
-  // INVARIANT: gate on AGENT_KEY_UNRELIABLE — see docs/decisions/0005-agent-key-unreliable-shared-contract.md
-  // Sort by receivedAt so the earliest-starting turn stays in main (codex R1:
+  // Post-pass (#221/#222): main must stay a serial chain — two turns whose
+  // time ranges overlap cannot be the same serial conversation, so the
+  // later-starting one is a parallel agent. Typically a fork, which inherits
+  // the parent's prompt and therefore carries the SAME authoritative
+  // 'orchestrator' agentKey — agentKey is authoritative about prompt
+  // content, NOT about instance identity, so it must never exempt a turn
+  // from this physical-overlap check (the Batch 11 merged-but-broken bug).
+  // INVARIANT: overlap overrides agentKey for lane placement — see
+  // docs/decisions/0008-temporal-overlap-overrides-agent-key.md
+  // Sort by receivedAt so the earliest-starting turn anchors main (codex R1:
   // entries arrive in completion order which may differ from start order).
+  // Overlap predicate matches entry-rendering.js (ADR 0005 alignment): a
+  // turn is parallel iff its start falls strictly inside the previous main
+  // turn's (start, end) — equal starts count as sequential.
   mainLane.turns.sort(function(a, b) { return (Number(a.receivedAt) || 0) - (Number(b.receivedAt) || 0); });
-  for (var oi = mainLane.turns.length - 1; oi >= 1; oi--) {
+  var serialTurns = [], overflowTurns = [];
+  for (var oi = 0; oi < mainLane.turns.length; oi++) {
     var cur = mainLane.turns[oi];
-    if (cur.agentKey && !AGENT_KEY_UNRELIABLE[cur.agentKey]) continue;
     var curStart = Number(cur.receivedAt) || 0;
-    if (!curStart) continue;
-    for (var oj = oi - 1; oj >= 0 && oj >= oi - 5; oj--) {
-      var prev = mainLane.turns[oj];
-      var prevStart = Number(prev.receivedAt) || 0;
-      var prevEnd = prevStart + (parseFloat(prev.elapsed) || 0) * 1000;
-      if (curStart < prevEnd && prevStart > 0) {
-        var olKey = _wfSubLaneKey('parallel-' + wfShortModel(cur.model), cur);
-        _wfPushToSubLane(laneMap, olKey, cur);
-        mainLane.turns.splice(oi, 1);
-        break;
+    var last = serialTurns[serialTurns.length - 1];
+    var lastStart = last ? (Number(last.receivedAt) || 0) : 0;
+    var lastEnd = last ? lastStart + (parseFloat(last.elapsed) || 0) * 1000 : 0;
+    if (curStart > lastStart && curStart < lastEnd) overflowTurns.push(cur);
+    else serialTurns.push(cur);
+  }
+  if (overflowTurns.length) {
+    mainLane.turns = serialTurns;
+    // Overflow turns go to numbered parallel lanes, best-fit: among lanes
+    // of the same base key (model+convId — forks share both), pick the one
+    // whose chain ends latest but still before this turn's start. Serial
+    // turns of the same fork tend to reconstruct as one lane; the numbered
+    // lanes bound out at the session's true max concurrency.
+    var pFamilies = new Map(); // baseKey → [{ key, lastEnd }]
+    for (var ov = 0; ov < overflowTurns.length; ov++) {
+      var oTurn = overflowTurns[ov];
+      var oStart = Number(oTurn.receivedAt) || 0;
+      var oEnd = oStart + (parseFloat(oTurn.elapsed) || 0) * 1000;
+      var baseKey = _wfSubLaneKey('parallel-' + wfShortModel(oTurn.model), oTurn);
+      var fam = pFamilies.get(baseKey);
+      if (!fam) { fam = []; pFamilies.set(baseKey, fam); }
+      var best = null;
+      for (var pi = 0; pi < fam.length; pi++) {
+        if (fam[pi].lastEnd <= oStart && (!best || fam[pi].lastEnd > best.lastEnd)) best = fam[pi];
       }
+      if (!best) {
+        best = { key: fam.length ? baseKey + '#' + (fam.length + 1) : baseKey, lastEnd: 0 };
+        fam.push(best);
+      }
+      best.lastEnd = Math.max(best.lastEnd, oEnd);
+      _wfPushToSubLane(laneMap, best.key, oTurn);
     }
   }
 
@@ -475,19 +500,26 @@ function wfAddEntry(entry) {
     needsSub = entry.isSubagent || (mainModel && entry.model !== mainModel);
     key = _wfSubLaneKey('subagent-' + wfShortModel(entry.model), entry);
   }
-  // INVARIANT: gate on AGENT_KEY_UNRELIABLE — see docs/decisions/0005-agent-key-unreliable-shared-contract.md
-  if (!needsSub && !(entry.agentKey && !AGENT_KEY_UNRELIABLE[entry.agentKey])) {
-    // Temporal overlap check (#221): if this entry's time range overlaps a
-    // recent main-lane turn, it must be a parallel agent (e.g. a fork
-    // sharing the parent's session_id) — split it to a sub-lane, mirroring
-    // the wfInferLanes post-pass. Entries with an authoritative agentKey
-    // already went through the WF_MAIN_AGENT_KEYS check above — exempt.
+  if (!needsSub) {
+    // Temporal overlap check (#221/#222): if this entry starts strictly
+    // inside a recent main-lane turn's time range, it must be a parallel
+    // agent (typically a fork sharing the parent's session_id AND its
+    // authoritative 'orchestrator' agentKey) — split it to a parallel lane,
+    // mirroring the wfInferLanes post-pass. agentKey never exempts a turn
+    // from this check: it's authoritative about prompt content, not about
+    // instance identity.
+    // INVARIANT: overlap overrides agentKey for lane placement — see
+    // docs/decisions/0008-temporal-overlap-overrides-agent-key.md
+    // Predicate matches entry-rendering.js (ADR 0005): strictly inside
+    // (start, end) — an entry that STARTED BEFORE the main turn (late
+    // arrival, completion order ≠ start order) stays in main; the batch
+    // rebuild's sorted sweep is the authoritative resolver for that case.
     var mainTurns = wfState.lanes[0]?.turns || [];
     for (var mi = mainTurns.length - 1; mi >= 0 && mi >= mainTurns.length - 5; mi--) {
       var mt = mainTurns[mi];
       var mtStart = Number(mt.receivedAt) || 0;
       var mtEnd = mtStart + (parseFloat(mt.elapsed) || 0) * 1000;
-      if (ts < mtEnd && mtStart > 0) {
+      if (mtStart > 0 && ts > mtStart && ts < mtEnd) {
         needsSub = true;
         key = _wfSubLaneKey('parallel-' + wfShortModel(entry.model), entry);
         break;
@@ -495,7 +527,24 @@ function wfAddEntry(entry) {
     }
   }
   if (needsSub) {
-    var lane = wfState.lanes.find(function(l) { return l.key === key; });
+    var lane;
+    if (key.indexOf('parallel-') === 0) {
+      // Best-fit among the numbered parallel lanes of this base key (forks
+      // share model+convId, so the key alone can't separate instances):
+      // reuse the lane whose chain ends latest but at/before this start;
+      // none fits → new numbered lane. Mirrors the wfInferLanes post-pass.
+      var famLanes = wfState.lanes.filter(function(l) {
+        return l.key === key || l.key.indexOf(key + '#') === 0;
+      });
+      var bestEnd = -1;
+      for (var fi = 0; fi < famLanes.length; fi++) {
+        var lt = famLanes[fi].turns[famLanes[fi].turns.length - 1];
+        var ltEnd = lt ? (Number(lt.receivedAt) || 0) + (parseFloat(lt.elapsed) || 0) * 1000 : 0;
+        if (ltEnd <= ts && ltEnd > bestEnd) { lane = famLanes[fi]; bestEnd = ltEnd; }
+      }
+      if (!lane && famLanes.length) key = key + '#' + (famLanes.length + 1);
+    }
+    if (!lane) lane = wfState.lanes.find(function(l) { return l.key === key; });
     if (!lane) {
       lane = { name: key, key: key, turns: [], model: entry.model, ctxWindow: entry.maxContext || 0, spawnParent: null, agentKey: entry.agentKey || null, agentLabel: entry.agentLabel || null, convId: entry.convId || null };
       wfState.lanes.push(lane);
@@ -585,9 +634,13 @@ function wfRenderLaneSvg(lane, laneIdx, W, xFn) {
   // Label block: agent name / model·ctx window / sysprompt version chips
   var prefix = isSel ? '▶ ' : '';
   var ctxK = Math.round((lane.ctxWindow || 0) / 1000);
+  // Numbered parallel-lane instances (ADR 0008) share agentLabel AND convId
+  // (forks inherit both) — surface the #k ordinal so 7 fork lanes don't all
+  // read as the same "Orchestrator 5212".
+  var laneOrd = /#(\d+)$/.exec(lane.key || '');
   var dispName = lane.childSessionId
     ? (lane.agentLabel || wfShortModel(lane.model)) + ' ' + lane.childSessionId.slice(0, 8)
-    : (laneIdx === 0 ? lane.name : (lane.agentLabel || lane.name) + (lane.convId ? ' ' + lane.convId.slice(0, 4) : ''));
+    : (laneIdx === 0 ? lane.name : (lane.agentLabel || lane.name) + (lane.convId ? ' ' + lane.convId.slice(0, 4) : '') + (laneOrd ? ' #' + laneOrd[1] : ''));
   var fullTitle = wfEsc(lane.name + ' · ' + (lane.agentLabel || '?') + ' · ' + (lane.model || '?') + ' · ' + ctxK + 'K');
   svg += '<text x="8" y="12" fill="var(--text)" style="font-size:11px;font-family:' + WF_MONO + '"><title>' + fullTitle + '</title>' + wfEsc(prefix + dispName) + '</text>';
   svg += wfGlyphSvg(wfLaneShape(lane), 14, 23, 6, wfLaneColor(lane));

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -120,9 +120,11 @@ describe('workflow-timeline data layer', () => {
       mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
       // model switch mid-session — must NOT leave the main lane
       mkEntry('t2', 's1', 'claude-fable-5', 6000, 3, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
-      // compact-style request: isSubagent flag but orchestrator prompt → main
-      mkEntry('t3', 's1', 'claude-fable-5', 8000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator', isSubagent: true }),
-      mkEntry('t4', 's1', 'claude-haiku-4-5', 9000, 2, { agentKey: 'explore', agentLabel: 'Explore', isSubagent: true }),
+      // compact-style request: isSubagent flag but orchestrator prompt → main.
+      // Starts after t2 ends (9000) — real compact requests are sequential;
+      // a genuinely overlapping start would now split per ADR 0008.
+      mkEntry('t3', 's1', 'claude-fable-5', 9500, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator', isSubagent: true }),
+      mkEntry('t4', 's1', 'claude-haiku-4-5', 12000, 2, { agentKey: 'explore', agentLabel: 'Explore', isSubagent: true }),
     ];
     var lanes = ctx.wfInferLanes(entries, []);
     assert.equal(lanes.length, 2);
@@ -342,7 +344,11 @@ describe('workflow-timeline data layer', () => {
     ctx.wfState = ctx.wfBuildState('s1');
     ctx.wfState.viewT0 = ctx.wfState.tMin;
     ctx.wfState.viewT1 = ctx.wfState.tMax;
-    const lane = ctx.wfState.lanes[0];
+    // Hand-built lane: since ADR 0008, temporally overlapping turns no longer
+    // share a lane, but bars can still overlap in PIXELS (min-width floor,
+    // equal starts) — this tests _wfNearestTurn's paint-order preference on
+    // overlapping pixel spans in isolation.
+    const lane = { turns: ctx.allEntries };
     const s1 = ctx._wfBarSpan(lane.turns[0]);
     const s2 = ctx._wfBarSpan(lane.turns[1]);
     const overlapMid = (s2.x0 + s1.x1) / 2;
@@ -1015,5 +1021,95 @@ describe('#222 temporal overlap does not false-positive on compaction or model s
     assert.equal(lanes[0].name, 'main');
     assert.equal(lanes[0].turns.length, 1);
     assert.equal(lanes[0].turns[0].id, 't1');
+  });
+});
+
+// ── #221/#222 redo: overlap overrides authoritative agentKey (ADR 0008) ─────
+// Fixture shape mirrors real fork traffic (e.g. session 86949194 on 2026-07-10):
+// forks inherit the parent's full prompt → agentKey 'orchestrator'
+// (authoritative main key), same convId, same model. The Batch 11 post-pass
+// exempted authoritative keys from the overlap split, so these stayed in main.
+describe('#221/#222 redo: overlap overrides authoritative agentKey (ADR 0008)', () => {
+  function mkFork(id, at, elapsed) {
+    return mkEntry(id, 's1', 'claude-opus-4-6', at, elapsed,
+      { agentKey: 'orchestrator', agentLabel: 'Orchestrator', convId: 'c0ffee' });
+  }
+  function assertNoIntraLaneOverlap(lanes) {
+    for (var li = 0; li < lanes.length; li++) {
+      var spans = lanes[li].turns.map(function(t) {
+        var s = Number(t.receivedAt) || 0;
+        return [s, s + (parseFloat(t.elapsed) || 0) * 1000];
+      }).sort(function(a, b) { return a[0] - b[0]; });
+      for (var i = 1; i < spans.length; i++) {
+        assert.ok(spans[i][0] >= spans[i - 1][1] || spans[i][0] === spans[i - 1][0],
+          'lane ' + lanes[li].key + ': turn @' + spans[i][0] + ' overlaps previous ending @' + spans[i - 1][1]);
+      }
+    }
+  }
+
+  it('fork with authoritative orchestrator agentKey is split out of main (fail-on-old)', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkFork('parent', 1000, 60),  // 1000..61000
+      mkFork('fork1', 11000, 55),  // starts strictly inside parent's span
+    ], []);
+    assert.equal(lanes.length, 2);
+    assert.equal(lanes[0].name, 'main');
+    assert.equal(lanes[0].turns.map(function(t) { return t.id; }).join(','), ['parent'].join(','));
+    assert.equal(lanes[1].turns[0].id, 'fork1');
+  });
+
+  it('fan-out: no lane holds overlapping turns; lane count bound at max concurrency', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkFork('parent', 1000, 60),
+      mkFork('f1', 11000, 50),
+      mkFork('f2', 13000, 55),
+      mkFork('f3', 15000, 52),
+    ], []);
+    assert.equal(lanes.length, 4); // main + 3 parallel instances
+    assertNoIntraLaneOverlap(lanes);
+    assert.equal(lanes[0].turns.map(function(t) { return t.id; }).join(','), ['parent'].join(','));
+  });
+
+  it("a fork's own serial turns reconstruct into one parallel lane (best-fit)", () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkFork('parent', 1000, 60),
+      mkFork('f1a', 11000, 10),  // 11000..21000
+      mkFork('f1b', 22000, 10),  // starts after f1a ends, still inside parent's span
+    ], []);
+    assert.equal(lanes.length, 2);
+    assert.equal(lanes[1].turns.map(function(t) { return t.id; }).join(','), ['f1a', 'f1b'].join(','));
+  });
+
+  it('live path (wfAddEntry) splits authoritative-key forks and best-fits instances', () => {
+    const ctx = loadWfModule();
+    ctx.allEntries = [mkFork('parent', 1000, 60)];
+    ctx.wfState = ctx.wfBuildState('s1');
+    ctx.wfAddEntry(mkFork('f1', 11000, 10));   // → first parallel lane
+    ctx.wfAddEntry(mkFork('f2', 13000, 10));   // overlaps f1 → second parallel lane
+    ctx.wfAddEntry(mkFork('f1b', 22000, 10));  // fits after f1 → back into first lane
+    assert.equal(ctx.wfState.lanes.length, 3);
+    assertNoIntraLaneOverlap(ctx.wfState.lanes);
+    assert.equal(ctx.wfState.lanes[0].turns.map(function(t) { return t.id; }).join(','), ['parent'].join(','));
+    assert.equal(ctx.wfState.lanes[1].turns.map(function(t) { return t.id; }).join(','), ['f1', 'f1b'].join(','));
+    assert.equal(ctx.wfState.lanes[2].turns.map(function(t) { return t.id; }).join(','), ['f2'].join(','));
+  });
+
+  it('equal receivedAt stays sequential in main (entry-rendering predicate alignment)', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([mkFork('t1', 1000, 5), mkFork('t2', 1000, 3)], []);
+    assert.equal(lanes.length, 1);
+    assert.equal(lanes[0].turns.length, 2);
+  });
+
+  it('serial orchestrator turns never split (no false positives)', () => {
+    const ctx = loadWfModule();
+    var entries = [];
+    for (var i = 0; i < 6; i++) entries.push(mkFork('t' + i, 1000 + i * 10000, 8));
+    var lanes = ctx.wfInferLanes(entries, []);
+    assert.equal(lanes.length, 1);
+    assert.equal(lanes[0].turns.length, 6);
   });
 });


### PR DESCRIPTION
## 摘要

Batch 11 重做（UI 分軌路徑）。前次修復（PR #226）的 temporal-overlap 拆分豁免了帶 authoritative agentKey 的 turn——但 fork 繼承 parent prompt、agentKey 恰為 `orchestrator`（authoritative），豁免正好排除了修復目標本身。驗收失敗證據見 #221/#222 的 verification-failed comment（main@9a784dd、15 sessions、547 組 main-lane 內重疊、最高 8 併發畫成同一條 serial lane）。

本 PR：lane placement 中**物理重疊優先於 agentKey**——main 重建為 serial chain，重疊 turn 以 best-fit 溢流到編號 parallel lane（`…#2`、`…#3`），lane 數以 session 真實最大併發為上界。新 invariant（ADR 0008）：任何 lane 內不得有兩個時間重疊的 turn。

## Details

- `wfInferLanes` (batch): sorted sweep rebuilds main as a serial chain; overflow turns go to numbered parallel lanes by best-fit (latest-ending lane that stays serial), so one fork's serial turns tend to reconstruct as a single lane.
- `wfAddEntry` (live): same predicate + best-fit instance selection, mirroring batch.
- Overlap predicate = start strictly inside previous main turn's (start, end) — matches `entry-rendering.js`'s `_recentMainSpans` check exactly (ADR 0005 alignment preserved; equal starts remain sequential).
- Lane labels surface the `#k` ordinal so N fork lanes don't all render as the same "Orchestrator 5212".
- New ADR: `docs/decisions/0008-temporal-overlap-overrides-agent-key.md` + CLAUDE.md invariant row + INVARIANT guard comments at both sites.
- `.gitignore` += `.visual-review/` (untracked acceptance-report bundles, ops runbook UI-track rule 3).

## Evidence（機器已驗）

| Gate | 指令 | 結果 |
|---|---|---|
| diff-check（fail-on-old） | `scripts/diff-check.sh origin/main test/workflow-timeline.test.js -- node --test test/workflow-timeline.test.js` | `exit 0`（舊碼 4 fail / 新碼全過） |
| 全套測試 | `perl -e 'alarm ...' 300 sh -c 'node --test test/*.test.js'`（空 `CCXRAY_HOME`） | 1205/1205 pass |
| 真實資料 re-audit | vm harness 餵 5000 真實 entries 進 `wfInferLanes`（隔離 `CCXRAY_HOME` 復原） | main-lane 重疊 547 → **0**（15 sessions 全乾淨） |
| 隔離 boot smoke | `scripts/boot-smoke.sh 5648`（worktree build，PR #231 的 script） | `exit 0`，`BOOT OK: dashboard HTTP 200` |

Fixture 修正兩處既有測試：一處 compact fixture 誤造了時間重疊（真實 compact 是 sequential，時間戳改為不重疊）；一處 `_wfNearestTurn` SVG paint-order 測試改為手建 lane（時間重疊的 turn 依新 invariant 不再同 lane；該測試驗的是像素層疊，與時間無關）。

## 視覺證據（截圖見下方 comment；本機驗收報告 `$WT/.visual-review/<pr>/index.html`）

- Session `86949194`（fork fan-out、max 8 併發）：before 單一 main lane 吞 128 turns → after main 78 turns + `Orchestrator 5212` + `#2..#7` 七條編號 lane。
- Session `f06c8b58`（#221 自己引用的證據 session）：before 2 lanes → after 9 lanes，4 個曾隱形的 Agent subagent（fc73/6988/dd2a/28ce）各佔一條。
- hover / click-lock / lane-focus 在新 lane 幾何上均正常（ADR 0006）。

## 沒驗什麼（誠實邊界）

- 互動程式碼路徑（hover/lock/focus handler）本 PR 未改動，僅驗證其在新 lane 組成下行為正常——未附操作錄影，附三態截圖。
- Fork 身分仍是推斷：編號 lane 是「併發軌」，非經 wire 驗證的 per-instance 身分（#222 的 upstream ask 仍 open）。永不重疊的 sequential fork 依然留在 main（無訊號可辨）。
- Hung-stream + client retry 的罕見邊緣會被畫成 parallel lane（兩個 request 確實同時在飛，視覺上誠實）。

Closes #221. Closes #229 (same root cause, independently diagnosed — supersedes the partial fix/229-overlap-exemption branch: exemption removal alone piles concurrent forks into ONE shared parallel lane that still overlaps internally; this PR adds numbered best-fit partitioning). Refs #222, #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
