### PR TITLE
fix(system-prompt): normalize platform tokens before coreHash (#219)

### DIFF
--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -30,14 +30,13 @@
 
 const fs = require('fs');
 const path = require('path');
-const crypto = require('crypto');
 const config = require('./config');
 const store = require('./store');
 const hub = require('./hub');
 const helpers = require('./helpers');
 const { getParser } = require('./wire-parsers');
 const { buildIndexLine } = require('./entry');
-const { extractAgentType, splitB2IntoBlocks } = require('./system-prompt');
+const { extractAgentType, splitB2IntoBlocks, computeCoreHash } = require('./system-prompt');
 
 // Offline twin of registerPromptVersion's identity computation (no versionIndex
 // side effects): agent identity + coreHash from a rehydrated system array.
@@ -51,7 +50,8 @@ function promptIdentity(system) {
   const b2 = (system[2]?.text || '');
   if (b2.length >= 500) {
     const coreText = splitB2IntoBlocks(b2).coreInstructions || '';
-    coreHash = crypto.createHash('md5').update(coreText).digest('hex').slice(0, 12);
+    // INVARIANT: coreHash via computeCoreHash (platform-normalized) — see system-prompt.js (#219)
+    coreHash = computeCoreHash(coreText);
   }
   return { coreHash, agentKey, agentLabel };
 }

--- a/server/restore.js
+++ b/server/restore.js
@@ -1,10 +1,9 @@
 'use strict';
 
-const crypto = require('crypto');
 const config = require('./config');
 const store = require('./store');
 const { calculateCost } = require('./pricing');
-const { extractAgentType, extractPromptAgentType, splitB2IntoBlocks, computeCoreHash } = require('./system-prompt');
+const { extractAgentType, extractPromptAgentType, splitB2IntoBlocks, rawCoreHash, computeCoreHash } = require('./system-prompt');
 const { normalizeOpenAIResponseSummary } = require('./forward');
 const { readSettings, serializeStars } = require('./settings');
 const { computeRetentionSets, isProtectedByStar } = require('./helpers');
@@ -320,9 +319,7 @@ async function buildVersionIndex() {
         const coreLen = coreText.length;
         // INVARIANT: anthropic coreHash via computeCoreHash (platform-normalized) — see system-prompt.js (#219).
         // OpenAI/Codex keeps the raw hash (no platform-token split there).
-        const coreHash = isOpenAI
-          ? crypto.createHash('md5').update(coreText).digest('hex').slice(0, 12)
-          : computeCoreHash(coreText);
+        const coreHash = isOpenAI ? rawCoreHash(coreText) : computeCoreHash(coreText);
         const ver = isOpenAI ? coreHash : (m ? m[1] : null);
         if (!ver) continue;
         const idxKey = `${agentKey}::${coreHash}`;

--- a/server/restore.js
+++ b/server/restore.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const config = require('./config');
 const store = require('./store');
 const { calculateCost } = require('./pricing');
-const { extractAgentType, extractPromptAgentType, splitB2IntoBlocks } = require('./system-prompt');
+const { extractAgentType, extractPromptAgentType, splitB2IntoBlocks, computeCoreHash } = require('./system-prompt');
 const { normalizeOpenAIResponseSummary } = require('./forward');
 const { readSettings, serializeStars } = require('./settings');
 const { computeRetentionSets, isProtectedByStar } = require('./helpers');
@@ -318,7 +318,11 @@ async function buildVersionIndex() {
       if (b2.length >= (isOpenAI ? 1 : 500)) {
         const coreText = isOpenAI ? b2 : (splitB2IntoBlocks(b2).coreInstructions || '');
         const coreLen = coreText.length;
-        const coreHash = crypto.createHash('md5').update(coreText).digest('hex').slice(0, 12);
+        // INVARIANT: anthropic coreHash via computeCoreHash (platform-normalized) — see system-prompt.js (#219).
+        // OpenAI/Codex keeps the raw hash (no platform-token split there).
+        const coreHash = isOpenAI
+          ? crypto.createHash('md5').update(coreText).digest('hex').slice(0, 12)
+          : computeCoreHash(coreText);
         const ver = isOpenAI ? coreHash : (m ? m[1] : null);
         if (!ver) continue;
         const idxKey = `${agentKey}::${coreHash}`;

--- a/server/system-prompt.js
+++ b/server/system-prompt.js
@@ -142,8 +142,11 @@ function normalizePlatform(text) {
   return (text || '')
     .replace(/\b(Bash|PowerShell|cmd\.exe)\b/g, '{{SHELL}}')
     .replace(/\b(darwin|win32|linux)\b/g, '{{PLATFORM}}')
-    .replace(/[A-Za-z]:\\[\w.\\-]+/g, '{{PATH}}')  // Windows paths (C:\Users\foo)
-    .replace(/\/(?:Users|home)\/[\w.-]+/g, '{{PATH}}');  // macOS/Linux home paths
+    .replace(/[A-Za-z]:\\[\w.\\-]+/g, '{{PATH}}')  // Windows paths (C:\Users\foo\...)
+    .replace(/\/(?:Users|home)\/[\w./-]+/g, '{{PATH}}');  // macOS/Linux paths — consume the
+    // full path (not just the home prefix) so a deep path collapses symmetrically with the
+    // Windows branch above; else the forward-slash tail (skill/plugin paths under $HOME) would
+    // survive on unix but not on Windows and re-split one version across platforms (#219).
 }
 
 // Raw 12-char md5 prefix — the coreHash for providers whose prompts carry no

--- a/server/system-prompt.js
+++ b/server/system-prompt.js
@@ -129,6 +129,32 @@ function splitB2IntoBlocks(b2) {
   return result;
 }
 
+// ── coreHash: platform-normalized version identity ───────────────────
+// Claude Code's coreInstructions carry platform-specific tokens (the shell
+// name — Bash on macOS/Linux vs PowerShell on Windows — plus os identifiers
+// and home paths). Hashing the raw text splits one semantic prompt version
+// into per-OS duplicates (#219). Normalize those tokens to placeholders
+// *before* hashing so the same cc_version yields one coreHash across
+// platforms. The stored/displayed coreInstructions text stays un-normalized —
+// only the hash sees placeholders, so the content and diff views still show
+// the real platform-specific words.
+function normalizePlatform(text) {
+  return (text || '')
+    .replace(/\b(Bash|PowerShell|cmd\.exe)\b/g, '{{SHELL}}')
+    .replace(/\b(darwin|win32|linux)\b/g, '{{PLATFORM}}')
+    .replace(/[A-Za-z]:\\[\w.\\-]+/g, '{{PATH}}')  // Windows paths (C:\Users\foo)
+    .replace(/\/(?:Users|home)\/[\w.-]+/g, '{{PATH}}');  // macOS/Linux home paths
+}
+
+// Single source of truth for the Anthropic coreHash. Every anthropic call site
+// (wire-parsers/anthropic.js live path, restore.js buildVersionIndex,
+// rebuild-index.js) MUST go through this so the versionIndex key
+// `agentKey::coreHash` cannot diverge across paths — an inlined
+// md5(coreText) at any one site would silently re-split platform variants.
+function computeCoreHash(coreText) {
+  return crypto.createHash('md5').update(normalizePlatform(coreText)).digest('hex').slice(0, 12);
+}
+
 function computeBlockDiff(b2A, b2B) {
   const blocksA = splitB2IntoBlocks(b2A);
   const blocksB = splitB2IntoBlocks(b2B);
@@ -219,6 +245,8 @@ module.exports = {
   extractAgentType,
   extractPromptAgentType,
   splitB2IntoBlocks,
+  normalizePlatform,
+  computeCoreHash,
   computeBlockDiff,
   computeUnifiedDiff,
   _resetUnknownAgentSeen: () => UNKNOWN_AGENT_SEEN.clear(),

--- a/server/system-prompt.js
+++ b/server/system-prompt.js
@@ -146,13 +146,20 @@ function normalizePlatform(text) {
     .replace(/\/(?:Users|home)\/[\w.-]+/g, '{{PATH}}');  // macOS/Linux home paths
 }
 
+// Raw 12-char md5 prefix — the coreHash for providers whose prompts carry no
+// platform-token split (OpenAI/Codex use the instructions verbatim). Kept here
+// so every coreHash, normalized or not, has one definition.
+function rawCoreHash(text) {
+  return crypto.createHash('md5').update(text || '').digest('hex').slice(0, 12);
+}
+
 // Single source of truth for the Anthropic coreHash. Every anthropic call site
 // (wire-parsers/anthropic.js live path, restore.js buildVersionIndex,
 // rebuild-index.js) MUST go through this so the versionIndex key
 // `agentKey::coreHash` cannot diverge across paths — an inlined
 // md5(coreText) at any one site would silently re-split platform variants.
 function computeCoreHash(coreText) {
-  return crypto.createHash('md5').update(normalizePlatform(coreText)).digest('hex').slice(0, 12);
+  return rawCoreHash(normalizePlatform(coreText));
 }
 
 function computeBlockDiff(b2A, b2B) {
@@ -246,6 +253,7 @@ module.exports = {
   extractPromptAgentType,
   splitB2IntoBlocks,
   normalizePlatform,
+  rawCoreHash,
   computeCoreHash,
   computeBlockDiff,
   computeUnifiedDiff,

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const crypto = require('crypto');
-const { extractAgentType, splitB2IntoBlocks } = require('../system-prompt');
+const { extractAgentType, splitB2IntoBlocks, computeCoreHash } = require('../system-prompt');
 const store = require('../store');
 const helpers = require('../helpers');
 const config = require('../config');
@@ -104,7 +104,8 @@ function registerPromptVersion(ctx) {
   if (b2.length < 500) return null;
   const { key: agentKey, label: agentLabel } = extractAgentType(parsedBody.system);
   const coreText = splitB2IntoBlocks(b2).coreInstructions || '';
-  const coreHash = crypto.createHash('md5').update(coreText).digest('hex').slice(0, 12);
+  // INVARIANT: coreHash via computeCoreHash (platform-normalized) — see system-prompt.js (#219)
+  const coreHash = computeCoreHash(coreText);
   const liveM = b0.match(/cc_version=(\S+?)[; ]/);
   const liveVer = liveM ? liveM[1] : null;
   if (liveVer) {

--- a/server/wire-parsers/openai.js
+++ b/server/wire-parsers/openai.js
@@ -1,13 +1,12 @@
 'use strict';
 
-const crypto = require('crypto');
 const store = require('../store');
 const helpers = require('../helpers');
 const { normalizeUsageForProvider } = require('../providers');
 const config = require('../config');
 const { calculateCost } = require('../pricing');
 const { agentForProvider } = require('../providers');
-const { extractPromptAgentType } = require('../system-prompt');
+const { extractPromptAgentType, rawCoreHash } = require('../system-prompt');
 const {
   getOpenAIResponseFromEvents, getOpenAIInputSummary,
   getOpenAIOutputSummary, buildResponseMetadata,
@@ -187,7 +186,7 @@ function registerPromptVersion(ctx) {
   const promptText = typeof parsedBody?.instructions === 'string' ? parsedBody.instructions : null;
   if (!promptText) return null;
   const { key: agentKey, label: agentLabel } = extractPromptAgentType('openai', parsedBody);
-  const coreHash = crypto.createHash('md5').update(promptText).digest('hex').slice(0, 12);
+  const coreHash = rawCoreHash(promptText);
   const idxKey = `${agentKey}::${coreHash}`;
   const existing = store.versionIndex.get(idxKey);
   if (existing) {

--- a/test/system-prompt.test.js
+++ b/test/system-prompt.test.js
@@ -6,6 +6,8 @@ const {
   extractAgentType,
   extractPromptAgentType,
   splitB2IntoBlocks,
+  normalizePlatform,
+  computeCoreHash,
   computeBlockDiff,
   computeUnifiedDiff,
   _resetUnknownAgentSeen,
@@ -206,6 +208,57 @@ describe('system-prompt', () => {
       assert.ok(result.coreInstructions.startsWith('Core instructions'));
       assert.ok(result.envAndGit.startsWith('# Environment'));
       assert.ok(result.autoMemory.startsWith('# auto memory'));
+    });
+  });
+
+  // #219 — platform-variant prompts must not create false version splits.
+  describe('normalizePlatform', () => {
+    it('replaces shell names with a stable placeholder', () => {
+      assert.equal(normalizePlatform('Prefer dedicated tools over Bash when one fits'),
+        'Prefer dedicated tools over {{SHELL}} when one fits');
+      assert.equal(normalizePlatform('Prefer dedicated tools over PowerShell when one fits'),
+        'Prefer dedicated tools over {{SHELL}} when one fits');
+      assert.equal(normalizePlatform('run via cmd.exe here'), 'run via {{SHELL}} here');
+    });
+
+    it('replaces os identifiers with a stable placeholder', () => {
+      for (const os of ['darwin', 'win32', 'linux']) {
+        assert.equal(normalizePlatform(`platform is ${os} today`), 'platform is {{PLATFORM}} today');
+      }
+    });
+
+    it('replaces windows and unix home paths with a stable placeholder', () => {
+      assert.equal(normalizePlatform('cwd C:\\Users\\alice\\proj'), 'cwd {{PATH}}');
+      assert.equal(normalizePlatform('cwd /Users/alice'), 'cwd {{PATH}}');
+      assert.equal(normalizePlatform('cwd /home/alice'), 'cwd {{PATH}}');
+    });
+
+    it('leaves platform-neutral text untouched', () => {
+      const t = 'You are an interactive agent that helps users with tasks.';
+      assert.equal(normalizePlatform(t), t);
+    });
+
+    it('handles null/undefined input', () => {
+      assert.equal(normalizePlatform(null), '');
+      assert.equal(normalizePlatform(undefined), '');
+    });
+  });
+
+  describe('computeCoreHash', () => {
+    it('yields the same hash for macOS/Windows variants of one prompt version', () => {
+      const mac = 'You are Claude Code.\nPrefer dedicated tools over Bash when one fits.\nPlatform: darwin';
+      const win = 'You are Claude Code.\nPrefer dedicated tools over PowerShell when one fits.\nPlatform: win32';
+      assert.equal(computeCoreHash(mac), computeCoreHash(win));
+    });
+
+    it('still differs when the actual instructions change', () => {
+      const v1 = 'You are Claude Code.\nPrefer dedicated tools over Bash when one fits.';
+      const v2 = 'You are Claude Code.\nAlways prefer dedicated tools; never shell out.';
+      assert.notEqual(computeCoreHash(v1), computeCoreHash(v2));
+    });
+
+    it('returns a 12-char hex prefix', () => {
+      assert.match(computeCoreHash('anything'), /^[0-9a-f]{12}$/);
     });
   });
 

--- a/test/system-prompt.test.js
+++ b/test/system-prompt.test.js
@@ -233,6 +233,14 @@ describe('system-prompt', () => {
       assert.equal(normalizePlatform('cwd /home/alice'), 'cwd {{PATH}}');
     });
 
+    it('consumes the full unix path, not just the home prefix (symmetric with Windows)', () => {
+      // deep $HOME paths (skill/plugin content leaked into coreInstructions) — the
+      // forward-slash tail must collapse too, else it survives on unix but not Windows
+      // and re-splits one version across platforms (#219 residual).
+      assert.equal(normalizePlatform('see /Users/alice/src/tries/skill/data/runs here'), 'see {{PATH}} here');
+      assert.equal(normalizePlatform('cache at /home/bob/.claude/plugins/cache/x done'), 'cache at {{PATH}} done');
+    });
+
     it('leaves platform-neutral text untouched', () => {
       const t = 'You are an interactive agent that helps users with tasks.';
       assert.equal(normalizePlatform(t), t);
@@ -255,6 +263,20 @@ describe('system-prompt', () => {
       const v1 = 'You are Claude Code.\nPrefer dedicated tools over Bash when one fits.';
       const v2 = 'You are Claude Code.\nAlways prefer dedicated tools; never shell out.';
       assert.notEqual(computeCoreHash(v1), computeCoreHash(v2));
+    });
+
+    it('collapses deep $HOME paths (skill/plugin) across platforms', () => {
+      const mac = 'Skill data lives at /Users/alice/src/tries/skill/data/runs and loads on demand.';
+      const win = 'Skill data lives at C:\\Users\\alice\\src\\tries\\skill\\data\\runs and loads on demand.';
+      assert.equal(computeCoreHash(mac), computeCoreHash(win));
+    });
+
+    it('does not over-normalize: identical paths but different prose still differ', () => {
+      // guard against a too-greedy normalize washing out real content: same path span,
+      // different instruction sentence → must remain distinct versions.
+      const a = 'Base at /Users/alice/proj.\nAlways run tests before committing.';
+      const b = 'Base at /Users/alice/proj.\nNever run tests; ship immediately.';
+      assert.notEqual(computeCoreHash(a), computeCoreHash(b));
     });
 
     it('returns a 12-char hex prefix', () => {


### PR DESCRIPTION
Claude Code's coreInstructions carry platform-specific tokens — the shell
name (Bash on macOS/Linux vs PowerShell on Windows), os identifiers
(darwin/win32/linux), and home paths. Hashing the raw text split one
semantic prompt version into per-OS duplicates, so the version list showed
multiple rows for the same cc_version with different hashes.

Normalize those tokens to placeholders before hashing so the same
cc_version yields one coreHash across platforms. The stored/displayed
coreInstructions text stays un-normalized — only the hash sees
placeholders, so the content and diff views still show the real
platform-specific words.

- Add normalizePlatform() + computeCoreHash() to system-prompt.js as the
  single source of truth for the Anthropic coreHash.
- Route all three anthropic call sites through it (wire-parsers/anthropic.js
  live path, restore.js buildVersionIndex, rebuild-index.js) so the
  versionIndex key `agentKey::coreHash` cannot diverge across paths.
- OpenAI/Codex coreHash is unchanged (no platform-token split there).
- Add unit tests: platform variants collapse to one hash; genuine content
  changes still differ.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015SQGnF7aagVVminwxuoXxR