### PR TITLE
fix(workflow): lane color pool — ≥3:1 WCAG contrast on both themes

### DIFF
--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -13,8 +13,8 @@ function wfStepsRoot() {
 // ── Constants ─────────────────────────────────────────────────────────────
 // #144/#149: per-agent identity palette (docs/wf-color-identity/DESIGN.md).
 // `main` pinned; hashed off lane.key. 7 hues × 7 shapes = 50 combos.
-// CVD-verified: magenta (#d742a5) + indigo (#4242d7) clear all 9 reserved.
-const WF_LANE_COLORS = { main: '#42a3fd', hashed: ['#ffdbaa', '#dc7d96', '#a1a716', '#45f8ef', '#d1d843', '#d742a5', '#4242d7'] };
+// #233: all 8 colors ≥3:1 WCAG contrast on both dark (#0d1117) and light (#ffffff).
+const WF_LANE_COLORS = { main: '#3b82c4', hashed: ['#d07028', '#c24878', '#6d8f1c', '#1f9990', '#9a8818', '#9838a0', '#5060d4'] };
 const WF_LABEL_W = 240, WF_LANE_GAP = 4;
 // v8 ctx-split (#121): 44px ctx% bars + 8px cost track + event tracks (8px collapsed / 4×8px expanded)
 const WF_BAR_H = 44, WF_COST_TRACK_H = 8, WF_EV_H = 8, WF_EV_H_SEL = 32;

--- a/test/lane-color-contrast.test.js
+++ b/test/lane-color-contrast.test.js
@@ -1,0 +1,77 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+// WCAG 2.x relative luminance + contrast ratio
+function srgbToLinear(c) {
+  c = c / 255;
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+function luminance(hex) {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+}
+function contrast(a, b) {
+  const la = luminance(a), lb = luminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+function hue(hex) {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const max = Math.max(r, g, b), min = Math.min(r, g, b), d = max - min;
+  if (d === 0) return 0;
+  let h;
+  if (max === r) h = ((g - b) / d) % 6;
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  h = Math.round(h * 60);
+  return h < 0 ? h + 360 : h;
+}
+
+const DARK_BG = '#0d1117';
+const LIGHT_BG = '#ffffff';
+
+// Current palette (from workflow-timeline.js line 17)
+const CURRENT = { main: '#3b82c4', hashed: ['#d07028', '#c24878', '#6d8f1c', '#1f9990', '#9a8818', '#9838a0', '#5060d4'] };
+// Pre-fix palette (for diff-check evidence: old should FAIL)
+const OLD = { main: '#42a3fd', hashed: ['#ffdbaa', '#dc7d96', '#a1a716', '#45f8ef', '#d1d843', '#d742a5', '#4242d7'] };
+
+describe('Lane color contrast (#233)', () => {
+  const allCurrent = [CURRENT.main, ...CURRENT.hashed];
+  const allOld = [OLD.main, ...OLD.hashed];
+
+  it('all current colors ≥3:1 contrast vs dark bg', () => {
+    for (const c of allCurrent) {
+      const cr = contrast(c, DARK_BG);
+      assert.ok(cr >= 3.0, `${c} vs dark: ${cr.toFixed(2)} < 3.0`);
+    }
+  });
+
+  it('all current colors ≥3:1 contrast vs light bg', () => {
+    for (const c of allCurrent) {
+      const cr = contrast(c, LIGHT_BG);
+      assert.ok(cr >= 3.0, `${c} vs light: ${cr.toFixed(2)} < 3.0`);
+    }
+  });
+
+  it('pairwise hue distance ≥20° (distinguishability guard)', () => {
+    for (let i = 0; i < allCurrent.length; i++) {
+      for (let j = i + 1; j < allCurrent.length; j++) {
+        const h1 = hue(allCurrent[i]), h2 = hue(allCurrent[j]);
+        let dist = Math.abs(h1 - h2);
+        if (dist > 180) dist = 360 - dist;
+        assert.ok(dist >= 20, `${allCurrent[i]} (${h1}°) and ${allCurrent[j]} (${h2}°): hue dist ${dist}° < 20°`);
+      }
+    }
+  });
+
+  it('old colors FAIL contrast check (diff-check evidence)', () => {
+    let failures = 0;
+    for (const c of allOld) {
+      if (contrast(c, DARK_BG) < 3.0 || contrast(c, LIGHT_BG) < 3.0) failures++;
+    }
+    assert.ok(failures >= 5, `expected ≥5 old colors to fail, got ${failures}`);
+  });
+});


### PR DESCRIPTION
## 摘要

修復 #233：`WF_LANE_COLORS.hashed` 在 light theme 下 5/7 色對比不足（WCAG <3:1）。

修前：色池針對 dark theme 調色，light bg 下大半 lane 顏色不可辨。
修後：8 色（含 main）全部在 dark `#0d1117` 與 light `#ffffff` 兩主題下 ≥3:1 contrast。單一色池，無需 light/dark 雙套。

## 色值對照

| Slot | Old | New | vs dark | vs light | Hue |
|------|-----|-----|---------|----------|-----|
| main | `#42a3fd` ✗ | `#3b82c4` | 4.66 | 4.06 | 209° |
| 0 | `#ffdbaa` ✗ | `#d07028` | 5.43 | 3.48 | 26° |
| 1 | `#dc7d96` ✗ | `#c24878` | 4.05 | 4.67 | 336° |
| 2 | `#a1a716` ✗ | `#6d8f1c` | 5.04 | 3.75 | 78° |
| 3 | `#45f8ef` ✗ | `#1f9990` | 5.42 | 3.49 | 176° |
| 4 | `#d1d843` ✗ | `#9a8818` | 5.32 | 3.55 | 52° |
| 5 | `#d742a5` ✓ | `#9838a0` | 3.07 | 6.16 | 295° |
| 6 | `#4242d7` ✓ | `#5060d4` | 3.57 | 5.30 | 233° |

Min pairwise hue distance: 24° (≥20° guard)。

## 驗證

- `test/lane-color-contrast.test.js`: 4 cases — dark/light contrast ≥3:1, hue separation ≥20°, old colors FAIL (diff-check)
- Full suite: 1257/1259 pass (2 pre-existing flakes)
- Smoke boot: HTTP 200 ✓
- **知覺殘量**: 調色後視覺和諧度需 owner 看畫面確認（`pipeline:needs-visual-review`）

## 未驗

- Browser-harness 截圖（待補，evidence-check gate）
- Light theme 實際畫面（上方計算值為精確 WCAG 算法，但色感需人眼）

Closes #233