### PR TITLE
fix: step list numbering aligned with breadcrumb (#241)

### DIFF
--- a/public/messages.js
+++ b/public/messages.js
@@ -450,8 +450,6 @@ function toggleTimelineStepStar(event, btn) {
 function renderStepListHtml(steps, activeStepKey, toolSources) {
   let html = '';
   let lastSource = null;
-  let rowNum = 0;
-
   for (let si = 0; si < steps.length; si++) {
     const step = steps[si];
 
@@ -465,7 +463,7 @@ function renderStepListHtml(steps, activeStepKey, toolSources) {
       html += '<div class="step-separator" style="height:2px;background:var(--accent);margin:8px 0 2px"></div>';
       const sel = (activeStepKey === si + ':') ? ' active' : '';
       html += '<div class="tl-step-summary' + sel + '" data-step="' + si + '" onclick="selectStep(' + si + ')">';
-      html += renderTimelineStepNumHtml(++rowNum);
+      html += renderTimelineStepNumHtml(si + 1);
       html += '<div class="tl-step-main">';
       html += '<div style="color:var(--accent);padding:6px 8px;font-size:12px;white-space:normal;line-height:1.5;background:rgba(88,166,255,0.08);border-radius:4px;border-left:2px solid var(--accent);margin:4px 0">';
       html += '<span style="font-size:13px">👤</span> ' + escapeHtml((step.humanText || '').slice(0, 300));
@@ -481,7 +479,7 @@ function renderStepListHtml(steps, activeStepKey, toolSources) {
       if (step.thinking != null) {
         const tSel = (activeStepKey === si + ':thinking') ? ' active' : '';
         html += '<div class="tl-step-summary' + tSel + '" data-step="' + si + '" data-sub="thinking" onclick="selectStep(' + si + ',&quot;thinking&quot;)" style="color:var(--dim);padding-top:2px;padding-bottom:2px;font-size:11px">';
-        html += renderTimelineStepNumHtml(++rowNum);
+        html += renderTimelineStepNumHtml(si + 1);
         html += '<div class="tl-step-main">';
         if (step.source === 'history') {
           html += '🧠'; // indicator only — prior turn content not shown
@@ -506,7 +504,7 @@ function renderStepListHtml(steps, activeStepKey, toolSources) {
         const errAttr = c.isError ? ' data-has-error="1"' : '';
         const toolAttr = ' data-tool="' + escapeHtml(c.name) + '"';
         html += '<div class="tl-step-summary' + cSel + errCls + '" data-step="' + si + '" data-call="' + ci + '"' + errAttr + toolAttr + ' onclick="selectStep(' + si + ',' + ci + ')">';
-        html += renderTimelineStepNumHtml(++rowNum);
+        html += (ci === 0 && step.thinking == null) ? renderTimelineStepNumHtml(si + 1) : '<span class="tl-step-num"></span>';
         html += '<div class="tl-step-main">';
         html += '<div class="msg-list-row" style="gap:4px">';
         html += '<span style="color:var(--dim);width:8px;text-align:center;flex-shrink:0">' + bracket + '</span>';
@@ -535,7 +533,7 @@ function renderStepListHtml(steps, activeStepKey, toolSources) {
     } else if (step.type === 'assistant-text') {
       const aSel = (activeStepKey === si + ':') ? ' active' : '';
       html += '<div class="tl-step-summary' + aSel + '" data-step="' + si + '" onclick="selectStep(' + si + ')">';
-      html += renderTimelineStepNumHtml(++rowNum);
+      html += renderTimelineStepNumHtml(si + 1);
       html += '<div class="tl-step-main">';
       html += '<div style="color:var(--text);padding:6px 8px;font-size:12px;white-space:normal;line-height:1.5;background:rgba(63,185,80,0.08);border-radius:4px;border-left:2px solid var(--green);margin:4px 0">';
       html += '<span style="font-size:13px">🤖</span> ' + escapeHtml((step.text || '').slice(0, 200));

--- a/public/style.css
+++ b/public/style.css
@@ -477,7 +477,7 @@
   .tool-tag { background: var(--border); padding: 2px 8px; border-radius: 4px; font-size: 11px; color: var(--dim); }
   .content-block { margin-bottom: 6px; padding: 6px 8px; background: var(--bg); border-radius: 4px; }
   .content-block .type { font-size: 11px; color: var(--yellow); margin-bottom: 2px; }
-  .msg-list-row { display: flex; align-items: baseline; gap: 4px; font-size: 11px; line-height: 1.4; }
+  .msg-list-row { display: flex; align-items: baseline; gap: 4px; font-size: 11px; line-height: 1.4; overflow: hidden; }
   .msg-list-idx { flex-shrink: 0; color: var(--dim); }
   .msg-list-preview { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
   .msg-list-tok { flex-shrink: 0; font-size: 10px; color: var(--dim); margin-left: auto; }


### PR DESCRIPTION
## 摘要

Step list 的 `#N` 編號用獨立 `rowNum` 計數器（每行 +1，含 thinking 和每個 tool call），breadcrumb 用 `stepIdx`（`currentSteps[]` 索引，一個 tool-group = 1）。兩者都顯示 `#` 前綴但數字不同——點擊 step list 的 `#14` 卻看到 breadcrumb 顯示 `step #6 call #2`。

統一為 `stepIdx + 1`：每個 step group（human / tool-group / assistant-text）一個 `#N`，sub-item（thinking 行帶群組 `#`，個別 tool call 用空占位）不帶獨立編號。同時修復長 tool 名稱（如 `mcp__claude-in-chrome__*`）溢出到 star 欄的 pre-existing layout 問題。

## Details

**Step numbering (`messages.js`)**

`renderStepListHtml` used an independent `rowNum` counter that incremented per visible row — thinking lines, each individual tool call, human messages, and assistant-text blocks each got their own `#N`. The breadcrumb used `stepIdx` (index into `currentSteps[]`), where a tool-group containing thinking + 3 parallel calls = 1 step. Both displayed `#N` but the numbers diverged.

Fix: replace `rowNum` with `si + 1` (= `stepIdx + 1`, matching the breadcrumb). Each step group gets one `#N`. Sub-items within a tool-group:
- Thinking line carries the group's `#N` (it's the first rendered row)
- Individual tool calls use an empty `<span class="tl-step-num"></span>` placeholder to maintain the 3-column grid layout (`28px | 1fr | 24px`)
- If a tool-group has no thinking, the first call (`ci === 0`) carries the `#N`

Star IDs already used `stepIdx` via `getTimelineStepStarId` — no conflict.

**Layout overflow (`style.css`)**

Long tool names like `mcp__claude-in-chrome__tabs_context_mcp` overflowed the grid's middle column into the star column (24px). Add `overflow: hidden` to `.msg-list-row` to clip within the grid cell.

```
Before:                          After:
#14  🧠 3.2s                     #14  🧠 3.2s               ☆
#15  ┌ Read  file.js        ☆        ┌ Read  file.js   ☆
#16  └ Read  other.js       ☆        └ Read  other.js  ☆
#17  🧠 1.1s                     #15  🧠 1.1s               ☆
#18  ┌ Edit  main.js        ☆        ┌ Edit  main.js   ☆
#19  │ Edit  helper.js      ☆        │ Edit  helper.js ☆
#20  └ Edit  test.js        ☆        └ Edit  test.js   ☆
#21  🤖 Done!                    #16  🤖 Done!              ☆

Breadcrumb for Edit main.js:     Breadcrumb for Edit main.js:
  "step #5 call #1" (≠ #18)       "step #15 call #1" (= #15) ✓
```

## Verification

- 1231 tests pass (`CCXRAY_HOME=$(mktemp -d) npm test`)
- Smoke server with real logs: header count matches last `#N`, breadcrumb matches step list, stars functional
- Long tool names no longer overflow into star column

🤖 Generated with [Claude Code](https://claude.com/claude-code)