### PR TITLE
fix(workflow): coreHash + convId early-exit for teammate lane routing (#258)

### DIFF
--- a/docs/decisions/0005-agent-key-unreliable-shared-contract.md
+++ b/docs/decisions/0005-agent-key-unreliable-shared-contract.md
@@ -43,6 +43,9 @@ before trusting it, and fall back to the raw `isSubagent` flag otherwise:
 | `isSubagent` computation | `entry-rendering.js` `addEntry()` | `e.agentKey && !AGENT_KEY_UNRELIABLE[e.agentKey]` |
 | Batch lane build | `workflow-timeline.js` `wfInferLanes()` | `e.agentKey && !AGENT_KEY_UNRELIABLE[e.agentKey]` |
 | Live lane update | `workflow-timeline.js` `wfAddEntry()` | `entry.agentKey && !AGENT_KEY_UNRELIABLE[entry.agentKey]` |
+| coreHash identity routing (pre-scan) | `workflow-timeline.js` `wfInferLanes()` | coreHash+convId early-exit runs before `WF_MAIN_AGENT_KEYS` — see ADR 0010 |
+| coreHash identity routing (live) | `workflow-timeline.js` `wfAddEntry()` | reads `wfState.mainCoreHash` / `wfState.mainConvIds` — see ADR 0010 |
+| coreHash identity routing (turn list) | `entry-rendering.js` `addEntry()` | reads `wfState.mainCoreHash` / `wfState.mainConvIds`, gated on `wfState.sessionId === sid` — see ADR 0010 |
 
 ## Consequences
 

--- a/docs/decisions/0008-temporal-overlap-overrides-agent-key.md
+++ b/docs/decisions/0008-temporal-overlap-overrides-agent-key.md
@@ -87,3 +87,12 @@ runs, stitched fork continuations), labeled Fork/Teammate by conversation
 identity. This section is navigation only — the mechanism, its invariants,
 and the live-path convergence rules live in
 `0009-sequential-interleave-conv-bracketing.md`.
+
+## Amended by ADR 0010 (2026-07-16)
+
+coreHash identity routing (ADR 0010, #258) diverts teammate turns to an
+identity sublane *before* they ever reach main, so the overlap sweep in this
+ADR processes fewer candidates for sessions with teammates. Fork turns
+(same coreHash as main) are unaffected — they still transit main and remain
+fully subject to the overlap invariant this ADR establishes; ADR 0010 is
+explicitly scoped to not touch fork handling.

--- a/docs/decisions/0010-corehash-identity-routing.md
+++ b/docs/decisions/0010-corehash-identity-routing.md
@@ -1,0 +1,96 @@
+# 0010 — coreHash + convId identity routing for teammate lanes
+
+- Status: Accepted
+- Date: 2026-07-16
+- Related: #258 / #257 / ADR 0005 / ADR 0008
+
+## Context
+
+Teammate agents (dispatched via Claude Code's Agent tool) share
+`agentKey='orchestrator'` with the main agent, because their system prompt
+starts with the same `"You are an interactive agent"` text that matches the
+same `KNOWN_AGENTS` entry server-side (`server/system-prompt.js`). This
+routes teammate turns into the main lane by `WF_MAIN_AGENT_KEYS[agentKey]`.
+
+The existing temporal-overlap post-pass (ADR 0008) eventually exiles
+teammate turns to a `parallel-` lane, but the `parallel-` best-fit logic has
+no jitter tolerance: 8–30ms HTTP pipeline flush jitter between sequential
+turns of the *same* teammate conversation splits them across `#1`/`#2`
+numbered lanes — a visual bug, confirmed on real data (session `e622e4d2`,
+`docs/solutions/corehash-identity-routing.md`).
+
+A signal was going unused: `coreHash` (normalized system-prompt hash)
+genuinely differs between main and teammate prompts — they run different
+prompts — while forks (which inherit the parent's full prompt) correctly
+share `coreHash` with main. `coreHash` alone is not safe to route on: it has
+a documented history of mid-session instability (#218 autoMemory marker
+regex, #219 platform normalization), so a coreHash divergence that still
+shares main's `convId` (conversation identity, hash of `messages[0]`) is
+noise, not a new agent.
+
+## Decision
+
+Add a coreHash + convId **early-exit** ahead of the existing
+`WF_MAIN_AGENT_KEYS` routing: a turn with a main-agent `agentKey` is routed
+to an identity sublane (`agent-<agentKey>:<convId>`, not the `parallel-`
+family) iff **all** of the following hold —
+
+- `coreHash` exists and differs from main's `coreHash`
+- `convId` exists and is not in main's set of conv IDs
+
+Any missing value (`coreHash` or `convId` null on either side) falls through
+to the pre-existing classification path — legacy/incomplete data behaves as
+it did before this ADR.
+
+| Scenario | coreHash | convId | Result |
+|---|---|---|---|
+| Teammate | ≠ main | ∉ main set | → identity sublane |
+| Fork | = main | ∈ main set | → main → ADR 0008 overlap |
+| Upgrade/noise | ≠ main | ∈ main set | → stays main |
+| Compaction | = main | ∈ main set | → stays main |
+
+**Three-site contract (ADR 0005 shape)** — all three must apply the same
+condition, reading from the same computed main identity:
+
+| Site | File | mainCoreHash / mainConvIds source |
+|------|------|------|
+| Batch pre-scan + routing | `workflow-timeline.js` `wfInferLanes()` | scanned from `entries[]`: coreHash of the earliest-`receivedAt` `WF_MAIN_AGENT_KEYS` entry |
+| Live routing | `workflow-timeline.js` `wfAddEntry()` | `wfState.mainCoreHash` / `wfState.mainConvIds`, computed once in `wfBuildState()` from the final main lane (post overlap + seq passes), kept current as new main turns arrive |
+| Turn list `isSubagent` | `entry-rendering.js` `addEntry()` | same `wfState.mainCoreHash` / `wfState.mainConvIds`, gated additionally on `wfState.sessionId === sid` — `wfState` reflects only the *currently viewed* session; without this guard, a background session's turns would be classified against the wrong session's main identity |
+
+**Lane key**: identity-routed teammates use `agent-<agentKey>:<convId>`, the
+same family as other agentKey-based sublanes — never `parallel-`, which is
+reserved for the ADR 0008/0009 overlap/excursion mechanism and carries
+jitter-prone best-fit matching that this ADR exists to avoid.
+
+**Display name**: `_wfLaneDispName()` labels an identity-routed lane whose
+`agentKey` is a main-agent key as `"Teammate <convId prefix>"`.
+
+## Consequences
+
+**Good**: teammate turns from the same conversation land in one stable lane
+regardless of HTTP flush jitter — the `parallel-` best-fit's jitter
+sensitivity no longer applies to teammates. Verified on the `e622e4d2`
+fixture shape (unit tests in `test/workflow-timeline.test.js`, `#258
+coreHash identity routing` suite).
+
+**Bad — scope boundary**: this only fixes teammates (different coreHash).
+Forks (same coreHash) still transit through main and rely entirely on ADR
+0008's overlap sweep; a hypothetical future fork jitter-split is a separate,
+narrower problem (epsilon tuning on the exile best-fit) and is explicitly
+out of scope here.
+
+**Bad — coreHash instability remains latent**: the convId AND-guard
+prevents a coreHash blip from misrouting a genuine main turn (the blip keeps
+main's convId, so it fails the `∉ main set` condition), but if a future
+coreHash bug ever changes convId computation itself, this safety net does
+not apply. `coreHash` is still not trusted alone anywhere in this codebase.
+
+## Alternatives considered
+
+See `docs/solutions/corehash-identity-routing.md` for the full option
+comparison — Option B (pure convId, rejected: convId is conversation
+content, not identity, and ADR 0009 already rejected routing on it alone)
+and Option C (pure jitter-tolerance epsilon, rejected: leaves teammates
+transiting main with provisional-window pollution, and the same epsilon
+would weaken the fork overlap invariant).

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -432,6 +432,19 @@ function addEntry(e) {
   let isSubagent = e.agentKey && !AGENT_KEY_UNRELIABLE[e.agentKey]
     ? (typeof WF_MAIN_AGENT_KEYS !== 'undefined' ? !WF_MAIN_AGENT_KEYS[e.agentKey] : !!e.isSubagent)
     : (e.isSubagent || false);
+  // INVARIANT: coreHash identity routing — teammate with a main-agent key
+  // (e.g. 'orchestrator') but a different coreHash. Must agree with
+  // workflow-timeline.js (ADR 0005/0010). Gated on wfState.sessionId === sid:
+  // wfState is the swimlane's CURRENTLY VIEWED session, which is not
+  // necessarily this entry's session while other sessions stream live —
+  // trusting a foreign session's mainCoreHash/mainConvIds here would
+  // misclassify that session's own main turns.
+  if (!isSubagent && e.agentKey && typeof WF_MAIN_AGENT_KEYS !== 'undefined' && WF_MAIN_AGENT_KEYS[e.agentKey] &&
+      typeof wfState !== 'undefined' && wfState && wfState.sessionId === sid && wfState.mainCoreHash &&
+      e.coreHash && e.coreHash !== wfState.mainCoreHash &&
+      e.convId && wfState.mainConvIds && !wfState.mainConvIds.has(e.convId)) {
+    isSubagent = true;
+  }
   const isRetry = !isSubagent && !isHttpStatusOk(e.status) && !(usage && usage.output_tokens > 0);
   // #222: temporal overlap — mirrors wfAddEntry's parallel-fork detection so
   // the turn list and swimlane agree on classification (ADR 0005 contract).

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -418,15 +418,42 @@ function wfInferLanes(entries, childEntries, seqTracker) {
   laneMap.set('main', mainLane);
   var orchCtx = 0;
 
+  // INVARIANT: coreHash identity routing — see docs/decisions/0010-corehash-identity-routing.md
+  // Teammate agents (Agent-tool dispatch) share agentKey='orchestrator' with
+  // main because their system prompt matches the same KNOWN_AGENTS entry,
+  // but their coreHash (normalized system-prompt hash) differs — main and
+  // teammate genuinely run different prompts. Pre-scan: mainCoreHash = the
+  // coreHash of the earliest-starting WF_MAIN_AGENT_KEYS entry.
+  var mainCoreHash = null;
+  var _mchEarliest = Infinity;
+  for (var _mci = 0; _mci < entries.length; _mci++) {
+    var _mce = entries[_mci];
+    if (_mce.agentKey && WF_MAIN_AGENT_KEYS[_mce.agentKey] && _mce.coreHash) {
+      var _mct = Number(_mce.receivedAt) || Infinity;
+      if (_mct < _mchEarliest) { mainCoreHash = _mce.coreHash; _mchEarliest = _mct; }
+    }
+  }
+  var mainConvIds = new Set();
+
   for (var i = 0; i < entries.length; i++) {
     var e = entries[i];
     var sub = false;
 
     // INVARIANT: gate on AGENT_KEY_UNRELIABLE — see docs/decisions/0005-agent-key-unreliable-shared-contract.md
     if (e.agentKey && !AGENT_KEY_UNRELIABLE[e.agentKey]) {
-      // Agent-identity classification (server-detected, authoritative):
-      // main-agent keys → main lane regardless of model or isSubagent flag
-      if (!WF_MAIN_AGENT_KEYS[e.agentKey]) {
+      // INVARIANT: coreHash identity routing — see docs/decisions/0010-corehash-identity-routing.md
+      // Teammate agents share agentKey='orchestrator' but a different
+      // coreHash. Route to an identity lane before WF_MAIN_AGENT_KEYS would
+      // absorb them into main. convId AND-guard: coreHash has had past
+      // instability (#218/#219), so a mid-session coreHash divergence that
+      // keeps the same convId as main is NOT a teammate — it stays main.
+      if (WF_MAIN_AGENT_KEYS[e.agentKey] && mainCoreHash && e.coreHash &&
+          e.coreHash !== mainCoreHash && e.convId && !mainConvIds.has(e.convId)) {
+        _wfPushToSubLane(laneMap, _wfSubLaneKey('agent-' + e.agentKey, e), e);
+        sub = true;
+      } else if (!WF_MAIN_AGENT_KEYS[e.agentKey]) {
+        // Agent-identity classification (server-detected, authoritative):
+        // main-agent keys → main lane regardless of model or isSubagent flag
         _wfPushToSubLane(laneMap, _wfSubLaneKey('agent-' + e.agentKey, e), e);
         sub = true;
       }
@@ -449,6 +476,7 @@ function wfInferLanes(entries, childEntries, seqTracker) {
       mainLane.ctxWindow = e.maxContext || mainLane.ctxWindow;
       var p = wfCtxPct(e);
       if (p > orchCtx * 0.8) orchCtx = Math.max(orchCtx, p);
+      if (e.convId) mainConvIds.add(e.convId);
     }
   }
 
@@ -664,12 +692,27 @@ function wfBuildState(sessionId) {
     for (var ti = 0; ti < lanes[li].turns.length; ti++)
       turnIndex.set(lanes[li].turns[ti].id, { turn: lanes[li].turns[ti], laneIdx: li });
 
+  // INVARIANT: coreHash identity routing — see docs/decisions/0010-corehash-identity-routing.md
+  // mainCoreHash/mainConvIds are derived from the FINAL main lane (post
+  // overlap + seq post-passes) so wfAddEntry's live routing agrees with what
+  // the batch pass actually settled on as main.
+  var mainCoreHash = null;
+  var mainConvIds = new Set();
+  if (lanes[0]) {
+    for (var mci = 0; mci < lanes[0].turns.length; mci++) {
+      if (!mainCoreHash && lanes[0].turns[mci].coreHash) mainCoreHash = lanes[0].turns[mci].coreHash;
+      if (lanes[0].turns[mci].convId) mainConvIds.add(lanes[0].turns[mci].convId);
+    }
+  }
+
   return {
     lanes: lanes,
     sessionId: sessionId,
     childSids: childSids,
     turnIndex: turnIndex,
     _seqTracker: seqTracker,
+    mainCoreHash: mainCoreHash,
+    mainConvIds: mainConvIds,
     tMin: tMin, tMax: tMax,
     viewT0: tMin, viewT1: tMax,
     selectedLane: lanes[0] || null,
@@ -742,6 +785,15 @@ function wfAddEntry(entry) {
   }
 
   var needsSub, key;
+  // INVARIANT: coreHash identity routing — see docs/decisions/0010-corehash-identity-routing.md
+  // Mirrors wfInferLanes' pre-scan check, using the mainCoreHash/mainConvIds
+  // wfBuildState computed for this session. convId AND-guard: see ADR 0010.
+  if (entry.agentKey && WF_MAIN_AGENT_KEYS[entry.agentKey] &&
+      wfState.mainCoreHash && entry.coreHash && entry.coreHash !== wfState.mainCoreHash &&
+      entry.convId && wfState.mainConvIds && !wfState.mainConvIds.has(entry.convId)) {
+    needsSub = true;
+    key = _wfSubLaneKey('agent-' + entry.agentKey, entry);
+  } else
   // INVARIANT: gate on AGENT_KEY_UNRELIABLE — see docs/decisions/0005-agent-key-unreliable-shared-contract.md
   if (entry.agentKey && !AGENT_KEY_UNRELIABLE[entry.agentKey]) {
     needsSub = !WF_MAIN_AGENT_KEYS[entry.agentKey];
@@ -839,6 +891,10 @@ function wfAddEntry(entry) {
     wfState.lanes[0].turns.push(entry);
     wfState.lanes[0]._costMedian = null;
     if (wfState.turnIndex) wfState.turnIndex.set(entry.id, { turn: entry, laneIdx: 0 });
+    // INVARIANT: coreHash identity routing — see docs/decisions/0010-corehash-identity-routing.md
+    // Keep mainCoreHash/mainConvIds current so later live entries route correctly.
+    if (!wfState.mainCoreHash && entry.coreHash) wfState.mainCoreHash = entry.coreHash;
+    if (entry.convId && wfState.mainConvIds) wfState.mainConvIds.add(entry.convId);
   }
 
   // #230 R1: the trunk conv just returned — turns of the closed bracket were
@@ -992,6 +1048,12 @@ function _wfLaneDispName(lane, laneIdx, mainConvs) {
   if ((lane.key || '').indexOf('parallel-') === 0) {
     var kin = lane.convId && mainConvs && mainConvs.has(lane.convId) ? 'Fork' : 'Teammate';
     return kin + (lane.convId ? ' ' + lane.convId.slice(0, 4) : '') + ' #' + (laneOrd ? laneOrd[1] : '1');
+  }
+  // INVARIANT: coreHash identity routing — see docs/decisions/0010-corehash-identity-routing.md
+  // Identity-routed teammate: a main-agent key (e.g. 'orchestrator') placed
+  // in a sublane by the coreHash+convId early-exit, not the parallel- family.
+  if (lane.agentKey && WF_MAIN_AGENT_KEYS[lane.agentKey] && laneIdx > 0) {
+    return 'Teammate' + (lane.convId ? ' ' + lane.convId.slice(0, 4) : '');
   }
   return (lane.agentLabel || lane.name) + (lane.convId ? ' ' + lane.convId.slice(0, 4) : '');
 }

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -1643,6 +1643,58 @@ describe('#258 coreHash identity routing', () => {
     assert.ok(!state.mainConvIds.has('56a5def0'));
   });
 
+  it('upgrade/noise: ≠coreHash but same convId stays main (convId AND-guard)', () => {
+    const ctx = loadWfModule();
+    // Mid-session coreHash divergence (e.g. #218/#219 bugs) but SAME convId as main
+    // → convId ∈ mainConvIds → AND-guard blocks early-exit → stays main
+    var entries = [
+      mkMain('m1', 1000, 5),
+      mkMain('m2', 6000, 5),
+      mkEntry('noise', 's1', 'claude-opus-4-6', 11000, 3,
+        { agentKey: 'orchestrator', coreHash: 'fffff', convId: 'ebffe2' }), // ≠coreHash, same convId
+      mkMain('m3', 14000, 5),
+    ];
+    var lanes = ctx.wfInferLanes(entries, []);
+    assert.equal(lanes[0].turns.length, 4, 'noise entry must stay main — convId matches');
+    assert.ok(lanes[0].turns.some(function(t) { return t.id === 'noise'; }));
+  });
+
+  it('null convId with non-null coreHash falls through (backward compat)', () => {
+    const ctx = loadWfModule();
+    var entries = [
+      mkMain('m1', 1000, 5),
+      // Different coreHash but no convId → early-exit cannot fire
+      mkEntry('t1', 's1', 'claude-sonnet-5', 6000, 3,
+        { agentKey: 'orchestrator', coreHash: 'e6aa4', convId: null }),
+      mkMain('m2', 9000, 5),
+    ];
+    var lanes = ctx.wfInferLanes(entries, []);
+    assert.ok(lanes[0].turns.some(function(t) { return t.id === 't1'; }),
+      'entry without convId falls through to main');
+  });
+
+  it('live wfAddEntry routes teammate to identity lane', () => {
+    const ctx = loadWfModule();
+    // Build initial state with main entries
+    ctx.allEntries = [
+      mkMain('m1', 1000, 5),
+      mkMain('m2', 6000, 5),
+    ];
+    ctx.sessionsMap.set('s1', { entries: [] });
+    ctx.wfState = ctx.wfBuildState('s1');
+    assert.equal(ctx.wfState.mainCoreHash, '85771');
+
+    // Live: add a teammate entry
+    var t1 = mkTeammate('t1', 8000, 3, '56a5def0');
+    ctx.allEntries.push(t1);
+    var result = ctx.wfAddEntry(t1);
+    assert.ok(result.lanesChanged, 'new lane created');
+    var tmLane = ctx.wfState.lanes.find(function(l) { return l.key === 'agent-orchestrator:56a5def0'; });
+    assert.ok(tmLane, 'teammate routed to identity lane via wfAddEntry');
+    assert.equal(tmLane.turns.length, 1);
+    assert.equal(tmLane.turns[0].id, 't1');
+  });
+
   it('_wfLaneDispName: identity-routed teammate shows Teammate label', () => {
     const ctx = loadWfModule();
     var lane = { key: 'agent-orchestrator:56a5def0', agentKey: 'orchestrator', name: 'orchestrator', convId: '56a5def0', turns: [] };

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -1562,3 +1562,93 @@ describe('#230 late-arrival overturns closed excursion (codex P2 round 5)', () =
     assert.equal(ctx.wfState.viewT1, 140000);
   });
 });
+
+// ── #258 coreHash identity routing ────────────────────────────────────────
+describe('#258 coreHash identity routing', () => {
+  function mkMain(id, at, elapsed, opts) {
+    return mkEntry(id, 's1', 'claude-opus-4-6', at, elapsed, Object.assign(
+      { agentKey: 'orchestrator', agentLabel: 'Orchestrator', coreHash: '85771', convId: 'ebffe2' }, opts || {}));
+  }
+  function mkTeammate(id, at, elapsed, convId, opts) {
+    return mkEntry(id, 's1', 'claude-sonnet-5', at, elapsed, Object.assign(
+      { agentKey: 'orchestrator', agentLabel: 'Orchestrator', coreHash: 'e6aa4', convId: convId || '56a5def0' }, opts || {}));
+  }
+
+  it('teammates with same agentKey but different coreHash get identity lanes', () => {
+    const ctx = loadWfModule();
+    var m1 = mkMain('m1', 1000, 5);
+    var m2 = mkMain('m2', 6000, 5);
+    var m3 = mkMain('m3', 11000, 5);
+    var t1 = mkTeammate('t1', 2000, 3, '56a5def0');
+    var t2 = mkTeammate('t2', 6000, 3, '56a5def0');
+    var t3 = mkTeammate('t3', 9000, 3, '56a5def0');
+    var lanes = ctx.wfInferLanes([m1, m2, m3, t1, t2, t3], []);
+    assert.equal(lanes[0].turns.map(function(t) { return t.id; }).join(','), 'm1,m2,m3');
+    var teamLane = lanes.find(function(l) { return l.key === 'agent-orchestrator:56a5def0'; });
+    assert.ok(teamLane, 'expected an agent-orchestrator:56a5def0 lane');
+    assert.equal(teamLane.turns.map(function(t) { return t.id; }).join(','), 't1,t2,t3');
+  });
+
+  it('multiple teammate convIds get separate lanes', () => {
+    const ctx = loadWfModule();
+    var m1 = mkMain('m1', 1000, 5);
+    var t1 = mkTeammate('t1', 2000, 3, '56a5def0');
+    var t2 = mkTeammate('t2', 6000, 3, '56a5def0');
+    var t3 = mkTeammate('t3', 3000, 3, '16f4abcd');
+    var t4 = mkTeammate('t4', 7000, 3, '16f4abcd');
+    var lanes = ctx.wfInferLanes([m1, t1, t2, t3, t4], []);
+    var lane56a5 = lanes.find(function(l) { return l.key === 'agent-orchestrator:56a5def0'; });
+    var lane16f4 = lanes.find(function(l) { return l.key === 'agent-orchestrator:16f4abcd'; });
+    assert.ok(lane56a5, 'expected 56a5def0 lane');
+    assert.ok(lane16f4, 'expected 16f4abcd lane');
+    assert.equal(lane56a5.turns.map(function(t) { return t.id; }).join(','), 't1,t2');
+    assert.equal(lane16f4.turns.map(function(t) { return t.id; }).join(','), 't3,t4');
+  });
+
+  it('forks (same coreHash) still use overlap detection', () => {
+    const ctx = loadWfModule();
+    var m1 = mkMain('m1', 1000, 30);   // 1000..31000
+    var f1 = mkMain('f1', 10000, 5);   // nested inside m1's span, same coreHash+convId
+    var m2 = mkMain('m2', 31000, 5);
+    var lanes = ctx.wfInferLanes([m1, f1, m2], []);
+    assert.equal(lanes[0].turns.map(function(t) { return t.id; }).join(','), 'm1,m2',
+      'fork must not be absorbed by identity routing — same coreHash as main');
+    var forkLane = lanes.find(function(l) { return (l.key || '').indexOf('parallel-') === 0; });
+    assert.ok(forkLane, 'expected the fork to land in a parallel- lane via ADR 0008 overlap');
+    assert.equal(forkLane.turns.map(function(t) { return t.id; }).join(','), 'f1');
+  });
+
+  it('null coreHash falls through (backward compat)', () => {
+    const ctx = loadWfModule();
+    var m1 = mkMain('m1', 1000, 5);
+    var m2 = mkMain('m2', 6000, 5);
+    // legacy entry: main-agent key, but no coreHash/convId captured
+    var legacy = mkEntry('legacy1', 's1', 'claude-sonnet-5', 11000, 3,
+      { agentKey: 'orchestrator', agentLabel: 'Orchestrator' });
+    var lanes = ctx.wfInferLanes([m1, m2, legacy], []);
+    assert.equal(lanes.length, 1, 'no identity lane should be created without coreHash/convId');
+    assert.equal(lanes[0].turns.map(function(t) { return t.id; }).join(','), 'm1,m2,legacy1');
+  });
+
+  it('ADR-0005: wfBuildState computes mainCoreHash/mainConvIds for entry-rendering to share', () => {
+    const ctx = loadWfModule();
+    var m1 = mkMain('m1', 1000, 5);
+    var m2 = mkMain('m2', 6000, 5);
+    var t1 = mkTeammate('t1', 2000, 3, '56a5def0');
+    ctx.allEntries = [m1, m2, t1];
+    ctx.sessionsMap.set('s1', { entries: [] });
+    var state = ctx.wfBuildState('s1');
+    assert.equal(state.mainCoreHash, '85771');
+    assert.ok(state.mainConvIds.has('ebffe2'));
+    assert.ok(!state.mainConvIds.has('56a5def0'));
+  });
+
+  it('_wfLaneDispName: identity-routed teammate shows Teammate label', () => {
+    const ctx = loadWfModule();
+    var lane = { key: 'agent-orchestrator:56a5def0', agentKey: 'orchestrator', name: 'orchestrator', convId: '56a5def0', turns: [] };
+    var mainConvs = new Set(['ebffe2']);
+    var name = ctx._wfLaneDispName(lane, 1, mainConvs);
+    assert.ok(name.indexOf('Teammate') === 0, 'expected label to start with Teammate, got: ' + name);
+    assert.ok(name.indexOf('56a5') !== -1, 'expected convId prefix in label, got: ' + name);
+  });
+});


### PR DESCRIPTION
## 摘要

Teammate agents 共享 `agentKey='orchestrator'`（system prompt 開頭相同匹配 KNOWN_AGENTS），
被 `WF_MAIN_AGENT_KEYS` 吸收進 main lane。事後 overlap post-pass 踢出時，8-30ms HTTP 
jitter 把同一 teammate 的 sequential turns 拆成 #1/#2 兩條 parallel lane。

修法：在三個 ADR-0005 合約站加入 coreHash + convId early-exit——main 和 teammate 的 
system prompt hash (coreHash) 不同，提早路由到 identity lane (`agent-orchestrator:<convId>`)
避免進入 jitter-prone 的 `parallel-` best-fit 分支。Fork（同 coreHash）不受影響。

## Changes

- **`public/workflow-timeline.js`**: pre-scan `mainCoreHash`, early-exit at `wfInferLanes` + `wfAddEntry`, 
  store `mainCoreHash`/`mainConvIds` in `wfState`, `_wfLaneDispName` "Teammate" label
- **`public/entry-rendering.js`**: mirror coreHash check for `isSubagent` (gated on `wfState.sessionId === sid`)
- **`docs/decisions/0010-corehash-identity-routing.md`**: new ADR
- **`docs/decisions/0005-*.md`**, **`0008-*.md`**: amendment rows
- **`test/workflow-timeline.test.js`**: 9 new tests

## 驗證證據

### diff-check (old-fail / new-pass)
```
✅ old FAIL / new PASS — 差異檢查成立
old: 4 subtests failed (teammates absorbed into main)
new: 0 failures
```

### 測試 (104/104 pass)
```
# tests 104 / # pass 104 / # fail 0
```

### 全套測試 (isolated CCXRAY_HOME)
```
# tests 1269 / # pass 1267 / # fail 2 (puppeteer Chrome version — pre-existing)
```

### Smoke boot
```
Server HTTP: 200, PID: 78154
```

### 孤兒參照掃描
零刪除 symbol — 純增量修改。

## 未驗項目

- 瀏覽器視覺驗收（UI 改動：lane 標籤從 "Fork/Teammate #N" 改為 "Teammate 56a5"）
- entry-rendering Site 3 在 background session 的 provisional-main 邊界（reviewer 已標 low-severity, 同 ADR 0009 accepted boundary shape）

## 二審

code-reviewer agent（degraded mode — codex CLI 未用）。
Verdict: **sound, mergeable**。coverage gap 已補（+3 tests：upgrade/noise convId guard, null-convId fallthrough, live wfAddEntry routing）。

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)