### PR TITLE
fix(dashboard): estimate current-turn minimap tokens from output_tokens

### DIFF
--- a/public/messages.js
+++ b/public/messages.js
@@ -847,9 +847,32 @@ function mmBlockColor(stepType, blockType) {
 
 // Build minimap block data from currentSteps + tok.perMessage
 // Returns array of { stepIdx, color, tokens, label, isError }
-function buildMinimapBlocks(steps, perMessage) {
+function buildMinimapBlocks(steps, perMessage, usage) {
   const blocks = [];
   if (!steps || !steps.length) return blocks;
+
+  // Current-turn steps (source:'current') have empty msgIndices — their output
+  // isn't in the context window yet, so no per-message token count exists. Split
+  // the turn's real output_tokens across them by text length instead of the
+  // fabricated tokens:1 fallback, keeping the minimap proportion honest.
+  const curTokensByStep = new Map();
+  const outputTokens = (usage && usage.output_tokens) || 0;
+  if (outputTokens > 0) {
+    const curSteps = steps.filter(s => s.source === 'current');
+    if (curSteps.length) {
+      const lenOf = (s) => {
+        let n = (s.thinking ? s.thinking.length : 0) + (s.text ? s.text.length : 0);
+        if (s.calls) for (const c of s.calls) { try { n += JSON.stringify(c.input || {}).length; } catch {} }
+        return n;
+      };
+      const lens = curSteps.map(lenOf);
+      const totalLen = lens.reduce((a, b) => a + b, 0);
+      curSteps.forEach((s, i) => {
+        const share = totalLen > 0 ? lens[i] / totalLen : 1 / curSteps.length;
+        curTokensByStep.set(s, Math.max(1, Math.round(outputTokens * share)));
+      });
+    }
+  }
 
   for (let si = 0; si < steps.length; si++) {
     const step = steps[si];
@@ -878,7 +901,8 @@ function buildMinimapBlocks(steps, perMessage) {
         }
       }
     } else {
-      blocks.push({ stepIdx: si, color: mmBlockColor(step.type), tokens: 1, label: step.type, isError: hasError });
+      const estTok = curTokensByStep.get(step) || 1;
+      blocks.push({ stepIdx: si, color: mmBlockColor(step.type), tokens: estTok, label: step.type, isError: hasError });
     }
   }
   return blocks;
@@ -886,15 +910,19 @@ function buildMinimapBlocks(steps, perMessage) {
 
 // Render minimap HTML — cache bar + blocks + viewport + usage label
 function renderMinimapHtml(steps, perMessage, activeStepIdx, maxContext, usage) {
-  const blocks = buildMinimapBlocks(steps, perMessage);
+  const blocks = buildMinimapBlocks(steps, perMessage, usage);
   if (!blocks.length) return '';
 
-  const estimatedTotal = blocks.reduce((s, b) => s + b.tokens, 0) || 1;
-  // Use API usage as authoritative total when available (same logic as progress bar)
+  // For usedRatio consistency with session card and swimlane (ADR: in+cr+cc, no output),
+  // exclude current-turn block weights from the estimated total used for the occupied region.
+  const estimatedInput = blocks.reduce((s, b) => {
+    const step = steps[b.stepIdx];
+    return s + (step && step.source === 'current' ? 0 : b.tokens);
+  }, 0) || 1;
   const apiTotal = usage
     ? (usage.input_tokens || 0) + (usage.cache_read_input_tokens || 0) + (usage.cache_creation_input_tokens || 0)
     : 0;
-  const totalTokens = apiTotal > estimatedTotal ? apiTotal : estimatedTotal;
+  const totalTokens = apiTotal > estimatedInput ? apiTotal : estimatedInput;
   const ctxWindow = maxContext || 200000;
   const usedPct = Math.min(100, totalTokens / ctxWindow * 100).toFixed(0);
   const remaining = Math.max(0, ctxWindow - totalTokens);

--- a/public/messages.js
+++ b/public/messages.js
@@ -913,8 +913,8 @@ function renderMinimapHtml(steps, perMessage, activeStepIdx, maxContext, usage) 
   const blocks = buildMinimapBlocks(steps, perMessage, usage);
   if (!blocks.length) return '';
 
-  // For usedRatio consistency with session card and swimlane (ADR: in+cr+cc, no output),
-  // exclude current-turn block weights from the estimated total used for the occupied region.
+  // For usedRatio consistency with session card (ctxUsed, entry-rendering.js:540) and
+  // swimlane: in+cr+cc, no output. Exclude current-turn block weights from the occupied region.
   const estimatedInput = blocks.reduce((s, b) => {
     const step = steps[b.stepIdx];
     return s + (step && step.source === 'current' ? 0 : b.tokens);

--- a/test/messages-ui.test.js
+++ b/test/messages-ui.test.js
@@ -103,6 +103,14 @@ describe('buildMinimapBlocks — current-turn token estimate', () => {
     assert.equal(context.buildMinimapBlocks(curSteps(), null, undefined)[0].tokens, 1);
     assert.equal(context.buildMinimapBlocks(curSteps(), null, { output_tokens: 0 })[1].tokens, 1);
   });
+
+  it('excludes current-turn output from occupancy total (usedRatio parity with ctxUsed)', () => {
+    const context = loadMessagesContext();
+    const html = context.renderMinimapHtml(curSteps(), null, -1, 1000000, { input_tokens: 500, output_tokens: 1000 });
+    const m = html.match(/data-total-tokens="(\d+)"/);
+    assert.ok(m, 'data-total-tokens attribute should exist');
+    assert.equal(Number(m[1]), 500);
+  });
 });
 
 describe('renderEditedBanner — intercept-edited badge (client render)', () => {

--- a/test/messages-ui.test.js
+++ b/test/messages-ui.test.js
@@ -81,6 +81,30 @@ describe('dashboard timeline rendering helpers', () => {
   });
 });
 
+describe('buildMinimapBlocks — current-turn token estimate', () => {
+  const curSteps = () => ([
+    { type: 'tool-group', source: 'current', thinking: 'x'.repeat(300), calls: [], msgIndices: [] },
+    { type: 'assistant-text', source: 'current', text: 'y'.repeat(100), msgIndices: [] },
+  ]);
+
+  it('splits real output_tokens across current-turn steps by text length instead of tokens:1', () => {
+    const context = loadMessagesContext();
+    const blocks = context.buildMinimapBlocks(curSteps(), null, { output_tokens: 1000 });
+    assert.equal(blocks.length, 2);
+    // 300:100 text-length ratio → 750:250 of 1000 output_tokens.
+    assert.equal(blocks[0].tokens, 750);
+    assert.equal(blocks[1].tokens, 250);
+    // The bug: both were 1 (fabricated fallback). Guard against regression.
+    assert.ok(blocks[0].tokens > 1 && blocks[1].tokens > 1);
+  });
+
+  it('falls back to tokens:1 only when no output_tokens is available (legacy/no-usage)', () => {
+    const context = loadMessagesContext();
+    assert.equal(context.buildMinimapBlocks(curSteps(), null, undefined)[0].tokens, 1);
+    assert.equal(context.buildMinimapBlocks(curSteps(), null, { output_tokens: 0 })[1].tokens, 1);
+  });
+});
+
 describe('renderEditedBanner — intercept-edited badge (client render)', () => {
   function ctxWithStubs() {
     const context = loadMessagesContext();


### PR DESCRIPTION
## 摘要

Minimap 的 current-turn blocks（Phase 3 步驟）原本用 `tokens: 1` 假數，在 32K+ context 的 turn 裡被 scale 壓成 0.5px 不可見。改用 `usage.output_tokens` 按文字長度比例分配真實 token 數。

## 改動

- `buildMinimapBlocks` 接收 `usage` 參數，current-turn steps 按 thinking+text+tool input 長度比例分配 `output_tokens`
- `usedRatio`（占用區高度）維持 input-only（`in+cr+cc`），與 session card / swimlane 三處一致
- 無 usage 時仍 fallback 到 `tokens: 1`（legacy/codex 相容）

## 驗證

- 單元測試：比例分配 750/250 + legacy fallback（2 tests）
- Diff-check：舊碼 `[1,1]` FAIL → 新碼 `[750,250]` PASS
- UsedRatio 一致性：minimap % = session card % = swimlane %（verified with test fixture）
- 全套件：`CCXRAY_HOME=$(mktemp -d) npm test` → 1247 pass / 0 fail

## Follow-up

全系統 ctxUsed 語義（input-only → input+output）是正交議題，需三處一起改 + severity 門檻 review，不在本 PR scope。

## Test plan

- [ ] Smoke test: 開真實 session，確認 minimap 最後幾步有可見高度
- [ ] 對比 session card 的 context % 和 minimap usage label 數字一致
- [ ] 無 usage 的 turn（error/中斷）不 crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)