### PR TITLE
fix: timeline detail step count matches breadcrumb and badge (#240)

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2672,13 +2672,13 @@ function renderDetailCol() {
         }
         const toolFreqPreview = {};
         currentSteps.forEach(s => { if (s.type === 'tool-group') s.calls.forEach(c => { toolFreqPreview[c.name] = (toolFreqPreview[c.name] || 0) + 1; }); });
-        const totalPreview = currentSteps.filter(s => s.type === 'tool-group').length;
+        const totalPreview = currentSteps.length;
         const errorPreview = currentSteps.filter(s => s.type === 'tool-group' && s.calls.some(c => c.isError)).length;
         const promptBadge = (typeof renderPromptBadgeHtml === 'function') ? renderPromptBadgeHtml(e) : '';
         const summaryPreview = promptBadge
           + '<div style="padding:4px 8px 6px;border-bottom:1px solid var(--border);font-size:11px;color:var(--dim)">'
-          + totalPreview + ' steps · ' + (totalPreview - errorPreview) + '✓'
-          + (errorPreview ? ' <span style="color:var(--red)">' + errorPreview + '✗</span>' : '')
+          + totalPreview + ' steps'
+          + (errorPreview ? ' · <span style="color:var(--red)">' + errorPreview + '✗</span>' : '')
           + '</div>';
         const previewStepsHtml = renderStepListHtml(currentSteps, getActiveStepKey(), e.toolSources);
         const previewMinimapHtml = (typeof renderMinimapHtml === 'function')
@@ -2702,13 +2702,13 @@ function renderDetailCol() {
       // Tool frequency summary
       const toolFreq = {};
       currentSteps.forEach(s => { if (s.type === 'tool-group') s.calls.forEach(c => { toolFreq[c.name] = (toolFreq[c.name] || 0) + 1; }); });
-      const totalSteps = currentSteps.filter(s => s.type === 'tool-group').length;
+      const totalSteps = currentSteps.length;
       const errorCount = currentSteps.filter(s => s.type === 'tool-group' && s.calls.some(c => c.isError)).length;
       const focusedBadge = (typeof renderPromptBadgeHtml === 'function') ? renderPromptBadgeHtml(e) : '';
       const summaryHtml = focusedBadge
         + '<div style="padding:4px 8px 6px;border-bottom:1px solid var(--border);font-size:11px;color:var(--dim)">'
-        + totalSteps + ' steps · ' + (totalSteps - errorCount) + '✓'
-        + (errorCount ? ' <span style="color:var(--red)">' + errorCount + '✗</span>' : '')
+        + totalSteps + ' steps'
+        + (errorCount ? ' · <span style="color:var(--red)">' + errorCount + '✗</span>' : '')
         + '</div>';
 
       const activeKey = getActiveStepKey();


### PR DESCRIPTION
## 摘要

Timeline detail header 的 step 計數跟 breadcrumb / sections badge 用不同分母——header 只算 tool-group，其他兩處用完整 `currentSteps[]`。統一為全量計數，移除 ✓ 指標改為只在有 error 時顯示 ✗，與 sections badge 同構。

## Details

The timeline detail header counted only `tool-group` steps via `.filter(s => s.type === 'tool-group').length`, while the breadcrumb (`stepIdx + 1`) and sections badge (`previewSteps.length`) both used the full `currentSteps[]` array. All three displayed the label "steps" but with different denominators.

**Fix**: both the preview and focused timeline headers now use `currentSteps.length`. The `✓` count (`total - errors`) is removed — no-error is the default; errors display as `N✗` only when present. This matches the existing sections badge pattern (line 2410).

| Location | Before | After |
|----------|--------|-------|
| Breadcrumb | `step #24` (full count) | unchanged |
| Sections badge | `24 steps` (full count) | unchanged |
| Timeline header (no error) | `19 steps · 19✓` | `24 steps` |
| Timeline header (with error) | `19 steps · 17✓ 2✗` | `24 steps · 2✗` |

4 lines changed in `public/miller-columns.js` (lines 2675, 2680, 2705, 2710).

**Note**: the step list's `#N` row numbers (rowNum) still differ from the header's step count — that is a separate numbering-system issue tracked in #241.

## Verification

Before (breadcrumb `step #24`, header `19 steps · 19✓` — mismatch):

<!-- paste before screenshot here -->

After (breadcrumb `step #181`, header `181 steps · 2✗` — consistent):

<!-- paste after screenshot here -->

## Test plan

- [x] `npm test` — pass
- [x] `boot-smoke.sh` on :5602 — pass
- [x] Codex review — clean, no findings
- [x] Browser verify with real logs: breadcrumb step count matches header step count

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)