### PR TITLE
feat(dashboard): show cache-creation 5m/1h TTL split in turn detail (#196)

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2323,6 +2323,37 @@ function selectSection(name) {
   if (typeof renderCmdBar === 'function') renderCmdBar();
 }
 
+// #196: cache-creation TTL split (5m vs 1h). The Anthropic ephemeral breakdown
+// (usage.cache_creation.{ephemeral_5m,ephemeral_1h}_input_tokens) is parsed
+// server-side (wire-parsers/anthropic.js:34-39) but was never surfaced — the
+// turn-detail cache row only showed the flat cache_creation_input_tokens.
+// Returns the cache-create segment(s) for the detail line's `parts` array:
+//   - object present AND 5m+1h === flat  → split into `new 5m X / 1h Y`
+//     (one <span data-cache-ttl> per non-zero tier — a single all-5m or all-1h
+//     turn yields one tagged node, which is truthful, not a fake split)
+//   - object absent, non-object, or drifted sum → flat `new X`, prefer the
+//     authoritative flat value (obs-fragile defense; wire-protocol-reference §4.3)
+// Empty array when there is no cache-creation at all (no fake `5m 0 / 1h 0`).
+function cacheCreateParts(usage) {
+  const flat = (usage && usage.cache_creation_input_tokens) || 0;
+  if (!flat) return [];
+  const cc = usage && usage.cache_creation;
+  if (cc && typeof cc === 'object') {
+    const m5 = cc.ephemeral_5m_input_tokens || 0;
+    const h1 = cc.ephemeral_1h_input_tokens || 0;
+    if ((m5 || h1) && m5 + h1 === flat) {
+      const segs = [];
+      if (m5) segs.push('<span data-cache-ttl="5m">5m ' + fmt(m5) + '</span>');
+      if (h1) segs.push('<span data-cache-ttl="1h">1h ' + fmt(h1) + '</span>');
+      return ['new ' + segs.join(' / ')];
+    }
+    if (m5 + h1 !== flat && typeof console !== 'undefined' && console.debug) {
+      console.debug('[ccxray #196] cache_creation split ' + (m5 + h1) + ' ≠ flat ' + flat + ', using flat');
+    }
+  }
+  return ['new ' + fmt(flat)];
+}
+
 function renderSectionsCol(idx) {
   const e = allEntries[idx];
   if (!e) { colSections.innerHTML = '<div class="col-empty">No data</div>'; return; }
@@ -2359,7 +2390,7 @@ function renderSectionsCol(idx) {
     html += ' <span style="color:var(--dim);font-size:10px">(';
     const parts = [];
     if (cacheRead) parts.push('cache ' + fmt(cacheRead));
-    if (cacheCreate) parts.push('new ' + fmt(cacheCreate));
+    for (const p of cacheCreateParts(usage)) parts.push(p);
     html += parts.join(' · ') + ')</span>';
   }
   html += '</div>';

--- a/test/cache-ttl-split.test.js
+++ b/test/cache-ttl-split.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+// #196: cache-creation 5m/1h TTL split in the turn-detail cache row.
+// The Anthropic ephemeral breakdown (usage.cache_creation.{ephemeral_5m,
+// ephemeral_1h}_input_tokens) is parsed server-side but was never shown; the
+// client only read the flat cache_creation_input_tokens. These tests lock the
+// display-layer helper cacheCreateParts(usage) that renderSectionsCol feeds.
+//
+// Fixture provenance: synthetic. usage shape follows
+// server/wire-parsers/anthropic.js:34-39 and docs/wire-protocol-reference.md
+// §4.3 — no real logs embedded.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+// Load miller-columns.js in a browser-like VM and read cacheCreateParts.
+// Same harness shape as test/ctx-color.test.js.
+function loadClient() {
+  const publicDir = path.join(__dirname, '..', 'public');
+  const el = () => ({
+    style: {}, dataset: {}, innerHTML: '', textContent: '',
+    classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+    addEventListener() {}, appendChild() {}, insertBefore() {},
+    querySelector: () => el(), querySelectorAll: () => [], remove() {},
+  });
+  const context = {
+    console, window: {},
+    document: { getElementById: () => el(), createElement: () => el(), querySelector: () => el(), querySelectorAll: () => [], addEventListener() {}, body: el() },
+    localStorage: { getItem: () => null, setItem() {} }, sessionStorage: { getItem: () => null, setItem() {} },
+    navigator: {}, location: { search: '', hash: '' }, history: { replaceState() {} },
+    URLSearchParams, setTimeout, clearTimeout,
+  };
+  vm.createContext(context);
+  vm.runInContext(`
+    function updateSysPromptBadge() {} function startQuotaTicker() {}
+    function EventSource() { this.onmessage = null; } function setInterval() { return 0; }
+    function clearInterval() {} window.ccxraySettings = { visibleProviders: [] };
+    function fetch() { return Promise.resolve({ ok: false, json() { return Promise.resolve({}); } }); }
+  `, context);
+  vm.runInContext(fs.readFileSync(path.join(publicDir, 'format.js'), 'utf8'), context);
+  vm.runInContext(fs.readFileSync(path.join(publicDir, 'miller-columns.js'), 'utf8'), context);
+  return context;
+}
+
+describe('#196 cache-creation TTL split (cacheCreateParts)', () => {
+  const ctx = loadClient();
+
+  it('exposes cacheCreateParts', () => {
+    assert.equal(typeof ctx.cacheCreateParts, 'function');
+  });
+
+  // ── target metric: object present + 5m+1h === flat → two tagged nodes ──
+  it('renders 5m and 1h as two nodes with correct values', () => {
+    const parts = ctx.cacheCreateParts({
+      cache_creation_input_tokens: 3000,
+      cache_creation: { ephemeral_5m_input_tokens: 1200, ephemeral_1h_input_tokens: 1800 },
+    });
+    assert.equal(parts.length, 1, 'one cache-create part');
+    const html = parts[0];
+    const ttlNodes = html.match(/data-cache-ttl=/g) || [];
+    assert.equal(ttlNodes.length, 2, 'exactly two TTL-tagged nodes');
+    assert.match(html, /data-cache-ttl="5m">5m 1,200</, '5m node shows 1,200');
+    assert.match(html, /data-cache-ttl="1h">1h 1,800</, '1h node shows 1,800');
+  });
+
+  // ── consistency guard: 5m + 1h must equal the flat total ──
+  it('sum of the two tiers equals the flat cache_creation_input_tokens', () => {
+    const flat = 3000, m5 = 1200, h1 = 1800;
+    assert.equal(m5 + h1, flat, 'fixture is internally consistent');
+    const parts = ctx.cacheCreateParts({
+      cache_creation_input_tokens: flat,
+      cache_creation: { ephemeral_5m_input_tokens: m5, ephemeral_1h_input_tokens: h1 },
+    });
+    assert.match(parts[0], /data-cache-ttl="5m"/);
+    assert.match(parts[0], /data-cache-ttl="1h"/);
+  });
+
+  // ── obs-fragile guard: object absent → flat fallback, no fake split ──
+  it('falls back to a single flat node when cache_creation object is absent', () => {
+    const parts = ctx.cacheCreateParts({ cache_creation_input_tokens: 2500 });
+    assert.equal(parts.length, 1);
+    assert.doesNotMatch(parts[0], /data-cache-ttl/, 'no TTL nodes');
+    assert.doesNotMatch(parts[0], /5m 0|1h 0/, 'no fake `5m 0 / 1h 0`');
+    assert.match(parts[0], /new 2,500/, 'flat value shown');
+  });
+
+  // ── drift guard: 5m + 1h !== flat → prefer flat, no split ──
+  it('prefers the flat value when the tiers do not sum to it', () => {
+    const parts = ctx.cacheCreateParts({
+      cache_creation_input_tokens: 3000,
+      cache_creation: { ephemeral_5m_input_tokens: 1000, ephemeral_1h_input_tokens: 1000 },
+    });
+    assert.equal(parts.length, 1);
+    assert.doesNotMatch(parts[0], /data-cache-ttl/, 'no split on drift');
+    assert.match(parts[0], /new 3,000/, 'flat value shown');
+  });
+
+  // ── single-tier is truthful, not a fake split ──
+  it('renders one tagged node when all cache creation is a single tier', () => {
+    const parts = ctx.cacheCreateParts({
+      cache_creation_input_tokens: 1500,
+      cache_creation: { ephemeral_5m_input_tokens: 1500, ephemeral_1h_input_tokens: 0 },
+    });
+    assert.equal((parts[0].match(/data-cache-ttl=/g) || []).length, 1);
+    assert.match(parts[0], /data-cache-ttl="5m">5m 1,500</);
+    assert.doesNotMatch(parts[0], /1h/, 'no zero-valued 1h node');
+  });
+
+  // ── no cache creation → empty (nothing to render) ──
+  it('returns an empty array when there is no cache creation', () => {
+    // length checks (not deepEqual) — the array is created in the VM realm,
+    // so its Array.prototype differs from this realm's under deepStrictEqual.
+    assert.equal(ctx.cacheCreateParts({ cache_creation_input_tokens: 0 }).length, 0);
+    assert.equal(ctx.cacheCreateParts({}).length, 0);
+    assert.equal(ctx.cacheCreateParts(null).length, 0);
+  });
+});


### PR DESCRIPTION
Closes #196.

## 摘要

Anthropic 的 ephemeral cache 拆分（`usage.cache_creation.ephemeral_5m/1h_input_tokens`）早在 `server/wire-parsers/anthropic.js:34-39` 就解析進 `entry.usage`，但 dashboard 只讀扁平的 `cache_creation_input_tokens`，5 分鐘 vs 1 小時快取的分佈完全看不到。本 PR 在 turn 詳情的 cache 行把它顯示出來。

## 改動

**`public/miller-columns.js`** — 新增純函式 `cacheCreateParts(usage)`，`renderSectionsCol` 的 cache 行改用它：

- ephemeral 物件存在且 `5m + 1h === flat` → 拆成 `new 5m X / 1h Y`，每個非零 tier 一個 `<span data-cache-ttl>` 節點（全 5m 或全 1h 只出一個節點，是真實而非假拆分）
- 物件缺失／非物件／兩段和與扁平值漂移 → 回退扁平 `new X`，以權威扁平值為準（obs-fragile 防禦，見 `docs/wire-protocol-reference.md` §4.3；漂移時 `console.debug`）
- 完全無 cache-creation → 空，不出現假的 `5m 0 / 1h 0`

**Provider scope**：Anthropic-only。OpenAI/Codex 的 cache 是 server-managed，usage 只有扁平 `cached_tokens` 命中數，沒有 5m/1h TTL 分層，無 Codex parity 需求。

**`test/cache-ttl-split.test.js`** — 合成 fixture（usage 形狀依 `anthropic.js:34-39` 與 wire-protocol-reference §4.3，不嵌真實 log），涵蓋：目標指標（兩節點值正確）、一致性 guard（`5m+1h===flat`）、缺物件 fallback、和漂移回退、單一 tier、無 cache 空回傳。

## 已完成的驗證

- **old-fail/new-pass 差異**（依 `docs/verification-principles.md`）：新測試在**舊碼 0/7 pass**（`cacheCreateParts` 不存在）、**新碼 7/7 pass**。
- **無回歸**：所有載入 `public/miller-columns.js` 的 client-render 單元套件 **103/103 pass**（ctx-color、escapehtml、image-xss、retry-grouping、seq-interleave、cost-budget-ui、messages-ui、resume-button-render、markerdefs-consistency + 本新測試）。
- 全套件在 CI 有網路／`puppeteer` 時應為綠。本 PR 只動一個 client 顯示 helper。

## ⚠️ 仍需驗證（Reviewer 請補）

1. **真實瀏覽器 smoke（必要，CLAUDE.md 要求）** — 本 PR 在沙盒環境開發，該環境**未安裝 puppeteer／缺 browser-harness，我沒有跑到真實瀏覽器**。請依 CLAUDE.md「Smoke Testing」段落用真實 CDP/Chrome 確認：
   ```bash
   CCXRAY_HOME=/tmp/ccxray-smoke-$$ ccxray --port 5602 --no-browser
   ```
   要看的東西：一個含 1h 快取的真實 turn，其詳情 cache 行呈現 `new 5m X / 1h Y`；只有 5m 的 turn 呈現單段 `new 5m X`；舊/無 ephemeral 物件的 turn 回退為扁平 `new X`——版面（`ch-line2` 那一行）不換行、不溢出。

2. **真實 wire 資料抽樣（建議）** — 確認實際 Anthropic 回應中 `ephemeral_5m + ephemeral_1h` 確實等於扁平 `cache_creation_input_tokens`（單元測試用的是合成 fixture）。若真實資料常態漂移，會走 fallback 而看不到拆分——那代表 wire 假設需修正，不是本顯示層 bug。

3. **視覺/設計**（可選）— 分隔符目前用 ` / `，與同行既有的 ` · ` 區隔；若偏好其他呈現（例如各自著色、tooltip），可在 review 指出。

## 完整測試指令

```bash
CCXRAY_HOME=$(mktemp -d) npm test          # CI backstop：空 home
node --test test/cache-ttl-split.test.js   # 本 PR 新測試
```

> 沙盒環境下全套件有 38 個 network/hub/websocket/auth/launcher e2e 及缺 puppeteer 的 e2e 失敗，皆為環境性、與本改動無關（這些套件均不 import `miller-columns.js`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016i4LWByy5drN79B1bnzLL3)_