### PR TITLE
fix(workflow): lane placement eligibility — retries & 0-msg probes to fault track, not phantom lanes (#236)

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -637,8 +637,13 @@ function addEntry(e) {
     cwd: e.cwd || null,
   });
 
-  // Workflow timeline: incremental update for live entries (direct or child session)
-  if (typeof wfState !== 'undefined' && wfState && !isRetry) {
+  // Workflow timeline: incremental update for live entries (direct or child session).
+  // Retries reach wfAddEntry too (no !isRetry gate here): its eligibility gate
+  // (#236) fault-marks them, matching the batch wfInferLanes path — otherwise a
+  // live retry would never get a fault marker while a refresh would (parity break).
+  // NOTE: the SEPARATE seq-tracker feed above stays gated on !isRetry — retries
+  // must never feed the tracker; only this render dispatch admits them.
+  if (typeof wfState !== 'undefined' && wfState) {
     var isDirectSession = sid === selectedSessionId;
     var isChildSession = !isDirectSession && sessionsMap.get(sid)?.parentSessionId === selectedSessionId;
     if (isDirectSession || isChildSession) {

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -231,6 +231,19 @@ function _wfSubLaneKey(base, entry) {
   return entry.convId ? base + ':' + entry.convId : base;
 }
 
+// INVARIANT: lane eligibility (#236) — a lane asserts "an agent exists here",
+// so only real conversation turns (a request that carried messages) may
+// mint/join a lane. Retries and 0-msg error probes are diagnostic signals,
+// routed to the main lane's fault track instead. Do NOT broaden: legit turns
+// always have a model; codex/legacy entries have a model and stay eligible;
+// isSubagent alone must not exclude (real subagents are conversation turns).
+// Gated at wfInferLanes (batch) and wfAddEntry (live).
+function _wfIsLaneEligible(e) {
+  if (e.isRetry) return false;                                   // non-2xx, no output — a retry, not a turn
+  if (!e.model && (Number(e.msgCount) || 0) === 0) return false; // 0-msg error probe (404 etc.)
+  return true;
+}
+
 // ── Sequential-interleave tracker (#230) ──────────────────────────────────
 // Temporal overlap (ADR 0008) only catches PARALLEL agents. A sequential
 // teammate — dispatched while main idles, zero time overlap — leaves two
@@ -434,9 +447,15 @@ function wfInferLanes(entries, childEntries, seqTracker) {
     }
   }
   var mainConvIds = new Set();
+  var faultEntries = [];
 
   for (var i = 0; i < entries.length; i++) {
     var e = entries[i];
+    // INVARIANT: lane eligibility (#236) — non-conversation entries (retries,
+    // 0-msg error probes) must NOT enter the agent-topology channel. Route to
+    // the fault track and skip ALL classification + seq machinery, so they
+    // can't corrupt convId bracketing or msgCount stitching. See _wfIsLaneEligible.
+    if (!_wfIsLaneEligible(e)) { faultEntries.push(e); continue; }
     var sub = false;
 
     // INVARIANT: gate on AGENT_KEY_UNRELIABLE — see docs/decisions/0005-agent-key-unreliable-shared-contract.md
@@ -653,6 +672,11 @@ function wfInferLanes(entries, childEntries, seqTracker) {
     if (topA) { lane.agentKey = topA[0]; lane.agentLabel = topA[1].label; }
   }
 
+  // #236: fault entries (retries, 0-msg probes) travel with the main lane so
+  // the fault track can render them. Authoritative rebuild — overwrite any
+  // pre-existing list.
+  mainLane.faultEntries = faultEntries;
+
   return result;
 }
 
@@ -762,6 +786,18 @@ function wfAddEntry(entry) {
   var oldTMax = wfState.tMax;
   if (ts && ts < wfState.tMin) wfState.tMin = ts;
   if (end > wfState.tMax) wfState.tMax = end;
+
+  // INVARIANT: lane eligibility (#236) — mirror wfInferLanes' batch gate.
+  // Retries usually never reach here (entry-rendering.js gates the wf update
+  // on !isRetry) but a 0-msg 404 probe (isSubagent, not isRetry) does — route
+  // it to the main lane's fault track and return WITHOUT placing it in a lane
+  // or feeding the seq tracker. See _wfIsLaneEligible.
+  if (!_wfIsLaneEligible(entry)) {
+    if (wfState.lanes[0]) {
+      (wfState.lanes[0].faultEntries || (wfState.lanes[0].faultEntries = [])).push(entry);
+    }
+    return { lanesChanged: false };
+  }
 
   // childSids is snapshotted at build time; a child session that spawns while
   // the view is already live isn't in it yet. Refresh from the live sessionsMap
@@ -1258,6 +1294,23 @@ function wfRenderLaneSvg(lane, laneIdx, W, xFn, mainConvs) {
       perTrackN[isSel ? info.ti : 0]++;
     }
   }
+
+  // #236: fault entries (retries, 0-msg probes) never mint a lane — they ride
+  // the main lane's fault track (ti 0) as diagnostic markers. Same track row
+  // in both collapsed and selected views; geometry unchanged (ADR 0006). Pass
+  // tidx -1 so the turn-hover highlight sync never matches a fault marker.
+  if (lane.faultEntries && lane.faultEntries.length) {
+    for (var fj = 0; fj < lane.faultEntries.length; fj++) {
+      var fe = lane.faultEntries[fj];
+      var fts = Number(fe.receivedAt) || 0;
+      if (fts < wfState.viewT0 || fts > wfState.viewT1) continue;
+      var fx = Math.max(WF_LABEL_W, xFn(fts));
+      var fInfo = fe.isRetry ? WF_EV_INFO['retry'] : WF_EV_INFO['error'];
+      var fDetail = String(fe.status || '') + ' · ' + (fe.id || '');
+      svg += '<g><title>' + wfEsc(fDetail) + '</title>' + wfDotSvg(fInfo.shape, fInfo.color, fx, evY, -1) + '</g>';
+    }
+  }
+
   if (isSel) {
     for (var li2 = 0; li2 < WF_TRACKS.length; li2++) {
       svg += '<text x="' + (WF_LABEL_W - 6) + '" y="' + (evY + li2 * WF_EV_H + 7) + '" text-anchor="end" fill="' + WF_TRACKS[li2].color + '" opacity="0.8" style="font-size:9px;font-family:' + WF_MONO + '">' + WF_TRACKS[li2].label + '</text>';

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -234,13 +234,19 @@ function _wfSubLaneKey(base, entry) {
 // INVARIANT: lane eligibility (#236) — a lane asserts "an agent exists here",
 // so only real conversation turns (a request that carried messages) may
 // mint/join a lane. Retries and 0-msg error probes are diagnostic signals,
-// routed to the main lane's fault track instead. Do NOT broaden: legit turns
-// always have a model; codex/legacy entries have a model and stay eligible;
-// isSubagent alone must not exclude (real subagents are conversation turns).
-// Gated at wfInferLanes (batch) and wfAddEntry (live).
+// routed to the main lane's fault track instead. Do NOT broaden: a legit turn
+// has an OK status (first clause false); a codex/legacy entry with status 200
+// and no msgCount stays eligible; isSubagent alone must not exclude (real
+// subagents are conversation turns). Gated at wfInferLanes (batch) and
+// wfAddEntry (live).
 function _wfIsLaneEligible(e) {
   if (e.isRetry) return false;                                   // non-2xx, no output — a retry, not a turn
-  if (!e.model && (Number(e.msgCount) || 0) === 0) return false; // 0-msg error probe (404 etc.)
+  // 0-msg error probe (404 not_found etc.): errored AND carried no messages.
+  // Keys on status+msgCount, NOT model — entry-rendering.js normalizes a
+  // missing model to the truthy sentinel '?', so a `!e.model` check silently
+  // no-ops (the real 0-msg 404 arrives with model === '?'). Do NOT exclude on
+  // msgCount===0 alone: legacy/codex entries may lack msgCount but are OK (200).
+  if ((typeof isHttpStatusOk === 'function' ? !isHttpStatusOk(e.status) : false) && (Number(e.msgCount) || 0) === 0) return false;
   return true;
 }
 
@@ -441,6 +447,10 @@ function wfInferLanes(entries, childEntries, seqTracker) {
   var _mchEarliest = Infinity;
   for (var _mci = 0; _mci < entries.length; _mci++) {
     var _mce = entries[_mci];
+    // INVARIANT: lane eligibility (#236) — diagnostic entries (retries, 0-msg
+    // probes) must never establish main identity: a retry's coreHash landing
+    // here first would misroute the real turn to agent-orchestrator:*.
+    if (!_wfIsLaneEligible(_mce)) continue;
     if (_mce.agentKey && WF_MAIN_AGENT_KEYS[_mce.agentKey] && _mce.coreHash) {
       var _mct = Number(_mce.receivedAt) || Infinity;
       if (_mct < _mchEarliest) { mainCoreHash = _mce.coreHash; _mchEarliest = _mct; }
@@ -627,6 +637,11 @@ function wfInferLanes(entries, childEntries, seqTracker) {
     var childBySid = new Map();
     for (var ci = 0; ci < childEntries.length; ci++) {
       var ce = childEntries[ci];
+      // INVARIANT: lane eligibility (#236) — a child session's retry/probe is
+      // diagnostic too. Route it to the same main fault track (mirrors the
+      // live path, where the wfAddEntry gate fires before child-lane routing)
+      // so it never mints/populates a child-* lane. See _wfIsLaneEligible.
+      if (!_wfIsLaneEligible(ce)) { faultEntries.push(ce); continue; }
       var sid = ce.sessionId;
       if (!childBySid.has(sid)) childBySid.set(sid, []);
       childBySid.get(sid).push(ce);
@@ -796,6 +811,10 @@ function wfAddEntry(entry) {
     if (wfState.lanes[0]) {
       (wfState.lanes[0].faultEntries || (wfState.lanes[0].faultEntries = [])).push(entry);
     }
+    // tMax advanced above; keep the tail in view like the normal path, else the
+    // new fault marker exceeds viewT1 (filtered out) and later turns misread the
+    // advanced tMax as a user scroll-back.
+    _wfFollowTail(oldTMax);
     return { lanesChanged: false };
   }
 

--- a/test/seq-interleave-rendering.test.js
+++ b/test/seq-interleave-rendering.test.js
@@ -196,4 +196,26 @@ describe('#230 codex P2 round 6: reordered arrival recomputes the turn list seq 
         ' vs swimlane ' + (mainIds.has(en.id) ? 'main' : 'sub-lane'));
     }
   });
+
+  // #236 live retry parity: a retry arriving while the timeline is open must
+  // reach wfAddEntry (entry-rendering.js dropped its !isRetry gate on the wf
+  // dispatch), where the eligibility gate fault-marks it — matching a refresh
+  // (batch wfInferLanes). The SEPARATE seq-tracker feed stays !isRetry-gated.
+  it('#236: a retry arriving live is routed to the main fault track via addEntry', () => {
+    const ctx = loadDashboardContext();
+    ctx.addEntry(mkTurn(1000, 5, 'convA', 10));           // establishes the session
+    vm.runInContext('selectedSessionId = ' + JSON.stringify(SID), ctx);
+    ctx.wfState = ctx.wfBuildState(SID);                  // open the timeline on this session
+    // a retry: non-2xx, no output → addEntry computes isRetry=true
+    ctx.addEntry(mkTurn(6000, 3, 'convA', 10, { id: 'rLive', status: 500, usage: null }));
+    const rEntry = ctx.allEntries.find(e => e.id === 'rLive');
+    assert.equal(rEntry.isRetry, true, 'precondition: the entry classified as a retry');
+    const faults = (ctx.wfState.lanes[0].faultEntries || []).map(f => f.id);
+    assert.ok(faults.indexOf('rLive') !== -1, 'live retry fault-marked by wfAddEntry (parity with batch)');
+    const inLane = ctx.wfState.lanes.some(l => l.turns.some(t => t.id === 'rLive'));
+    assert.equal(inLane, false, 'retry is never placed in a lane');
+    // seq tracker must NOT have seen the retry (its feed stays !isRetry-gated)
+    assert.equal(ctx.sessionsMap.get(SID).retryCount, 1, 'retry counted as a retry, not a main/sub turn');
+    assert.equal(ctx.sessionsMap.get(SID).mainCount, 1, 'retry did not inflate mainCount');
+  });
 });

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -1806,3 +1806,80 @@ describe('#258 coreHash identity routing', () => {
     assert.ok(name.indexOf('56a5') !== -1, 'expected convId prefix in label, got: ' + name);
   });
 });
+
+// ── #236 lane eligibility: non-conversation entries never mint a lane ────────
+// A lane asserts "an agent exists here" — only real conversation turns may
+// mint/join one. Retries and 0-msg error probes are diagnostic signals routed
+// to the main lane's fault track. (fail-on-old style)
+describe('#236 lane eligibility', () => {
+  function allTurnIds(lanes) {
+    var s = [];
+    for (var i = 0; i < lanes.length; i++)
+      for (var j = 0; j < lanes[i].turns.length; j++) s.push(lanes[i].turns[j].id);
+    return s;
+  }
+  function faultIds(lane) {
+    return (lane.faultEntries || []).map(function(f) { return f.id; }).sort().join(',');
+  }
+  function laneSig(lanes) {
+    return lanes.filter(function(l) { return l.turns.length; })
+      .map(function(l) { return l.turns.map(function(t) { return t.id; }).sort().join(','); })
+      .sort().join('|');
+  }
+
+  it('AC1 — retry overlapping a hung main turn mints no lane, rides the fault track', () => {
+    const ctx = loadWfModule();
+    // m1 is a long/hung turn (span 1000..61000); the retry starts strictly inside it.
+    var lanes = ctx.wfInferLanes([
+      mkEntry('m1', 's1', 'claude-opus-4-6', 1000, 60, {}),
+      mkEntry('r1', 's1', 'claude-opus-4-6', 20000, 5, { status: 500, isRetry: true }),
+    ], []);
+    assert.equal(lanes.length, 1, 'no parallel lane — the retry is not a turn');
+    assert.deepEqual(allTurnIds(lanes), ['m1'], 'retry must not be in any lane turns');
+    assert.equal(faultIds(lanes[0]), 'r1', 'retry rides the main lane fault track');
+  });
+
+  it('AC2 — 0-msg 404 error probe is not a lane, rides the fault track', () => {
+    const ctx = loadWfModule();
+    var lanes = ctx.wfInferLanes([
+      mkEntry('m1', 's1', 'claude-opus-4-6', 1000, 5, {}),
+      mkEntry('p404', 's1', null, 3000, 0, { status: 404, isSubagent: true, msgCount: 0 }),
+    ], []);
+    assert.equal(lanes.length, 1, 'probe mints no subagent lane');
+    assert.deepEqual(allTurnIds(lanes), ['m1'], 'probe must not be in any lane turns');
+    assert.equal(faultIds(lanes[0]), 'p404', 'probe rides the main lane fault track');
+  });
+
+  it('AC3 — batch/live parity for lane structure AND fault entries', () => {
+    var entries = [
+      mkEntry('m1', 's1', 'claude-opus-4-6', 1000, 5, {}),
+      mkEntry('p404', 's1', null, 3000, 0, { status: 404, isSubagent: true, msgCount: 0 }),
+      mkEntry('r1', 's1', 'claude-opus-4-6', 4000, 3, { status: 500, isRetry: true }),
+      mkEntry('m2', 's1', 'claude-opus-4-6', 8000, 5, {}),
+      mkEntry('sub1', 's1', 'claude-sonnet-5', 12000, 3, { isSubagent: true, msgCount: 20 }),
+    ];
+    const batchCtx = loadWfModule();
+    var batch = batchCtx.wfInferLanes(entries.slice(), []);
+
+    const liveCtx = loadWfModule();
+    liveCtx.allEntries = entries.slice(0, 1);
+    liveCtx.wfState = liveCtx.wfBuildState('s1');
+    for (var i = 1; i < entries.length; i++) {
+      liveCtx.allEntries.push(entries[i]);
+      liveCtx.wfAddEntry(entries[i]);
+    }
+    var live = liveCtx.wfState.lanes;
+
+    assert.equal(laneSig(live), laneSig(batch), 'lane count + per-lane turn ids match');
+    assert.equal(faultIds(live[0]), faultIds(batch[0]), 'main lane fault entries match');
+    assert.equal(faultIds(batch[0]), 'p404,r1', 'both ineligible entries collected as faults');
+  });
+
+  it('_wfIsLaneEligible: false for retry / 0-msg-no-model, true for turns + real subagents', () => {
+    const ctx = loadWfModule();
+    assert.equal(ctx._wfIsLaneEligible({ isRetry: true, model: 'claude-opus-4-6', msgCount: 40 }), false, 'retry');
+    assert.equal(ctx._wfIsLaneEligible({ model: null, msgCount: 0 }), false, '0-msg error probe');
+    assert.equal(ctx._wfIsLaneEligible(mkEntry('t', 's1', 'claude-opus-4-6', 1000, 5, { msgCount: 40 })), true, 'normal turn');
+    assert.equal(ctx._wfIsLaneEligible(mkEntry('s', 's1', 'claude-sonnet-5', 1000, 5, { isSubagent: true, msgCount: 20 })), true, 'real subagent');
+  });
+});

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -1875,11 +1875,79 @@ describe('#236 lane eligibility', () => {
     assert.equal(faultIds(batch[0]), 'p404,r1', 'both ineligible entries collected as faults');
   });
 
-  it('_wfIsLaneEligible: false for retry / 0-msg-no-model, true for turns + real subagents', () => {
+  it('AC2-prod — production-shape 404 probe (model sentinel "?") is excluded, rides the fault track', () => {
     const ctx = loadWfModule();
-    assert.equal(ctx._wfIsLaneEligible({ isRetry: true, model: 'claude-opus-4-6', msgCount: 40 }), false, 'retry');
-    assert.equal(ctx._wfIsLaneEligible({ model: null, msgCount: 0 }), false, '0-msg error probe');
-    assert.equal(ctx._wfIsLaneEligible(mkEntry('t', 's1', 'claude-opus-4-6', 1000, 5, { msgCount: 40 })), true, 'normal turn');
+    // entry-rendering.js normalizes a missing model to the truthy sentinel '?',
+    // so the real 0-msg 404 that reaches wfInferLanes carries model === '?'.
+    // FAILS on the old `!e.model` predicate (sentinel is truthy → not excluded).
+    var lanes = ctx.wfInferLanes([
+      mkEntry('m1', 's1', 'claude-opus-4-6', 1000, 5, {}),
+      mkEntry('p404', 's1', '?', 3000, 0, { status: 404, isSubagent: true, msgCount: 0 }),
+    ], []);
+    assert.equal(lanes.length, 1, 'sentinel-model probe mints no subagent lane');
+    assert.deepEqual(allTurnIds(lanes), ['m1'], 'probe must not be in any lane turns');
+    assert.equal(faultIds(lanes[0]), 'p404', 'probe rides the main lane fault track');
+  });
+
+  it('coreHash pre-scan ignores ineligible entries — an early retry cannot seed main identity', () => {
+    const ctx = loadWfModule();
+    // r1 (retry) arrives first with a DIFFERENT coreHash than the real turn.
+    // Without the pre-scan eligibility gate it would seed mainCoreHash and
+    // misroute m1 into an agent-orchestrator:* identity lane (coreHash routing).
+    var lanes = ctx.wfInferLanes([
+      mkEntry('r1', 's1', 'claude-opus-4-6', 1000, 5, { status: 500, isRetry: true, agentKey: 'orchestrator', coreHash: 'HASH_RETRY', convId: 'cvR' }),
+      mkEntry('m1', 's1', 'claude-opus-4-6', 2000, 5, { msgCount: 5, agentKey: 'orchestrator', coreHash: 'HASH_MAIN', convId: 'cvA' }),
+    ], []);
+    assert.equal(lanes.length, 1, 'no agent-orchestrator lane minted from the retry coreHash');
+    assert.equal(lanes[0].name, 'main');
+    assert.deepEqual(allTurnIds(lanes), ['m1'], 'real turn lands in main, not an identity lane');
+    assert.equal(faultIds(lanes[0]), 'r1', 'the retry is a fault');
+  });
+
+  it('childEntries — a child-session retry mints no child lane, rides the fault track (batch/live parity)', () => {
+    var entries = [ mkEntry('m1', 's1', 'claude-opus-4-6', 1000, 5, { msgCount: 5 }) ];
+    var childEntries = [
+      mkEntry('c1', 's2', 'claude-sonnet-5', 2000, 3, { msgCount: 8 }),
+      mkEntry('cRetry', 's2', 'claude-sonnet-5', 3000, 2, { status: 500, isRetry: true }),
+    ];
+    const batchCtx = loadWfModule();
+    var batch = batchCtx.wfInferLanes(entries.slice(), childEntries.slice());
+    var childLane = batch.filter(function(l) { return l.childSessionId === 's2'; })[0];
+    assert.ok(childLane, 'eligible child turn still forms a child lane');
+    assert.equal(childLane.turns.map(function(t) { return t.id; }).join(','), 'c1', 'child lane excludes the retry');
+    assert.equal(faultIds(batch[0]), 'cRetry', 'child retry rides the MAIN lane fault track');
+
+    const liveCtx = loadWfModule();
+    liveCtx.sessionsMap.set('s2', { parentSessionId: 's1' });
+    liveCtx.allEntries = entries.slice();
+    liveCtx.wfState = liveCtx.wfBuildState('s1');
+    liveCtx.allEntries.push(childEntries[0]); liveCtx.wfAddEntry(childEntries[0]);
+    liveCtx.allEntries.push(childEntries[1]); liveCtx.wfAddEntry(childEntries[1]);
+    var live = liveCtx.wfState.lanes;
+    var liveChild = live.filter(function(l) { return l.childSessionId === 's2'; })[0];
+    assert.ok(liveChild, 'live: eligible child turn forms a child lane');
+    assert.equal(liveChild.turns.map(function(t) { return t.id; }).join(','), 'c1', 'live: child lane excludes the retry');
+    assert.equal(faultIds(live[0]), 'cRetry', 'live: child retry on main fault track — parity with batch');
+  });
+
+  it('live: a retry reaching wfAddEntry is fault-marked, never laned (parity with batch)', () => {
+    const ctx = loadWfModule();
+    ctx.allEntries = [ mkEntry('m1', 's1', 'claude-opus-4-6', 1000, 5, { msgCount: 5 }) ];
+    ctx.wfState = ctx.wfBuildState('s1');
+    var r = ctx.wfAddEntry(mkEntry('rLive', 's1', 'claude-opus-4-6', 6000, 2, { status: 500, isRetry: true }));
+    assert.equal(r.lanesChanged, false, 'retry never changes lane structure');
+    assert.deepEqual(allTurnIds(ctx.wfState.lanes), ['m1'], 'retry not placed in any lane');
+    assert.equal(faultIds(ctx.wfState.lanes[0]), 'rLive', 'retry on the main fault track');
+  });
+
+  it('_wfIsLaneEligible: keys on status+msgCount (not the model sentinel)', () => {
+    const ctx = loadWfModule();
+    assert.equal(ctx._wfIsLaneEligible({ isRetry: true, status: 500, model: 'claude-opus-4-6', msgCount: 40 }), false, 'retry');
+    assert.equal(ctx._wfIsLaneEligible({ status: 404, model: '?', msgCount: 0 }), false, 'prod 0-msg 404 probe (sentinel model)');
+    assert.equal(ctx._wfIsLaneEligible({ status: 404, model: null, msgCount: 0 }), false, '0-msg 404 probe (null model)');
+    assert.equal(ctx._wfIsLaneEligible(mkEntry('t', 's1', 'claude-opus-4-6', 1000, 5, { msgCount: 40 })), true, 'normal 200 turn');
     assert.equal(ctx._wfIsLaneEligible(mkEntry('s', 's1', 'claude-sonnet-5', 1000, 5, { isSubagent: true, msgCount: 20 })), true, 'real subagent');
+    assert.equal(ctx._wfIsLaneEligible({ status: 200 }), true, 'legacy 200 entry with no msgCount stays eligible');
+    assert.equal(ctx._wfIsLaneEligible({ status: 404, msgCount: 12 }), true, 'errored turn that DID carry messages is eligible');
   });
 });


### PR DESCRIPTION
## 摘要

swimlane 是 agent 拓樸頻道——一條 lane 主張「這裡有一個 agent」。目前 lane placement 不檢查 entry 是否為真實對話 turn,兩類非對話 entry 鑄出假 lane:**retry**(hung stream + overlap → 假 parallel「Fork」lane)與 **0-msg 錯誤探測**(404,無 model/convId、msgCount=0 → `subagent-?` lane)。依 owner 定案(2026-07-11):這些是診斷訊號不得濾除,錯的是頻道——改掛 main lane 的 fault/event track。

Closes #236

## Changes(`public/workflow-timeline.js`,純增量 +53)

- **`_wfIsLaneEligible(e)`** 新判準:`isRetry` → 不合格;`!model && msgCount===0`(錯誤探測)→ 不合格;其餘合格。**不放寬**——合法 turn 一律有 model,`isSubagent` 單獨不排除(真 subagent 是對話 turn)。
- **batch `wfInferLanes`**:loop 首行 `if (!_wfIsLaneEligible(e)) { faultEntries.push(e); continue; }`——不進任何 lane、不進 seqStream/seq tracker(不污染 convId bracketing / msgCount stitching)。`mainLane.faultEntries` 隨 lane 回傳。
- **live `wfAddEntry`**:同 gate 於函式頂端,不合格 → 推入 `lanes[0].faultEntries`、`return {lanesChanged:false}`,不餵 seq tracker。
- **render `wfRenderLaneSvg`**:`faultEntries` 以 marker 畫在 main 的 faults track(ti 0),retry→retry glyph、探測→error glyph,`<title>` hover 顯示 `status · id`。**不動 lane 高度/數量/geometry**(ADR 0006)。

## 驗證證據

### 真實 render pipeline(隔離實例 + 合成資料,browser-harness)
| 場景 | laneCount | lane turns | faultEntries | 渲染的 fault marker |
|---|---|---|---|---|
| hung main + 重疊 retry | **1**(僅 main) | `m1,m2` | `[r1]` | `500 · r1` ✅ |
| 0-msg 404 探測 | **1**(僅 main) | `m1,m2` | `[p404]` | `404 · p404` ✅ |

retry 不再鑄假 parallel lane、404 不再鑄 `subagent-?` lane;兩者皆以 fault marker 呈現於 main faults track。

![retry: no phantom lane, 500 fault marker](https://raw.githubusercontent.com/lis186/ccxray/evidence/pr-236/retry.png)
![404 probe: no subagent-? lane, 404 fault marker](https://raw.githubusercontent.com/lis186/ccxray/evidence/pr-236/probe404.png)

### 機器已驗（orchestrator 親跑）
| 項目 | 結果 |
|---|---|
| workflow-timeline 套件 | **113/113** |
| diff-check(base origin/main) | exit 0(舊 109/113、新全過;4 個新 AC 測試 fail-on-old) |
| boot-smoke | HTTP 200 / exit 0 |
| 孤兒參照 | 零刪除符號 |

### AC 對照
- **AC1**(retry overlap 不鑄 lane)✅ · **AC2**(404 呈現為 fault、lane 不含)✅ · **AC3**(batch/live parity,測試斷言 lane 結構 + faultEntries 相等)✅ · **AC5**(ADR 0008 overlap + #230 seq 測試不變綠)✅
- **AC4(全量真實資料 re-audit)— 邊界未做**:原 AC 要 vm harness 重放全部真實 session 斷言「isRetry/0-msg 落在任何 lane = 0」。該步驟須讀真實 `~/.ccxray`(pipeline 環境安全硬規則禁止 orchestrator 觸碰活資料)。已用合成多-session parity fixture(AC3)覆蓋兩種 shape;**全量真實 re-audit 留待 owner 在活資料上跑**。

## 標記
動 `public/` render → `pipeline:needs-visual-review`:fault marker 為新視覺呈現,請 owner 確認 A/B 兩圖:main 下方**無**多餘 lane、faults track 上有對應紅點(hover 見 `status·id`)。
