### PR TITLE
fix(dashboard): include output_tokens in ctxUsed across all views (#253)

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -232,11 +232,11 @@ function isProxyLifecycleShutdown(entry) {
 }
 
 function classifySeverity(entry, ctxPct, dupesMax) {
-  if (ctxPct > 95) return 'critical';
+  if (ctxPct > 97) return 'critical';
   if (isProxyLifecycleShutdown(entry)) return 'warning';
   if (entry.status != null && !isHttpStatusOk(entry.status)) return 'critical';
   if (isAbnormalStop(entry.stopReason)) return 'critical';
-  if (ctxPct > 85) return 'warning';
+  if (ctxPct > 90) return 'warning';
   if (entry.hasCredential) return 'warning';
   if (entry.toolFail) return 'warning';
   if (dupesMax >= 2) return 'notice';
@@ -537,7 +537,7 @@ function addEntry(e) {
   const ctxCacheCreate = usage ? (usage.cache_creation_input_tokens || 0) : 0;
   const ctxCacheRead   = usage ? (usage.cache_read_input_tokens || 0) : 0;
   const ctxInput       = usage ? (usage.input_tokens || 0) : 0;
-  const ctxUsed = ctxCacheCreate + ctxCacheRead + ctxInput;
+  const ctxUsed = computeCtxUsed(usage);
 
   sess.inputTokens = (sess.inputTokens || 0) + (usage ? (usage.input_tokens || 0) : 0);
   sess.outputTokens = (sess.outputTokens || 0) + (usage ? (usage.output_tokens || 0) : 0);
@@ -729,7 +729,7 @@ function addEntry(e) {
   // with L1/L3's 83.5/75 thresholds; L2 scans turns for spikes, not absolute
   // proximity to auto-compact. Changing these to 83.5/75 produces a wall of
   // red in late-session turns (pre-mortem F1).
-  const ctxPctClass = ctxPct > 95 ? 'ctx-critical' : ctxPct > 85 ? 'ctx-warning' : '';
+  const ctxPctClass = ctxPct > 97 ? 'ctx-critical' : ctxPct > 90 ? 'ctx-warning' : '';
   const ctxPctLabel = '<span class="turn-ctx-pct' + (ctxPctClass ? ' ' + ctxPctClass : '') + '">ctx:' + ctxPct.toFixed(0) + '%</span>';
   const hitPct = totalUsed > 0 ? Math.round(ctxCacheRead / totalUsed * 100) : null;
   const hitPctClass = hitPct !== null && hitPct < 10 ? ' hit-cold' : '';

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -150,15 +150,17 @@ function renderContextBreakdownBar(tok, maxContext, usage) {
   // Scale category segments proportionally if API total is larger
   const scale = estimatedTotal > 0 && total > estimatedTotal ? total / estimatedTotal : 1;
   const windowSize = maxContext || DEFAULT_MAX_CTX;
-  const pct = (total / windowSize * 100).toFixed(0);
-  const usedPct = Math.min(100, total / windowSize * 100);
+  const rawPct = total / windowSize * 100;
+  const pct = Math.min(100, rawPct).toFixed(0);
+  const usedPct = Math.min(100, rawPct);
   const barColor = ctxZone(usedPct).cssVar;
 
+  const barDenom = Math.max(total, windowSize);
   let bar = '<div class="ctx-big-bar" style="display:flex;height:8px;border-radius:2px;overflow:visible;margin:4px 0 2px;background:var(--border)">';
   for (const c of cats) {
     if (!c.tokens) continue;
     const scaled = c.tokens * scale;
-    const w = (scaled / windowSize * 100).toFixed(3);
+    const w = (scaled / barDenom * 100).toFixed(3);
     bar += '<div style="width:' + w + '%;background:' + (barColor || c.color) + ';min-width:1px" title="' + escapeHtml(c.label) + ': ' + Math.round(scaled).toLocaleString() + '"></div>';
   }
   bar += '</div>';
@@ -184,11 +186,12 @@ function renderContextBreakdownSticky(tok, maxContext, usage) {
   const barColor = ctxZone(usedPct).cssVar;
 
   // Each segment is a fraction of windowSize; bar total = usedPct% of full width
+  const stickyDenom = Math.max(total, windowSize);
   let bar = '<div class="ctx-big-bar" style="display:flex;height:12px;border-radius:3px;overflow:visible;margin-bottom:6px;background:var(--border)">';
   for (const c of cats) {
     if (!c.tokens) continue;
     const scaled = c.tokens * scale;
-    const pct = (scaled / windowSize * 100).toFixed(3);
+    const pct = (scaled / stickyDenom * 100).toFixed(3);
     const bg = barColor || c.color;
     bar += '<div style="width:' + pct + '%;background:' + bg + ';min-width:1px" title="' + escapeHtml(c.label) + ': ' + Math.round(scaled).toLocaleString() + ' (' + (c.tokens / estimatedTotal * 100).toFixed(1) + '% of used)"></div>';
   }

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -235,11 +235,11 @@ function isProxyLifecycleShutdown(entry) {
 }
 
 function classifySeverity(entry, ctxPct, dupesMax) {
-  if (ctxPct > 97) return 'critical';
+  if (ctxPct > 95) return 'critical';
   if (isProxyLifecycleShutdown(entry)) return 'warning';
   if (entry.status != null && !isHttpStatusOk(entry.status)) return 'critical';
   if (isAbnormalStop(entry.stopReason)) return 'critical';
-  if (ctxPct > 90) return 'warning';
+  if (ctxPct > 85) return 'warning';
   if (entry.hasCredential) return 'warning';
   if (entry.toolFail) return 'warning';
   if (dupesMax >= 2) return 'notice';
@@ -247,7 +247,7 @@ function classifySeverity(entry, ctxPct, dupesMax) {
 }
 
 function getCriticalMarker(stopReason, httpStatus, ctxPct) {
-  // ctx > 97%: no inline marker (left bar only)
+  // ctx > 95%: no inline marker (left bar only)
   if (httpStatus === 499 && typeof stopReason === 'string' && stopReason.includes('ccxray shutdown')) return '!stop';
   if (httpStatus != null && !isHttpStatusOk(httpStatus)) return '!http';
   if (stopReason === 'max_tokens') return '!max';
@@ -733,7 +733,7 @@ function addEntry(e) {
   // with L1/L3's 83.5/75 thresholds; L2 scans turns for spikes, not absolute
   // proximity to auto-compact. Changing these to 83.5/75 produces a wall of
   // red in late-session turns (pre-mortem F1).
-  const ctxPctClass = ctxPct > 97 ? 'ctx-critical' : ctxPct > 90 ? 'ctx-warning' : '';
+  const ctxPctClass = ctxPct > 95 ? 'ctx-critical' : ctxPct > 85 ? 'ctx-warning' : '';
   const ctxPctLabel = '<span class="turn-ctx-pct' + (ctxPctClass ? ' ' + ctxPctClass : '') + '">ctx:' + ctxPct.toFixed(0) + '%</span>';
   const hitPct = totalUsed > 0 ? Math.round(ctxCacheRead / totalUsed * 100) : null;
   const hitPctClass = hitPct !== null && hitPct < 10 ? ' hit-cold' : '';

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -145,7 +145,7 @@ function renderContextBreakdownBar(tok, maxContext, usage) {
   if (!data) return '';
   const { cats, total: estimatedTotal } = data;
   // Use API usage as authoritative total when available (tokenizeRequest underestimates by 20-40%)
-  const apiTotal = usage ? (usage.input_tokens || 0) + (usage.cache_read_input_tokens || 0) + (usage.cache_creation_input_tokens || 0) : 0;
+  const apiTotal = computeCtxUsed(usage);
   const total = apiTotal > estimatedTotal ? apiTotal : estimatedTotal;
   // Scale category segments proportionally if API total is larger
   const scale = estimatedTotal > 0 && total > estimatedTotal ? total / estimatedTotal : 1;
@@ -176,7 +176,7 @@ function renderContextBreakdownSticky(tok, maxContext, usage) {
   if (!data) return '';
   const { cats, total: estimatedTotal, mcpPlugins } = data;
   // Use API usage as authoritative total when available
-  const apiTotal = usage ? (usage.input_tokens || 0) + (usage.cache_read_input_tokens || 0) + (usage.cache_creation_input_tokens || 0) : 0;
+  const apiTotal = computeCtxUsed(usage);
   const total = apiTotal > estimatedTotal ? apiTotal : estimatedTotal;
   const scale = estimatedTotal > 0 && total > estimatedTotal ? total / estimatedTotal : 1;
   const windowSize = maxContext || DEFAULT_MAX_CTX;
@@ -244,7 +244,7 @@ function classifySeverity(entry, ctxPct, dupesMax) {
 }
 
 function getCriticalMarker(stopReason, httpStatus, ctxPct) {
-  // ctx > 95%: no inline marker (left bar only)
+  // ctx > 97%: no inline marker (left bar only)
   if (httpStatus === 499 && typeof stopReason === 'string' && stopReason.includes('ccxray shutdown')) return '!stop';
   if (httpStatus != null && !isHttpStatusOk(httpStatus)) return '!http';
   if (stopReason === 'max_tokens') return '!max';
@@ -546,7 +546,8 @@ function addEntry(e) {
   if (!isSubagent && ctxUsed > 0) {
     sess.latestMainCtxPct = Math.min(100, ctxUsed / (e.maxContext || DEFAULT_MAX_CTX) * 100);
     sess.latestCacheReadTokens = ctxCacheRead;
-    sess.latestCacheHitRatio = ctxUsed > 0 ? ctxCacheRead / ctxUsed : 0;
+    const ctxInputTotal = ctxCacheRead + ctxCacheCreate + (usage ? (usage.input_tokens || 0) : 0);
+    sess.latestCacheHitRatio = ctxInputTotal > 0 ? ctxCacheRead / ctxInputTotal : 0;
     sess.latestMaxContext = e.maxContext || DEFAULT_MAX_CTX;
     const sessElCtx = document.getElementById('sess-' + sid.slice(0, 8));
     if (sessElCtx) sessElCtx.innerHTML = renderSessionItem(sess, sid, sessElCtx);

--- a/public/format.js
+++ b/public/format.js
@@ -3,10 +3,10 @@
 // entry-rendering.js, and intercept-ui.js — every function here is consumed as a
 // bare global by those files.
 
-// #142: single source for context-usage bands (pct>85 red / >=45 yellow / else safe).
+// #142: single source for context-usage bands (pct>80 red / >=40 yellow / else safe).
 function ctxZone(pct) {
-  if (pct > 85) return { zone: 'danger', cssVar: 'var(--red)', hex: '#f85149' };
-  if (pct >= 45) return { zone: 'warn', cssVar: 'var(--yellow)', hex: '#d29922' };
+  if (pct > 80) return { zone: 'danger', cssVar: 'var(--red)', hex: '#f85149' };
+  if (pct >= 40) return { zone: 'warn', cssVar: 'var(--yellow)', hex: '#d29922' };
   return { zone: 'safe', cssVar: null, hex: '#3fb950' };
 }
 

--- a/public/format.js
+++ b/public/format.js
@@ -3,11 +3,21 @@
 // entry-rendering.js, and intercept-ui.js — every function here is consumed as a
 // bare global by those files.
 
-// #142: single source for context-usage bands (pct>80 red / >=40 yellow / else safe).
+// #142: single source for context-usage bands (pct>85 red / >=45 yellow / else safe).
 function ctxZone(pct) {
-  if (pct > 80) return { zone: 'danger', cssVar: 'var(--red)', hex: '#f85149' };
-  if (pct >= 40) return { zone: 'warn', cssVar: 'var(--yellow)', hex: '#d29922' };
+  if (pct > 85) return { zone: 'danger', cssVar: 'var(--red)', hex: '#f85149' };
+  if (pct >= 45) return { zone: 'warn', cssVar: 'var(--yellow)', hex: '#d29922' };
   return { zone: 'safe', cssVar: null, hex: '#3fb950' };
+}
+
+// #253: single source of truth for context-window usage — cache creation +
+// cache read + input + output tokens (the full request cost the next turn pays).
+function computeCtxUsed(usage) {
+  if (!usage) return 0;
+  return (usage.cache_creation_input_tokens || 0)
+    + (usage.cache_read_input_tokens || 0)
+    + (usage.input_tokens || 0)
+    + (usage.output_tokens || 0);
 }
 
 // Strip the "claude-" prefix and a trailing YYYYMMDD date suffix.

--- a/public/messages.js
+++ b/public/messages.js
@@ -913,15 +913,13 @@ function renderMinimapHtml(steps, perMessage, activeStepIdx, maxContext, usage) 
   const blocks = buildMinimapBlocks(steps, perMessage, usage);
   if (!blocks.length) return '';
 
-  // For usedRatio consistency with session card (ctxUsed, entry-rendering.js:540) and
-  // swimlane: in+cr+cc, no output. Exclude current-turn block weights from the occupied region.
+  // For usedRatio consistency with session card (ctxUsed, entry-rendering.js) — see
+  // computeCtxUsed (#253). Exclude current-turn block weights from the occupied region.
   const estimatedInput = blocks.reduce((s, b) => {
     const step = steps[b.stepIdx];
     return s + (step && step.source === 'current' ? 0 : b.tokens);
   }, 0) || 1;
-  const apiTotal = usage
-    ? (usage.input_tokens || 0) + (usage.cache_read_input_tokens || 0) + (usage.cache_creation_input_tokens || 0)
-    : 0;
+  const apiTotal = computeCtxUsed(usage);
   const totalTokens = apiTotal > estimatedInput ? apiTotal : estimatedInput;
   const ctxWindow = maxContext || 200000;
   const usedPct = Math.min(100, totalTokens / ctxWindow * 100).toFixed(0);

--- a/test/ctx-color.test.js
+++ b/test/ctx-color.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-// #142/#156: unified context-usage color thresholds — pct>80 red / pct>=40 yellow / else safe.
-// Contract test locks the band boundaries (39/40/80/81) on both sides.
+// #142/#156/#253: unified context-usage color thresholds — pct>85 red / pct>=45 yellow / else safe.
+// Contract test locks the band boundaries (44/45/85/86) on both sides.
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
@@ -40,14 +40,14 @@ function loadClient() {
 describe('#156 client ctxZone(pct) band boundaries', () => {
   const ctx = loadClient();
   it('exposes ctxZone', () => assert.equal(typeof ctx.ctxZone, 'function'));
-  it('39 -> safe (null cssVar)', () => {
-    const z = ctx.ctxZone(39);
+  it('44 -> safe (null cssVar)', () => {
+    const z = ctx.ctxZone(44);
     assert.equal(z.zone, 'safe');
     assert.equal(z.cssVar, null);
   });
-  it('40 -> yellow', () => assert.equal(ctx.ctxZone(40).cssVar, 'var(--yellow)'));
-  it('80 -> yellow (not red at exactly 80)', () => assert.equal(ctx.ctxZone(80).cssVar, 'var(--yellow)'));
-  it('81 -> red', () => assert.equal(ctx.ctxZone(81).cssVar, 'var(--red)'));
+  it('45 -> yellow', () => assert.equal(ctx.ctxZone(45).cssVar, 'var(--yellow)'));
+  it('85 -> yellow (not red at exactly 85)', () => assert.equal(ctx.ctxZone(85).cssVar, 'var(--yellow)'));
+  it('86 -> red', () => assert.equal(ctx.ctxZone(86).cssVar, 'var(--red)'));
   it('0 -> safe (null cssVar)', () => assert.equal(ctx.ctxZone(0).cssVar, null));
   it('100 -> red', () => assert.equal(ctx.ctxZone(100).cssVar, 'var(--red)'));
 });

--- a/test/ctx-color.test.js
+++ b/test/ctx-color.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-// #142/#156/#253: unified context-usage color thresholds — pct>85 red / pct>=45 yellow / else safe.
-// Contract test locks the band boundaries (44/45/85/86) on both sides.
+// #142/#156/#253: unified context-usage color thresholds — pct>80 red / pct>=40 yellow / else safe.
+// Contract test locks the band boundaries (39/40/80/81) on both sides.
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
@@ -40,14 +40,14 @@ function loadClient() {
 describe('#156 client ctxZone(pct) band boundaries', () => {
   const ctx = loadClient();
   it('exposes ctxZone', () => assert.equal(typeof ctx.ctxZone, 'function'));
-  it('44 -> safe (null cssVar)', () => {
-    const z = ctx.ctxZone(44);
+  it('39 -> safe (null cssVar)', () => {
+    const z = ctx.ctxZone(39);
     assert.equal(z.zone, 'safe');
     assert.equal(z.cssVar, null);
   });
-  it('45 -> yellow', () => assert.equal(ctx.ctxZone(45).cssVar, 'var(--yellow)'));
-  it('85 -> yellow (not red at exactly 85)', () => assert.equal(ctx.ctxZone(85).cssVar, 'var(--yellow)'));
-  it('86 -> red', () => assert.equal(ctx.ctxZone(86).cssVar, 'var(--red)'));
+  it('40 -> yellow', () => assert.equal(ctx.ctxZone(40).cssVar, 'var(--yellow)'));
+  it('80 -> yellow (not red at exactly 80)', () => assert.equal(ctx.ctxZone(80).cssVar, 'var(--yellow)'));
+  it('81 -> red', () => assert.equal(ctx.ctxZone(81).cssVar, 'var(--red)'));
   it('0 -> safe (null cssVar)', () => assert.equal(ctx.ctxZone(0).cssVar, null));
   it('100 -> red', () => assert.equal(ctx.ctxZone(100).cssVar, 'var(--red)'));
 });

--- a/test/messages-ui.test.js
+++ b/test/messages-ui.test.js
@@ -16,6 +16,7 @@ function loadMessagesContext() {
   }
   // Promote window globals into context scope (messages.js reads getRenderer as a global)
   vm.runInContext('var RENDERERS = window.RENDERERS; var getRenderer = window.getRenderer;', context);
+  vm.runInContext(fs.readFileSync(path.join(publicDir, 'format.js'), 'utf8'), context);
   vm.runInContext(fs.readFileSync(path.join(publicDir, 'messages.js'), 'utf8'), context);
   return context;
 }
@@ -104,12 +105,12 @@ describe('buildMinimapBlocks — current-turn token estimate', () => {
     assert.equal(context.buildMinimapBlocks(curSteps(), null, { output_tokens: 0 })[1].tokens, 1);
   });
 
-  it('excludes current-turn output from occupancy total (usedRatio parity with ctxUsed)', () => {
+  it('includes output_tokens in occupancy total (#253 ctxUsed = in+out)', () => {
     const context = loadMessagesContext();
     const html = context.renderMinimapHtml(curSteps(), null, -1, 1000000, { input_tokens: 500, output_tokens: 1000 });
     const m = html.match(/data-total-tokens="(\d+)"/);
     assert.ok(m, 'data-total-tokens attribute should exist');
-    assert.equal(Number(m[1]), 500);
+    assert.equal(Number(m[1]), 1500);
   });
 });
 

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -885,24 +885,24 @@ describe('#149 wfLaneShape — per-agent identity glyph', () => {
   });
 });
 
-// ── #142/#253: workflow ctx zone color must share the >85/>=45 band contract ──
+// ── #142/#253: workflow ctx zone color must share the >80/>=40 band contract ──
 describe('#142 wfCtxZoneColor band boundaries', () => {
   const t = (pct) => ({ ctxUsed: pct / 100 * 200000, maxContext: 200000 });
-  it('85% -> yellow, not red (boundary is >85)', () => {
+  it('80% -> yellow, not red (boundary is >80)', () => {
     const ctx = loadWfModule();
-    assert.equal(ctx.wfCtxZoneColor(t(85)), '#d29922');
+    assert.equal(ctx.wfCtxZoneColor(t(80)), '#d29922');
   });
-  it('86% -> red', () => {
+  it('81% -> red', () => {
     const ctx = loadWfModule();
-    assert.equal(ctx.wfCtxZoneColor(t(86)), '#f85149');
+    assert.equal(ctx.wfCtxZoneColor(t(81)), '#f85149');
   });
-  it('45% -> yellow', () => {
+  it('40% -> yellow', () => {
     const ctx = loadWfModule();
-    assert.equal(ctx.wfCtxZoneColor(t(45)), '#d29922');
+    assert.equal(ctx.wfCtxZoneColor(t(40)), '#d29922');
   });
-  it('44% -> green', () => {
+  it('39% -> green', () => {
     const ctx = loadWfModule();
-    assert.equal(ctx.wfCtxZoneColor(t(44)), '#3fb950');
+    assert.equal(ctx.wfCtxZoneColor(t(39)), '#3fb950');
   });
 });
 

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -885,24 +885,24 @@ describe('#149 wfLaneShape — per-agent identity glyph', () => {
   });
 });
 
-// ── #142: workflow ctx zone color must share the >80/>=40 band contract ──────
+// ── #142/#253: workflow ctx zone color must share the >85/>=45 band contract ──
 describe('#142 wfCtxZoneColor band boundaries', () => {
   const t = (pct) => ({ ctxUsed: pct / 100 * 200000, maxContext: 200000 });
-  it('80% -> yellow, not red (boundary is >80)', () => {
+  it('85% -> yellow, not red (boundary is >85)', () => {
     const ctx = loadWfModule();
-    assert.equal(ctx.wfCtxZoneColor(t(80)), '#d29922');
+    assert.equal(ctx.wfCtxZoneColor(t(85)), '#d29922');
   });
-  it('81% -> red', () => {
+  it('86% -> red', () => {
     const ctx = loadWfModule();
-    assert.equal(ctx.wfCtxZoneColor(t(81)), '#f85149');
+    assert.equal(ctx.wfCtxZoneColor(t(86)), '#f85149');
   });
-  it('40% -> yellow', () => {
+  it('45% -> yellow', () => {
     const ctx = loadWfModule();
-    assert.equal(ctx.wfCtxZoneColor(t(40)), '#d29922');
+    assert.equal(ctx.wfCtxZoneColor(t(45)), '#d29922');
   });
-  it('39% -> green', () => {
+  it('44% -> green', () => {
     const ctx = loadWfModule();
-    assert.equal(ctx.wfCtxZoneColor(t(39)), '#3fb950');
+    assert.equal(ctx.wfCtxZoneColor(t(44)), '#3fb950');
   });
 });
 


### PR DESCRIPTION
## Summary

- `ctxUsed` 公式改為 `input + cache_read + cache_creation + output_tokens`，反映真實 context window 佔用
- 三處 inline 公式收斂為 `computeCtxUsed(usage)` (format.js)，單一定義點
- ctxZone 門檻調整：80→85 danger, 40→45 warn（補償 output 造成的百分比上移）
- classifySeverity 門檻調整：95→97 critical, 85→90 warning
- L2 inline label 門檻同步至 97/90（reviewer 攔到的新引入不一致）
- cacheHitRatio 改用 input-only 分母（output 不影響 cache 效率指標）

## 驗證

- `computeCtxUsed` grep 唯一定義（format.js:15），3 個消費端
- 舊 inline 公式 grep 零殘留
- ctxZone 測試（44/45/85/86 邊界）+ wfCtxZoneColor 測試全更新
- minimap usedRatio 測試更新（500→1500）
- messages-ui VM context 補載 format.js（修 computeCtxUsed not defined）
- boot smoke HTTP 200
- 非 E2E 單元測試全綠（E2E 因 Puppeteer Chrome 版本問題 flaky，非本 PR 引入）
- code-reviewer 二審完成（degraded: Claude 審 Claude，codex CLI 不可用）

## 未驗

- browser-harness 視覺驗收（動 `public/`，需 owner 確認視覺正確性）
- `renderContextBreakdownBar` 的 segment scaling：input-only 分類 bar 現在被 input+output 的 total 拉伸，不存在「output」segment——視覺上 bar 寬度正確反映 window 佔用率，但分類色段比例略失真。Reviewer 建議 decouple，留 follow-up
- miller-columns.js:1810 虛線標記仍為 0.8（80%），ctx80 event 仍在 ≥80 觸發——概念性里程碑標記，非 zone 門檻，保留
- classifySeverity 門檻無獨立測試（函式簡單，code review 可見）

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)