### PR TITLE
fix(workflow-ux): sequential teammate/fork interleave detection — convId bracketing + msgCount dip stitching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ These constraints have guard comments at their mutation sites. Read the linked A
 - **Lane-focus geometry must match what `_wfRenderSvgContent` actually draws** — `_wfTotalLanesHeight`, `_wfLaneIdxAtY`, and the label-click hit-test in `workflow-timeline.js` must all agree with it under `laneFocusMode` — @docs/decisions/0006-lane-focus-geometry-consistency.md
 - **Use `_wfIsMainLane(lane)` for main/orchestrator detection, never `!lane.spawnParent`** (`spawnParent` is always `null`, in every lane object, everywhere) — @docs/decisions/0007-wf-is-main-lane-not-spawn-parent.md
 - **Temporal overlap overrides agentKey for lane placement** — no lane may hold two temporally-overlapping turns; never exempt a turn from the overlap split because its agentKey looks authoritative (forks carry the parent's `orchestrator` key) — @docs/decisions/0008-temporal-overlap-overrides-agent-key.md
+- **Sequential-interleave classification goes through the shared seq tracker in both files** (`wfCreateSeqTracker` in `workflow-timeline.js`; instances in `wfInferLanes`, `wfAddEntry`, and `entry-rendering.js` `addEntry`), and the tracker never consults `isCompacted` (fan-out first-turns carry a false flag) — @docs/decisions/0009-sequential-interleave-conv-bracketing.md
 
 ## Smoke Testing
 

--- a/docs/decisions/0008-temporal-overlap-overrides-agent-key.md
+++ b/docs/decisions/0008-temporal-overlap-overrides-agent-key.md
@@ -76,3 +76,14 @@ signature. Overlap is the strictly stronger signal.
 **One shared parallel lane per model+convId (the #226 shape)**: rejected —
 concurrent forks share model AND convId, so they pile into one lane that
 overlaps internally, recreating the bug one level down.
+
+## Amended by ADR 0009 (2026-07-11)
+
+The overlap sweep is no longer a single terminal pass, and `parallel-*`
+lanes no longer imply temporal overlap alone: #230's sequential-interleave
+post-pass iterates with the sweep to a fixpoint inside `wfInferLanes`, and
+parallel lanes now also hold *sequential* excursions (teammates, fan-out
+runs, stitched fork continuations), labeled Fork/Teammate by conversation
+identity. This section is navigation only — the mechanism, its invariants,
+and the live-path convergence rules live in
+`0009-sequential-interleave-conv-bracketing.md`.

--- a/docs/decisions/0009-sequential-interleave-conv-bracketing.md
+++ b/docs/decisions/0009-sequential-interleave-conv-bracketing.md
@@ -80,6 +80,22 @@ per-turn signals — the ADR 0005 shape, like `AGENT_KEY_UNRELIABLE`:
 - Turns without `convId` or `receivedAt` are inert: never boundaries,
   never moved (legacy data, codex sessions).
 
+## Invariants (mutation-site guards)
+
+- **Reordered convergence is two-sided**: when the swimlane falls back to
+  `_wfSeqRebuild` on an inserted-before-tail arrival, the turn list must
+  run `_seqRecomputeSession` (flips AND unflips) on the same signal —
+  fixing only one side recreates the ADR 0005 round-4 divergence shape.
+- **Batch hands its final classification to the live tracker**: the
+  finalStream replay at the end of `wfInferLanes` seeds the caller's
+  tracker with the converged state; removing it paints the first frame
+  correctly and corrupts every live update after it.
+- **Closed-bracket excursions immediately become R2 frontiers**
+  (`wfSeqFeedSplit` inside `_wfSeqCloseBrackets`): dropping that feed makes
+  later same-conv sequential continuations silently fall back into main.
+- **Rebuilds treat `allEntries` as the authoritative snapshot** — callers
+  must push the entry into `allEntries` before invoking `wfAddEntry`.
+
 ## Consequences
 
 **Good**: real-data replay (439 sessions): 1,018 turns leave main lanes

--- a/docs/decisions/0009-sequential-interleave-conv-bracketing.md
+++ b/docs/decisions/0009-sequential-interleave-conv-bracketing.md
@@ -1,0 +1,103 @@
+# 0009 — Sequential interleave: convId bracketing + msgCount dip stitching
+
+- Status: Accepted
+- Date: 2026-07-11
+- Related: #230 / #229 / #232 (ADR 0008), #222
+
+## Context
+
+ADR 0008's temporal-overlap split only catches **parallel** agents — physics
+proves concurrency. A *sequential* teammate (dispatched while main idles,
+zero time overlap) or a fork's between-main-turns continuation leaves no
+overlap footprint. Real-data audit after #232 (2026-07-11, 439 sessions):
+session `4b15c248` still had 12 msgCount non-monotonic residues and five
+models ping-ponging inside its main lane (sequential dev teammates);
+`86949194` had exactly one residue (55→51 — a fork turn that started 1s
+after main's turn ended); `a7fef8a8` had 7 Opus fan-out turns inside a
+Fable-5 main.
+
+Two wire signals remain when overlap is blind, each with a failure mode the
+other covers:
+
+- **convId** (messages[0] hash): main's convId only moves forward —
+  compaction replaces messages[0] with a summary and never goes back;
+  /resume, retry, and rewind all keep messages[0]. So *conv A resuming
+  after foreign-conv runs* proves those runs were excursions. But a fork
+  shares the parent's convId — convId alone is blind to exactly the #229
+  warning case.
+- **msgCount monotonicity**: a serial conversation's msgCount never drops
+  outside compaction. But rewind/edit (`7e1d9272`'s 540→493, then steady
+  +2 regrowth) is a legal main-lane drop, and fan-out first-turns get
+  *mislabeled* `isCompacted` (big msg+token drop vs. the previous main
+  turn — `a7fef8a8` evidence), so neither "any drop splits" nor "trust
+  isCompacted" works.
+
+## Decision
+
+A shared **sequential-interleave tracker** (`wfCreateSeqTracker` /
+`wfSeqFeedSplit` / `wfSeqFeedMain` in `workflow-timeline.js`) implements
+both rules once; `wfInferLanes` (batch), `wfAddEntry` (live), and
+`entry-rendering.js` `addEntry()` each hold an instance fed the same
+per-turn signals — the ADR 0005 shape, like `AGENT_KEY_UNRELIABLE`:
+
+- **R1 — convId run bracketing with trunk-advance**: main-candidate turns
+  form convId runs in arrival order. Foreign-conv runs are *provisionally
+  main*; when the trunk conv reappears, everything in between is an
+  excursion (retro-moved out). A trunk that never returns = compaction —
+  the pending runs stay main. `isCompacted` is never consulted.
+- **R2 — same-conv msgCount dip stitching**: a turn whose msgCount drops
+  below its conv's previous main turn is an excursion **iff** it continues
+  a frontier already split out of main (same conv, `tailMsg ≤ msg ≤
+  tailMsg + 2`, starting at/after the tail ends — Δ=2 is one exchange, the
+  natural msgCount step; owner-approved 2026-07-11). No frontier → rewind/
+  edit → stays main.
+- **Batch = live by construction**: the tracker re-runs the full trunk walk
+  on every feed, so the live path equals the batch pass on every prefix.
+  In `wfInferLanes` the overlap sweep (ADR 0008) and the seq pass iterate
+  to a fixpoint: excursing a turn re-runs the sweep without it, so a main
+  turn that only overlapped an excursion is re-admitted — otherwise a
+  batch rebuild would disagree with the live path, which never saw the
+  excursion in main (round-4-bug shape, cross-pass edition).
+- Turns without `convId` or `receivedAt` are inert: never boundaries,
+  never moved (legacy data, codex sessions).
+
+## Consequences
+
+**Good**: real-data replay (439 sessions): 1,018 turns leave main lanes
+across 38 sessions; `4b15c248` residues 12→0 (all sonnet dev-agent turns
+out); `86949194` 55→51 → 0; `a7fef8a8` main becomes pure Fable 5;
+`7e1d9272` (767-turn healthy session, one compaction, two rewinds)
+unchanged. Compaction, rewind, and legacy no-convId data are structurally
+exempt, not threshold-exempt.
+
+**Bad — known misses (accepted, owner decision 2026-07-11)**: a fully
+sequential same-conv fork with no split-out frontier is invisible (4
+corpus residues, all pre-#232 sessions, "dip then discontinuous jump
+back" shape). Deliberately not chased: the lookahead rule that would catch
+them risks false-splitting rewinds (queued user messages also jump >4) —
+precision is a separate acceptance axis (see the isRetry follow-up issue).
+Root fix remains #222's wire-level identity ask.
+
+**Bad — provisional-main window**: live, a teammate run sits in main until
+the trunk conv returns (retro-move on bracket close; the turn list
+renumbers via `_seqRetroFlip`). Same acceptance as #229's reverse
+retro-move.
+
+**Bad — rewind-across-compaction**: /rewind restoring a pre-compaction
+checkpoint makes the old conv "return", so the compacted run in between
+would split as an excursion. Rare; rendered lanes are at least visually
+honest ("a discarded branch").
+
+## Alternatives considered
+
+**Pure msgCount monotonicity (no convId structure)**: rejected —
+`a7fef8a8`'s fan-out first-turns carry a false `isCompacted`, so a
+msgCount-only rule either trusts the flag (misses the whole fan-out) or
+ignores it (splits every real compaction).
+
+**Pure convId bracketing (the original #230 sketch)**: rejected — forks
+share the parent's convId (#229's warning); the `86949194` 55→51 fixture
+is invisible to it.
+
+**Lookahead jump-return rule to catch the 4 remaining residues**: rejected
+for recall-vs-precision reasons above; documented as known limitation.

--- a/docs/decisions/0009-sequential-interleave-conv-bracketing.md
+++ b/docs/decisions/0009-sequential-interleave-conv-bracketing.md
@@ -109,7 +109,17 @@ the authoritative resolver — pre-existing gap, unchanged here). What the
 sorted candidate list fixes is the seq tracker's own order sensitivity:
 arrival order can no longer poison the trunk, and when the nested
 early-arriver is a *foreign* conv, the R1 bracket close now also heals the
-turn list live via retro-flip.
+turn list live via retro-flip. One case needs more than the sorted list:
+an earlier-starting turn arriving after an R1 bracket already **closed**
+can overturn the closed excursion — the trunk itself changes (B0-A-B-A
+truth discovered late), and the closed turns have left the tracker list,
+so no incremental step can reopen them. The swimlane heals by falling back
+to a full `wfBuildState` rebuild whenever the tracker reports an
+inserted-before-tail arrival (`_wfSeqRebuild`, view state migrated;
+bounded — only overlap-inversion arrivals trigger it). The turn list
+deliberately does NOT overturn closed excursions: its numbering stays
+forward-only per this same boundary, batch remains the authority (codex
+P2, round 5).
 
 **Bad — rewind-across-compaction**: /rewind restoring a pre-compaction
 checkpoint makes the old conv "return", so the compacted run in between

--- a/docs/decisions/0009-sequential-interleave-conv-bracketing.md
+++ b/docs/decisions/0009-sequential-interleave-conv-bracketing.md
@@ -55,12 +55,15 @@ per-turn signals — the ADR 0005 shape, like `AGENT_KEY_UNRELIABLE`:
   a frontier already split out of main (same conv, `tailMsg ≤ msg ≤
   tailMsg + 2`, starting at/after the tail ends — Δ=2 is one exchange, the
   natural msgCount step; owner-approved 2026-07-11). No frontier → rewind/
-  edit → stays main. Frontiers are tracked **per conversation**
-  (`Map(convId → [frontier…])`, one element per concurrent same-conv
-  track), unbounded by design: a shared FIFO cap would evict still-active
-  frontiers once enough split turns pass — fan-out sessions or one
-  chatty fork would silently disable R2 for the evicted conv (codex P2,
-  round 3).
+  edit → stays main. Tail points are tracked **per conversation and
+  append-only** (`Map(convId → [point…])`, one point per split turn, no
+  cap, never merged): a shared FIFO cap would evict still-active convs'
+  evidence (codex P2, round 3), and merging a "continuation" split into
+  an earlier point erases the historical branch point that another
+  concurrent track's sequential continuation still needs — the merge
+  variant regressed the 439-session re-audit from 3 to 8 jumpreturn
+  residues (2026-07-11). Only an R2 stitch advances a point, because the
+  dip consumed it. Memory is O(split turns) per session.
 - **Batch = live by construction**: the tracker re-runs the full trunk walk
   on every feed, so the live path equals the batch pass on every prefix.
   In `wfInferLanes` the overlap sweep (ADR 0008) and the seq pass iterate

--- a/docs/decisions/0009-sequential-interleave-conv-bracketing.md
+++ b/docs/decisions/0009-sequential-interleave-conv-bracketing.md
@@ -113,13 +113,15 @@ turn list live via retro-flip. One case needs more than the sorted list:
 an earlier-starting turn arriving after an R1 bracket already **closed**
 can overturn the closed excursion — the trunk itself changes (B0-A-B-A
 truth discovered late), and the closed turns have left the tracker list,
-so no incremental step can reopen them. The swimlane heals by falling back
-to a full `wfBuildState` rebuild whenever the tracker reports an
-inserted-before-tail arrival (`_wfSeqRebuild`, view state migrated;
-bounded — only overlap-inversion arrivals trigger it). The turn list
-deliberately does NOT overturn closed excursions: its numbering stays
-forward-only per this same boundary, batch remains the authority (codex
-P2, round 5).
+so no incremental step can reopen them. Both files converge symmetrically
+on that flag: the swimlane falls back to a full `wfBuildState` rebuild
+(`_wfSeqRebuild`, view state migrated — codex P2 round 5), and the turn
+list recomputes its session's seq layer (`_seqRecomputeSession`: fresh
+tracker, `(receivedAt, id)`-sorted replay, diff-and-apply of seq-caused
+flips in BOTH directions via `_seqFlipped` marks — codex P2 round 6;
+agentKey/overlap/raw classifications are never touched). Bounded — only
+overlap-inversion arrivals trigger either. The remaining forward-only
+boundary is the overlap spans check alone (pre-existing, unchanged).
 
 **Bad — rewind-across-compaction**: /rewind restoring a pre-compaction
 checkpoint makes the old conv "return", so the compacted run in between

--- a/docs/decisions/0009-sequential-interleave-conv-bracketing.md
+++ b/docs/decisions/0009-sequential-interleave-conv-bracketing.md
@@ -41,7 +41,12 @@ both rules once; `wfInferLanes` (batch), `wfAddEntry` (live), and
 per-turn signals — the ADR 0005 shape, like `AGENT_KEY_UNRELIABLE`:
 
 - **R1 — convId run bracketing with trunk-advance**: main-candidate turns
-  form convId runs in arrival order. Foreign-conv runs are *provisionally
+  form convId runs in **start order** — the tracker keeps its candidate
+  list sorted by `(receivedAt, id)` internally, because entries arrive in
+  completion order: a nested turn can finish before the longer turn that
+  started first, and arrival-order runs would let a foreign-conv turn
+  arriving first become the trunk, wedging every bracket open for the rest
+  of the session (codex P2, round 1). Foreign-conv runs are *provisionally
   main*; when the trunk conv reappears, everything in between is an
   excursion (retro-moved out). A trunk that never returns = compaction —
   the pending runs stay main. `isCompacted` is never consulted.
@@ -82,6 +87,15 @@ Root fix remains #222's wire-level identity ask.
 the trunk conv returns (retro-move on bracket close; the turn list
 renumbers via `_seqRetroFlip`). Same acceptance as #229's reverse
 retro-move.
+
+**Boundary — live reverse-overlap stays ADR 0008 territory**: the turn
+list's forward-only overlap check still records an early-arriving nested
+*same-conv* turn as main until the next batch rebuild (the sorted sweep is
+the authoritative resolver — pre-existing gap, unchanged here). What the
+sorted candidate list fixes is the seq tracker's own order sensitivity:
+arrival order can no longer poison the trunk, and when the nested
+early-arriver is a *foreign* conv, the R1 bracket close now also heals the
+turn list live via retro-flip.
 
 **Bad — rewind-across-compaction**: /rewind restoring a pre-compaction
 checkpoint makes the old conv "return", so the compacted run in between

--- a/docs/decisions/0009-sequential-interleave-conv-bracketing.md
+++ b/docs/decisions/0009-sequential-interleave-conv-bracketing.md
@@ -63,7 +63,13 @@ per-turn signals — the ADR 0005 shape, like `AGENT_KEY_UNRELIABLE`:
   concurrent track's sequential continuation still needs — the merge
   variant regressed the 439-session re-audit from 3 to 8 jumpreturn
   residues (2026-07-11). Only an R2 stitch advances a point, because the
-  dip consumed it. Memory is O(split turns) per session.
+  dip consumed it. Memory is O(split turns) per session. Points **retire
+  after 15 minutes** (`WF_SEQ_FRONTIER_TTL_MS`, judged at lookup — never
+  removed from the Map): measured over the 439-session audit, real stitch
+  gaps are p50=22s / p90=3min and every verified-good stitch is ≤2min,
+  while all 6 sampled >10min fits were edit/rewind shapes — 15min keeps
+  ~30× headroom yet structurally closes hour-scale rewind collisions with
+  stale branch points (codex P2 round 4; owner-approved 2026-07-11).
 - **Batch = live by construction**: the tracker re-runs the full trunk walk
   on every feed, so the live path equals the batch pass on every prefix.
   In `wfInferLanes` the overlap sweep (ADR 0008) and the seq pass iterate

--- a/docs/decisions/0009-sequential-interleave-conv-bracketing.md
+++ b/docs/decisions/0009-sequential-interleave-conv-bracketing.md
@@ -55,7 +55,12 @@ per-turn signals — the ADR 0005 shape, like `AGENT_KEY_UNRELIABLE`:
   a frontier already split out of main (same conv, `tailMsg ≤ msg ≤
   tailMsg + 2`, starting at/after the tail ends — Δ=2 is one exchange, the
   natural msgCount step; owner-approved 2026-07-11). No frontier → rewind/
-  edit → stays main.
+  edit → stays main. Frontiers are tracked **per conversation**
+  (`Map(convId → [frontier…])`, one element per concurrent same-conv
+  track), unbounded by design: a shared FIFO cap would evict still-active
+  frontiers once enough split turns pass — fan-out sessions or one
+  chatty fork would silently disable R2 for the evicted conv (codex P2,
+  round 3).
 - **Batch = live by construction**: the tracker re-runs the full trunk walk
   on every feed, so the live path equals the batch pass on every prefix.
   In `wfInferLanes` the overlap sweep (ADR 0008) and the seq pass iterate

--- a/docs/solutions/seq-tracker-event-time-ordering.md
+++ b/docs/solutions/seq-tracker-event-time-ordering.md
@@ -1,0 +1,29 @@
+# Seq tracker:到達序不是事件時序(一個根因、三種變形、一次回歸)
+
+- Issue: #230 · PR: #237 · ADR: `docs/decisions/0009-sequential-interleave-conv-bracketing.md`
+
+分類 tracker 的不變量定義在**事件時序**(receivedAt)上,但 live 路徑天然以
+**到達序(完成序)**餵資料——嵌套的短 turn 會比先開始的長 turn 先完成、先到達。
+同一個根因在 codex 審查中以三種變形出現:
+
+1. **Trunk 毒化(round 1)**:嵌套的異 conv turn 先到達,成為 runs[0] = trunk,
+   整個 session 的 bracket 永不關閉。修法:tracker 內部維護 `(receivedAt, id)`
+   排序的 candidate list,runs 永遠從 list 重建、不從到達序。
+2. **已關閉的 excursion 不可翻案(round 5)**:bracket 關閉後才到達的
+   「開始最早、跨全程」turn 會改寫主幹本身,但 closed turns 已離開 tracker
+   list——不存在增量修復。修法:inserted-before-tail 到達 → `wfAddEntry`
+   放棄增量,整段 `wfBuildState` 重建(UI 狀態搬移)。
+3. **單邊收斂(round 6)**:同一個 reordered flag 傳到 entry-rendering 卻被
+   忽略——swimlane 翻案回 main 的 turn,turn list 永遠留在 sN。修法:
+   `_seqRecomputeSession` 重放 session、雙向套用翻轉(`_seqFlipped` 標記
+   seq 層所有權)。
+
+**值得記住的回歸(069246a)**:對 R2 frontier store 做「顯而易見的清潔」——
+延續合併、FIFO 上限——摧毀了歷史分岔點、驅逐了仍活躍的 conv。**所有 unit
+fixture 全綠**;只有 439-session 真實資料 re-audit 攔到(jumpreturn 殘留
+3→8,append-only 重做後回到 3)。教訓:
+
+- 推論用的 evidence store 應 append-only,除非「消費」本身使該點退休
+  (R2 stitch-advance、15 分鐘 TTL)。
+- 分類/歸因類改動,unit 測試綠不等於完工——見
+  `docs/verification-principles.md` 的「真實資料全量重放」一節。

--- a/docs/verification-principles.md
+++ b/docs/verification-principles.md
@@ -97,6 +97,23 @@ git worktree remove --force /tmp/before
 
 ---
 
+## 分類/歸因類改動:unit fixture 綠不足以收工
+
+改的是「這筆資料屬於誰/哪條 lane/哪個 session」一類的**分類或歸因邏輯**時,
+手寫 fixture 只能覆蓋你想得到的形狀;真實流量的形狀分佈才是驗收面。收工前
+必須用 vm harness 模式(`test/workflow-timeline.test.js` 的 `loadWfModule`
+形狀)對**全量真實 session 重放**,以一個機械可判的殘留指標做 before/after:
+
+- #232:overlap 拆道——殘留 overlap pairs 547 → 0。
+- #230:sequential interleave——jumpreturn 殘留 3 → 8(069246a 的 frontier
+  合併回歸,**unit fixture 全綠、只有 439-session re-audit 攔到**)→ 3
+  (append-only 重做;詳見 `docs/solutions/seq-tracker-event-time-ordering.md`)。
+
+規則:改動涉及分類/歸因時,PR 證據欄必附全量重放的殘留指標數字;unit 綠
+但 re-audit 未跑 = 未驗證。
+
+---
+
 ## 一句話總結
 
 > 改完別只問「測試過了嗎?」,要問:

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -272,6 +272,11 @@ function _seqApplyFlips(sid, sess, flipIds, unflipIds) {
   for (let i = 0; i < allEntries.length; i++) {
     const en = allEntries[i];
     if (en.sessionId !== sid) continue;
+    // GUARD (_seqFlipped ownership): every seq-layer isSubagent flip is
+    // written HERE (or at the allEntries push for the arriving entry) and
+    // must set _seqFlipped alongside it; non-seq flips (agentKey/overlap/
+    // raw) must never set it — _seqRecomputeSession derives base
+    // classification from `isSubagent && !_seqFlipped`.
     if (flipIds && flipIds.has(en.id)) { en.isSubagent = true; en._seqFlipped = true; }
     else if (unflipIds && unflipIds.has(en.id)) { en.isSubagent = false; en._seqFlipped = false; }
     const num = en.isRetry ? 'r' + (++retryN) : en.isSubagent ? 's' + (++subN) : String(++mainN);
@@ -313,6 +318,9 @@ function _seqRecomputeSession(sid, sess, currentSeqTurn) {
   for (let i = 0; i < allEntries.length; i++) {
     const en = allEntries[i];
     if (en.sessionId !== sid || en.isRetry) continue; // retries: neither evidence nor candidates
+    // GUARD (_seqFlipped ownership): baseSub strips ONLY seq-layer flips —
+    // it must stay `isSubagent && !_seqFlipped`; using raw isSubagent here
+    // would feed seq excursions as split evidence and lock them in.
     replay.push({ id: en.id, convId: en.convId || null, msgCount: en.msgCount, receivedAt: en.receivedAt,
                   elapsed: en.elapsed, baseSub: !!(en.isSubagent && !en._seqFlipped), en });
   }
@@ -460,7 +468,11 @@ function addEntry(e) {
       // earlier-starting turn arriving late can overturn seq flips this
       // file already applied — including flipping a closed excursion BACK
       // to main. Recompute the session's seq layer from scratch so the
-      // turn list converges with the rebuilt swimlane (ADR 0005).
+      // turn list converges with the rebuilt swimlane.
+      // INVARIANT: reordered convergence is two-sided — this recompute and
+      // wfAddEntry's _wfSeqRebuild fire on the same flag; removing either
+      // side recreates the ADR 0005 round-4 divergence shape — see
+      // docs/decisions/0009-sequential-interleave-conv-bracketing.md
       if (seqVerdict.reordered) {
         if (_seqRecomputeSession(sid, sess, seqTurn) === 'excursion') { isSubagent = true; seqFlipped = true; }
         seqVerdict = null; // closed brackets were handled inside the recompute
@@ -588,6 +600,8 @@ function addEntry(e) {
     req: e.req || null, res: e.res || null, reqLoaded: !!(e.req || e.res),
     msgCount, toolCount, toolCalls: e.toolCalls || {}, stopReason,
     status: e.status, elapsed: e.elapsed, method: e.method, id: e.id,
+    // GUARD (_seqFlipped ownership): true iff the seq layer flipped THIS
+    // arrival (R2 stitch / reordered recompute) — see _seqApplyFlips guard
     isSubagent, isRetry, _seqFlipped: seqFlipped, sessionInferred: e.sessionInferred || false, displayNum, ctxUsed, isCompacted, receivedAt: e.receivedAt || null,
     thinkingDuration: e.thinkingDuration || null,
     duplicateToolCalls: e.duplicateToolCalls || null,
@@ -611,6 +625,8 @@ function addEntry(e) {
     var isDirectSession = sid === selectedSessionId;
     var isChildSession = !isDirectSession && sessionsMap.get(sid)?.parentSessionId === selectedSessionId;
     if (isDirectSession || isChildSession) {
+      // wfAddEntry caller contract: the entry is already in allEntries
+      // (pushed above) — its reordered-rebuild path recomputes from there.
       var lastEntry = allEntries[allEntries.length - 1];
       var wfResult = wfAddEntry(lastEntry);
       if (wfResult.lanesChanged) wfRenderTimeline();

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -258,6 +258,37 @@ function getCriticalMarker(stopReason, httpStatus, ctxPct) {
 }
 
 
+// #230 R1 retro: a closed bracket means turns previously numbered as main
+// were actually a sequential excursion (teammate/fan-out). Flip them to
+// subagent and renumber the whole session — numbering is arrival-ordered,
+// so every displayNum after the flip point shifts. DOM cards are patched in
+// place (class + number); the swimlane does its own retro (_wfSeqRetroMove).
+// sess._recentMainSpans may retain a flipped turn's span for up to 5 turns —
+// accepted transient (spans only feed the overlap check).
+function _seqRetroFlip(sid, sess, closedTurns) {
+  const closedIds = new Set(closedTurns.map(t => t.id));
+  let mainN = 0, subN = 0, retryN = 0;
+  for (let i = 0; i < allEntries.length; i++) {
+    const en = allEntries[i];
+    if (en.sessionId !== sid) continue;
+    if (closedIds.has(en.id)) en.isSubagent = true;
+    const num = en.isRetry ? 'r' + (++retryN) : en.isSubagent ? 's' + (++subN) : String(++mainN);
+    if (en.displayNum === num) continue;
+    en.displayNum = num;
+    if (window.entryById && window.entryById.has(en.id)) window.entryById.get(en.id).displayNum = num;
+    if (!_loading) {
+      const card = colTurns.querySelector('.turn-item[data-entry-idx="' + i + '"]');
+      if (card) {
+        card.classList.toggle('turn-sub', !!en.isSubagent);
+        card.dataset.sessNum = num;
+        const numEl = card.querySelector('.turn-num');
+        if (numEl) numEl.textContent = en.isSubagent ? '↳' + num : '#' + num;
+      }
+    }
+  }
+  sess.mainCount = mainN; sess.subCount = subN; sess.retryCount = retryN;
+}
+
 function addEntry(e) {
   if (entryCount === 0) colTurns.innerHTML = '<div class="col-sticky-header"><div class="col-title" style="display:flex;align-items:center">Turns<span id="scroll-toggle" onclick="toggleFollowLive()" style="cursor:pointer;font-size:10px;margin-left:auto"><span class="scroll-on active">ON</span> <span class="scroll-off">OFF</span></span></div><div id="session-tool-bar" style="display:none"></div><div id="ctx-legend"><span><span class="ctx-legend-dot" style="background:var(--color-cache-read)"></span>cache read</span><span><span class="ctx-legend-dot" style="background:var(--color-cache-write)"></span>cache write</span><span><span class="ctx-legend-dot" style="background:var(--color-input)"></span>input</span></div><div id="session-sparkline"></div></div>';
   const idx = entryCount++;
@@ -350,6 +381,27 @@ function addEntry(e) {
         isSubagent = true; break;
       }
     }
+  }
+  // #230 sequential interleave: agentKey and overlap can't see a sequential
+  // teammate/fork. The shared tracker (workflow-timeline.js, loaded first)
+  // classifies: R2 same-conv msgCount dips that continue a split-out
+  // frontier flip to subagent HERE, before numbering; R1 foreign-conv runs
+  // stay provisionally main and are retro-flipped by _seqRetroFlip when the
+  // trunk conv returns. Retries carry the original request's msgCount —
+  // they are neither frontier evidence nor main candidates.
+  // INVARIANT: same tracker semantics as wfInferLanes/wfAddEntry — see
+  // docs/decisions/0009-sequential-interleave-conv-bracketing.md
+  let seqVerdict = null;
+  if (typeof wfCreateSeqTracker === 'function' && !isRetry) {
+    if (!sess._seqTracker) sess._seqTracker = wfCreateSeqTracker();
+    const seqTurn = { id: entryId, convId: e.convId || null, msgCount, receivedAt: e.receivedAt, elapsed: e.elapsed };
+    if (isSubagent) {
+      wfSeqFeedSplit(sess._seqTracker, seqTurn);
+    } else {
+      seqVerdict = wfSeqFeedMain(sess._seqTracker, seqTurn);
+      if (seqVerdict.place === 'excursion') isSubagent = true;
+    }
+    if (seqVerdict && seqVerdict.closed) _seqRetroFlip(sid, sess, seqVerdict.closed);
   }
   sess.count++;
   if (isRetry) { sess.retryCount = (sess.retryCount || 0) + 1; }

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -258,20 +258,22 @@ function getCriticalMarker(stopReason, httpStatus, ctxPct) {
 }
 
 
-// #230 R1 retro: a closed bracket means turns previously numbered as main
-// were actually a sequential excursion (teammate/fan-out). Flip them to
-// subagent and renumber the whole session — numbering is arrival-ordered,
-// so every displayNum after the flip point shifts. DOM cards are patched in
-// place (class + number); the swimlane does its own retro (_wfSeqRetroMove).
+// #230 seq-layer flip machinery. _seqApplyFlips is the shared core: apply
+// flips (main→sub) and unflips (sub→main, round-6 overturns) caused by the
+// SEQ layer only — `_seqFlipped` marks them; agentKey/overlap/raw
+// classifications are never touched — then renumber the whole session
+// (numbering is arrival-ordered, so every displayNum after a flip point
+// shifts). DOM cards are patched in place (class + number); the swimlane
+// does its own retro (_wfSeqRetroMove / _wfSeqRebuild).
 // sess._recentMainSpans may retain a flipped turn's span for up to 5 turns —
 // accepted transient (spans only feed the overlap check).
-function _seqRetroFlip(sid, sess, closedTurns) {
-  const closedIds = new Set(closedTurns.map(t => t.id));
+function _seqApplyFlips(sid, sess, flipIds, unflipIds) {
   let mainN = 0, subN = 0, retryN = 0;
   for (let i = 0; i < allEntries.length; i++) {
     const en = allEntries[i];
     if (en.sessionId !== sid) continue;
-    if (closedIds.has(en.id)) en.isSubagent = true;
+    if (flipIds && flipIds.has(en.id)) { en.isSubagent = true; en._seqFlipped = true; }
+    else if (unflipIds && unflipIds.has(en.id)) { en.isSubagent = false; en._seqFlipped = false; }
     const num = en.isRetry ? 'r' + (++retryN) : en.isSubagent ? 's' + (++subN) : String(++mainN);
     if (en.displayNum === num) continue;
     en.displayNum = num;
@@ -287,6 +289,61 @@ function _seqRetroFlip(sid, sess, closedTurns) {
     }
   }
   sess.mainCount = mainN; sess.subCount = subN; sess.retryCount = retryN;
+}
+
+// #230 R1 retro: a closed bracket means turns previously numbered as main
+// were actually a sequential excursion (teammate/fan-out).
+function _seqRetroFlip(sid, sess, closedTurns) {
+  _seqApplyFlips(sid, sess, new Set(closedTurns.map(t => t.id)), null);
+}
+
+// #230 codex P2 round 6: full seq-layer recompute for one session, mirroring
+// the swimlane's _wfSeqRebuild. An earlier-starting turn arriving late can
+// overturn seq flips this file already applied — including flipping a
+// closed excursion BACK to main. Replay the session against a fresh tracker
+// in (receivedAt, id) order: base-classified subagents (agentKey/overlap —
+// isSubagent && !_seqFlipped) feed as split evidence, main candidates feed
+// as candidates; diff the resulting seq-flip set against the current one
+// and apply both directions. Overlap spans stay forward-only (pre-existing
+// ADR 0008 boundary, ADR 0009). Returns the current arrival's placement.
+function _seqRecomputeSession(sid, sess, currentSeqTurn) {
+  const tracker = wfCreateSeqTracker();
+  sess._seqTracker = tracker;
+  const replay = [];
+  for (let i = 0; i < allEntries.length; i++) {
+    const en = allEntries[i];
+    if (en.sessionId !== sid || en.isRetry) continue; // retries: neither evidence nor candidates
+    replay.push({ id: en.id, convId: en.convId || null, msgCount: en.msgCount, receivedAt: en.receivedAt,
+                  elapsed: en.elapsed, baseSub: !!(en.isSubagent && !en._seqFlipped), en });
+  }
+  // the current arrival is not in allEntries yet; it reached here as a
+  // main candidate (already past the agentKey + overlap checks)
+  replay.push(Object.assign({}, currentSeqTurn, { baseSub: false, en: null }));
+  replay.sort((a, b) => {
+    const ta = Number(a.receivedAt) || 0, tb = Number(b.receivedAt) || 0;
+    return (ta - tb) || (String(a.id) < String(b.id) ? -1 : 1);
+  });
+  const newFlipped = new Set();
+  let currentPlace = 'main';
+  for (const r of replay) {
+    if (r.baseSub) { wfSeqFeedSplit(tracker, r); continue; }
+    const v = wfSeqFeedMain(tracker, r);
+    if (v.place === 'excursion') { if (r.en) newFlipped.add(r.id); else currentPlace = 'excursion'; }
+    if (v.closed) for (const t of v.closed) {
+      if (t.id === currentSeqTurn.id) currentPlace = 'excursion';
+      else newFlipped.add(t.id);
+    }
+  }
+  const flipIds = new Set(), unflipIds = new Set();
+  for (const r of replay) {
+    if (!r.en) continue;
+    const cur = !!r.en._seqFlipped;
+    const next = newFlipped.has(r.id);
+    if (!cur && next) flipIds.add(r.id);
+    else if (cur && !next) unflipIds.add(r.id);
+  }
+  if (flipIds.size || unflipIds.size) _seqApplyFlips(sid, sess, flipIds, unflipIds);
+  return currentPlace;
 }
 
 function addEntry(e) {
@@ -391,7 +448,7 @@ function addEntry(e) {
   // they are neither frontier evidence nor main candidates.
   // INVARIANT: same tracker semantics as wfInferLanes/wfAddEntry — see
   // docs/decisions/0009-sequential-interleave-conv-bracketing.md
-  let seqVerdict = null;
+  let seqVerdict = null, seqFlipped = false;
   if (typeof wfCreateSeqTracker === 'function' && !isRetry) {
     if (!sess._seqTracker) sess._seqTracker = wfCreateSeqTracker();
     const seqTurn = { id: entryId, convId: e.convId || null, msgCount, receivedAt: e.receivedAt, elapsed: e.elapsed };
@@ -399,7 +456,15 @@ function addEntry(e) {
       wfSeqFeedSplit(sess._seqTracker, seqTurn);
     } else {
       seqVerdict = wfSeqFeedMain(sess._seqTracker, seqTurn);
-      if (seqVerdict.place === 'excursion') isSubagent = true;
+      // codex P2 round 6 (mirrors wfAddEntry's round-5 rebuild): an
+      // earlier-starting turn arriving late can overturn seq flips this
+      // file already applied — including flipping a closed excursion BACK
+      // to main. Recompute the session's seq layer from scratch so the
+      // turn list converges with the rebuilt swimlane (ADR 0005).
+      if (seqVerdict.reordered) {
+        if (_seqRecomputeSession(sid, sess, seqTurn) === 'excursion') { isSubagent = true; seqFlipped = true; }
+        seqVerdict = null; // closed brackets were handled inside the recompute
+      } else if (seqVerdict.place === 'excursion') { isSubagent = true; seqFlipped = true; }
     }
     if (seqVerdict && seqVerdict.closed) _seqRetroFlip(sid, sess, seqVerdict.closed);
   }
@@ -523,7 +588,7 @@ function addEntry(e) {
     req: e.req || null, res: e.res || null, reqLoaded: !!(e.req || e.res),
     msgCount, toolCount, toolCalls: e.toolCalls || {}, stopReason,
     status: e.status, elapsed: e.elapsed, method: e.method, id: e.id,
-    isSubagent, isRetry, sessionInferred: e.sessionInferred || false, displayNum, ctxUsed, isCompacted, receivedAt: e.receivedAt || null,
+    isSubagent, isRetry, _seqFlipped: seqFlipped, sessionInferred: e.sessionInferred || false, displayNum, ctxUsed, isCompacted, receivedAt: e.receivedAt || null,
     thinkingDuration: e.thinkingDuration || null,
     duplicateToolCalls: e.duplicateToolCalls || null,
     hasCredential: e.hasCredential || false,

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -396,7 +396,11 @@ function _wfSeqCloseBrackets(tracker) {
   excursed.forEach(function(r) {
     for (var e = 0; e < r.turns.length; e++) {
       turns.push(r.turns[e]);
-      wfSeqFeedSplit(tracker, r.turns[e]); // excursed turns become frontiers
+      // INVARIANT: a closed-bracket excursion must immediately become an
+      // R2 frontier — dropping this feed makes later same-conv sequential
+      // continuations silently fall back into main — see
+      // docs/decisions/0009-sequential-interleave-conv-bracketing.md
+      wfSeqFeedSplit(tracker, r.turns[e]);
     }
   });
   var turnSet = new Set(turns);
@@ -552,6 +556,9 @@ function wfInferLanes(entries, childEntries, seqTracker) {
   // Hand the converged classification to the live path: replay the final
   // stream into the caller's tracker so wfAddEntry continues from exactly
   // the batch state (R1 brackets spanning the build boundary still close).
+  // INVARIANT: this replay must survive any refactor — removing it paints
+  // the first frame correctly and corrupts every live update after it — see
+  // docs/decisions/0009-sequential-interleave-conv-bracketing.md
   var finalStream = [];
   for (var fv = 0; fv < fixedEvidence.length; fv++) finalStream.push({ t: fixedEvidence[fv], split: true });
   for (var fx = 0; fx < exiled.length; fx++) finalStream.push({ t: exiled[fx], split: true });
@@ -693,6 +700,10 @@ function _wfFollowTail(oldTMax) {
 }
 
 // ── Incremental Update ────────────────────────────────────────────────────
+// Caller contract: `entry` must already be pushed into allEntries before
+// this call — the reordered-arrival path (_wfSeqRebuild) recomputes the
+// whole state from allEntries and would otherwise drop the entry
+// (entry-rendering.js pushes at its allEntries.push site, then calls here).
 function wfAddEntry(entry) {
   if (!wfState) return { lanesChanged: false };
   var prevCount = wfState.lanes.length;
@@ -786,6 +797,10 @@ function wfAddEntry(entry) {
       // allEntries (the batch pass is the authority). Bounded: fires only
       // on inserted-before-tail arrivals (overlap inversion) — occasional
       // even in fork-heavy sessions.
+      // INVARIANT: reordered convergence is two-sided — entry-rendering.js
+      // must run _seqRecomputeSession (flips AND unflips) on the same flag,
+      // or the two files diverge (the ADR 0005 round-4 shape) — see
+      // docs/decisions/0009-sequential-interleave-conv-bracketing.md
       if (seqVerdict.reordered) return _wfSeqRebuild(oldTMax);
       if (seqVerdict.place === 'excursion') {
         needsSub = true;
@@ -839,9 +854,12 @@ function wfAddEntry(entry) {
 // overturn closed excursions, so recompute everything from allEntries via
 // wfBuildState (the entry is already in allEntries — entry-rendering pushes
 // before calling wfAddEntry) and migrate the user's view state onto the
-// fresh wfState. Turn-list (entry-rendering) classification stays
-// forward-only by design — same eventual-consistency boundary as ADR 0008's
-// reverse overlap, batch is the authority.
+// fresh wfState. entry-rendering converges on the same signal via
+// _seqRecomputeSession (round 6).
+// GUARD: the migration list below (view window, selection, focus, manual
+// lane height) must evolve together with wfBuildState's returned fields —
+// a new user-facing wfState field that isn't migrated here silently resets
+// on every reordered arrival.
 function _wfSeqRebuild(oldTMax) {
   var old = wfState;
   var fresh = wfBuildState(old.sessionId);

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -866,7 +866,40 @@ function wfDotSvg(shape, color, x, y, tidx) {
   return '<circle' + a + ' cx="' + (x + 2).toFixed(1) + '" cy="' + (y + 4) + '" r="2" fill="' + color + '"/>';
 }
 
-function wfRenderLaneSvg(lane, laneIdx, W, xFn) {
+// convIds present in the main lane — computed once per render pass and
+// passed down (rendering budget: never rescan lanes[0].turns per lane).
+function _wfMainConvSet(lanes) {
+  var s = new Set();
+  var main = lanes && lanes[0];
+  if (main && main.turns) {
+    for (var i = 0; i < main.turns.length; i++) {
+      if (main.turns[i].convId) s.add(main.turns[i].convId);
+    }
+  }
+  return s;
+}
+
+// Display name for a lane. Parallel-lane instances (ADR 0008/0009) share
+// agentLabel AND often convId, so they'd all read as the same
+// "Orchestrator 5212" — semantically wrong too: one session has one
+// orchestrator. Split by conversation identity (owner decision, PR #232
+// acceptance; refined 2026-07-11 #230 visual review):
+//   convId ∈ main's conv set  → "Fork <conv> #k"     (same-conversation
+//     twin: overlap-split fork, R2-stitched continuation)
+//   convId ∉ main's conv set  → "Teammate <conv> #k" (independent
+//     conversation: agent-team teammate, workflow fan-out — R1 excursion)
+function _wfLaneDispName(lane, laneIdx, mainConvs) {
+  if (lane.childSessionId) return (lane.agentLabel || wfShortModel(lane.model)) + ' ' + lane.childSessionId.slice(0, 8);
+  if (laneIdx === 0) return lane.name;
+  var laneOrd = /#(\d+)$/.exec(lane.key || '');
+  if ((lane.key || '').indexOf('parallel-') === 0) {
+    var kin = lane.convId && mainConvs && mainConvs.has(lane.convId) ? 'Fork' : 'Teammate';
+    return kin + (lane.convId ? ' ' + lane.convId.slice(0, 4) : '') + ' #' + (laneOrd ? laneOrd[1] : '1');
+  }
+  return (lane.agentLabel || lane.name) + (lane.convId ? ' ' + lane.convId.slice(0, 4) : '');
+}
+
+function wfRenderLaneSvg(lane, laneIdx, W, xFn, mainConvs) {
   var isSel = wfState.selectedLane?.key === lane.key;
   var laneH = isSel ? WF_LANE_H_SEL : WF_LANE_H;
   var boxH = laneH - WF_LANE_GAP;
@@ -885,18 +918,7 @@ function wfRenderLaneSvg(lane, laneIdx, W, xFn) {
   // Label block: agent name / model·ctx window / sysprompt version chips
   var prefix = isSel ? '▶ ' : '';
   var ctxK = Math.round((lane.ctxWindow || 0) / 1000);
-  // Parallel-lane instances (ADR 0008) share agentLabel AND convId (forks
-  // inherit both), so they'd all read as the same "Orchestrator 5212" —
-  // semantically wrong too: one session has one orchestrator. Label them
-  // "Fork <conv> #k" instead (owner decision, PR #232 acceptance).
-  var laneOrd = /#(\d+)$/.exec(lane.key || '');
-  var isParallelLane = (lane.key || '').indexOf('parallel-') === 0;
-  var dispName = lane.childSessionId
-    ? (lane.agentLabel || wfShortModel(lane.model)) + ' ' + lane.childSessionId.slice(0, 8)
-    : (laneIdx === 0 ? lane.name
-      : isParallelLane
-        ? 'Fork' + (lane.convId ? ' ' + lane.convId.slice(0, 4) : '') + ' #' + (laneOrd ? laneOrd[1] : '1')
-        : (lane.agentLabel || lane.name) + (lane.convId ? ' ' + lane.convId.slice(0, 4) : ''));
+  var dispName = _wfLaneDispName(lane, laneIdx, mainConvs);
   var fullTitle = wfEsc(lane.name + ' · ' + (lane.agentLabel || '?') + ' · ' + (lane.model || '?') + ' · ' + ctxK + 'K');
   svg += '<text x="8" y="12" fill="var(--text)" style="font-size:11px;font-family:' + WF_MONO + '"><title>' + fullTitle + '</title>' + wfEsc(prefix + dispName) + '</text>';
   svg += wfGlyphSvg(wfLaneShape(lane), 14, 23, 6, wfLaneColor(lane));
@@ -1150,8 +1172,13 @@ function _wfRenderSvgContent(mainSvg, subSvg, canvas) {
   var focusLi = _wfFocusLaneIdx();
   var laneCls = function(li) { return 'wf-lane' + (focusLi >= 0 && focusLi !== li ? ' dim' : ''); };
 
+  // Main conv set for lane naming — once per render pass, so it can't go
+  // stale when new turns arrive (every render recomputes) and never rescans
+  // main's turns inside the per-lane loop (rendering budget).
+  var mainConvs = _wfMainConvSet(lanes);
+
   var mainLaneY = WF_PAD + WF_AXIS_H;
-  ms += '<g class="' + laneCls(0) + '" data-lane="0" transform="translate(0,' + mainLaneY + ')">' + wfRenderLaneSvg(lanes[0], 0, W, xFn) + '</g>';
+  ms += '<g class="' + laneCls(0) + '" data-lane="0" transform="translate(0,' + mainLaneY + ')">' + wfRenderLaneSvg(lanes[0], 0, W, xFn, mainConvs) + '</g>';
   mainSvg.innerHTML = ms;
 
   // Sub SVG: remaining lanes (dynamic height per lane). Lane-focus mode
@@ -1178,7 +1205,7 @@ function _wfRenderSvgContent(mainSvg, subSvg, canvas) {
     var subY = WF_PAD;
     for (var si = 0; si < subIndices.length; si++) {
       var li = subIndices[si];
-      ss += '<g class="' + laneCls(li) + '" data-lane="' + li + '" transform="translate(0,' + subY + ')">' + wfRenderLaneSvg(lanes[li], li, W, xFn) + '</g>';
+      ss += '<g class="' + laneCls(li) + '" data-lane="' + li + '" transform="translate(0,' + subY + ')">' + wfRenderLaneSvg(lanes[li], li, W, xFn, mainConvs) + '</g>';
       subY += _wfLaneHeight(li);
     }
     subSvg.innerHTML = ss;

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -231,8 +231,122 @@ function _wfSubLaneKey(base, entry) {
   return entry.convId ? base + ':' + entry.convId : base;
 }
 
-function wfInferLanes(entries, childEntries) {
+// ── Sequential-interleave tracker (#230) ──────────────────────────────────
+// Temporal overlap (ADR 0008) only catches PARALLEL agents. A sequential
+// teammate — dispatched while main idles, zero time overlap — leaves two
+// wire-level footprints instead:
+//   R1: main's convId (messages[0] hash) only moves forward. If runs of
+//       conv A resume AFTER foreign-conv runs, the runs in between are
+//       excursions (bracketing). A conv change that never returns is a
+//       compaction — legal, stays main (trunk-advance). isCompacted is
+//       deliberately NOT consulted: real fan-out first-turns get mislabeled
+//       isCompacted (big msg+token drop), so gating on it would exempt
+//       exactly the target case (session a7fef8a8 evidence).
+//   R2: a fork shares main's convId, so R1 is blind to it — but its turns
+//       continue a frontier already split out of main (by overlap or R1):
+//       same conv, msgCount within [tail, tail+2], starting at/after the
+//       tail ends. A dip with NO such frontier is a rewind/edit and stays
+//       in main (session 7e1d9272's 540→493 must not split).
+// One tracker implementation serves BOTH entry-rendering.js and this file
+// (each holds an instance, fed the same per-turn signals), so the two
+// files cannot disagree — the ADR 0005 shape, like AGENT_KEY_UNRELIABLE.
+// INVARIANT: sequential-interleave classification must go through this
+// tracker in both files, and it never consults isCompacted — see
+// docs/decisions/0009-sequential-interleave-conv-bracketing.md
+function wfCreateSeqTracker() {
+  return { runs: [], tails: [] };
+}
+
+// Evidence feed: a turn already split out of main (agent-keyed lane,
+// overlap overflow, or a closed R1 bracket). Its (conv, msgCount, end)
+// frontier is what R2 stitches later same-conv dips onto.
+function wfSeqFeedSplit(tracker, turn) {
+  if (!tracker || !turn.convId || !(turn.msgCount > 0)) return;
+  var ts = Number(turn.receivedAt) || 0;
+  tracker.tails.push({ conv: turn.convId, msg: turn.msgCount, end: ts + (parseFloat(turn.elapsed) || 0) * 1000 });
+  if (tracker.tails.length > 16) tracker.tails.shift();
+}
+
+// Main-candidate feed. Returns { place: 'main'|'excursion', closed }.
+// 'excursion' = R2 stitch — route to a parallel lane now. closed = an R1
+// bracket just closed: those turns were provisionally main and the caller
+// must retro-move them out.
+function wfSeqFeedMain(tracker, turn) {
+  var res = { place: 'main', closed: null };
+  if (!tracker) return res;
+  var conv = turn.convId, msg = turn.msgCount || 0;
+  var ts = Number(turn.receivedAt) || 0;
+  if (!conv || !ts) return res; // inert: never a boundary, never moved
+  // R2 first: a dip that stitches onto a split-out frontier is NOT a trunk
+  // return — it must not extend a run or close a bracket.
+  var prevSame = null;
+  for (var i = tracker.runs.length - 1; i >= 0 && !prevSame; i--) {
+    if (tracker.runs[i].conv === conv) {
+      var rts = tracker.runs[i].turns;
+      prevSame = rts[rts.length - 1];
+    }
+  }
+  if (prevSame && msg > 0 && msg < (prevSame.msgCount || 0)) {
+    for (var j = tracker.tails.length - 1; j >= 0; j--) {
+      var t = tracker.tails[j];
+      if (t.conv === conv && t.msg <= msg && msg <= t.msg + 2 && t.end <= ts) {
+        t.msg = msg; // frontier advances with the stitched turn
+        t.end = ts + (parseFloat(turn.elapsed) || 0) * 1000;
+        res.place = 'excursion';
+        return res;
+      }
+    }
+  }
+  var last = tracker.runs[tracker.runs.length - 1];
+  if (last && last.conv === conv) last.turns.push(turn);
+  else tracker.runs.push({ conv: conv, turns: [turn] });
+  res.closed = _wfSeqCloseBrackets(tracker);
+  return res;
+}
+
+// Re-run the trunk walk over the accumulated runs. Any run bracketed by a
+// reappearance of an earlier conv is an excursion; leftover pending runs
+// mean that trunk conv never returned — trunk advances (compaction) and
+// they stay main. Because the whole walk reruns on every feed, the live
+// path equals the batch pass on every prefix by construction.
+function _wfSeqCloseBrackets(tracker) {
+  var runs = tracker.runs;
+  if (runs.length < 3) return null;
+  var excursed = new Set();
+  var work = runs;
+  while (work.length) {
+    var trunk = work[0].conv;
+    var pending = [];
+    for (var i = 1; i < work.length; i++) {
+      if (work[i].conv === trunk) {
+        for (var p = 0; p < pending.length; p++) excursed.add(pending[p]);
+        pending = [];
+      } else pending.push(work[i]);
+    }
+    work = pending;
+  }
+  if (!excursed.size) return null;
+  var out = [], turns = [];
+  for (var r = 0; r < runs.length; r++) {
+    if (excursed.has(runs[r])) {
+      for (var e = 0; e < runs[r].turns.length; e++) {
+        turns.push(runs[r].turns[e]);
+        wfSeqFeedSplit(tracker, runs[r].turns[e]); // excursed turns become frontiers
+      }
+      continue;
+    }
+    var lastOut = out[out.length - 1];
+    if (lastOut && lastOut.conv === runs[r].conv) lastOut.turns = lastOut.turns.concat(runs[r].turns);
+    else out.push(runs[r]);
+  }
+  tracker.runs = out;
+  turns.sort(function(a, b) { return (Number(a.receivedAt) || 0) - (Number(b.receivedAt) || 0); });
+  return turns;
+}
+
+function wfInferLanes(entries, childEntries, seqTracker) {
   if (!entries.length && !childEntries.length) return [];
+  if (!seqTracker) seqTracker = wfCreateSeqTracker();
 
   var laneMap = new Map();
   var mainLane = { name: 'main', key: 'main', turns: [], model: null, ctxWindow: 0, spawnParent: null };
@@ -288,42 +402,103 @@ function wfInferLanes(entries, childEntries) {
   // turn is parallel iff its start falls strictly inside the previous main
   // turn's (start, end) — equal starts count as sequential.
   mainLane.turns.sort(function(a, b) { return (Number(a.receivedAt) || 0) - (Number(b.receivedAt) || 0); });
-  var serialTurns = [], overflowTurns = [];
-  for (var oi = 0; oi < mainLane.turns.length; oi++) {
-    var cur = mainLane.turns[oi];
-    var curStart = Number(cur.receivedAt) || 0;
-    var last = serialTurns[serialTurns.length - 1];
-    var lastStart = last ? (Number(last.receivedAt) || 0) : 0;
-    var lastEnd = last ? lastStart + (parseFloat(last.elapsed) || 0) * 1000 : 0;
-    if (curStart > lastStart && curStart < lastEnd) overflowTurns.push(cur);
-    else serialTurns.push(cur);
-  }
-  if (overflowTurns.length) {
-    mainLane.turns = serialTurns;
-    // Overflow turns go to numbered parallel lanes, best-fit: among lanes
-    // of the same base key (model+convId — forks share both), pick the one
-    // whose chain ends latest but still before this turn's start. Serial
-    // turns of the same fork tend to reconstruct as one lane; the numbered
-    // lanes bound out at the session's true max concurrency.
-    var pFamilies = new Map(); // baseKey → [{ key, lastEnd }]
-    for (var ov = 0; ov < overflowTurns.length; ov++) {
-      var oTurn = overflowTurns[ov];
-      var oStart = Number(oTurn.receivedAt) || 0;
-      var oEnd = oStart + (parseFloat(oTurn.elapsed) || 0) * 1000;
-      var baseKey = _wfSubLaneKey('parallel-' + wfShortModel(oTurn.model), oTurn);
-      var fam = pFamilies.get(baseKey);
-      if (!fam) { fam = []; pFamilies.set(baseKey, fam); }
-      var best = null;
-      for (var pi = 0; pi < fam.length; pi++) {
-        if (fam[pi].lastEnd <= oStart && (!best || fam[pi].lastEnd > best.lastEnd)) best = fam[pi];
-      }
-      if (!best) {
-        best = { key: fam.length ? baseKey + '#' + (fam.length + 1) : baseKey, lastEnd: 0 };
-        fam.push(best);
-      }
-      best.lastEnd = Math.max(best.lastEnd, oEnd);
-      _wfPushToSubLane(laneMap, best.key, oTurn);
+
+  // Post-pass 2 (#230): sequential interleave, interleaved with the overlap
+  // sweep to a fixpoint. Overlap only proves PARALLEL agents; a sequential
+  // teammate/fork leaves only main's convId run structure (R1) or a
+  // split-out frontier's msgCount continuation (R2) as its footprint. Each
+  // round: sweep the candidates into a serial chain (ADR 0008), then feed
+  // the tracker the same chronological stream the live path sees — split
+  // turns as frontier evidence, serial turns as main candidates. When the
+  // seq pass excurses a turn, the sweep re-runs WITHOUT it, so a main turn
+  // that only overlapped an excursion is re-admitted — keeping the batch
+  // rebuild equal to the live path (which never saw the excursion in main).
+  // Terminates: each extra round removes ≥1 excursed turn from candidates.
+  // INVARIANT: the sweep runs before the seq pass in every round, and the
+  // seq pass never consults isCompacted — see
+  // docs/decisions/0009-sequential-interleave-conv-bracketing.md
+  var fixedEvidence = [];
+  laneMap.forEach(function(lane, lk) {
+    if (lk === 'main') return;
+    for (var si = 0; si < lane.turns.length; si++) fixedEvidence.push(lane.turns[si]);
+  });
+  var candidates = mainLane.turns;
+  var exiled = [];
+  for (;;) {
+    var serialTurns = [], overflowTurns = [];
+    for (var oi = 0; oi < candidates.length; oi++) {
+      var cur = candidates[oi];
+      var curStart = Number(cur.receivedAt) || 0;
+      var last = serialTurns[serialTurns.length - 1];
+      var lastStart = last ? (Number(last.receivedAt) || 0) : 0;
+      var lastEnd = last ? lastStart + (parseFloat(last.elapsed) || 0) * 1000 : 0;
+      if (curStart > lastStart && curStart < lastEnd) overflowTurns.push(cur);
+      else serialTurns.push(cur);
     }
+    var roundTracker = wfCreateSeqTracker();
+    var seqStream = [];
+    for (var fe = 0; fe < fixedEvidence.length; fe++) seqStream.push({ t: fixedEvidence[fe], split: true });
+    for (var xe = 0; xe < exiled.length; xe++) seqStream.push({ t: exiled[xe], split: true });
+    for (var oe = 0; oe < overflowTurns.length; oe++) seqStream.push({ t: overflowTurns[oe], split: true });
+    for (var se = 0; se < serialTurns.length; se++) seqStream.push({ t: serialTurns[se], split: false });
+    seqStream.sort(function(a, b) { return (Number(a.t.receivedAt) || 0) - (Number(b.t.receivedAt) || 0); });
+    var excursed = [];
+    for (var qi = 0; qi < seqStream.length; qi++) {
+      if (seqStream[qi].split) { wfSeqFeedSplit(roundTracker, seqStream[qi].t); continue; }
+      var verdict = wfSeqFeedMain(roundTracker, seqStream[qi].t);
+      if (verdict.place === 'excursion') excursed.push(seqStream[qi].t);
+      if (verdict.closed) for (var vc = 0; vc < verdict.closed.length; vc++) excursed.push(verdict.closed[vc]);
+    }
+    if (!excursed.length) {
+      mainLane.turns = serialTurns;
+      exiled = exiled.concat(overflowTurns);
+      break;
+    }
+    exiled = exiled.concat(excursed);
+    var exSet = new Set(excursed);
+    candidates = serialTurns.filter(function(t) { return !exSet.has(t); }).concat(overflowTurns);
+    candidates.sort(function(a, b) { return (Number(a.receivedAt) || 0) - (Number(b.receivedAt) || 0); });
+  }
+
+  // Excursion/parallel turns go to numbered parallel lanes, best-fit: among
+  // lanes of the same base key (model+convId — forks share both), pick the
+  // one whose chain ends latest but still before this turn's start. Serial
+  // turns of the same fork tend to reconstruct as one lane; the numbered
+  // lanes bound out at the session's true max concurrency. One family map
+  // for overlap overflow AND seq excursions, so a stitched dip lands in the
+  // same lane as its overlap-split siblings.
+  var pFamilies = new Map(); // baseKey → [{ key, lastEnd }]
+  exiled.sort(function(a, b) { return (Number(a.receivedAt) || 0) - (Number(b.receivedAt) || 0); });
+  for (var ex = 0; ex < exiled.length; ex++) {
+    var oTurn = exiled[ex];
+    var oStart = Number(oTurn.receivedAt) || 0;
+    var oEnd = oStart + (parseFloat(oTurn.elapsed) || 0) * 1000;
+    var baseKey = _wfSubLaneKey('parallel-' + wfShortModel(oTurn.model), oTurn);
+    var fam = pFamilies.get(baseKey);
+    if (!fam) { fam = []; pFamilies.set(baseKey, fam); }
+    var best = null;
+    for (var pi = 0; pi < fam.length; pi++) {
+      if (fam[pi].lastEnd <= oStart && (!best || fam[pi].lastEnd > best.lastEnd)) best = fam[pi];
+    }
+    if (!best) {
+      best = { key: fam.length ? baseKey + '#' + (fam.length + 1) : baseKey, lastEnd: 0 };
+      fam.push(best);
+    }
+    best.lastEnd = Math.max(best.lastEnd, oEnd);
+    _wfPushToSubLane(laneMap, best.key, oTurn);
+  }
+
+  // Hand the converged classification to the live path: replay the final
+  // stream into the caller's tracker so wfAddEntry continues from exactly
+  // the batch state (R1 brackets spanning the build boundary still close).
+  var finalStream = [];
+  for (var fv = 0; fv < fixedEvidence.length; fv++) finalStream.push({ t: fixedEvidence[fv], split: true });
+  for (var fx = 0; fx < exiled.length; fx++) finalStream.push({ t: exiled[fx], split: true });
+  for (var fm = 0; fm < mainLane.turns.length; fm++) finalStream.push({ t: mainLane.turns[fm], split: false });
+  finalStream.sort(function(a, b) { return (Number(a.t.receivedAt) || 0) - (Number(b.t.receivedAt) || 0); });
+  for (var ff = 0; ff < finalStream.length; ff++) {
+    if (finalStream[ff].split) wfSeqFeedSplit(seqTracker, finalStream[ff].t);
+    else wfSeqFeedMain(seqTracker, finalStream[ff].t);
   }
 
   // Child session entries → their own lanes
@@ -410,7 +585,10 @@ function wfBuildState(sessionId) {
   }
   if (tMin === Infinity) { tMin = 0; if (tMax === -Infinity) tMax = 1; }
 
-  var lanes = wfInferLanes(entries, childEntries);
+  // #230: the tracker built during the batch pass carries over to the live
+  // path (wfAddEntry) so R1 brackets spanning the build boundary still close.
+  var seqTracker = wfCreateSeqTracker();
+  var lanes = wfInferLanes(entries, childEntries, seqTracker);
 
   // E1: O(1) turn lookup — avoids repeated O(lanes×turns) scans in hot paths
   var turnIndex = new Map();
@@ -423,6 +601,7 @@ function wfBuildState(sessionId) {
     sessionId: sessionId,
     childSids: childSids,
     turnIndex: turnIndex,
+    _seqTracker: seqTracker,
     tMin: tMin, tMax: tMax,
     viewT0: tMin, viewT1: tMax,
     selectedLane: lanes[0] || null,
@@ -526,6 +705,24 @@ function wfAddEntry(entry) {
       }
     }
   }
+  // #230 sequential interleave: after agentKey and overlap both said "main",
+  // ask the tracker. R2 dips route to a parallel lane immediately; R1
+  // foreign-conv turns stay provisionally in main until the trunk conv
+  // returns, at which point _wfSeqRetroMove relocates the closed bracket.
+  // INVARIANT: same tracker semantics as wfInferLanes' post-pass and
+  // entry-rendering.js — see docs/decisions/0009-sequential-interleave-conv-bracketing.md
+  var seqVerdict = null;
+  if (wfState._seqTracker) {
+    if (needsSub) {
+      wfSeqFeedSplit(wfState._seqTracker, entry);
+    } else {
+      seqVerdict = wfSeqFeedMain(wfState._seqTracker, entry);
+      if (seqVerdict.place === 'excursion') {
+        needsSub = true;
+        key = _wfSubLaneKey('parallel-' + wfShortModel(entry.model), entry);
+      }
+    }
+  }
   if (needsSub) {
     var lane;
     if (key.indexOf('parallel-') === 0) {
@@ -559,8 +756,45 @@ function wfAddEntry(entry) {
     if (wfState.turnIndex) wfState.turnIndex.set(entry.id, { turn: entry, laneIdx: 0 });
   }
 
+  // #230 R1: the trunk conv just returned — turns of the closed bracket were
+  // provisionally drawn in main and must relocate to parallel lanes.
+  if (seqVerdict && seqVerdict.closed) _wfSeqRetroMove(seqVerdict.closed);
+
   _wfFollowTail(oldTMax);
   return { lanesChanged: wfState.lanes.length !== prevCount };
+}
+
+// Retro-move a closed R1 bracket (#230) out of the live main lane, using the
+// same best-fit-by-family placement as the batch pass (latest-ending lane of
+// key/key#N that still ends at/before the turn's start — keeps every lane
+// serial, preserving the ADR 0008 no-intra-lane-overlap invariant).
+function _wfSeqRetroMove(closedTurns) {
+  if (!wfState.lanes[0] || !closedTurns.length) return;
+  var closedSet = new Set(closedTurns);
+  wfState.lanes[0].turns = wfState.lanes[0].turns.filter(function(t) { return !closedSet.has(t); });
+  wfState.lanes[0]._costMedian = null;
+  for (var i = 0; i < closedTurns.length; i++) {
+    var t = closedTurns[i];
+    var ts = Number(t.receivedAt) || 0;
+    var key = _wfSubLaneKey('parallel-' + wfShortModel(t.model), t);
+    var famLanes = wfState.lanes.filter(function(l) {
+      return l.key === key || l.key.indexOf(key + '#') === 0;
+    });
+    var lane = null, bestEnd = -1;
+    for (var fi = 0; fi < famLanes.length; fi++) {
+      var lt = famLanes[fi].turns[famLanes[fi].turns.length - 1];
+      var ltEnd = lt ? (Number(lt.receivedAt) || 0) + (parseFloat(lt.elapsed) || 0) * 1000 : 0;
+      if (ltEnd <= ts && ltEnd > bestEnd) { lane = famLanes[fi]; bestEnd = ltEnd; }
+    }
+    if (!lane) {
+      if (famLanes.length) key = key + '#' + (famLanes.length + 1);
+      lane = { name: key, key: key, turns: [], model: t.model, ctxWindow: t.maxContext || 0, spawnParent: null, agentKey: t.agentKey || null, agentLabel: t.agentLabel || null, convId: t.convId || null };
+      wfState.lanes.push(lane);
+    }
+    lane.turns.push(t);
+    lane._costMedian = null;
+    if (wfState.turnIndex) wfState.turnIndex.set(t.id, { turn: t, laneIdx: wfState.lanes.indexOf(lane) });
+  }
 }
 
 // ── Lane Summary ──────────────────────────────────────────────────────────

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -350,6 +350,12 @@ function wfSeqFeedMain(tracker, turn) {
       return res;
     }
   }
+  // Inserted before existing turns ⇒ chronological truth was reordered:
+  // already-closed excursions may need overturning (the trunk itself can
+  // change), but closed turns have left this list — no incremental step
+  // can reopen them. The live caller uses this flag to fall back to a
+  // full batch rebuild (codex P2, round 5).
+  res.reordered = lo < list.length;
   list.splice(lo, 0, turn);
   res.closed = _wfSeqCloseBrackets(tracker);
   return res;
@@ -772,6 +778,15 @@ function wfAddEntry(entry) {
       wfSeqFeedSplit(wfState._seqTracker, entry);
     } else {
       seqVerdict = wfSeqFeedMain(wfState._seqTracker, entry);
+      // codex P2 round 5: an earlier-starting turn arriving late can
+      // invalidate ALREADY-CLOSED excursions — the chronological truth can
+      // reorder the trunk itself (B0-A-B-A where B was already retro-moved
+      // on the A-B-A prefix). Closed turns left the tracker list, so no
+      // incremental step can reopen them: rebuild the whole state from
+      // allEntries (the batch pass is the authority). Bounded: fires only
+      // on inserted-before-tail arrivals (overlap inversion) — occasional
+      // even in fork-heavy sessions.
+      if (seqVerdict.reordered) return _wfSeqRebuild(oldTMax);
       if (seqVerdict.place === 'excursion') {
         needsSub = true;
         key = _wfSubLaneKey('parallel-' + wfShortModel(entry.model), entry);
@@ -817,6 +832,32 @@ function wfAddEntry(entry) {
 
   _wfFollowTail(oldTMax);
   return { lanesChanged: wfState.lanes.length !== prevCount };
+}
+
+// Full-state rebuild for the live path (#230 codex P2 round 5): a
+// late-arriving turn that starts earlier than already-processed turns can
+// overturn closed excursions, so recompute everything from allEntries via
+// wfBuildState (the entry is already in allEntries — entry-rendering pushes
+// before calling wfAddEntry) and migrate the user's view state onto the
+// fresh wfState. Turn-list (entry-rendering) classification stays
+// forward-only by design — same eventual-consistency boundary as ADR 0008's
+// reverse overlap, batch is the authority.
+function _wfSeqRebuild(oldTMax) {
+  var old = wfState;
+  var fresh = wfBuildState(old.sessionId);
+  if (!fresh) return { lanesChanged: false };
+  fresh.viewT0 = old.viewT0;
+  fresh.viewT1 = old.viewT1;
+  fresh.selectedTurnId = old.selectedTurnId;
+  fresh.selectedSection = old.selectedSection;
+  fresh.laneFocusMode = old.laneFocusMode;
+  fresh.laneHeightManual = old.laneHeightManual;
+  if (old.selectedLane) {
+    fresh.selectedLane = fresh.lanes.find(function(l) { return l.key === old.selectedLane.key; }) || fresh.lanes[0];
+  }
+  wfState = fresh;
+  _wfFollowTail(oldTMax);
+  return { lanesChanged: true };
 }
 
 // Retro-move a closed R1 bracket (#230) out of the live main lane, using the

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -254,7 +254,13 @@ function _wfSubLaneKey(base, entry) {
 // tracker in both files, and it never consults isCompacted — see
 // docs/decisions/0009-sequential-interleave-conv-bracketing.md
 function wfCreateSeqTracker() {
-  return { runs: [], tails: [] };
+  // list: main-candidate turns kept sorted by (receivedAt, id) — entries
+  // arrive in COMPLETION order (a nested turn can finish before the longer
+  // turn that started first), so run structure must derive from start
+  // order, never arrival order: a foreign-conv turn arriving first would
+  // otherwise become the trunk and no bracket would ever close (codex P2,
+  // round 1).
+  return { list: [], tails: [] };
 }
 
 // Evidence feed: a turn already split out of main (agent-keyed lane,
@@ -277,14 +283,23 @@ function wfSeqFeedMain(tracker, turn) {
   var conv = turn.convId, msg = turn.msgCount || 0;
   var ts = Number(turn.receivedAt) || 0;
   if (!conv || !ts) return res; // inert: never a boundary, never moved
+  // Sorted insertion point by (receivedAt, id): deterministic under the
+  // arrival-order ≠ start-order inversions of nested turns (codex P2).
+  var list = tracker.list;
+  var lo = 0, hi = list.length;
+  while (lo < hi) {
+    var mid = (lo + hi) >> 1;
+    var mts = Number(list[mid].receivedAt) || 0;
+    if (mts < ts || (mts === ts && String(list[mid].id) <= String(turn.id))) lo = mid + 1;
+    else hi = mid;
+  }
   // R2 first: a dip that stitches onto a split-out frontier is NOT a trunk
-  // return — it must not extend a run or close a bracket.
+  // return — it must not join the list or close a bracket. prevSame is the
+  // chronologically previous same-conv turn (scan back from the insertion
+  // point), never the last-ARRIVED one.
   var prevSame = null;
-  for (var i = tracker.runs.length - 1; i >= 0 && !prevSame; i--) {
-    if (tracker.runs[i].conv === conv) {
-      var rts = tracker.runs[i].turns;
-      prevSame = rts[rts.length - 1];
-    }
+  for (var i = lo - 1; i >= 0 && !prevSame; i--) {
+    if (list[i].convId === conv) prevSame = list[i];
   }
   if (prevSame && msg > 0 && msg < (prevSame.msgCount || 0)) {
     for (var j = tracker.tails.length - 1; j >= 0; j--) {
@@ -297,20 +312,27 @@ function wfSeqFeedMain(tracker, turn) {
       }
     }
   }
-  var last = tracker.runs[tracker.runs.length - 1];
-  if (last && last.conv === conv) last.turns.push(turn);
-  else tracker.runs.push({ conv: conv, turns: [turn] });
+  list.splice(lo, 0, turn);
   res.closed = _wfSeqCloseBrackets(tracker);
   return res;
 }
 
-// Re-run the trunk walk over the accumulated runs. Any run bracketed by a
-// reappearance of an earlier conv is an excursion; leftover pending runs
-// mean that trunk conv never returned — trunk advances (compaction) and
-// they stay main. Because the whole walk reruns on every feed, the live
-// path equals the batch pass on every prefix by construction.
+// Rebuild convId runs from the (receivedAt, id)-sorted candidate list and
+// re-run the trunk walk. Any run bracketed by a reappearance of an earlier
+// conv is an excursion; leftover pending runs mean that trunk conv never
+// returned — trunk advances (compaction) and they stay main. Because runs
+// derive from the sorted list (never arrival order) and the walk reruns on
+// every feed, the live path converges to the batch pass regardless of the
+// order entries complete in.
 function _wfSeqCloseBrackets(tracker) {
-  var runs = tracker.runs;
+  var list = tracker.list;
+  if (list.length < 3) return null;
+  var runs = [];
+  for (var li = 0; li < list.length; li++) {
+    var last = runs[runs.length - 1];
+    if (last && last.conv === list[li].convId) last.turns.push(list[li]);
+    else runs.push({ conv: list[li].convId, turns: [list[li]] });
+  }
   if (runs.length < 3) return null;
   var excursed = new Set();
   var work = runs;
@@ -326,20 +348,15 @@ function _wfSeqCloseBrackets(tracker) {
     work = pending;
   }
   if (!excursed.size) return null;
-  var out = [], turns = [];
-  for (var r = 0; r < runs.length; r++) {
-    if (excursed.has(runs[r])) {
-      for (var e = 0; e < runs[r].turns.length; e++) {
-        turns.push(runs[r].turns[e]);
-        wfSeqFeedSplit(tracker, runs[r].turns[e]); // excursed turns become frontiers
-      }
-      continue;
+  var turns = [];
+  excursed.forEach(function(r) {
+    for (var e = 0; e < r.turns.length; e++) {
+      turns.push(r.turns[e]);
+      wfSeqFeedSplit(tracker, r.turns[e]); // excursed turns become frontiers
     }
-    var lastOut = out[out.length - 1];
-    if (lastOut && lastOut.conv === runs[r].conv) lastOut.turns = lastOut.turns.concat(runs[r].turns);
-    else out.push(runs[r]);
-  }
-  tracker.runs = out;
+  });
+  var turnSet = new Set(turns);
+  tracker.list = list.filter(function(t) { return !turnSet.has(t); });
   turns.sort(function(a, b) { return (Number(a.receivedAt) || 0) - (Number(b.receivedAt) || 0); });
   return turns;
 }

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -260,12 +260,14 @@ function wfCreateSeqTracker() {
   // order, never arrival order: a foreign-conv turn arriving first would
   // otherwise become the trunk and no bracket would ever close (codex P2,
   // round 1).
-  // tails: Map(convId → [ { msg, end }, ... ]) — one frontier per
-  // concurrent track of that conv (same-conv forks run in parallel). No
-  // global cap: conv count and per-conv concurrency are naturally bounded
-  // within a session, and a shared FIFO would evict still-active frontiers
-  // once enough split turns pass, silently disabling R2 for the evicted
-  // conv (codex P2, round 3).
+  // tails: Map(convId → [ { msg, end }, ... ]) — APPEND-ONLY tail points,
+  // one per split turn of that conv. Per-conv so no shared FIFO can evict
+  // a still-active conv's evidence (codex P2, round 3); append-only so a
+  // historical branch point survives later splits that "continue" it —
+  // merging erased the fork point another concurrent track's sequential
+  // continuation still needed (439-session re-audit regression,
+  // 2026-07-11: jumpreturn residue 3→8). No cap: memory is O(split turns)
+  // per session — trivial.
   return { list: [], tails: new Map() };
 }
 
@@ -282,20 +284,20 @@ function _wfSeqBestFrontier(frontiers, msg, ts) {
 }
 
 // Evidence feed: a turn already split out of main (agent-keyed lane,
-// overlap overflow, or a closed R1 bracket). Its (msg, end) frontier is
-// what R2 stitches later same-conv dips onto. A split turn that continues
-// an existing frontier advances it; otherwise it opens a new concurrent
-// track for its conv.
+// overlap overflow, or a closed R1 bracket). Its (msg, end) becomes an
+// append-only tail point for its conv — R2 stitches later same-conv dips
+// onto the best-fitting point. NEVER merged: a fork can branch several
+// concurrent tracks from the same historical msgCount, and folding a
+// "continuation" split into an earlier point erases the branch point that
+// another track's sequential continuation still needs. Only an R2 stitch
+// advances a point — the dip consumed it, so its old value has no further
+// consumer.
 function wfSeqFeedSplit(tracker, turn) {
   if (!tracker || !turn.convId || !(turn.msgCount > 0)) return;
   var ts = Number(turn.receivedAt) || 0;
-  var msg = turn.msgCount;
-  var end = ts + (parseFloat(turn.elapsed) || 0) * 1000;
   var frontiers = tracker.tails.get(turn.convId);
-  if (!frontiers) { tracker.tails.set(turn.convId, [{ msg: msg, end: end }]); return; }
-  var best = _wfSeqBestFrontier(frontiers, msg, ts);
-  if (best) { best.msg = msg; best.end = end; }
-  else frontiers.push({ msg: msg, end: end });
+  if (!frontiers) tracker.tails.set(turn.convId, frontiers = []);
+  frontiers.push({ msg: turn.msgCount, end: ts + (parseFloat(turn.elapsed) || 0) * 1000 });
 }
 
 // Main-candidate feed. Returns { place: 'main'|'excursion', closed }.

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -260,17 +260,42 @@ function wfCreateSeqTracker() {
   // order, never arrival order: a foreign-conv turn arriving first would
   // otherwise become the trunk and no bracket would ever close (codex P2,
   // round 1).
-  return { list: [], tails: [] };
+  // tails: Map(convId → [ { msg, end }, ... ]) — one frontier per
+  // concurrent track of that conv (same-conv forks run in parallel). No
+  // global cap: conv count and per-conv concurrency are naturally bounded
+  // within a session, and a shared FIFO would evict still-active frontiers
+  // once enough split turns pass, silently disabling R2 for the evicted
+  // conv (codex P2, round 3).
+  return { list: [], tails: new Map() };
+}
+
+// Best-fit continuation frontier: msg within [f.msg, f.msg+2] and the
+// frontier ends at/before this turn starts; among fits, the latest-ending
+// one (mirrors the parallel-lane best-fit).
+function _wfSeqBestFrontier(frontiers, msg, ts) {
+  var best = null;
+  for (var i = 0; i < frontiers.length; i++) {
+    var f = frontiers[i];
+    if (f.msg > 0 && f.msg <= msg && msg <= f.msg + 2 && f.end <= ts && (!best || f.end > best.end)) best = f;
+  }
+  return best;
 }
 
 // Evidence feed: a turn already split out of main (agent-keyed lane,
-// overlap overflow, or a closed R1 bracket). Its (conv, msgCount, end)
-// frontier is what R2 stitches later same-conv dips onto.
+// overlap overflow, or a closed R1 bracket). Its (msg, end) frontier is
+// what R2 stitches later same-conv dips onto. A split turn that continues
+// an existing frontier advances it; otherwise it opens a new concurrent
+// track for its conv.
 function wfSeqFeedSplit(tracker, turn) {
   if (!tracker || !turn.convId || !(turn.msgCount > 0)) return;
   var ts = Number(turn.receivedAt) || 0;
-  tracker.tails.push({ conv: turn.convId, msg: turn.msgCount, end: ts + (parseFloat(turn.elapsed) || 0) * 1000 });
-  if (tracker.tails.length > 16) tracker.tails.shift();
+  var msg = turn.msgCount;
+  var end = ts + (parseFloat(turn.elapsed) || 0) * 1000;
+  var frontiers = tracker.tails.get(turn.convId);
+  if (!frontiers) { tracker.tails.set(turn.convId, [{ msg: msg, end: end }]); return; }
+  var best = _wfSeqBestFrontier(frontiers, msg, ts);
+  if (best) { best.msg = msg; best.end = end; }
+  else frontiers.push({ msg: msg, end: end });
 }
 
 // Main-candidate feed. Returns { place: 'main'|'excursion', closed }.
@@ -302,14 +327,13 @@ function wfSeqFeedMain(tracker, turn) {
     if (list[i].convId === conv) prevSame = list[i];
   }
   if (prevSame && msg > 0 && msg < (prevSame.msgCount || 0)) {
-    for (var j = tracker.tails.length - 1; j >= 0; j--) {
-      var t = tracker.tails[j];
-      if (t.conv === conv && t.msg <= msg && msg <= t.msg + 2 && t.end <= ts) {
-        t.msg = msg; // frontier advances with the stitched turn
-        t.end = ts + (parseFloat(turn.elapsed) || 0) * 1000;
-        res.place = 'excursion';
-        return res;
-      }
+    var frontiers = tracker.tails.get(conv);
+    var fit = frontiers ? _wfSeqBestFrontier(frontiers, msg, ts) : null;
+    if (fit) {
+      fit.msg = msg; // frontier advances with the stitched turn
+      fit.end = ts + (parseFloat(turn.elapsed) || 0) * 1000;
+      res.place = 'excursion';
+      return res;
     }
   }
   list.splice(lo, 0, turn);

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -271,14 +271,26 @@ function wfCreateSeqTracker() {
   return { list: [], tails: new Map() };
 }
 
-// Best-fit continuation frontier: msg within [f.msg, f.msg+2] and the
-// frontier ends at/before this turn starts; among fits, the latest-ending
-// one (mirrors the parallel-lane best-fit).
+// R2 frontier time-to-live: a dip only stitches onto a frontier whose
+// track ended within this window. Measurement basis (439-session audit,
+// 2026-07-11, owner-approved): real stitch gaps p50=22s, p90=3min, every
+// verified-good stitch ≤2min; all 6 sampled >10min fits were edit/rewind
+// shapes, not fork continuations. 15min keeps ~30× headroom over the real
+// distribution while structurally closing hour-scale rewind collisions
+// with stale branch points (codex P2, round 4).
+var WF_SEQ_FRONTIER_TTL_MS = 15 * 60 * 1000;
+
+// Best-fit continuation frontier: msg within [f.msg, f.msg+2], the
+// frontier ends at/before this turn starts AND within the TTL window;
+// among fits, the latest-ending one (mirrors the parallel-lane best-fit).
+// Retired points stay in the Map — eligibility is decided at lookup.
 function _wfSeqBestFrontier(frontiers, msg, ts) {
   var best = null;
   for (var i = 0; i < frontiers.length; i++) {
     var f = frontiers[i];
-    if (f.msg > 0 && f.msg <= msg && msg <= f.msg + 2 && f.end <= ts && (!best || f.end > best.end)) best = f;
+    if (f.msg > 0 && f.msg <= msg && msg <= f.msg + 2 && f.end <= ts &&
+        ts - f.end <= WF_SEQ_FRONTIER_TTL_MS &&
+        (!best || f.end > best.end)) best = f;
   }
   return best;
 }

--- a/test/seq-interleave-rendering.test.js
+++ b/test/seq-interleave-rendering.test.js
@@ -151,3 +151,19 @@ describe('#230 entry-rendering sequential interleave (ADR 0005/0009)', () => {
     }
   });
 });
+
+describe('#230 codex P2: entry-rendering arrival-order independence', () => {
+  it('early-arriving nested foreign conv is retro-flipped when the real trunk returns (fail-on-old)', () => {
+    const ctx = loadDashboardContext();
+    // completion order: nested teammate turn b1 arrives before the long a1
+    ctx.addEntry(mkTurn(13000, 5, 'convB', 4, { model: 'claude-sonnet-5' }));  // b1: 13000..18000
+    ctx.addEntry(mkTurn(1000, 60, 'convA', 10));                               // a1: 1000..61000, arrives second
+    ctx.addEntry(mkTurn(62000, 5, 'convA', 12));                               // a2 → trunk A returns
+    assert.equal(ctx.allEntries.map(e => e.isSubagent).join(','), 'true,false,false',
+      'the first-arrived foreign-conv turn must not poison the trunk');
+    assert.equal(ctx.allEntries.map(e => e.displayNum).join(','), 's1,1,2');
+    const sess = ctx.sessionsMap.get(SID);
+    assert.equal(sess.mainCount, 2);
+    assert.equal(sess.subCount, 1);
+  });
+});

--- a/test/seq-interleave-rendering.test.js
+++ b/test/seq-interleave-rendering.test.js
@@ -167,3 +167,33 @@ describe('#230 codex P2: entry-rendering arrival-order independence', () => {
     assert.equal(sess.subCount, 1);
   });
 });
+
+describe('#230 codex P2 round 6: reordered arrival recomputes the turn list seq layer', () => {
+  it('overturned closed excursion flips back to main; displayNums match batch classification (fail-on-old)', () => {
+    const ctx = loadDashboardContext();
+    // completion order: A1, B1, A2 close the B bracket (B1 → s1), then B0 —
+    // same conv as B1, starts earliest, spans A1 — arrives last
+    ctx.addEntry(mkTurn(130000, 5, 'convA', 10));   // A1
+    ctx.addEntry(mkTurn(140000, 5, 'convB', 12));   // B1
+    ctx.addEntry(mkTurn(150000, 5, 'convA', 12));   // A2 → bracket closes
+    assert.equal(ctx.allEntries[1].isSubagent, true, 'precondition: B1 retro-flipped by A-B-A');
+    assert.equal(ctx.allEntries[1].displayNum, 's1');
+    ctx.addEntry(mkTurn(1000, 136, 'convB', 8));    // B0: 1000..137000, reordered arrival
+    // chronological truth B0-A1-B1-A2: trunk = conv B, A1 is the excursion,
+    // B1 flips BACK to main, A2 stays main (trunk-advance pending tail)
+    assert.equal(ctx.allEntries.map(e => e.isSubagent).join(','), 'true,false,false,false');
+    assert.equal(ctx.allEntries.map(e => e.displayNum).join(','), 's1,1,2,3');
+    const sess = ctx.sessionsMap.get(SID);
+    assert.equal(sess.mainCount, 3);
+    assert.equal(sess.subCount, 1);
+    // AC5: the turn list and the swimlane agree on every turn
+    const sessEntries = ctx.allEntries.filter(e => e.sessionId === SID);
+    const lanes = ctx.wfInferLanes(sessEntries, []);
+    const mainIds = new Set(lanes[0].turns.map(t => t.id));
+    for (const en of sessEntries) {
+      assert.equal(!en.isSubagent, mainIds.has(en.id),
+        'entry ' + en.id + ': turn list isSubagent=' + en.isSubagent +
+        ' vs swimlane ' + (mainIds.has(en.id) ? 'main' : 'sub-lane'));
+    }
+  });
+});

--- a/test/seq-interleave-rendering.test.js
+++ b/test/seq-interleave-rendering.test.js
@@ -1,0 +1,153 @@
+'use strict';
+
+// #230 / ADR 0009 — entry-rendering.js side of the sequential-interleave
+// contract (ADR 0005: the turn list and the swimlane must classify the same
+// turn identically). Harness mirrors test/retry-grouping.test.js, plus
+// workflow-timeline.js loaded FIRST (same order as public/index.html) so the
+// shared tracker (wfCreateSeqTracker) is available to addEntry.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadDashboardContext() {
+  const publicDir = path.join(__dirname, '..', 'public');
+  function el() {
+    return {
+      style: {}, dataset: {}, innerHTML: '', textContent: '',
+      classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+      addEventListener() {}, appendChild() {}, insertBefore() {},
+      querySelector: () => el(), querySelectorAll: () => [],
+      remove() {},
+    };
+  }
+  const context = {
+    console, window: { innerHeight: 800, addEventListener() {} },
+    document: {
+      getElementById: () => el(), createElement: () => el(),
+      createElementNS: () => el(),
+      querySelector: () => el(), querySelectorAll: () => [],
+      addEventListener() {}, body: el(), documentElement: {},
+    },
+    localStorage: { getItem: () => null, setItem() {} },
+    sessionStorage: { getItem: () => null, setItem() {} },
+    navigator: {}, location: { search: '', hash: '' }, history: { replaceState() {} },
+    URLSearchParams, setTimeout, clearTimeout,
+    getComputedStyle: () => ({ getPropertyValue: () => '' }),
+    requestAnimationFrame: () => 1, cancelAnimationFrame() {},
+    Set, Map,
+  };
+  vm.createContext(context);
+  vm.runInContext(`
+    function updateSysPromptBadge() {}
+    function startQuotaTicker() {}
+    function EventSource() { this.onmessage = null; }
+    function setInterval() { return 0; }
+    function clearInterval() {}
+    window.ccxraySettings = { visibleProviders: [] };
+    function fetch() { return Promise.resolve({ ok: false, json() { return Promise.resolve({}); } }); }
+  `, context);
+  for (const f of ['format.js', 'session-label.js', 'workflow-timeline.js', 'miller-columns.js', 'entry-rendering.js']) {
+    vm.runInContext(fs.readFileSync(path.join(publicDir, f), 'utf8'), context);
+  }
+  vm.runInContext(`
+    this.allEntries = allEntries;
+    this.sessionsMap = sessionsMap;
+    this.selectedSessionId = null;
+    _loading = true;
+  `, context);
+  return context;
+}
+
+const SID = 'seq_sess';
+let _autoId = 0;
+
+// Real shape (86949194 / 4b15c248): fork and teammate turns carry the
+// authoritative 'orchestrator' agentKey — never agentKey:null (the Batch 11
+// fake-fixture trap).
+function mkTurn(at, elapsed, conv, msg, overrides) {
+  _autoId++;
+  return Object.assign({
+    id: 'e' + String(_autoId).padStart(3, '0'), ts: '10:00:00',
+    sessionId: SID, model: 'claude-opus-4-6', provider: 'anthropic',
+    status: 200, elapsed: String(elapsed), method: 'POST',
+    usage: { input_tokens: 30000, output_tokens: 500, cache_read_input_tokens: 15000, cache_creation_input_tokens: 5000 },
+    maxContext: 200000, isSubagent: false, sessionInferred: false,
+    toolCalls: {}, title: 'turn', receivedAt: String(at),
+    agentKey: 'orchestrator', agentLabel: 'Orchestrator',
+    convId: conv, msgCount: msg,
+  }, overrides || {});
+}
+
+describe('#230 entry-rendering sequential interleave (ADR 0005/0009)', () => {
+  it('R1: A-B-A teammate run retro-flips to subagent and renumbers the session', () => {
+    const ctx = loadDashboardContext();
+    ctx.addEntry(mkTurn(1000, 5, 'convA', 10));
+    ctx.addEntry(mkTurn(7000, 5, 'convA', 12));
+    ctx.addEntry(mkTurn(13000, 5, 'convB', 4, { model: 'claude-sonnet-5' }));
+    ctx.addEntry(mkTurn(19000, 5, 'convB', 6, { model: 'claude-sonnet-5' }));
+    // provisional: foreign conv counts as main until the trunk returns
+    assert.equal(ctx.sessionsMap.get(SID).mainCount, 4);
+    ctx.addEntry(mkTurn(25000, 5, 'convA', 14));
+    const sess = ctx.sessionsMap.get(SID);
+    assert.equal(sess.mainCount, 3, 'B run no longer counted as main');
+    assert.equal(sess.subCount, 2);
+    assert.equal(ctx.allEntries.map(e => e.displayNum).join(','), '1,2,s1,s2,3');
+    assert.equal(ctx.allEntries.map(e => e.isSubagent).join(','), 'false,false,true,true,false');
+  });
+
+  it('R2: sequential fork dip flips immediately when a split-out frontier exists (fail-on-old)', () => {
+    const ctx = loadDashboardContext();
+    ctx.addEntry(mkTurn(1000, 5, 'convA', 53));
+    ctx.addEntry(mkTurn(10000, 60, 'convA', 55));  // long main turn 10000..70000
+    ctx.addEntry(mkTurn(20000, 5, 'convA', 51));   // starts inside → overlap → subagent (frontier)
+    assert.equal(ctx.allEntries[2].isSubagent, true, 'precondition: overlap split the concurrent fork turn');
+    ctx.addEntry(mkTurn(71000, 5, 'convA', 51));   // sequential continuation — overlap-blind
+    assert.equal(ctx.allEntries[3].isSubagent, true, 'dip with frontier must flip before numbering');
+    assert.equal(ctx.allEntries[3].displayNum, 's2');
+    ctx.addEntry(mkTurn(80000, 5, 'convA', 57));
+    assert.equal(ctx.allEntries[4].displayNum, '3');
+    assert.equal(ctx.sessionsMap.get(SID).mainCount, 3);
+  });
+
+  it('rewind: same-conv dip with no frontier stays main (7e1d9272 540→493 shape)', () => {
+    const ctx = loadDashboardContext();
+    ctx.addEntry(mkTurn(1000, 5, 'convA', 540));
+    ctx.addEntry(mkTurn(7000, 5, 'convA', 493));
+    ctx.addEntry(mkTurn(13000, 5, 'convA', 495));
+    assert.equal(ctx.allEntries.map(e => e.isSubagent).join(','), 'false,false,false');
+    assert.equal(ctx.sessionsMap.get(SID).mainCount, 3);
+  });
+
+  it('compaction: conv advance that never returns stays main (no retro)', () => {
+    const ctx = loadDashboardContext();
+    ctx.addEntry(mkTurn(1000, 5, 'convA', 100));
+    ctx.addEntry(mkTurn(7000, 5, 'convA', 102));
+    ctx.addEntry(mkTurn(13000, 5, 'convB', 10));
+    ctx.addEntry(mkTurn(19000, 5, 'convB', 12));
+    assert.equal(ctx.allEntries.map(e => e.isSubagent).join(','), 'false,false,false,false');
+    assert.equal(ctx.sessionsMap.get(SID).mainCount, 4);
+  });
+
+  it('AC5: turn-list classification matches wfInferLanes lane placement on the same entries', () => {
+    const ctx = loadDashboardContext();
+    ctx.addEntry(mkTurn(1000, 5, 'convA', 10));
+    ctx.addEntry(mkTurn(7000, 5, 'convA', 12));
+    ctx.addEntry(mkTurn(13000, 5, 'convB', 4, { model: 'claude-sonnet-5' }));
+    ctx.addEntry(mkTurn(19000, 5, 'convB', 6, { model: 'claude-sonnet-5' }));
+    ctx.addEntry(mkTurn(25000, 60, 'convA', 14));  // long turn 25000..85000
+    ctx.addEntry(mkTurn(30000, 5, 'convA', 13));   // overlaps → subagent + frontier
+    ctx.addEntry(mkTurn(86000, 5, 'convA', 13));   // sequential fork dip
+    ctx.addEntry(mkTurn(90000, 5, 'convA', 16));
+    const sessEntries = ctx.allEntries.filter(e => e.sessionId === SID);
+    const lanes = ctx.wfInferLanes(sessEntries, []);
+    const mainIds = new Set(lanes[0].turns.map(t => t.id));
+    for (const en of sessEntries) {
+      assert.equal(!en.isSubagent, mainIds.has(en.id),
+        'entry ' + en.id + ': turn list says isSubagent=' + en.isSubagent +
+        ' but swimlane says ' + (mainIds.has(en.id) ? 'main' : 'sub-lane'));
+    }
+  });
+});

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -1366,3 +1366,44 @@ describe('#230 seq tracker arrival-order independence (codex P2)', () => {
     assert.equal(nonMainIds(batch), nonMainIds(completion));
   });
 });
+
+// ── #230 lane naming: Fork vs Teammate (owner visual review, 2026-07-11) ────
+// Display-name only — lane keys and classification are untouched. A parallel
+// lane whose convId appears in main = a same-conversation twin ("Fork");
+// a convId main never ran = an independent conversation ("Teammate").
+describe('#230 lane naming: Fork vs Teammate', () => {
+  function mkSeq(id, at, elapsed, conv, msg, opts) {
+    return mkEntry(id, 's1', 'claude-opus-4-6', at, elapsed, Object.assign(
+      { agentKey: 'orchestrator', agentLabel: 'Orchestrator', convId: conv, msgCount: msg }, opts || {}));
+  }
+
+  it('same-conv overlap fork lane reads "Fork <conv> #k"', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkSeq('m1', 1000, 5, '5212b91b', 53),
+      mkSeq('m2', 10000, 60, '5212b91b', 55),
+      mkSeq('f1', 20000, 5, '5212b91b', 51),   // overlap-split fork
+      mkSeq('f2', 71000, 5, '5212b91b', 51),   // R2-stitched continuation
+      mkSeq('m3', 80000, 5, '5212b91b', 57),
+    ], []);
+    assert.equal(lanes.length, 2);
+    var mainConvs = ctx._wfMainConvSet(lanes);
+    assert.equal(ctx._wfLaneDispName(lanes[1], 1, mainConvs), 'Fork 5212 #1');
+  });
+
+  it('foreign-conv R1 excursion lane reads "Teammate <conv> #k"', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkSeq('a1', 1000, 5, 'aaaa1111', 10),
+      mkSeq('a2', 7000, 5, 'aaaa1111', 12),
+      mkSeq('b1', 13000, 5, 'f4ef1004', 4, { model: 'claude-sonnet-5' }),
+      mkSeq('b2', 19000, 5, 'f4ef1004', 6, { model: 'claude-sonnet-5' }),
+      mkSeq('a3', 25000, 5, 'aaaa1111', 14),
+    ], []);
+    assert.equal(lanes.length, 2);
+    var mainConvs = ctx._wfMainConvSet(lanes);
+    assert.equal(ctx._wfLaneDispName(lanes[1], 1, mainConvs), 'Teammate f4ef #1');
+    // main lane name untouched
+    assert.equal(ctx._wfLaneDispName(lanes[0], 0, mainConvs), 'main');
+  });
+});

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -1113,3 +1113,187 @@ describe('#221/#222 redo: overlap overrides authoritative agentKey (ADR 0008)', 
     assert.equal(lanes[0].turns.length, 6);
   });
 });
+
+// ── #230: sequential interleave — convId bracketing + msgCount dip (ADR 0009) ─
+// Overlap (ADR 0008) only catches PARALLEL agents. These fixtures mirror the
+// two real residue shapes it cannot see:
+//  - teammate: agentKey 'orchestrator' (inherits the standard CC prompt), own
+//    convId, interleaved A-B-A with zero time overlap (session 4b15c248)
+//  - sequential fork continuation: agentKey 'orchestrator', SAME convId as
+//    main, msgCount dip continuing an overlap-split frontier (session
+//    86949194's 55→51). Never agentKey:null — Batch 11's fake-fixture trap.
+describe('#230 sequential interleave (ADR 0009)', () => {
+  function mkSeq(id, at, elapsed, conv, msg, opts) {
+    return mkEntry(id, 's1', 'claude-opus-4-6', at, elapsed, Object.assign(
+      { agentKey: 'orchestrator', agentLabel: 'Orchestrator', convId: conv, msgCount: msg }, opts || {}));
+  }
+  function assertSerialLanes(lanes) {
+    for (var li = 0; li < lanes.length; li++) {
+      var spans = lanes[li].turns.map(function(t) {
+        var s = Number(t.receivedAt) || 0;
+        return [s, s + (parseFloat(t.elapsed) || 0) * 1000];
+      }).sort(function(a, b) { return a[0] - b[0]; });
+      for (var i = 1; i < spans.length; i++) {
+        assert.ok(spans[i][0] >= spans[i - 1][1] || spans[i][0] === spans[i - 1][0],
+          'lane ' + lanes[li].key + ': turn @' + spans[i][0] + ' overlaps previous ending @' + spans[i - 1][1]);
+      }
+    }
+  }
+  function ids(lane) { return lane.turns.map(function(t) { return t.id; }).join(','); }
+
+  it('AC1: A-B-A convId runs with zero overlap → B run splits to a sub-lane (fail-on-old)', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkSeq('a1', 1000, 5, 'convA', 10),
+      mkSeq('a2', 7000, 5, 'convA', 12),
+      mkSeq('b1', 13000, 5, 'convB', 4, { model: 'claude-sonnet-5' }),
+      mkSeq('b2', 19000, 5, 'convB', 6, { model: 'claude-sonnet-5' }),
+      mkSeq('a3', 25000, 5, 'convA', 14),
+    ], []);
+    assert.equal(lanes.length, 2);
+    assert.equal(ids(lanes[0]), 'a1,a2,a3');
+    assert.equal(ids(lanes[1]), 'b1,b2');
+    assertSerialLanes(lanes);
+  });
+
+  it('R2: sequential fork dip stitches onto its overlap-split frontier lane (fail-on-old)', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkSeq('m1', 1000, 5, 'convA', 53),
+      mkSeq('m2', 10000, 60, 'convA', 55),   // long main turn 10000..70000
+      mkSeq('f1', 20000, 5, 'convA', 51),    // starts inside m2 → overlap split
+      mkSeq('f2', 71000, 5, 'convA', 51),    // after m2 ends — overlap-blind
+      mkSeq('m3', 80000, 5, 'convA', 57),
+    ], []);
+    assert.equal(lanes.length, 2);
+    assert.equal(ids(lanes[0]), 'm1,m2,m3');
+    assert.equal(ids(lanes[1]), 'f1,f2', 'dip must land in the same fork lane as its frontier');
+    assertSerialLanes(lanes);
+  });
+
+  it('compaction: conv advance that never returns stays in main (isCompacted true)', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkSeq('c1', 1000, 5, 'convA', 100),
+      mkSeq('c2', 7000, 5, 'convA', 102),
+      mkSeq('c3', 13000, 5, 'convB', 10, { isCompacted: true }),
+      mkSeq('c4', 19000, 5, 'convB', 12),
+    ], []);
+    assert.equal(lanes.length, 1);
+    assert.equal(lanes[0].turns.length, 4);
+  });
+
+  it('compaction variant: same shape without the isCompacted flag also stays in main', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkSeq('c1', 1000, 5, 'convA', 100),
+      mkSeq('c2', 7000, 5, 'convA', 102),
+      mkSeq('c3', 13000, 5, 'convB', 10),
+      mkSeq('c4', 19000, 5, 'convB', 12),
+    ], []);
+    assert.equal(lanes.length, 1);
+    assert.equal(lanes[0].turns.length, 4);
+  });
+
+  it('rewind: same-conv msgCount dip with no split-out frontier stays in main (7e1d9272 shape)', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkSeq('r1', 1000, 5, 'convA', 540),
+      mkSeq('r2', 7000, 5, 'convA', 493),
+      mkSeq('r3', 13000, 5, 'convA', 495),
+      mkSeq('r4', 19000, 5, 'convA', 497),
+    ], []);
+    assert.equal(lanes.length, 1);
+    assert.equal(lanes[0].turns.length, 4);
+  });
+
+  it('fan-out: multi-conv interleave splits fully even when a first turn is mislabeled isCompacted (a7fef8a8 shape)', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkSeq('m1', 1000, 5, 'convA', 294),
+      mkSeq('x1', 7000, 5, 'convX', 2, { model: 'claude-opus-4-8', isCompacted: true }),
+      mkSeq('m2', 13000, 5, 'convA', 296),
+      mkSeq('y1', 19000, 5, 'convY', 2, { model: 'claude-opus-4-8' }),
+      mkSeq('m3', 25000, 5, 'convA', 298),
+      mkSeq('x2', 31000, 5, 'convX', 5, { model: 'claude-opus-4-8' }),
+      mkSeq('m4', 37000, 5, 'convA', 300),
+    ], []);
+    assert.equal(ids(lanes[0]), 'm1,m2,m3,m4');
+    for (var i = 0; i < lanes[0].turns.length; i++)
+      assert.equal(lanes[0].turns[i].model, 'claude-opus-4-6', 'main must be model-pure after the split');
+    assert.equal(lanes.length, 3); // main + convX lane + convY lane
+    assertSerialLanes(lanes);
+  });
+
+  it('live path: R1 bracket retro-moves out of main when the trunk conv returns', () => {
+    const ctx = loadWfModule();
+    ctx.allEntries = [mkSeq('a1', 1000, 5, 'convA', 10)];
+    ctx.wfState = ctx.wfBuildState('s1');
+    ctx.wfAddEntry(mkSeq('a2', 7000, 5, 'convA', 12));
+    ctx.wfAddEntry(mkSeq('b1', 13000, 5, 'convB', 4, { model: 'claude-sonnet-5' }));
+    ctx.wfAddEntry(mkSeq('b2', 19000, 5, 'convB', 6, { model: 'claude-sonnet-5' }));
+    // provisional: foreign-conv turns sit in main until the trunk returns
+    assert.equal(ctx.wfState.lanes[0].turns.length, 4);
+    var res = ctx.wfAddEntry(mkSeq('a3', 25000, 5, 'convA', 14));
+    assert.equal(res.lanesChanged, true);
+    assert.equal(ids(ctx.wfState.lanes[0]), 'a1,a2,a3');
+    var sub = ctx.wfState.lanes.find(function(l) { return l.key !== 'main' && l.turns.length; });
+    assert.equal(ids(sub), 'b1,b2');
+    // turnIndex must follow the retro-move (ADR 0003-style consistency)
+    assert.equal(ctx.wfState.turnIndex.get('b1').laneIdx, ctx.wfState.lanes.indexOf(sub));
+    assertSerialLanes(ctx.wfState.lanes);
+  });
+
+  it('live path: R2 dip routes to the frontier lane immediately (no retro needed)', () => {
+    const ctx = loadWfModule();
+    ctx.allEntries = [
+      mkSeq('m1', 1000, 5, 'convA', 53),
+      mkSeq('m2', 10000, 60, 'convA', 55),
+      mkSeq('f1', 20000, 5, 'convA', 51),
+    ];
+    ctx.wfState = ctx.wfBuildState('s1');
+    assert.equal(ctx.wfState.lanes.length, 2, 'overlap already split f1');
+    ctx.wfAddEntry(mkSeq('f2', 71000, 5, 'convA', 51));
+    assert.equal(ids(ctx.wfState.lanes[1]), 'f1,f2');
+    ctx.wfAddEntry(mkSeq('m3', 80000, 5, 'convA', 57));
+    assert.equal(ids(ctx.wfState.lanes[0]), 'm1,m2,m3');
+    assertSerialLanes(ctx.wfState.lanes);
+  });
+
+  it('batch/live equivalence: incremental feed (with retro) matches one-shot wfInferLanes', () => {
+    const ctx = loadWfModule();
+    var entries = [
+      mkSeq('a1', 1000, 5, 'convA', 10),
+      mkSeq('a2', 7000, 5, 'convA', 12),
+      mkSeq('b1', 13000, 5, 'convB', 4, { model: 'claude-sonnet-5' }),
+      mkSeq('b2', 19000, 5, 'convB', 6, { model: 'claude-sonnet-5' }),
+      mkSeq('a3', 25000, 60, 'convA', 14),   // long turn 25000..85000
+      mkSeq('f1', 30000, 5, 'convA', 13),    // overlaps a3 → parallel
+      mkSeq('f2', 86000, 5, 'convA', 13),    // sequential fork continuation (dip)
+      mkSeq('a4', 90000, 5, 'convA', 16),
+    ];
+    function sig(lanes) {
+      return lanes.filter(function(l) { return l.turns.length; })
+        .map(function(l) { return l.turns.map(function(t) { return t.id; }).sort().join(','); })
+        .sort().join('|');
+    }
+    var batch = ctx.wfInferLanes(entries.slice(), []);
+    const ctx2 = loadWfModule();
+    ctx2.allEntries = entries.slice(0, 1);
+    ctx2.wfState = ctx2.wfBuildState('s1');
+    for (var i = 1; i < entries.length; i++) ctx2.wfAddEntry(entries[i]);
+    assert.equal(sig(ctx2.wfState.lanes), sig(batch));
+    assertSerialLanes(ctx2.wfState.lanes);
+  });
+
+  it('legacy data without convId is inert: no boundaries, nothing moved', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, { msgCount: 40 }),
+      mkEntry('t2', 's1', 'claude-opus-4-6', 7000, 5, { msgCount: 10 }),
+      mkEntry('t3', 's1', 'claude-opus-4-6', 13000, 5, { msgCount: 42 }),
+    ], []);
+    assert.equal(lanes.length, 1);
+    assert.equal(lanes[0].turns.length, 3);
+  });
+});

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -1456,3 +1456,32 @@ describe('#230 seq tracker per-conv frontiers (codex P2 round 3)', () => {
     assert.equal(fr.map(function(f) { return f.msg; }).sort().join(','), '45,53');
   });
 });
+
+// ── #230 re-audit regression: tail points are append-only, never merged ─────
+// A fork branches concurrent tracks from the same historical msgCount. The
+// merge variant (069246a) folded a later "continuation" split (53) into the
+// branch point (51), erasing it — the other track's sequential continuation
+// (dip 51) could no longer stitch and stayed in main (439-session re-audit:
+// jumpreturn residue 3→8, sessions f38af1fd/a5d66419/67f906d9).
+describe('#230 append-only tail points (re-audit regression)', () => {
+  function mkSeq(id, at, elapsed, conv, msg, opts) {
+    return mkEntry(id, 's1', 'claude-opus-4-6', at, elapsed, Object.assign(
+      { agentKey: 'orchestrator', agentLabel: 'Orchestrator', convId: conv, msgCount: msg }, opts || {}));
+  }
+
+  it('historical branch point survives a later continuation split (fail-on-old)', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkSeq('m1', 1000, 5, 'convA', 53),
+      mkSeq('m2', 10000, 60, 'convA', 55),   // 10000..70000
+      mkSeq('s1', 20000, 5, 'convA', 51),    // overlap-split: branch point 51
+      mkSeq('s2', 30000, 6, 'convA', 53),    // overlap-split: same-track continuation
+      mkSeq('d1', 71000, 5, 'convA', 51),    // other track's sequential continuation
+      mkSeq('m3', 80000, 5, 'convA', 57),
+    ], []);
+    assert.equal(lanes[0].turns.map(function(t) { return t.id; }).join(','), 'm1,m2,m3',
+      'dip 51 must stitch onto the preserved branch point, not stay in main');
+    var forkLane = lanes.find(function(l) { return (l.key || '').indexOf('parallel-') === 0; });
+    assert.equal(forkLane.turns.map(function(t) { return t.id; }).join(','), 's1,s2,d1');
+  });
+});

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -1407,3 +1407,52 @@ describe('#230 lane naming: Fork vs Teammate', () => {
     assert.equal(ctx._wfLaneDispName(lanes[0], 0, mainConvs), 'main');
   });
 });
+
+// ── #230 codex P2 (round 3): per-conv frontiers — no FIFO eviction ──────────
+// tails used to be a single 16-entry FIFO: after 16 split turns, an older
+// but still-active fork frontier was evicted and its sequential
+// continuation could no longer satisfy R2, silently staying in main.
+describe('#230 seq tracker per-conv frontiers (codex P2 round 3)', () => {
+  function mkSeq(id, at, elapsed, conv, msg, opts) {
+    return mkEntry(id, 's1', 'claude-opus-4-6', at, elapsed, Object.assign(
+      { agentKey: 'orchestrator', agentLabel: 'Orchestrator', convId: conv, msgCount: msg }, opts || {}));
+  }
+
+  it('fork frontier survives 17 intervening split turns of other convs (fail-on-old)', () => {
+    const ctx = loadWfModule();
+    var entries = [
+      mkSeq('m1', 1000, 5, 'convA', 53),
+      mkSeq('m2', 10000, 60, 'convA', 55),   // 10000..70000
+      mkSeq('f1', 20000, 5, 'convA', 51),    // overlap-split → frontier for convA
+    ];
+    // 17 agent-keyed split turns, each its own conv — the old shared FIFO
+    // (cap 16) evicted convA's frontier here
+    for (var i = 1; i <= 17; i++) {
+      entries.push(mkSeq('w' + i, 25000 + i * 1000, 0.5, 'w' + i, 3,
+        { agentKey: 'web-search', agentLabel: 'Web Search' }));
+    }
+    entries.push(mkSeq('f2', 71000, 5, 'convA', 51));  // sequential fork continuation
+    entries.push(mkSeq('m3', 80000, 5, 'convA', 57));
+    var lanes = ctx.wfInferLanes(entries, []);
+    var forkLane = lanes.find(function(l) { return (l.key || '').indexOf('parallel-') === 0; });
+    assert.equal(forkLane.turns.map(function(t) { return t.id; }).join(','), 'f1,f2',
+      'the dip must still stitch onto its frontier after 17 unrelated split turns');
+    assert.equal(lanes[0].turns.map(function(t) { return t.id; }).join(','), 'm1,m2,m3');
+  });
+
+  it('same-conv concurrent forks keep separate frontiers; continuations stitch their own track', () => {
+    const ctx = loadWfModule();
+    var tr = ctx.wfCreateSeqTracker();
+    ctx.wfSeqFeedMain(tr, { id: 'm1', convId: 'A', msgCount: 55, receivedAt: 1000, elapsed: 5 });
+    ctx.wfSeqFeedSplit(tr, { convId: 'A', msgCount: 51, receivedAt: 20000, elapsed: 5 });  // track F1
+    ctx.wfSeqFeedSplit(tr, { convId: 'A', msgCount: 45, receivedAt: 21000, elapsed: 5 });  // track F2
+    var fr = tr.tails.get('A');
+    assert.equal(fr.length, 2, 'two concurrent tracks → two frontiers');
+    var r1 = ctx.wfSeqFeedMain(tr, { id: 'c1', convId: 'A', msgCount: 53, receivedAt: 30000, elapsed: 5 });
+    assert.equal(r1.place, 'excursion', 'F1 continuation stitches');
+    var r2 = ctx.wfSeqFeedMain(tr, { id: 'c2', convId: 'A', msgCount: 45, receivedAt: 31000, elapsed: 5 });
+    assert.equal(r2.place, 'excursion', 'F2 continuation stitches');
+    // each continuation advanced its own frontier — no cross-stealing
+    assert.equal(fr.map(function(f) { return f.msg; }).sort().join(','), '45,53');
+  });
+});

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -1297,3 +1297,72 @@ describe('#230 sequential interleave (ADR 0009)', () => {
     assert.equal(lanes[0].turns.length, 3);
   });
 });
+
+// ── #230 codex P2 (round 1): arrival order must not poison the seq tracker ──
+// Entries arrive in COMPLETION order. A nested turn (starts later, finishes
+// first) arrives before the long turn that contains it — if the tracker
+// derived run structure from arrival order, a foreign-conv turn arriving
+// first would become the trunk and no bracket would ever close.
+describe('#230 seq tracker arrival-order independence (codex P2)', () => {
+  function mkSeq(id, at, elapsed, conv, msg, opts) {
+    return mkEntry(id, 's1', 'claude-opus-4-6', at, elapsed, Object.assign(
+      { agentKey: 'orchestrator', agentLabel: 'Orchestrator', convId: conv, msgCount: msg }, opts || {}));
+  }
+  function mainIds(lanes) {
+    return lanes[0].turns.map(function(t) { return t.id; }).sort().join(',');
+  }
+  function nonMainIds(lanes) {
+    var out = [];
+    for (var i = 1; i < lanes.length; i++)
+      for (var j = 0; j < lanes[i].turns.length; j++) out.push(lanes[i].turns[j].id);
+    return out.sort().join(',');
+  }
+
+  it('early-arriving nested foreign conv cannot become the trunk (fail-on-old)', () => {
+    const ctx = loadWfModule();
+    // b1 is nested inside a1's span and completes first → arrives first
+    var b1 = mkSeq('b1', 13000, 5, 'convB', 4, { model: 'claude-sonnet-5' });
+    var a1 = mkSeq('a1', 1000, 60, 'convA', 10); // 1000..61000, arrives second
+    var a2 = mkSeq('a2', 62000, 5, 'convA', 12);
+    ctx.allEntries = [b1];
+    ctx.wfState = ctx.wfBuildState('s1');
+    ctx.wfAddEntry(a1);
+    ctx.wfAddEntry(a2);
+    assert.equal(mainIds(ctx.wfState.lanes), 'a1,a2', 'trunk must be conv A (chronologically first), not the first-arrived conv B');
+    assert.equal(nonMainIds(ctx.wfState.lanes), 'b1');
+    // and the batch rebuild agrees on classification
+    var batch = ctx.wfInferLanes([b1, a1, a2], []);
+    assert.equal(mainIds(batch), 'a1,a2');
+    assert.equal(nonMainIds(batch), 'b1');
+  });
+
+  it('classification is arrival-order independent: completion-order == chronological == batch', () => {
+    function fixture() {
+      return {
+        a1: mkSeq('a1', 1000, 60, 'convA', 10),  // 1000..61000
+        b1: mkSeq('b1', 13000, 5, 'convB', 4, { model: 'claude-sonnet-5' }),
+        b2: mkSeq('b2', 19000, 5, 'convB', 6, { model: 'claude-sonnet-5' }),
+        a2: mkSeq('a2', 62000, 5, 'convA', 12),
+        a3: mkSeq('a3', 68000, 5, 'convA', 14),
+      };
+    }
+    function liveFeed(order) {
+      const c = loadWfModule();
+      var f = fixture();
+      c.allEntries = [f[order[0]]];
+      c.wfState = c.wfBuildState('s1');
+      for (var i = 1; i < order.length; i++) c.wfAddEntry(f[order[i]]);
+      return c.wfState.lanes;
+    }
+    var completion = liveFeed(['b1', 'b2', 'a1', 'a2', 'a3']); // nested b's finish first
+    var chrono = liveFeed(['a1', 'b1', 'b2', 'a2', 'a3']);
+    const cb = loadWfModule();
+    var f = fixture();
+    var batch = cb.wfInferLanes([f.a1, f.b1, f.b2, f.a2, f.a3], []);
+    assert.equal(mainIds(completion), 'a1,a2,a3');
+    assert.equal(mainIds(chrono), mainIds(completion));
+    assert.equal(mainIds(batch), mainIds(completion));
+    assert.equal(nonMainIds(chrono), nonMainIds(completion));
+    assert.equal(nonMainIds(batch), nonMainIds(completion));
+  });
+});

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -1485,3 +1485,29 @@ describe('#230 append-only tail points (re-audit regression)', () => {
     assert.equal(forkLane.turns.map(function(t) { return t.id; }).join(','), 's1,s2,d1');
   });
 });
+
+// ── #230 codex P2 (round 4): frontier TTL — stale branch points retire ──────
+// Real stitch gaps: p50=22s, p90=3min, every verified-good stitch ≤2min
+// (439-session audit). A dip landing on a branch point from an hour ago is
+// an edit/rewind collision, not a fork continuation.
+describe('#230 frontier TTL (codex P2 round 4)', () => {
+  function mkSeq(id, at, elapsed, conv, msg, opts) {
+    return mkEntry(id, 's1', 'claude-opus-4-6', at, elapsed, Object.assign(
+      { agentKey: 'orchestrator', agentLabel: 'Orchestrator', convId: conv, msgCount: msg }, opts || {}));
+  }
+
+  it('a dip 16 minutes after the frontier ended does not stitch — stays in main (fail-on-old)', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkSeq('m1', 1000, 5, 'convA', 53),
+      mkSeq('m2', 10000, 60, 'convA', 55),                 // 10000..70000
+      mkSeq('s1', 20000, 5, 'convA', 51),                  // overlap-split → frontier ends 25000
+      mkSeq('d1', 25000 + 16 * 60 * 1000, 5, 'convA', 51), // 16min later: rewind-shaped
+      mkSeq('m3', 25000 + 17 * 60 * 1000, 5, 'convA', 57),
+    ], []);
+    assert.equal(lanes[0].turns.map(function(t) { return t.id; }).join(','), 'm1,m2,d1,m3',
+      'a 16-minute-later dip is an edit/rewind, not a fork continuation');
+    var forkLane = lanes.find(function(l) { return (l.key || '').indexOf('parallel-') === 0; });
+    assert.equal(forkLane.turns.map(function(t) { return t.id; }).join(','), 's1');
+  });
+});

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -1326,8 +1326,10 @@ describe('#230 seq tracker arrival-order independence (codex P2)', () => {
     var a2 = mkSeq('a2', 62000, 5, 'convA', 12);
     ctx.allEntries = [b1];
     ctx.wfState = ctx.wfBuildState('s1');
-    ctx.wfAddEntry(a1);
-    ctx.wfAddEntry(a2);
+    // real caller contract: entry-rendering pushes to allEntries BEFORE
+    // calling wfAddEntry (the reorder-rebuild path reads allEntries)
+    ctx.allEntries.push(a1); ctx.wfAddEntry(a1);
+    ctx.allEntries.push(a2); ctx.wfAddEntry(a2);
     assert.equal(mainIds(ctx.wfState.lanes), 'a1,a2', 'trunk must be conv A (chronologically first), not the first-arrived conv B');
     assert.equal(nonMainIds(ctx.wfState.lanes), 'b1');
     // and the batch rebuild agrees on classification
@@ -1351,7 +1353,7 @@ describe('#230 seq tracker arrival-order independence (codex P2)', () => {
       var f = fixture();
       c.allEntries = [f[order[0]]];
       c.wfState = c.wfBuildState('s1');
-      for (var i = 1; i < order.length; i++) c.wfAddEntry(f[order[i]]);
+      for (var i = 1; i < order.length; i++) { c.allEntries.push(f[order[i]]); c.wfAddEntry(f[order[i]]); }
       return c.wfState.lanes;
     }
     var completion = liveFeed(['b1', 'b2', 'a1', 'a2', 'a3']); // nested b's finish first
@@ -1509,5 +1511,54 @@ describe('#230 frontier TTL (codex P2 round 4)', () => {
       'a 16-minute-later dip is an edit/rewind, not a fork continuation');
     var forkLane = lanes.find(function(l) { return (l.key || '').indexOf('parallel-') === 0; });
     assert.equal(forkLane.turns.map(function(t) { return t.id; }).join(','), 's1');
+  });
+});
+
+// ── #230 codex P2 (round 5): closed excursions can be overturned via rebuild ─
+// Live arrival A-B-A closes the B bracket (B retro-moved). Then B0 — same
+// conv as B, starts earliest, spans A's turn — arrives late: chronological
+// truth is B0-A-B-A, trunk is conv B, and the excursion is A. Closed turns
+// left the tracker list, so the live path falls back to a full wfBuildState
+// rebuild whenever an arrival lands before the list tail.
+describe('#230 late-arrival overturns closed excursion (codex P2 round 5)', () => {
+  function mkSeq(id, at, elapsed, conv, msg, opts) {
+    return mkEntry(id, 's1', 'claude-opus-4-6', at, elapsed, Object.assign(
+      { agentKey: 'orchestrator', agentLabel: 'Orchestrator', convId: conv, msgCount: msg }, opts || {}));
+  }
+  function sig(lanes) {
+    return lanes.filter(function(l) { return l.turns.length; })
+      .map(function(l) { return l.turns.map(function(t) { return t.id; }).sort().join(','); })
+      .sort().join('|');
+  }
+
+  it('span-all same-conv turn arriving after the bracket closed: live == batch (fail-on-old)', () => {
+    const ctx = loadWfModule();
+    var B0 = mkSeq('B0', 1000, 136, 'convB', 8);    // 1000..137000, arrives LAST
+    var A1 = mkSeq('A1', 130000, 5, 'convA', 10);   // nested inside B0's span
+    var B1 = mkSeq('B1', 140000, 5, 'convB', 12);
+    var A2 = mkSeq('A2', 150000, 5, 'convA', 12);
+    ctx.allEntries = [A1];
+    ctx.wfState = ctx.wfBuildState('s1');
+    ctx.allEntries.push(B1); ctx.wfAddEntry(B1);
+    ctx.allEntries.push(A2); ctx.wfAddEntry(A2);
+    // A-B-A prefix: B1 was retro-moved out of main
+    assert.equal(ctx.wfState.lanes[0].turns.map(function(t) { return t.id; }).join(','), 'A1,A2');
+    // user view state that the rebuild must migrate
+    ctx.wfState.selectedTurnId = 'A2';
+    ctx.wfState.laneFocusMode = true;
+    ctx.wfState.viewT0 = 130000; ctx.wfState.viewT1 = 140000;
+    ctx.allEntries.push(B0);
+    var res = ctx.wfAddEntry(B0);
+    assert.equal(res.lanesChanged, true);
+    // chronological truth: trunk = conv B; A1 is the excursion (overlap with
+    // B0); B1 rejoins main; A2 (trunk-advance pending tail) stays main
+    assert.equal(ctx.wfState.lanes[0].turns.map(function(t) { return t.id; }).join(','), 'B0,B1,A2');
+    var batch = loadWfModule().wfInferLanes([A1, B1, A2, B0], []);
+    assert.equal(sig(ctx.wfState.lanes), sig(batch), 'live after rebuild must equal the batch pass');
+    // migrated view state survives the wholesale wfState swap
+    assert.equal(ctx.wfState.selectedTurnId, 'A2');
+    assert.equal(ctx.wfState.laneFocusMode, true);
+    assert.equal(ctx.wfState.viewT0, 130000);
+    assert.equal(ctx.wfState.viewT1, 140000);
   });
 });


### PR DESCRIPTION
## 摘要

- temporal overlap(ADR 0008 / #232)只抓得到**平行** agent;序列型 teammate(派工時 main 閒置)與 fork 的殘餘 turn 完全不重疊,殘留 main lane——實測 4b15c248 main 內 236 個 teammate turns 五模型 ping-pong、a7fef8a8 main 混入 7 個 Opus fan-out turns、86949194 剩 1 筆 fork 殘留(55→51)。
- 新增**共用 sequential-interleave tracker**(單一實作,`wfInferLanes` batch / `wfAddEntry` live / `entry-rendering.js addEntry` 三個消費點各持 instance——ADR 0005 形狀):
  - **R1 convId run bracketing**:trunk conv 重現 → 夾層異 conv runs 全判 excursion;trunk 前進不回頭 = compaction,結構性豁免(不依賴 `isCompacted` flag——它會被 fan-out 首 turn 誤觸)。
  - **R2 同 conv msgCount dip 縫合**:dip 且無縫接上既有 split-out frontier(同 conv、`tailMsg ≤ msg ≤ tailMsg+2`、時間不重疊)才拆;無 frontier = rewind/edit,留 main。Δ=2 為 msgCount 自然步長(owner 簽核 2026-07-11)。
- batch 以 overlap sweep + seq pass **迭代至收斂**:excursion 移出後重掃,只與 excursion 重疊的 main turn 被回收——否則 batch 重建會與 live 路徑(從未見過 excursion 在 main)分歧。
- live:R2 即時分類;R1 於 bracket 關閉時 retro-move(swimlane)/retro-flip 重編號(turn list)。tracker 內部按 `(receivedAt, id)` 排序,分類不受完成序影響(codex round 1 P2 修正)。
- ADR 0009 + 三層 guard(code INVARIANT ×4 + CLAUDE.md @ref + ADR 檔)。

## Real-data re-audit (439 sessions, vm-harness replay old=a588904 vs new)

| Gate | Result |
|---|---|
| 86949194: main residual drops → 0 | PASS (old 1 → new 0; main 78→80, two re-admitted) |
| 4b15c248: no sonnet dev-agent in main | PASS (main now opus-4-6 192 + fable-5 73 only) |
| 4b15c248: excursion-shaped residual → 0 | PASS (12 → 1, the 1 = single-message user-edit growback, legal) |
| 7e1d9272: main unchanged (0 false positives) | PASS (768 turns identical; rewinds 540→493, 1140→1138 kept) |
| a7fef8a8: main pure fable-5 (owner case) | PASS (7 Opus fan-out turns out) |
| ADR 0008: main+parallel overlap-free | PASS (0 violations) |
| ADR 0008: no overlap regression (all lanes) | PASS (7290 → 7290) |
| jumpreturn residual ≤ known-limit list | PASS (3, all pre-#232 sessions; list in ADR 0009) |

Corpus: 928 turns moved out of main across 38 sessions; lanes 1761 → 1818.

## Evidence

- **diff-check** (`scripts/diff-check.sh origin/main test/workflow-timeline.test.js test/seq-interleave-rendering.test.js -- …bounded node --test…`): **exit 0** — old 84/94 (10 fail-on-old: A-B-A bracketing, R2 stitch, fan-out isCompacted mislabel, live retro ×2, entry-rendering retro/R2, order-independence ×3), new **94/94**.
- **Full suite**: 1223/1223 pass (bounded `node --test test/*.test.js`, empty `CCXRAY_HOME`; two independent runs). Under heavy parallel load (4 concurrent suites + 2 servers + corpus replay on one machine) `websocket-proxy.test.js` e2e flaked 1–9 tests across runs — server-side suite, zero server files in this diff; annotated pending baseline cross-check.
- **Boot smoke** (`scripts/boot-smoke.sh 5646`): `BOOT OK: dashboard HTTP 200 on :5646`, exit 0.
- **Live smoke**: real `claude -p` traffic through an isolated instance (fresh `CCXRAY_HOME`, real session logs) → SSE → `addEntry` → correct classification/numbering, page intact; batch view cross-checked against vm-harness numbers via live DOM lane dumps for all 3 evidence sessions.
- **codex review**: round 1 → one P2 (tracker arrival-order sensitivity; worst case an early-arriving nested foreign-conv turn poisons the trunk) → fixed in `a6b5b38` with 3 more fail-on-old tests; round 2 → clean ("no actionable correctness regression").

## Known limits / not verified here

- 4 corpus jumpreturn residues (all pre-#232 sessions) = fully-sequential same-conv forks with no frontier — documented known limitation (owner decision: lookahead rule rejected, it risks false-splitting rewinds; root fix is #222's wire-level identity ask).
- rewind-across-compaction makes the old conv "return" and would split the compacted run (rare; ADR 0009).
- live retro-move visual sequence not video-recorded — covered by batch/live equivalence tests instead.
- reverse-overlap live classification stays eventual (pre-existing ADR 0008 boundary, unchanged).
- hung-stream retry minting false parallel lanes = precision axis, tracked separately in #236.
- Teammate lanes reuse the #232 "Fork <conv> #k" naming — naming taste deferred to visual review.

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)
