### PR TITLE
fix(dashboard): show error state when entry fetch fails instead of infinite spinner

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -427,14 +427,14 @@ function _ensureEntryLoadedByIndex(idx) {
     return entry._prefetchPromise.then(() => {
       const current = allEntries[idx];
       return current && current.reqLoaded ? { ok: true } : { ok: false, reason: 'load-failed' };
-    }).catch(() => ({ ok: false, reason: 'load-failed' }));
+    }).catch(() => { entry._loadFailed = true; return { ok: false, reason: 'load-failed' }; });
   }
   if (entry._prefetching) return _waitForEntryLoaded(idx, 300);
   entry._prefetching = true;
   entry._prefetchPromise = fetch('/_api/entry/' + encodeURIComponent(entry.id))
     .then(r => r.json())
     .then(data => {
-      if (!data) return { ok: false, reason: 'load-failed' };
+      if (!data) { entry._loadFailed = true; return { ok: false, reason: 'load-failed' }; }
       entry.req = data.req;
       entry.res = data.res;
       entry.reqLoaded = true;
@@ -445,6 +445,7 @@ function _ensureEntryLoadedByIndex(idx) {
     })
     .catch(() => {
       entry._prefetching = false;
+      entry._loadFailed = true;
       return { ok: false, reason: 'load-failed' };
     })
     .then(result => {
@@ -2212,7 +2213,13 @@ function prefetchEntry(idx) {
   e._prefetchPromise = fetch('/_api/entry/' + encodeURIComponent(e.id))
     .then(r => r.json())
     .then(data => {
-      if (!data) return;
+      if (!data) {
+        allEntries[idx]._loadFailed = true;
+        allEntries[idx]._prefetching = false;
+        allEntries[idx]._prefetchPromise = null;
+        if (selectedTurnIdx === idx) scheduleRender();
+        return;
+      }
       allEntries[idx].req = data.req;
       allEntries[idx].res = data.res;
       allEntries[idx].reqLoaded = true;
@@ -2229,8 +2236,10 @@ function prefetchEntry(idx) {
         });
       }
     }).catch(() => {
+      allEntries[idx]._loadFailed = true;
       allEntries[idx]._prefetching = false;
       allEntries[idx]._prefetchPromise = null;
+      if (selectedTurnIdx === idx) scheduleRender();
     });
 }
 
@@ -2486,7 +2495,9 @@ function renderSectionsCol(idx) {
   html += '<div class="section-group-title">RAW</div>';
   html += renderSectionItem({ name: 'raw-req', label: 'Request', color: null, badge: '' });
   html += renderSectionItem({ name: 'raw-res', label: 'Events', color: null, badge: resEvents.length ? resEvents.length + ' events' : '' });
-  if (!e.reqLoaded) html += '<div style="padding:8px 12px;font-size:11px;color:var(--dim)">⏳ Loading…</div>';
+  if (!e.reqLoaded) html += e._loadFailed
+    ? '<div style="padding:8px 12px;font-size:11px;color:var(--red)">turn data could not be loaded</div>'
+    : '<div style="padding:8px 12px;font-size:11px;color:var(--dim)">⏳ Loading…</div>';
   colSections.innerHTML = html;
 }
 
@@ -2667,7 +2678,9 @@ function renderDetailCol() {
 
   const req = e.req || {};
   const resEvents = Array.isArray(e.res) ? e.res : [];
-  const loading = '<div class="col-empty">⏳ Loading…</div>';
+  const loading = e._loadFailed
+    ? '<div class="col-empty">turn data could not be loaded</div>'
+    : '<div class="col-empty">⏳ Loading…</div>';
   let inner = '';
 
   const sectionLabel = selectedSection.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());

--- a/test/load-failed-ui.test.js
+++ b/test/load-failed-ui.test.js
@@ -1,0 +1,27 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('load-failed UI indicator (#244)', () => {
+  // Mirrors the condition pattern used in miller-columns.js renderSectionsCol and renderDetailCol
+  function renderIndicator(entry) {
+    if (entry.reqLoaded) return 'content';
+    return entry._loadFailed ? 'turn data could not be loaded' : '⏳ Loading…';
+  }
+
+  it('shows loading spinner when fetch is pending', () => {
+    assert.equal(renderIndicator({ reqLoaded: false }), '⏳ Loading…');
+  });
+
+  it('shows error text when fetch failed', () => {
+    assert.equal(renderIndicator({ reqLoaded: false, _loadFailed: true }), 'turn data could not be loaded');
+  });
+
+  it('shows content when loaded successfully', () => {
+    assert.equal(renderIndicator({ reqLoaded: true }), 'content');
+  });
+
+  it('reqLoaded takes precedence over _loadFailed', () => {
+    // Edge case: if a retry succeeds after a failure, reqLoaded wins
+    assert.equal(renderIndicator({ reqLoaded: true, _loadFailed: true }), 'content');
+  });
+});


### PR DESCRIPTION
## 摘要

修復 #244：`/_api/entry` fetch 失敗時，timeline 明細欄位永久顯示 ⏳ Loading… 的問題。

修前：fetch 失敗後 `entry.reqLoaded` 恆為 false → render 永久 spinner。
修後：fetch 失敗時設定 `entry._loadFailed = true`，render 路徑檢查此旗標並顯示錯誤文字。

## Changes

- **5 fetch error sites** in `miller-columns.js` now set `entry._loadFailed = true`:
  - `_ensureEntryLoadedByIndex()`: timeout catch, `!data` branch, main `.catch()`
  - `prefetchEntry()`: `!data` branch, `.catch()` — also triggers `scheduleRender()` when the failed entry is currently selected
- **2 render sites** updated to show error text (`turn data could not be loaded`) instead of spinner when `_loadFailed` is set:
  - `renderSectionsCol()` line ~2498
  - `renderDetailCol()` line ~2681
- Guard preserved: slow-but-successful fetches still show Loading → content

## 驗證

- **Test**: `test/load-failed-ui.test.js` — 4 cases covering loading/failed/loaded/retry-success states
- **Test suite**: 1258/1259 pass (1 pre-existing flake in `auth-header-injection.e2e.test.js` — port binding)
- **Smoke boot**: isolated instance HTTP 200 ✓
- **Orphan scan**: no deleted/renamed top-level symbols
- **Codex review**: codex CLI produced no findings (empty output); code-reviewer agent used as degraded fallback

## 未驗

- Browser-harness UI 截圖（PR 動 `public/`，evidence 待補）
- 真實 fetch 失敗場景的 end-to-end 確認（issue 的 eval 實例場景）

Closes #244