### PR TITLE
chore: add scripts/stable-server.sh — guarded swap for the pinned monitoring server

### DIFF
--- a/scripts/stable-server.sh
+++ b/scripts/stable-server.sh
@@ -30,28 +30,38 @@ while [[ $# -gt 0 ]]; do
 done
 [[ -n "$WORKTREE" && -n "$REF" && -n "$ROLLBACK" ]] || { echo "need --worktree --ref --rollback-ref" >&2; exit 3; }
 [[ -d "$WORKTREE" ]] || { echo "worktree not found: $WORKTREE" >&2; exit 3; }
-WORKTREE_ABS="$(cd "$WORKTREE" && pwd)"
+# pwd -P resolves symlinks (/tmp → /private/tmp on macOS)
+WORKTREE_ABS="$(cd "$WORKTREE" && pwd -P)"
 
 LOG="${HOME}/.ccxray/stable-server.log"
 LOCKDIR="${HOME}/.ccxray/stable-server.lock"
 say() { echo "[stable-server] $*"; }
 
+# ── canonicalization ──────────────────────────────────────────────────────
+# Portable realpath: resolve symlinks via cd+pwd -P.
+canon() { (cd "$(dirname "$1")" 2>/dev/null && echo "$(pwd -P)/$(basename "$1")") || echo "$1"; }
+
 # ── serialisation ─────────────────────────────────────────────────────────
-# Prevent concurrent swaps on the same port. mkdir is atomic on all platforms.
 mkdir "$LOCKDIR" 2>/dev/null || { echo "another stable-server is running (lock: $LOCKDIR)" >&2; exit 3; }
 trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
 
 # ── identity helpers ──────────────────────────────────────────────────────
-# is_ccxray_on_port PID — true when PID is a node server/index.js whose cwd
-# is inside WORKTREE_ABS.  Prevents killing unrelated listeners on the port.
-is_ccxray_on_port() {
+# is_ccxray_process PID — true when PID is a `node .../server/index.js`
+# whose cwd is exactly WORKTREE_ABS (not a prefix/sibling).
+is_ccxray_process() {
   local pid="$1"
   local cmd
   cmd=$(ps -o command= -p "$pid" 2>/dev/null) || return 1
+  # argv must be: node ... server/index.js (reject arbitrary commands
+  # that happen to contain the substring)
+  [[ "$cmd" =~ ^node[[:space:]] ]] || return 1
   [[ "$cmd" == *server/index.js* ]] || return 1
   local cwd
   cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | grep '^n' | head -1 | cut -c2-)
-  [[ "$cwd" == "$WORKTREE_ABS"* ]] || return 1
+  [[ -z "$cwd" ]] && return 1
+  # Canonicalize lsof path (macOS: /private/tmp vs /tmp)
+  cwd="$(canon "$cwd")"
+  [[ "$cwd" == "$WORKTREE_ABS" ]] || return 1
   return 0
 }
 
@@ -68,17 +78,16 @@ CUR=$(git -C "$WORKTREE" rev-parse HEAD)
 
 health() { [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:$PORT/" 2>/dev/null)" = "200" ]; }
 
-# Idempotence: already at target and serving → done.
+# Idempotence: already at target, serving, AND the listener is our ccxray → done.
 if [[ "$CUR" == "$TARGET" ]] && health; then
-  say "already at $(git -C "$WORKTREE" rev-parse --short "$TARGET") and healthy on :$PORT"
-  exit 0
+  LP=$(listener_pid)
+  if [[ -n "$LP" ]] && is_ccxray_process "$LP"; then
+    say "already at $(git -C "$WORKTREE" rev-parse --short "$TARGET") and healthy on :$PORT (pid $LP)"
+    exit 0
+  fi
 fi
 
 # ── idle check (skippable with --force) ───────────────────────────────────
-# Approximation: last completed entry within IDLE_MIN minutes = sessions are
-# active. In-flight requests that started AFTER a quiet period are invisible
-# to this check (entries record on completion) — hence supervised first runs
-# and --force being explicit. ponytail: refine only if false swaps happen.
 if [[ "$FORCE" -ne 1 ]] && health; then
   LAST_MS=$(curl -s --max-time 5 "http://127.0.0.1:$PORT/_api/entries" 2>/dev/null \
     | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const es=JSON.parse(d).entries;const last=es[es.length-1];console.log(last?Math.round(Number(last.receivedAt)+(parseFloat(last.elapsed)||0)*1000):0)}catch(e){console.log(0)}})")
@@ -90,33 +99,51 @@ if [[ "$FORCE" -ne 1 ]] && health; then
   fi
 fi
 
-# ── pin + install + side-port verification (live server untouched so far) ─
-pin_and_verify() { # $1 = commit
-  git -C "$WORKTREE" checkout --detach --quiet "$1" || return 1
-  local PREV="$CUR"
-  if ! git -C "$WORKTREE" diff --quiet "$PREV" "$1" -- package-lock.json 2>/dev/null; then
-    say "package-lock changed — npm ci"
-    (cd "$WORKTREE" && npm ci --silent) || return 1
+# ── checked pin + deps restore ────────────────────────────────────────────
+# restore_pin COMMIT FROM — checked checkout + conditional npm ci.
+# Used for: target pin, side-smoke failure restore, and rollback.
+restore_pin() {
+  local to="$1" from="$2"
+  if ! git -C "$WORKTREE" checkout --detach --quiet "$to"; then
+    say "ERROR: checkout $to failed"
+    return 1
   fi
+  if ! git -C "$WORKTREE" diff --quiet "$from" "$to" -- package-lock.json 2>/dev/null; then
+    say "package-lock changed ($from → $to) — npm ci"
+    if ! (cd "$WORKTREE" && npm ci --silent); then
+      say "ERROR: npm ci failed for $to"
+      return 1
+    fi
+  fi
+  return 0
+}
+
+# ── side-port verification (live server untouched) ────────────────────────
+side_verify() { # $1 = commit
+  restore_pin "$1" "$CUR" || return 1
   local SIDE=$(( PORT + 71 ))
   if [[ -x "$WORKTREE/scripts/boot-smoke.sh" ]]; then
     "$WORKTREE/scripts/boot-smoke.sh" "$SIDE" || return 1
   else
-    # ref predates boot-smoke.sh — inline minimal check (mirrors boot-smoke.sh contract)
-    local SMOKE_HOME
+    # ref predates boot-smoke.sh — inline minimal check (mirrors contract)
+    local SMOKE_HOME SMOKE_LOG BP
     SMOKE_HOME="$(mktemp -d)"
-    local SMOKE_LOG
     SMOKE_LOG="$(mktemp)"
+    local _smoke_cleanup_done=0
+    _smoke_cleanup() {
+      [[ "$_smoke_cleanup_done" -eq 1 ]] && return; _smoke_cleanup_done=1
+      kill "$BP" 2>/dev/null; wait "$BP" 2>/dev/null
+      rm -rf "$SMOKE_HOME" "$SMOKE_LOG"
+    }
+    trap '_smoke_cleanup' RETURN INT TERM
     env -u ANTHROPIC_BASE_URL CCXRAY_HOME="$SMOKE_HOME" PROXY_PORT="$SIDE" \
-      node "$WORKTREE/server/index.js" >"$SMOKE_LOG" 2>&1 & local BP=$!
-    trap 'kill "$BP" 2>/dev/null; wait "$BP" 2>/dev/null; rm -rf "$SMOKE_HOME" "$SMOKE_LOG"' RETURN
+      node "$WORKTREE/server/index.js" >"$SMOKE_LOG" 2>&1 & BP=$!
     local ok=1
     for _ in $(seq 1 30); do
       if [ "$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$SIDE/" 2>/dev/null)" = "200" ]; then
-        # Verify the 200 came from our spawned process, not a stale listener
-        local side_listener
-        side_listener=$(lsof -nP -iTCP:"$SIDE" -sTCP:LISTEN -t 2>/dev/null | head -1)
-        if [[ "$side_listener" == "$BP" ]]; then
+        local side_lp
+        side_lp=$(lsof -nP -iTCP:"$SIDE" -sTCP:LISTEN -t 2>/dev/null | head -1)
+        if [[ "$side_lp" == "$BP" ]]; then
           grep -m1 "listening" "$SMOKE_LOG" || true
           say "BOOT OK: dashboard HTTP 200 on :$SIDE (pid $BP)"
           ok=0; break
@@ -125,20 +152,19 @@ pin_and_verify() { # $1 = commit
       kill -0 "$BP" 2>/dev/null || break
       sleep 0.5
     done
-    kill "$BP" 2>/dev/null; wait "$BP" 2>/dev/null
-    rm -rf "$SMOKE_HOME" "$SMOKE_LOG"
-    trap - RETURN
     if [[ "$ok" -ne 0 ]]; then
       say "BOOT FAIL: no dashboard HTTP 200 on :$SIDE within bound"
+      tail -20 "$SMOKE_LOG" >&2
     fi
+    _smoke_cleanup
+    trap - RETURN INT TERM
     return $ok
   fi
 }
 
 # ── swap with identity verification ───────────────────────────────────────
-swap_to() { # $1 = commit (used for checkout before launch)
+swap_to() { # $1 = commit
   local commit="$1"
-  # Ensure worktree is at the requested commit
   local head_now
   head_now=$(git -C "$WORKTREE" rev-parse HEAD)
   if [[ "$head_now" != "$(git -C "$WORKTREE" rev-parse --verify "$commit^{commit}" 2>/dev/null)" ]]; then
@@ -148,11 +174,11 @@ swap_to() { # $1 = commit (used for checkout before launch)
   local OLD_PID
   OLD_PID=$(listener_pid)
   if [[ -n "$OLD_PID" ]]; then
-    if ! is_ccxray_on_port "$OLD_PID"; then
+    if ! is_ccxray_process "$OLD_PID"; then
       say "ERROR: pid $OLD_PID on :$PORT is NOT a ccxray process in $WORKTREE_ABS — refusing to kill"
       return 1
     fi
-    kill "$OLD_PID" 2>/dev/null   # SIGTERM → gracefulExit drains writes (≤5s)
+    kill "$OLD_PID" 2>/dev/null
     for _ in $(seq 1 20); do
       kill -0 "$OLD_PID" 2>/dev/null || break
       sleep 0.5
@@ -161,7 +187,6 @@ swap_to() { # $1 = commit (used for checkout before launch)
       say "ERROR: old listener (pid $OLD_PID) did not exit within 10s"
       return 1
     fi
-    # Verify port actually released (another process could have grabbed it)
     local stale
     stale=$(listener_pid)
     if [[ -n "$stale" ]]; then
@@ -170,20 +195,16 @@ swap_to() { # $1 = commit (used for checkout before launch)
     fi
   fi
 
-  ( cd "$WORKTREE" && env -u ANTHROPIC_BASE_URL PROXY_PORT="$PORT" \
-      nohup node server/index.js >> "$LOG" 2>&1 & echo $! > /tmp/.ccxray-swap-pid-$PORT ) </dev/null
-  local NEW_PID
-  NEW_PID=$(cat /tmp/.ccxray-swap-pid-$PORT 2>/dev/null)
-  rm -f /tmp/.ccxray-swap-pid-$PORT
-
-  if [[ -z "$NEW_PID" ]]; then
-    say "ERROR: failed to capture new server PID"
-    return 1
-  fi
+  # Launch node directly: exec inside subshell replaces the subshell with
+  # the node process, so $! == the actual listener PID (no wrapper layer).
+  # trap '' HUP replaces nohup; </dev/null detaches stdin.
+  (cd "$WORKTREE" && trap '' HUP && exec env -u ANTHROPIC_BASE_URL PROXY_PORT="$PORT" \
+    node server/index.js >> "$LOG" 2>&1) </dev/null &
+  local NEW_PID=$!
+  disown "$NEW_PID" 2>/dev/null
 
   for _ in $(seq 1 30); do
     if health; then
-      # Verify the listener is our new process
       local live_pid
       live_pid=$(listener_pid)
       if [[ "$live_pid" == "$NEW_PID" ]]; then
@@ -199,9 +220,11 @@ swap_to() { # $1 = commit (used for checkout before launch)
 }
 
 say "verifying $(git -C "$WORKTREE" rev-parse --short "$TARGET") on side port before touching :$PORT"
-if ! pin_and_verify "$TARGET"; then
-  say "side-port verification FAILED — restoring pin, live server untouched"
-  git -C "$WORKTREE" checkout --detach --quiet "$CUR"
+if ! side_verify "$TARGET"; then
+  say "side-port verification FAILED — restoring pin+deps, live server untouched"
+  restore_pin "$CUR" "$TARGET" || {
+    say "WARNING: could not restore worktree to $CUR — manually: git -C $WORKTREE checkout --detach $CUR && (cd $WORKTREE && npm ci)"
+  }
   exit 1
 fi
 
@@ -214,21 +237,10 @@ fi
 # ── rollback ──────────────────────────────────────────────────────────────
 say "swap FAILED — rolling back to $(git -C "$WORKTREE" rev-parse --short "$ROLLBACK")"
 
-# Checkout rollback ref — must succeed or we're in manual-recovery territory
-if ! git -C "$WORKTREE" checkout --detach --quiet "$ROLLBACK"; then
-  echo "[stable-server] FATAL: rollback checkout failed — :$PORT may be DOWN." >&2
+if ! restore_pin "$ROLLBACK" "$TARGET"; then
+  echo "[stable-server] FATAL: rollback pin+deps failed — :$PORT may be DOWN." >&2
   echo "  manual recovery: (cd $WORKTREE && git checkout --detach $ROLLBACK && npm ci --silent && env -u ANTHROPIC_BASE_URL PROXY_PORT=$PORT nohup node server/index.js >> $LOG 2>&1 &)" >&2
   exit 2
-fi
-
-# Restore dependencies if rollback ref has different package-lock
-if ! git -C "$WORKTREE" diff --quiet "$TARGET" "$ROLLBACK" -- package-lock.json 2>/dev/null; then
-  say "rollback: package-lock differs — npm ci"
-  (cd "$WORKTREE" && npm ci --silent) || {
-    echo "[stable-server] FATAL: rollback npm ci failed — :$PORT may be DOWN." >&2
-    echo "  manual recovery: (cd $WORKTREE && npm ci && env -u ANTHROPIC_BASE_URL PROXY_PORT=$PORT nohup node server/index.js >> $LOG 2>&1 &)" >&2
-    exit 2
-  }
 fi
 
 if swap_to "$ROLLBACK"; then

--- a/scripts/stable-server.sh
+++ b/scripts/stable-server.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Stable monitoring-server swap: pin a worktree to a merged ref, verify it
+# boots on a side port, then gracefully swap the live server — with automatic
+# rollback to --rollback-ref if the new pin fails to serve.
+#
+# Single invocation contains verify → swap → post-check → rollback, so the
+# operator (or an agent whose own traffic rides this proxy) never has to make
+# a mid-flight decision. Idempotent: already-at-ref + healthy → exit 0.
+#
+# Usage:
+#   scripts/stable-server.sh --worktree <path> --ref <sha|origin/main> \
+#       --rollback-ref <sha> [--port 5577] [--idle-min 3] [--force]
+#
+# Exit: 0 = serving requested ref   1 = swap failed, ROLLED BACK OK
+#       2 = swap AND rollback failed (server down — see recovery line)
+#       3 = precondition/usage error (nothing touched)
+set -u
+
+WORKTREE="" REF="" ROLLBACK="" PORT=5577 IDLE_MIN=3 FORCE=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --worktree) WORKTREE="$2"; shift 2 ;;
+    --ref) REF="$2"; shift 2 ;;
+    --rollback-ref) ROLLBACK="$2"; shift 2 ;;
+    --port) PORT="$2"; shift 2 ;;
+    --idle-min) IDLE_MIN="$2"; shift 2 ;;
+    --force) FORCE=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 3 ;;
+  esac
+done
+[[ -n "$WORKTREE" && -n "$REF" && -n "$ROLLBACK" ]] || { echo "need --worktree --ref --rollback-ref" >&2; exit 3; }
+[[ -d "$WORKTREE" ]] || { echo "worktree not found: $WORKTREE" >&2; exit 3; }
+
+LOG="${HOME}/.ccxray/stable-server.log"
+say() { echo "[stable-server] $*"; }
+
+# ── preconditions ──────────────────────────────────────────────────────────
+git -C "$WORKTREE" diff --quiet && git -C "$WORKTREE" diff --cached --quiet \
+  || { echo "worktree dirty — refusing to move pin: $WORKTREE" >&2; exit 3; }
+git -C "$WORKTREE" fetch origin --quiet || { echo "git fetch failed" >&2; exit 3; }
+TARGET=$(git -C "$WORKTREE" rev-parse --verify "$REF^{commit}" 2>/dev/null) || { echo "bad --ref: $REF" >&2; exit 3; }
+git -C "$WORKTREE" rev-parse --verify "$ROLLBACK^{commit}" >/dev/null 2>&1 || { echo "bad --rollback-ref: $ROLLBACK" >&2; exit 3; }
+CUR=$(git -C "$WORKTREE" rev-parse HEAD)
+
+health() { [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:$PORT/" 2>/dev/null)" = "200" ]; }
+
+# Idempotence: already at target and serving → done.
+if [[ "$CUR" == "$TARGET" ]] && health; then
+  say "already at $(git -C "$WORKTREE" rev-parse --short "$TARGET") and healthy on :$PORT"
+  exit 0
+fi
+
+# ── idle check (skippable with --force) ────────────────────────────────────
+# Approximation: last completed entry within IDLE_MIN minutes = sessions are
+# active. In-flight requests that started AFTER a quiet period are invisible
+# to this check (entries record on completion) — hence supervised first runs
+# and --force being explicit. ponytail: refine only if false swaps happen.
+if [[ "$FORCE" -ne 1 ]] && health; then
+  LAST_MS=$(curl -s --max-time 5 "http://127.0.0.1:$PORT/_api/entries" 2>/dev/null \
+    | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const es=JSON.parse(d).entries;const last=es[es.length-1];console.log(last?Math.round(Number(last.receivedAt)+(parseFloat(last.elapsed)||0)*1000):0)}catch(e){console.log(0)}})")
+  NOW_MS=$(node -e 'console.log(Date.now())')
+  AGE_MIN=$(( (NOW_MS - LAST_MS) / 60000 ))
+  if [[ "$LAST_MS" -gt 0 && "$AGE_MIN" -lt "$IDLE_MIN" ]]; then
+    echo "not idle: last activity ${AGE_MIN}m ago (< ${IDLE_MIN}m). Re-run with --force to swap anyway." >&2
+    exit 3
+  fi
+fi
+
+# ── pin + install + side-port verification (live server untouched so far) ──
+pin_and_verify() { # $1 = commit
+  git -C "$WORKTREE" checkout --detach --quiet "$1" || return 1
+  if ! git -C "$WORKTREE" diff --quiet "$CUR" "$1" -- package-lock.json 2>/dev/null; then
+    say "package-lock changed — npm ci"
+    (cd "$WORKTREE" && npm ci --silent) || return 1
+  fi
+  local SIDE=$(( PORT + 71 ))
+  if [[ -x "$WORKTREE/scripts/boot-smoke.sh" ]]; then
+    "$WORKTREE/scripts/boot-smoke.sh" "$SIDE" || return 1
+  else
+    # ref predates boot-smoke.sh — inline minimal check
+    env -u ANTHROPIC_BASE_URL CCXRAY_HOME="$(mktemp -d)" PROXY_PORT="$SIDE" \
+      node "$WORKTREE/server/index.js" >/dev/null 2>&1 & local BP=$!
+    local ok=1
+    for _ in $(seq 1 30); do
+      [ "$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$SIDE/" 2>/dev/null)" = "200" ] && { ok=0; break; }
+      kill -0 "$BP" 2>/dev/null || break; sleep 0.5
+    done
+    kill "$BP" 2>/dev/null; wait "$BP" 2>/dev/null
+    return $ok
+  fi
+}
+
+swap_to() { # $1 = commit; returns 0 when :PORT serves 200 from $WORKTREE
+  local OLD_PID
+  OLD_PID=$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | head -1)
+  if [[ -n "$OLD_PID" ]]; then
+    kill "$OLD_PID" 2>/dev/null   # SIGTERM → gracefulExit drains writes (≤5s)
+    for _ in $(seq 1 20); do lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1 || break; sleep 0.5; done
+  fi
+  ( cd "$WORKTREE" && env -u ANTHROPIC_BASE_URL PROXY_PORT="$PORT" \
+      nohup node server/index.js >> "$LOG" 2>&1 & ) </dev/null
+  for _ in $(seq 1 30); do health && return 0; sleep 0.5; done
+  return 1
+}
+
+say "verifying $(git -C "$WORKTREE" rev-parse --short "$TARGET") on side port before touching :$PORT"
+if ! pin_and_verify "$TARGET"; then
+  say "side-port verification FAILED — restoring pin, live server untouched"
+  git -C "$WORKTREE" checkout --detach --quiet "$CUR"
+  exit 1
+fi
+
+say "swapping :$PORT to $(git -C "$WORKTREE" rev-parse --short "$TARGET")"
+if swap_to "$TARGET"; then
+  say "OK — :$PORT serving $(git -C "$WORKTREE" rev-parse --short HEAD) (log: $LOG)"
+  exit 0
+fi
+
+say "swap FAILED — rolling back to $(git -C "$WORKTREE" rev-parse --short "$ROLLBACK")"
+git -C "$WORKTREE" checkout --detach --quiet "$ROLLBACK"
+if swap_to "$ROLLBACK"; then
+  say "rolled back — :$PORT serving $(git -C "$WORKTREE" rev-parse --short HEAD)"
+  exit 1
+fi
+
+echo "[stable-server] FATAL: rollback also failed — :$PORT is DOWN." >&2
+echo "  manual recovery: (cd $WORKTREE && git checkout --detach $ROLLBACK && PROXY_PORT=$PORT nohup node server/index.js >> $LOG 2>&1 &)" >&2
+exit 2

--- a/scripts/stable-server.sh
+++ b/scripts/stable-server.sh
@@ -12,7 +12,7 @@
 #       --rollback-ref <sha> [--port 5577] [--idle-min 3] [--force]
 #
 # Exit: 0 = serving requested ref   1 = swap failed, ROLLED BACK OK
-#       2 = swap AND rollback failed (server down — see recovery line)
+#       2 = auto-recovery failed (worktree or server may need manual fix)
 #       3 = precondition/usage error (nothing touched)
 set -u
 
@@ -30,7 +30,6 @@ while [[ $# -gt 0 ]]; do
 done
 [[ -n "$WORKTREE" && -n "$REF" && -n "$ROLLBACK" ]] || { echo "need --worktree --ref --rollback-ref" >&2; exit 3; }
 [[ -d "$WORKTREE" ]] || { echo "worktree not found: $WORKTREE" >&2; exit 3; }
-# pwd -P resolves symlinks (/tmp → /private/tmp on macOS)
 WORKTREE_ABS="$(cd "$WORKTREE" && pwd -P)"
 
 LOG="${HOME}/.ccxray/stable-server.log"
@@ -38,7 +37,6 @@ LOCKDIR="${HOME}/.ccxray/stable-server.lock"
 say() { echo "[stable-server] $*"; }
 
 # ── canonicalization ──────────────────────────────────────────────────────
-# Portable realpath: resolve symlinks via cd+pwd -P.
 canon() { (cd "$(dirname "$1")" 2>/dev/null && echo "$(pwd -P)/$(basename "$1")") || echo "$1"; }
 
 # ── serialisation ─────────────────────────────────────────────────────────
@@ -46,26 +44,31 @@ mkdir "$LOCKDIR" 2>/dev/null || { echo "another stable-server is running (lock: 
 trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
 
 # ── identity helpers ──────────────────────────────────────────────────────
-# is_ccxray_process PID — true when PID is a `node .../server/index.js`
-# whose cwd is exactly WORKTREE_ABS (not a prefix/sibling).
+# is_ccxray_process PID — true when PID is `node server/index.js` (argv[0]
+# ends with /node or is literally "node", argv[1] is exactly
+# "server/index.js") and its cwd is exactly WORKTREE_ABS.
 is_ccxray_process() {
   local pid="$1"
   local cmd
   cmd=$(ps -o command= -p "$pid" 2>/dev/null) || return 1
-  # argv must be: node ... server/index.js (reject arbitrary commands
-  # that happen to contain the substring)
-  [[ "$cmd" =~ ^node[[:space:]] ]] || return 1
-  [[ "$cmd" == *server/index.js* ]] || return 1
+  # Parse argv tokens: $1=executable, $2=script.  A flag before the script
+  # (e.g. node -e "..." server/index.js) makes $2="-e", not the script.
+  local exe script
+  exe=$(awk '{print $1}' <<< "$cmd")
+  script=$(awk '{print $2}' <<< "$cmd")
+  [[ "$(basename "$exe")" == "node" ]] || return 1
+  [[ "$script" == "server/index.js" ]] || return 1
+  # Verify the script file exists at the expected path
+  [[ -f "$WORKTREE_ABS/server/index.js" ]] || return 1
+  # Verify cwd is exactly the worktree (canonicalized)
   local cwd
   cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | grep '^n' | head -1 | cut -c2-)
   [[ -z "$cwd" ]] && return 1
-  # Canonicalize lsof path (macOS: /private/tmp vs /tmp)
   cwd="$(canon "$cwd")"
   [[ "$cwd" == "$WORKTREE_ABS" ]] || return 1
   return 0
 }
 
-# listener_pid — PID of the TCP LISTEN-er on PORT, or empty string.
 listener_pid() { lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | head -1; }
 
 # ── preconditions ─────────────────────────────────────────────────────────
@@ -78,7 +81,7 @@ CUR=$(git -C "$WORKTREE" rev-parse HEAD)
 
 health() { [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:$PORT/" 2>/dev/null)" = "200" ]; }
 
-# Idempotence: already at target, serving, AND the listener is our ccxray → done.
+# Idempotence: already at target, serving, AND listener is our ccxray → done.
 if [[ "$CUR" == "$TARGET" ]] && health; then
   LP=$(listener_pid)
   if [[ -n "$LP" ]] && is_ccxray_process "$LP"; then
@@ -100,8 +103,6 @@ if [[ "$FORCE" -ne 1 ]] && health; then
 fi
 
 # ── checked pin + deps restore ────────────────────────────────────────────
-# restore_pin COMMIT FROM — checked checkout + conditional npm ci.
-# Used for: target pin, side-smoke failure restore, and rollback.
 restore_pin() {
   local to="$1" from="$2"
   if ! git -C "$WORKTREE" checkout --detach --quiet "$to"; then
@@ -119,14 +120,13 @@ restore_pin() {
 }
 
 # ── side-port verification (live server untouched) ────────────────────────
-side_verify() { # $1 = commit
+side_verify() {
   restore_pin "$1" "$CUR" || return 1
   local SIDE=$(( PORT + 71 ))
   if [[ -x "$WORKTREE/scripts/boot-smoke.sh" ]]; then
     "$WORKTREE/scripts/boot-smoke.sh" "$SIDE" || return 1
   else
-    # ref predates boot-smoke.sh — inline minimal check (mirrors contract)
-    local SMOKE_HOME SMOKE_LOG BP
+    local SMOKE_HOME SMOKE_LOG BP _smoke_trapped_sig=""
     SMOKE_HOME="$(mktemp -d)"
     SMOKE_LOG="$(mktemp)"
     local _smoke_cleanup_done=0
@@ -135,9 +135,18 @@ side_verify() { # $1 = commit
       kill "$BP" 2>/dev/null; wait "$BP" 2>/dev/null
       rm -rf "$SMOKE_HOME" "$SMOKE_LOG"
     }
-    trap '_smoke_cleanup' RETURN INT TERM
+    _smoke_signal_handler() {
+      _smoke_trapped_sig="$1"
+      _smoke_cleanup
+      trap - "$1"
+      kill -s "$1" $$
+    }
     env -u ANTHROPIC_BASE_URL CCXRAY_HOME="$SMOKE_HOME" PROXY_PORT="$SIDE" \
       node "$WORKTREE/server/index.js" >"$SMOKE_LOG" 2>&1 & BP=$!
+    # Trap installed AFTER BP is assigned (set -u safe)
+    trap '_smoke_cleanup' RETURN
+    trap '_smoke_signal_handler INT' INT
+    trap '_smoke_signal_handler TERM' TERM
     local ok=1
     for _ in $(seq 1 30); do
       if [ "$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$SIDE/" 2>/dev/null)" = "200" ]; then
@@ -163,7 +172,7 @@ side_verify() { # $1 = commit
 }
 
 # ── swap with identity verification ───────────────────────────────────────
-swap_to() { # $1 = commit
+swap_to() {
   local commit="$1"
   local head_now
   head_now=$(git -C "$WORKTREE" rev-parse HEAD)
@@ -195,9 +204,6 @@ swap_to() { # $1 = commit
     fi
   fi
 
-  # Launch node directly: exec inside subshell replaces the subshell with
-  # the node process, so $! == the actual listener PID (no wrapper layer).
-  # trap '' HUP replaces nohup; </dev/null detaches stdin.
   (cd "$WORKTREE" && trap '' HUP && exec env -u ANTHROPIC_BASE_URL PROXY_PORT="$PORT" \
     node server/index.js >> "$LOG" 2>&1) </dev/null &
   local NEW_PID=$!
@@ -222,9 +228,11 @@ swap_to() { # $1 = commit
 say "verifying $(git -C "$WORKTREE" rev-parse --short "$TARGET") on side port before touching :$PORT"
 if ! side_verify "$TARGET"; then
   say "side-port verification FAILED — restoring pin+deps, live server untouched"
-  restore_pin "$CUR" "$TARGET" || {
-    say "WARNING: could not restore worktree to $CUR — manually: git -C $WORKTREE checkout --detach $CUR && (cd $WORKTREE && npm ci)"
-  }
+  if ! restore_pin "$CUR" "$TARGET"; then
+    echo "[stable-server] FATAL: side-verify failed AND pin restore failed — worktree at wrong ref." >&2
+    echo "  manual recovery: (cd $WORKTREE && git checkout --detach $CUR && npm ci --silent)" >&2
+    exit 2
+  fi
   exit 1
 fi
 

--- a/scripts/stable-server.sh
+++ b/scripts/stable-server.sh
@@ -30,11 +30,35 @@ while [[ $# -gt 0 ]]; do
 done
 [[ -n "$WORKTREE" && -n "$REF" && -n "$ROLLBACK" ]] || { echo "need --worktree --ref --rollback-ref" >&2; exit 3; }
 [[ -d "$WORKTREE" ]] || { echo "worktree not found: $WORKTREE" >&2; exit 3; }
+WORKTREE_ABS="$(cd "$WORKTREE" && pwd)"
 
 LOG="${HOME}/.ccxray/stable-server.log"
+LOCKDIR="${HOME}/.ccxray/stable-server.lock"
 say() { echo "[stable-server] $*"; }
 
-# ── preconditions ──────────────────────────────────────────────────────────
+# ── serialisation ─────────────────────────────────────────────────────────
+# Prevent concurrent swaps on the same port. mkdir is atomic on all platforms.
+mkdir "$LOCKDIR" 2>/dev/null || { echo "another stable-server is running (lock: $LOCKDIR)" >&2; exit 3; }
+trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+
+# ── identity helpers ──────────────────────────────────────────────────────
+# is_ccxray_on_port PID — true when PID is a node server/index.js whose cwd
+# is inside WORKTREE_ABS.  Prevents killing unrelated listeners on the port.
+is_ccxray_on_port() {
+  local pid="$1"
+  local cmd
+  cmd=$(ps -o command= -p "$pid" 2>/dev/null) || return 1
+  [[ "$cmd" == *server/index.js* ]] || return 1
+  local cwd
+  cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | grep '^n' | head -1 | cut -c2-)
+  [[ "$cwd" == "$WORKTREE_ABS"* ]] || return 1
+  return 0
+}
+
+# listener_pid — PID of the TCP LISTEN-er on PORT, or empty string.
+listener_pid() { lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | head -1; }
+
+# ── preconditions ─────────────────────────────────────────────────────────
 git -C "$WORKTREE" diff --quiet && git -C "$WORKTREE" diff --cached --quiet \
   || { echo "worktree dirty — refusing to move pin: $WORKTREE" >&2; exit 3; }
 git -C "$WORKTREE" fetch origin --quiet || { echo "git fetch failed" >&2; exit 3; }
@@ -50,7 +74,7 @@ if [[ "$CUR" == "$TARGET" ]] && health; then
   exit 0
 fi
 
-# ── idle check (skippable with --force) ────────────────────────────────────
+# ── idle check (skippable with --force) ───────────────────────────────────
 # Approximation: last completed entry within IDLE_MIN minutes = sessions are
 # active. In-flight requests that started AFTER a quiet period are invisible
 # to this check (entries record on completion) — hence supervised first runs
@@ -66,10 +90,11 @@ if [[ "$FORCE" -ne 1 ]] && health; then
   fi
 fi
 
-# ── pin + install + side-port verification (live server untouched so far) ──
+# ── pin + install + side-port verification (live server untouched so far) ─
 pin_and_verify() { # $1 = commit
   git -C "$WORKTREE" checkout --detach --quiet "$1" || return 1
-  if ! git -C "$WORKTREE" diff --quiet "$CUR" "$1" -- package-lock.json 2>/dev/null; then
+  local PREV="$CUR"
+  if ! git -C "$WORKTREE" diff --quiet "$PREV" "$1" -- package-lock.json 2>/dev/null; then
     say "package-lock changed — npm ci"
     (cd "$WORKTREE" && npm ci --silent) || return 1
   fi
@@ -77,29 +102,99 @@ pin_and_verify() { # $1 = commit
   if [[ -x "$WORKTREE/scripts/boot-smoke.sh" ]]; then
     "$WORKTREE/scripts/boot-smoke.sh" "$SIDE" || return 1
   else
-    # ref predates boot-smoke.sh — inline minimal check
-    env -u ANTHROPIC_BASE_URL CCXRAY_HOME="$(mktemp -d)" PROXY_PORT="$SIDE" \
-      node "$WORKTREE/server/index.js" >/dev/null 2>&1 & local BP=$!
+    # ref predates boot-smoke.sh — inline minimal check (mirrors boot-smoke.sh contract)
+    local SMOKE_HOME
+    SMOKE_HOME="$(mktemp -d)"
+    local SMOKE_LOG
+    SMOKE_LOG="$(mktemp)"
+    env -u ANTHROPIC_BASE_URL CCXRAY_HOME="$SMOKE_HOME" PROXY_PORT="$SIDE" \
+      node "$WORKTREE/server/index.js" >"$SMOKE_LOG" 2>&1 & local BP=$!
+    trap 'kill "$BP" 2>/dev/null; wait "$BP" 2>/dev/null; rm -rf "$SMOKE_HOME" "$SMOKE_LOG"' RETURN
     local ok=1
     for _ in $(seq 1 30); do
-      [ "$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$SIDE/" 2>/dev/null)" = "200" ] && { ok=0; break; }
-      kill -0 "$BP" 2>/dev/null || break; sleep 0.5
+      if [ "$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$SIDE/" 2>/dev/null)" = "200" ]; then
+        # Verify the 200 came from our spawned process, not a stale listener
+        local side_listener
+        side_listener=$(lsof -nP -iTCP:"$SIDE" -sTCP:LISTEN -t 2>/dev/null | head -1)
+        if [[ "$side_listener" == "$BP" ]]; then
+          grep -m1 "listening" "$SMOKE_LOG" || true
+          say "BOOT OK: dashboard HTTP 200 on :$SIDE (pid $BP)"
+          ok=0; break
+        fi
+      fi
+      kill -0 "$BP" 2>/dev/null || break
+      sleep 0.5
     done
     kill "$BP" 2>/dev/null; wait "$BP" 2>/dev/null
+    rm -rf "$SMOKE_HOME" "$SMOKE_LOG"
+    trap - RETURN
+    if [[ "$ok" -ne 0 ]]; then
+      say "BOOT FAIL: no dashboard HTTP 200 on :$SIDE within bound"
+    fi
     return $ok
   fi
 }
 
-swap_to() { # $1 = commit; returns 0 when :PORT serves 200 from $WORKTREE
-  local OLD_PID
-  OLD_PID=$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | head -1)
-  if [[ -n "$OLD_PID" ]]; then
-    kill "$OLD_PID" 2>/dev/null   # SIGTERM → gracefulExit drains writes (≤5s)
-    for _ in $(seq 1 20); do lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1 || break; sleep 0.5; done
+# ── swap with identity verification ───────────────────────────────────────
+swap_to() { # $1 = commit (used for checkout before launch)
+  local commit="$1"
+  # Ensure worktree is at the requested commit
+  local head_now
+  head_now=$(git -C "$WORKTREE" rev-parse HEAD)
+  if [[ "$head_now" != "$(git -C "$WORKTREE" rev-parse --verify "$commit^{commit}" 2>/dev/null)" ]]; then
+    git -C "$WORKTREE" checkout --detach --quiet "$commit" || return 1
   fi
+
+  local OLD_PID
+  OLD_PID=$(listener_pid)
+  if [[ -n "$OLD_PID" ]]; then
+    if ! is_ccxray_on_port "$OLD_PID"; then
+      say "ERROR: pid $OLD_PID on :$PORT is NOT a ccxray process in $WORKTREE_ABS — refusing to kill"
+      return 1
+    fi
+    kill "$OLD_PID" 2>/dev/null   # SIGTERM → gracefulExit drains writes (≤5s)
+    for _ in $(seq 1 20); do
+      kill -0 "$OLD_PID" 2>/dev/null || break
+      sleep 0.5
+    done
+    if kill -0 "$OLD_PID" 2>/dev/null; then
+      say "ERROR: old listener (pid $OLD_PID) did not exit within 10s"
+      return 1
+    fi
+    # Verify port actually released (another process could have grabbed it)
+    local stale
+    stale=$(listener_pid)
+    if [[ -n "$stale" ]]; then
+      say "ERROR: port :$PORT still occupied by pid $stale after old listener exited"
+      return 1
+    fi
+  fi
+
   ( cd "$WORKTREE" && env -u ANTHROPIC_BASE_URL PROXY_PORT="$PORT" \
-      nohup node server/index.js >> "$LOG" 2>&1 & ) </dev/null
-  for _ in $(seq 1 30); do health && return 0; sleep 0.5; done
+      nohup node server/index.js >> "$LOG" 2>&1 & echo $! > /tmp/.ccxray-swap-pid-$PORT ) </dev/null
+  local NEW_PID
+  NEW_PID=$(cat /tmp/.ccxray-swap-pid-$PORT 2>/dev/null)
+  rm -f /tmp/.ccxray-swap-pid-$PORT
+
+  if [[ -z "$NEW_PID" ]]; then
+    say "ERROR: failed to capture new server PID"
+    return 1
+  fi
+
+  for _ in $(seq 1 30); do
+    if health; then
+      # Verify the listener is our new process
+      local live_pid
+      live_pid=$(listener_pid)
+      if [[ "$live_pid" == "$NEW_PID" ]]; then
+        return 0
+      fi
+    fi
+    kill -0 "$NEW_PID" 2>/dev/null || { say "ERROR: new server (pid $NEW_PID) died during startup"; return 1; }
+    sleep 0.5
+  done
+  say "ERROR: new server (pid $NEW_PID) did not become healthy within 15s"
+  kill "$NEW_PID" 2>/dev/null
   return 1
 }
 
@@ -112,17 +207,35 @@ fi
 
 say "swapping :$PORT to $(git -C "$WORKTREE" rev-parse --short "$TARGET")"
 if swap_to "$TARGET"; then
-  say "OK — :$PORT serving $(git -C "$WORKTREE" rev-parse --short HEAD) (log: $LOG)"
+  say "OK — :$PORT serving $(git -C "$WORKTREE" rev-parse --short HEAD) pid $(listener_pid) (log: $LOG)"
   exit 0
 fi
 
+# ── rollback ──────────────────────────────────────────────────────────────
 say "swap FAILED — rolling back to $(git -C "$WORKTREE" rev-parse --short "$ROLLBACK")"
-git -C "$WORKTREE" checkout --detach --quiet "$ROLLBACK"
+
+# Checkout rollback ref — must succeed or we're in manual-recovery territory
+if ! git -C "$WORKTREE" checkout --detach --quiet "$ROLLBACK"; then
+  echo "[stable-server] FATAL: rollback checkout failed — :$PORT may be DOWN." >&2
+  echo "  manual recovery: (cd $WORKTREE && git checkout --detach $ROLLBACK && npm ci --silent && env -u ANTHROPIC_BASE_URL PROXY_PORT=$PORT nohup node server/index.js >> $LOG 2>&1 &)" >&2
+  exit 2
+fi
+
+# Restore dependencies if rollback ref has different package-lock
+if ! git -C "$WORKTREE" diff --quiet "$TARGET" "$ROLLBACK" -- package-lock.json 2>/dev/null; then
+  say "rollback: package-lock differs — npm ci"
+  (cd "$WORKTREE" && npm ci --silent) || {
+    echo "[stable-server] FATAL: rollback npm ci failed — :$PORT may be DOWN." >&2
+    echo "  manual recovery: (cd $WORKTREE && npm ci && env -u ANTHROPIC_BASE_URL PROXY_PORT=$PORT nohup node server/index.js >> $LOG 2>&1 &)" >&2
+    exit 2
+  }
+fi
+
 if swap_to "$ROLLBACK"; then
   say "rolled back — :$PORT serving $(git -C "$WORKTREE" rev-parse --short HEAD)"
   exit 1
 fi
 
 echo "[stable-server] FATAL: rollback also failed — :$PORT is DOWN." >&2
-echo "  manual recovery: (cd $WORKTREE && git checkout --detach $ROLLBACK && PROXY_PORT=$PORT nohup node server/index.js >> $LOG 2>&1 &)" >&2
+echo "  manual recovery: (cd $WORKTREE && git checkout --detach $ROLLBACK && npm ci --silent && env -u ANTHROPIC_BASE_URL PROXY_PORT=$PORT nohup node server/index.js >> $LOG 2>&1 &)" >&2
 exit 2


### PR DESCRIPTION
## 摘要

拓樸分工定案（2026-07-11 owner+ops）：5577 stable 監控 server 由 script 管理、dev session 永不直接碰。本 script 單次呼叫內完成 pin → 旁路 boot-smoke 驗證 → graceful swap → 失敗自動回滾 `--rollback-ref`，冪等、拒絕 dirty worktree、預設 idle-check（`--force` 可越過）。rollback pin 以參數傳入，不寫死在公開 repo（ops 決策）。

## Details

- Side-port verification happens BEFORE the live port is touched; a ref that fails to boot leaves the live server untouched (exit 1).
- Swap uses SIGTERM → `gracefulExit` drain; post-check polls HTTP 200 (15s bound); failure triggers automatic rollback, and a failed rollback prints a one-line manual recovery command (exit 2).
- `npm ci` runs only when package-lock changed between pins.
- Idle-check approximates via last-entry age from `/_api/entries` (in-flight requests are invisible until completion — documented; supervised first runs + explicit `--force` cover the gap).

## Verification（隔離 rig：port 5661、拋棄式 CCXRAY_HOME、測試 worktree）

| Path | 結果 |
|---|---|
| 冷啟 swap 到新 main | exit 0，side-port `BOOT OK` → live 200 |
| 冪等重跑 | exit 0，`already at … healthy` |
| 回舊 pin（lockfile 變更） | 自動 `npm ci`，exit 0 |
| 壞 ref（boot 即 throw） | side-port 驗證 FAIL，exit 1，**live server 全程 200 未被碰**，pin 還原 |

未測（結構上同組件複用）：live-port swap 失敗 → 回滾路徑（`swap_to`+checkout 均已在上表個別驗證）。首次真實執行依 ops 條件由 owner 在場督跑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)