### PR TITLE
feat(workflow): lane labels reflect mixed-model content + seq-stitched marker (#238)

### DIFF
--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -432,6 +432,15 @@ function wfInferLanes(entries, childEntries, seqTracker) {
   if (!entries.length && !childEntries.length) return [];
   if (!seqTracker) seqTracker = wfCreateSeqTracker();
 
+  // #238 part 2: reset across ALL input turns before lane partitioning — a
+  // turn tagged _wfSeqStitched on a prior build can route straight into an
+  // identity sublane (coreHash change) on this build and never enter
+  // mainLane.turns, so a reset scoped to mainLane.turns alone would miss it
+  // and leave a stale tag on its tooltip. Display-only — never read by the
+  // routing logic below.
+  for (var _ri = 0; _ri < entries.length; _ri++) entries[_ri]._wfSeqStitched = false;
+  for (var _rj = 0; _rj < childEntries.length; _rj++) childEntries[_rj]._wfSeqStitched = false;
+
   var laneMap = new Map();
   var mainLane = { name: 'main', key: 'main', turns: [], model: null, ctxWindow: 0, spawnParent: null };
   laneMap.set('main', mainLane);
@@ -544,11 +553,6 @@ function wfInferLanes(entries, childEntries, seqTracker) {
     if (lk === 'main') return;
     for (var si = 0; si < lane.turns.length; si++) fixedEvidence.push(lane.turns[si]);
   });
-  // #238 part 2: reset before the fixpoint loop so a turn that stops being an
-  // R2 excursion on rebuild (more entries arrived, verdict flipped) never
-  // carries a stale tag from an earlier wfInferLanes call. Display-only —
-  // never read by the routing logic above or below.
-  for (var _si = 0; _si < mainLane.turns.length; _si++) mainLane.turns[_si]._wfSeqStitched = false;
   var candidates = mainLane.turns;
   var exiled = [];
   for (;;) {
@@ -801,6 +805,14 @@ function _wfFollowTail(oldTMax) {
   }
 }
 
+// #238: keep lane.models current on live appends (batch recomputes dominant-
+// first by count; live just ensures the model is present so a switch shows).
+function _wfLaneTrackModel(lane, model) {
+  if (!model) return;
+  if (!lane.models) lane.models = lane.model ? [lane.model] : [];
+  if (lane.models.indexOf(model) === -1) lane.models.push(model);
+}
+
 // ── Incremental Update ────────────────────────────────────────────────────
 // Caller contract: `entry` must already be pushed into allEntries before
 // this call — the reordered-arrival path (_wfSeqRebuild) recomputes the
@@ -853,6 +865,7 @@ function wfAddEntry(entry) {
       wfState.lanes.push(clane);
     }
     clane.turns.push(entry);
+    _wfLaneTrackModel(clane, entry.model);
     clane._costMedian = null;
     if (wfState.turnIndex) wfState.turnIndex.set(entry.id, { turn: entry, laneIdx: wfState.lanes.indexOf(clane) });
     _wfFollowTail(oldTMax);
@@ -970,11 +983,13 @@ function wfAddEntry(entry) {
     // nested turn completes before an earlier longer turn) — insert sorted
     // so the live path matches wfInferLanes' order (batch/live parity).
     if (pooledReuse) _wfInsertTurnSorted(lane, entry); else lane.turns.push(entry);
+    _wfLaneTrackModel(lane, entry.model);
     lane._costMedian = null;
     if (!lane.agentKey && entry.agentKey) { lane.agentKey = entry.agentKey; lane.agentLabel = entry.agentLabel; }
     if (wfState.turnIndex) wfState.turnIndex.set(entry.id, { turn: entry, laneIdx: wfState.lanes.indexOf(lane) });
   } else if (wfState.lanes[0]) {
     wfState.lanes[0].turns.push(entry);
+    _wfLaneTrackModel(wfState.lanes[0], entry.model);
     wfState.lanes[0]._costMedian = null;
     if (wfState.turnIndex) wfState.turnIndex.set(entry.id, { turn: entry, laneIdx: 0 });
     // INVARIANT: coreHash identity routing — see docs/decisions/0010-corehash-identity-routing.md
@@ -1056,6 +1071,7 @@ function _wfSeqRetroMove(closedTurns) {
     // #261: pooled convId lane can receive turns out of start order — insert
     // sorted so the live path matches wfInferLanes' order (batch/live parity).
     if (pooledReuse) _wfInsertTurnSorted(lane, t); else lane.turns.push(t);
+    _wfLaneTrackModel(lane, t.model);
     lane._costMedian = null;
     if (wfState.turnIndex) wfState.turnIndex.set(t.id, { turn: t, laneIdx: wfState.lanes.indexOf(lane) });
   }
@@ -1219,7 +1235,10 @@ function wfRenderLaneSvg(lane, laneIdx, W, xFn, mainConvs) {
   var fullTitle = wfEsc(lane.name + ' · ' + (lane.agentLabel || '?') + ' · ' + (modelLbl.title || '?') + ' · ' + ctxK + 'K');
   svg += '<text x="8" y="12" fill="var(--text)" style="font-size:11px;font-family:' + WF_MONO + '"><title>' + fullTitle + '</title>' + wfEsc(prefix + dispName) + '</text>';
   svg += wfGlyphSvg(wfLaneShape(lane), 14, 23, 6, wfLaneColor(lane));
-  svg += '<text x="20" y="26" fill="var(--dim)" style="font-size:10px;font-family:' + WF_MONO + '"><tspan fill="' + wfLaneColor(lane) + '">' + wfEsc(modelLbl.text) + '</tspan>' + wfEsc(' · ' + ctxK + 'K') + '</text>';
+  // #238 P3: <title> on the model text itself — hovering the abbreviated
+  // "opus-4-6 +2" form must reveal the full model list, same as the name
+  // text above; the fullTitle <title> only covers the name row's box.
+  svg += '<text x="20" y="26" fill="var(--dim)" style="font-size:10px;font-family:' + WF_MONO + '"><title>' + wfEsc(modelLbl.title) + '</title><tspan fill="' + wfLaneColor(lane) + '">' + wfEsc(modelLbl.text) + '</tspan>' + wfEsc(' · ' + ctxK + 'K') + '</text>';
   // sysprompt versions: distinct coreHash in first-seen order; chip click = jump
   // to the turn where that version first appeared; ↗ opens the System Prompt page
   // Hashes go into innerHTML data attributes — accept hex only (index.ndjson

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -695,11 +695,11 @@ function wfInferLanes(entries, childEntries, seqTracker) {
       }
     }
     // #238: a lane can legally hold multiple models (mid-session /model
-    // switches survive ADR 0008/0009 lane placement) — keep the full
-    // dominant-first breakdown so the label can show more than the winner.
-    var _models = Object.entries(mc).sort(function(a, b) { return b[1] - a[1]; });
-    lane.model = _models[0][0];
-    lane.models = _models.map(function(p) { return p[0]; });
+    // switches survive ADR 0008/0009 lane placement). Dominant model still
+    // drives color/placement; the full breakdown for the label is derived
+    // from lane.turns at render time by _wfLaneModelLabel (no maintained
+    // copy — see that function's comment).
+    lane.model = Object.entries(mc).sort(function(a, b) { return b[1] - a[1]; })[0][0];
     lane.ctxWindow = lane.turns[0].maxContext || lane.ctxWindow;
     var topA = Object.entries(ac).sort(function(a, b) { return b[1].n - a[1].n; })[0];
     if (topA) { lane.agentKey = topA[0]; lane.agentLabel = topA[1].label; }
@@ -805,14 +805,6 @@ function _wfFollowTail(oldTMax) {
   }
 }
 
-// #238: keep lane.models current on live appends (batch recomputes dominant-
-// first by count; live just ensures the model is present so a switch shows).
-function _wfLaneTrackModel(lane, model) {
-  if (!model) return;
-  if (!lane.models) lane.models = lane.model ? [lane.model] : [];
-  if (lane.models.indexOf(model) === -1) lane.models.push(model);
-}
-
 // ── Incremental Update ────────────────────────────────────────────────────
 // Caller contract: `entry` must already be pushed into allEntries before
 // this call — the reordered-arrival path (_wfSeqRebuild) recomputes the
@@ -865,7 +857,6 @@ function wfAddEntry(entry) {
       wfState.lanes.push(clane);
     }
     clane.turns.push(entry);
-    _wfLaneTrackModel(clane, entry.model);
     clane._costMedian = null;
     if (wfState.turnIndex) wfState.turnIndex.set(entry.id, { turn: entry, laneIdx: wfState.lanes.indexOf(clane) });
     _wfFollowTail(oldTMax);
@@ -983,13 +974,11 @@ function wfAddEntry(entry) {
     // nested turn completes before an earlier longer turn) — insert sorted
     // so the live path matches wfInferLanes' order (batch/live parity).
     if (pooledReuse) _wfInsertTurnSorted(lane, entry); else lane.turns.push(entry);
-    _wfLaneTrackModel(lane, entry.model);
     lane._costMedian = null;
     if (!lane.agentKey && entry.agentKey) { lane.agentKey = entry.agentKey; lane.agentLabel = entry.agentLabel; }
     if (wfState.turnIndex) wfState.turnIndex.set(entry.id, { turn: entry, laneIdx: wfState.lanes.indexOf(lane) });
   } else if (wfState.lanes[0]) {
     wfState.lanes[0].turns.push(entry);
-    _wfLaneTrackModel(wfState.lanes[0], entry.model);
     wfState.lanes[0]._costMedian = null;
     if (wfState.turnIndex) wfState.turnIndex.set(entry.id, { turn: entry, laneIdx: 0 });
     // INVARIANT: coreHash identity routing — see docs/decisions/0010-corehash-identity-routing.md
@@ -1071,7 +1060,6 @@ function _wfSeqRetroMove(closedTurns) {
     // #261: pooled convId lane can receive turns out of start order — insert
     // sorted so the live path matches wfInferLanes' order (batch/live parity).
     if (pooledReuse) _wfInsertTurnSorted(lane, t); else lane.turns.push(t);
-    _wfLaneTrackModel(lane, t.model);
     lane._costMedian = null;
     if (wfState.turnIndex) wfState.turnIndex.set(t.id, { turn: t, laneIdx: wfState.lanes.indexOf(lane) });
   }
@@ -1200,8 +1188,23 @@ function _wfLaneDispName(lane, laneIdx, mainConvs) {
 
 // #238: a lane can hold multiple models (legal /model switches). Show the
 // dominant + a "+extra" hint instead of hiding the minority model(s).
+// No maintained lane.models copy — derive the breakdown from lane.turns
+// (the source of truth) on every call, so batch and live can never drift:
+// a live append is picked up on the very next render, and a turn moved out
+// of the lane (e.g. _wfSeqRetroMove) stops contributing immediately.
 function _wfLaneModelLabel(lane) {
-  var ms = (lane.models && lane.models.length) ? lane.models : [lane.model];
+  var turns = lane.turns || [];
+  var mc = {}, order = [];
+  for (var i = 0; i < turns.length; i++) {
+    var m = turns[i].model;
+    if (!m) continue;
+    if (mc[m] === undefined) { mc[m] = 0; order.push(m); }
+    mc[m]++;
+  }
+  // dominant-first by count; stable tie-break = first-seen (order[]) so the
+  // result is deterministic and matches wfInferLanes' Object.entries+sort.
+  var ms = order.slice().sort(function(a, b) { return mc[b] - mc[a]; });
+  if (!ms.length) ms = lane.model ? [lane.model] : [];
   var head = wfShortModel(ms[0]);
   if (ms.length <= 1) return { text: head, title: head };
   var rest = ms.slice(1).map(wfShortModel);

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -544,6 +544,11 @@ function wfInferLanes(entries, childEntries, seqTracker) {
     if (lk === 'main') return;
     for (var si = 0; si < lane.turns.length; si++) fixedEvidence.push(lane.turns[si]);
   });
+  // #238 part 2: reset before the fixpoint loop so a turn that stops being an
+  // R2 excursion on rebuild (more entries arrived, verdict flipped) never
+  // carries a stale tag from an earlier wfInferLanes call. Display-only —
+  // never read by the routing logic above or below.
+  for (var _si = 0; _si < mainLane.turns.length; _si++) mainLane.turns[_si]._wfSeqStitched = false;
   var candidates = mainLane.turns;
   var exiled = [];
   for (;;) {
@@ -568,7 +573,11 @@ function wfInferLanes(entries, childEntries, seqTracker) {
     for (var qi = 0; qi < seqStream.length; qi++) {
       if (seqStream[qi].split) { wfSeqFeedSplit(roundTracker, seqStream[qi].t); continue; }
       var verdict = wfSeqFeedMain(roundTracker, seqStream[qi].t);
-      if (verdict.place === 'excursion') excursed.push(seqStream[qi].t);
+      // #238 part 2: tag the R2-stitch verdict (never verdict.closed, which is
+      // R1 bracket-close — a different mechanism, see wfSeqFeedMain's doc
+      // comment) so the hover tooltip can distinguish a seq-stitch from an
+      // ADR 0008 temporal-overlap split. Display-only; doesn't affect placement.
+      if (verdict.place === 'excursion') { seqStream[qi].t._wfSeqStitched = true; excursed.push(seqStream[qi].t); }
       if (verdict.closed) for (var vc = 0; vc < verdict.closed.length; vc++) excursed.push(verdict.closed[vc]);
     }
     if (!excursed.length) {
@@ -681,7 +690,12 @@ function wfInferLanes(entries, childEntries, seqTracker) {
         ac[ak].n++;
       }
     }
-    lane.model = Object.entries(mc).sort(function(a, b) { return b[1] - a[1]; })[0][0];
+    // #238: a lane can legally hold multiple models (mid-session /model
+    // switches survive ADR 0008/0009 lane placement) — keep the full
+    // dominant-first breakdown so the label can show more than the winner.
+    var _models = Object.entries(mc).sort(function(a, b) { return b[1] - a[1]; });
+    lane.model = _models[0][0];
+    lane.models = _models.map(function(p) { return p[0]; });
     lane.ctxWindow = lane.turns[0].maxContext || lane.ctxWindow;
     var topA = Object.entries(ac).sort(function(a, b) { return b[1].n - a[1].n; })[0];
     if (topA) { lane.agentKey = topA[0]; lane.agentLabel = topA[1].label; }
@@ -918,6 +932,9 @@ function wfAddEntry(entry) {
       if (seqVerdict.place === 'excursion') {
         needsSub = true;
         key = _wfSubLaneKey('parallel-' + wfShortModel(entry.model), entry);
+        // #238 part 2: same R2-stitch signal as wfInferLanes' post-pass —
+        // display-only, doesn't affect placement (already decided above).
+        entry._wfSeqStitched = true;
       }
     }
   }
@@ -1165,6 +1182,19 @@ function _wfLaneDispName(lane, laneIdx, mainConvs) {
   return (lane.agentLabel || lane.name) + (lane.convId ? ' ' + lane.convId.slice(0, 4) : '');
 }
 
+// #238: a lane can hold multiple models (legal /model switches). Show the
+// dominant + a "+extra" hint instead of hiding the minority model(s).
+function _wfLaneModelLabel(lane) {
+  var ms = (lane.models && lane.models.length) ? lane.models : [lane.model];
+  var head = wfShortModel(ms[0]);
+  if (ms.length <= 1) return { text: head, title: head };
+  var rest = ms.slice(1).map(wfShortModel);
+  // two models → "opus-4-6 +fable-5"; three+ → "opus-4-6 +2"
+  var text = ms.length === 2 ? head + ' +' + rest[0] : head + ' +' + rest.length;
+  var title = ms.map(wfShortModel).join(', ');
+  return { text: text, title: title };
+}
+
 function wfRenderLaneSvg(lane, laneIdx, W, xFn, mainConvs) {
   var isSel = wfState.selectedLane?.key === lane.key;
   var laneH = isSel ? WF_LANE_H_SEL : WF_LANE_H;
@@ -1185,10 +1215,11 @@ function wfRenderLaneSvg(lane, laneIdx, W, xFn, mainConvs) {
   var prefix = isSel ? '▶ ' : '';
   var ctxK = Math.round((lane.ctxWindow || 0) / 1000);
   var dispName = _wfLaneDispName(lane, laneIdx, mainConvs);
-  var fullTitle = wfEsc(lane.name + ' · ' + (lane.agentLabel || '?') + ' · ' + (lane.model || '?') + ' · ' + ctxK + 'K');
+  var modelLbl = _wfLaneModelLabel(lane);
+  var fullTitle = wfEsc(lane.name + ' · ' + (lane.agentLabel || '?') + ' · ' + (modelLbl.title || '?') + ' · ' + ctxK + 'K');
   svg += '<text x="8" y="12" fill="var(--text)" style="font-size:11px;font-family:' + WF_MONO + '"><title>' + fullTitle + '</title>' + wfEsc(prefix + dispName) + '</text>';
   svg += wfGlyphSvg(wfLaneShape(lane), 14, 23, 6, wfLaneColor(lane));
-  svg += '<text x="20" y="26" fill="var(--dim)" style="font-size:10px;font-family:' + WF_MONO + '"><tspan fill="' + wfLaneColor(lane) + '">' + wfEsc(wfShortModel(lane.model)) + '</tspan>' + wfEsc(' · ' + ctxK + 'K') + '</text>';
+  svg += '<text x="20" y="26" fill="var(--dim)" style="font-size:10px;font-family:' + WF_MONO + '"><tspan fill="' + wfLaneColor(lane) + '">' + wfEsc(modelLbl.text) + '</tspan>' + wfEsc(' · ' + ctxK + 'K') + '</text>';
   // sysprompt versions: distinct coreHash in first-seen order; chip click = jump
   // to the turn where that version first appeared; ↗ opens the System Prompt page
   // Hashes go into innerHTML data attributes — accept hex only (index.ndjson
@@ -2123,7 +2154,7 @@ function _wfShowTooltip(e, t, lane) {
     ? ' <span class="wf-tt-lock">🔒#' + wfEsc(String(lock.lane.turns[lock.tidx].displayNum || lock.tidx + 1)) + '</span>' : '';
   var row = function(l, v) { return '<div class="r"><span class="l">' + l + '</span><span class="v">' + v + '</span></div>'; };
   _wfTooltipEl.innerHTML =
-    row('#' + wfEsc(String(t.displayNum || '?')), wfEsc(wfShortModel(t.model)) + lockLbl)
+    row('#' + wfEsc(String(t.displayNum || '?')), wfEsc(wfShortModel(t.model)) + (t._wfSeqStitched ? ' · seq-stitched' : '') + lockLbl)
     + row('Context', '<span class="' + zoneCls + '">' + pct.toFixed(1) + '%</span> (' + zone + ')')
     + row('Cache', _wfFmtTok(cr) + ' read / ' + _wfFmtTok(cc) + ' write')
     + row('Cost', '$' + (t.cost || 0).toFixed(4) + outlier)
@@ -2316,7 +2347,8 @@ function wfRenderAgentCard(lane) {
   var topTools = Object.entries(toolTotals).sort(function(a, b) { return b[1] - a[1]; }).slice(0, 6);
 
   var html = '<div class="wf-agent-card" style="border-left:2px solid ' + color + '">';
-  html += '<div class="wf-ac-name">' + wfGlyphHtml(wfLaneShape(lane), 10, color) + ' ' + wfEsc(lane.name) + ' <span class="wf-ac-model" style="background:' + color + '22;color:' + color + '">' + wfEsc(wfShortModel(lane.model)) + '</span></div>';
+  var acModelLbl = _wfLaneModelLabel(lane);
+  html += '<div class="wf-ac-name">' + wfGlyphHtml(wfLaneShape(lane), 10, color) + ' ' + wfEsc(lane.name) + ' <span class="wf-ac-model" title="' + wfEsc(acModelLbl.title) + '" style="background:' + color + '22;color:' + color + '">' + wfEsc(acModelLbl.text) + '</span></div>';
   // INVARIANT: main/subagent label must use _wfIsMainLane, not lane.spawnParent
   // — see docs/decisions/0007-wf-is-main-lane-not-spawn-parent.md
   html += '<div class="wf-ac-meta">' + summary.turnCount + ' turns · ' + wfFmtDur(summary.duration) + ' · ' + (isOrchestrator ? 'orchestrator' : 'subagent') + '</div>';

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -1951,3 +1951,112 @@ describe('#236 lane eligibility', () => {
     assert.equal(ctx._wfIsLaneEligible({ status: 404, msgCount: 12 }), true, 'errored turn that DID carry messages is eligible');
   });
 });
+
+describe('#238 mixed-model labels', () => {
+  it('mixed-model lane keeps dominant + minority model in lane.models, label shows both', () => {
+    const ctx = loadWfModule();
+    var entries = [
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('t2', 's1', 'claude-opus-4-6', 5000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('t3', 's1', 'claude-fable-5', 9000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('t4', 's1', 'claude-fable-5', 13000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('t5', 's1', 'claude-opus-4-6', 17000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+    ];
+    var lanes = ctx.wfInferLanes(entries, []);
+    assert.equal(lanes.length, 1, 'legal /model switches stay in one main lane');
+    var lane = lanes[0];
+    assert.equal(lane.models.join(','), 'claude-opus-4-6,claude-fable-5', 'dominant-first, both present');
+    assert.equal(lane.model, 'claude-opus-4-6', 'majority-vote lane.model is unchanged');
+    var lbl = ctx._wfLaneModelLabel(lane);
+    assert.equal(lbl.text, 'opus-4-6 +fable-5');
+    assert.ok(lbl.title.indexOf('opus-4-6') !== -1 && lbl.title.indexOf('fable-5') !== -1, 'title lists both models');
+  });
+
+  it('single-model lane label is unchanged (no +)', () => {
+    const ctx = loadWfModule();
+    var entries = [
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, {}),
+      mkEntry('t2', 's1', 'claude-opus-4-6', 6000, 3, {}),
+    ];
+    var lanes = ctx.wfInferLanes(entries, []);
+    assert.equal(lanes[0].models.join(','), 'claude-opus-4-6');
+    var lbl = ctx._wfLaneModelLabel(lanes[0]);
+    assert.equal(lbl.text, 'opus-4-6');
+    assert.equal(lbl.title, 'opus-4-6');
+    assert.ok(lbl.text.indexOf('+') === -1, 'no + hint for a single-model lane');
+  });
+
+  it('three+ models collapse to "+N" instead of listing every minority model', () => {
+    const ctx = loadWfModule();
+    var entries = [
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('t2', 's1', 'claude-opus-4-6', 5000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('t3', 's1', 'claude-opus-4-6', 9000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('t4', 's1', 'claude-fable-5', 13000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('t5', 's1', 'claude-fable-5', 17000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('t6', 's1', 'claude-sonnet-4-6', 21000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+    ];
+    var lanes = ctx.wfInferLanes(entries, []);
+    assert.equal(lanes.length, 1);
+    assert.equal(lanes[0].models.join(','), 'claude-opus-4-6,claude-fable-5,claude-sonnet-4-6');
+    var lbl = ctx._wfLaneModelLabel(lanes[0]);
+    assert.equal(lbl.text, 'opus-4-6 +2');
+  });
+
+  it('live path lanes never throw the label helper, even without a recomputed .models', () => {
+    const ctx = loadWfModule();
+    ctx.allEntries = [mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, {})];
+    ctx.wfState = ctx.wfBuildState('s1');
+    ctx.wfAddEntry(mkEntry('t2', 's1', 'claude-fable-5', 6000, 2, { isSubagent: true }));
+    // wfAddEntry doesn't recompute .models per-lane (only the batch tally
+    // does) — the helper's [lane.model] fallback must still hold for every
+    // lane the live path can produce.
+    for (var i = 0; i < ctx.wfState.lanes.length; i++) {
+      var lbl = ctx._wfLaneModelLabel(ctx.wfState.lanes[i]);
+      assert.equal(typeof lbl.text, 'string');
+      assert.ok(lbl.text.length > 0);
+    }
+  });
+
+  it('#238 part 2: R2 seq-stitch is tagged, ADR 0008 overlap split is not (batch, fail-on-old)', () => {
+    const ctx = loadWfModule();
+    function mkSeq(id, at, elapsed, conv, msg, opts) {
+      return mkEntry(id, 's1', 'claude-opus-4-6', at, elapsed, Object.assign(
+        { agentKey: 'orchestrator', agentLabel: 'Orchestrator', convId: conv, msgCount: msg }, opts || {}));
+    }
+    var lanes = ctx.wfInferLanes([
+      mkSeq('m1', 1000, 5, 'convA', 53),
+      mkSeq('m2', 10000, 60, 'convA', 55),   // long main turn 10000..70000
+      mkSeq('f1', 20000, 5, 'convA', 51),    // starts inside m2 -> ADR 0008 overlap split, NOT seq-stitched
+      mkSeq('f2', 71000, 5, 'convA', 51),    // after m2 ends -> ADR 0009 R2 dip stitch, IS seq-stitched
+      mkSeq('m3', 80000, 5, 'convA', 57),
+    ], []);
+    assert.equal(lanes.length, 2);
+    var main = lanes[0], sub = lanes[1];
+    assert.equal(sub.turns.map(function(t) { return t.id; }).join(','), 'f1,f2');
+    assert.ok(!sub.turns[0]._wfSeqStitched, 'f1 is an overlap split, not seq-stitched');
+    assert.equal(sub.turns[1]._wfSeqStitched, true, 'f2 is the R2 dip stitch');
+    for (var mi = 0; mi < main.turns.length; mi++) {
+      assert.ok(!main.turns[mi]._wfSeqStitched, 'main turns are never seq-stitched');
+    }
+  });
+
+  it('#238 part 2: live path agrees with batch on the same seq-stitch tag', () => {
+    const ctx = loadWfModule();
+    function mkSeq(id, at, elapsed, conv, msg, opts) {
+      return mkEntry(id, 's1', 'claude-opus-4-6', at, elapsed, Object.assign(
+        { agentKey: 'orchestrator', agentLabel: 'Orchestrator', convId: conv, msgCount: msg }, opts || {}));
+    }
+    ctx.allEntries = [mkSeq('m1', 1000, 5, 'convA', 53)];
+    ctx.wfState = ctx.wfBuildState('s1');
+    ctx.wfAddEntry(mkSeq('m2', 10000, 60, 'convA', 55));
+    ctx.wfAddEntry(mkSeq('f1', 20000, 5, 'convA', 51));
+    ctx.wfAddEntry(mkSeq('f2', 71000, 5, 'convA', 51));
+    ctx.wfAddEntry(mkSeq('m3', 80000, 5, 'convA', 57));
+    var sub = ctx.wfState.lanes.find(function(l) { return l.key !== 'main' && l.turns.length; });
+    assert.ok(sub, 'a sub-lane must exist');
+    assert.equal(sub.turns.map(function(t) { return t.id; }).join(','), 'f1,f2');
+    assert.ok(!sub.turns[0]._wfSeqStitched, 'live: f1 overlap split, not seq-stitched');
+    assert.equal(sub.turns[1]._wfSeqStitched, true, 'live: f2 seq-stitched, matches batch');
+  });
+});

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -1953,7 +1953,7 @@ describe('#236 lane eligibility', () => {
 });
 
 describe('#238 mixed-model labels', () => {
-  it('mixed-model lane keeps dominant + minority model in lane.models, label shows both', () => {
+  it('mixed-model lane: label derived from lane.turns shows dominant + minority', () => {
     const ctx = loadWfModule();
     var entries = [
       mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
@@ -1965,8 +1965,7 @@ describe('#238 mixed-model labels', () => {
     var lanes = ctx.wfInferLanes(entries, []);
     assert.equal(lanes.length, 1, 'legal /model switches stay in one main lane');
     var lane = lanes[0];
-    assert.equal(lane.models.join(','), 'claude-opus-4-6,claude-fable-5', 'dominant-first, both present');
-    assert.equal(lane.model, 'claude-opus-4-6', 'majority-vote lane.model is unchanged');
+    assert.equal(lane.model, 'claude-opus-4-6', 'majority-vote lane.model is unchanged (3 opus vs 2 fable)');
     var lbl = ctx._wfLaneModelLabel(lane);
     assert.equal(lbl.text, 'opus-4-6 +fable-5');
     assert.ok(lbl.title.indexOf('opus-4-6') !== -1 && lbl.title.indexOf('fable-5') !== -1, 'title lists both models');
@@ -1979,7 +1978,6 @@ describe('#238 mixed-model labels', () => {
       mkEntry('t2', 's1', 'claude-opus-4-6', 6000, 3, {}),
     ];
     var lanes = ctx.wfInferLanes(entries, []);
-    assert.equal(lanes[0].models.join(','), 'claude-opus-4-6');
     var lbl = ctx._wfLaneModelLabel(lanes[0]);
     assert.equal(lbl.text, 'opus-4-6');
     assert.equal(lbl.title, 'opus-4-6');
@@ -1998,20 +1996,18 @@ describe('#238 mixed-model labels', () => {
     ];
     var lanes = ctx.wfInferLanes(entries, []);
     assert.equal(lanes.length, 1);
-    assert.equal(lanes[0].models.join(','), 'claude-opus-4-6,claude-fable-5,claude-sonnet-4-6');
     var lbl = ctx._wfLaneModelLabel(lanes[0]);
     assert.equal(lbl.text, 'opus-4-6 +2');
   });
 
-  it('live path lanes never throw the label helper, even without a recomputed .models', () => {
+  it('live path lanes never throw the label helper, even for a lane the batch tally never saw', () => {
     const ctx = loadWfModule();
     ctx.allEntries = [mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, {})];
     ctx.wfState = ctx.wfBuildState('s1');
     ctx.wfAddEntry(mkEntry('t2', 's1', 'claude-fable-5', 6000, 2, { isSubagent: true }));
-    // wfAddEntry keeps .models current via _wfLaneTrackModel (#238 P1), but a
-    // lane the live path mints without ever going through the batch tally
-    // (e.g. this fresh subagent lane) still relies on the helper's
-    // [lane.model] fallback until .models is populated — must still hold.
+    // No .models field exists anymore (derived from lane.turns at call time),
+    // so a fresh subagent lane the live path mints has no maintained state to
+    // fall behind — the helper must still resolve cleanly off lane.turns.
     for (var i = 0; i < ctx.wfState.lanes.length; i++) {
       var lbl = ctx._wfLaneModelLabel(ctx.wfState.lanes[i]);
       assert.equal(typeof lbl.text, 'string');
@@ -2061,21 +2057,63 @@ describe('#238 mixed-model labels', () => {
     assert.equal(sub.turns[1]._wfSeqStitched, true, 'live: f2 seq-stitched, matches batch');
   });
 
-  it('#238 P1: live-appended new model on main lane updates lane.models', () => {
+  it('#238 P1: live-appended new model on main lane updates the label with no rebuild', () => {
     const ctx = loadWfModule();
     ctx.allEntries = [mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' })];
     ctx.wfState = ctx.wfBuildState('s1');
     var lane = ctx.wfState.lanes[0];
     assert.equal(lane.key, 'main');
-    assert.equal(lane.models.join(','), 'claude-opus-4-6');
+    assert.equal(ctx._wfLaneModelLabel(lane).text, 'opus-4-6', 'starts single-model');
     var newEntry = mkEntry('t2', 's1', 'claude-fable-5', 6000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' });
     ctx.allEntries.push(newEntry);
     ctx.wfAddEntry(newEntry);
     assert.ok(ctx.wfState.lanes[0].turns.some(function(t) { return t.id === 't2'; }), 'new turn landed in main');
-    assert.equal(ctx.wfState.lanes[0].models.join(','), 'claude-opus-4-6,claude-fable-5',
-      'live append must update lane.models (fails on old code — stays single-model)');
+    // Derived straight from lane.turns — the live append is reflected without
+    // any separate "keep the derived field current" step (the P1 bug class).
     var lbl = ctx._wfLaneModelLabel(ctx.wfState.lanes[0]);
-    assert.equal(lbl.text, 'opus-4-6 +fable-5', 'label reflects the live model switch (fails on old code)');
+    assert.equal(lbl.text, 'opus-4-6 +fable-5', 'label reflects the live model switch');
+  });
+
+  it('#238 codex P2#1: dominance ordering agrees between batch and live (count-dominant, not first-seen)', () => {
+    const ctx = loadWfModule();
+    // Opus arrives first but Fable ends up with more turns — the label's
+    // head must be the count-dominant model (fable-5) in both paths, not
+    // whichever model happened to appear first (the P1 live-append bug
+    // used first-seen order instead of count).
+    var batchEntries = [
+      mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('t2', 's1', 'claude-fable-5', 5000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+      mkEntry('t3', 's1', 'claude-fable-5', 9000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+    ];
+    var batchLanes = ctx.wfInferLanes(batchEntries, []);
+    assert.equal(batchLanes.length, 1);
+    var batchLbl = ctx._wfLaneModelLabel(batchLanes[0]);
+
+    const ctx2 = loadWfModule();
+    ctx2.allEntries = [mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' })];
+    ctx2.wfState = ctx2.wfBuildState('s1');
+    [mkEntry('t2', 's1', 'claude-fable-5', 5000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' }),
+     mkEntry('t3', 's1', 'claude-fable-5', 9000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' })].forEach(function(e) {
+      ctx2.allEntries.push(e);
+      ctx2.wfAddEntry(e);
+    });
+    var liveLbl = ctx2._wfLaneModelLabel(ctx2.wfState.lanes[0]);
+
+    assert.equal(batchLbl.text, 'fable-5 +opus-4-6', 'batch: count-dominant (fable x2) leads');
+    assert.equal(liveLbl.text, batchLbl.text, 'live matches batch — same derivation, same result');
+  });
+
+  it('#238 codex P2#2: derive-from-turns invariant — label reflects exactly what is in lane.turns', () => {
+    const ctx = loadWfModule();
+    var lane = { turns: [mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 2, {})], model: 'claude-opus-4-6' };
+    assert.equal(ctx._wfLaneModelLabel(lane).text, 'opus-4-6', 'label matches the single turn present');
+    var foreign = mkEntry('t2', 's1', 'claude-fable-5', 2000, 2, {});
+    lane.turns.push(foreign);
+    assert.equal(ctx._wfLaneModelLabel(lane).text, 'opus-4-6 +fable-5', 'adding a turn of model X makes the label include X');
+    // Simulate _wfSeqRetroMove / an overlap split removing a turn from a lane
+    // (main.models used to keep the stale model after this — the P2 bug).
+    lane.turns = lane.turns.filter(function(t) { return t !== foreign; });
+    assert.equal(ctx._wfLaneModelLabel(lane).text, 'opus-4-6', 'removing the turn drops it from the label immediately');
   });
 
   it('#238 P2: stale _wfSeqStitched tag is cleared even for turns routed straight to an identity sublane', () => {

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -2008,9 +2008,10 @@ describe('#238 mixed-model labels', () => {
     ctx.allEntries = [mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, {})];
     ctx.wfState = ctx.wfBuildState('s1');
     ctx.wfAddEntry(mkEntry('t2', 's1', 'claude-fable-5', 6000, 2, { isSubagent: true }));
-    // wfAddEntry doesn't recompute .models per-lane (only the batch tally
-    // does) — the helper's [lane.model] fallback must still hold for every
-    // lane the live path can produce.
+    // wfAddEntry keeps .models current via _wfLaneTrackModel (#238 P1), but a
+    // lane the live path mints without ever going through the batch tally
+    // (e.g. this fresh subagent lane) still relies on the helper's
+    // [lane.model] fallback until .models is populated — must still hold.
     for (var i = 0; i < ctx.wfState.lanes.length; i++) {
       var lbl = ctx._wfLaneModelLabel(ctx.wfState.lanes[i]);
       assert.equal(typeof lbl.text, 'string');
@@ -2058,5 +2059,37 @@ describe('#238 mixed-model labels', () => {
     assert.equal(sub.turns.map(function(t) { return t.id; }).join(','), 'f1,f2');
     assert.ok(!sub.turns[0]._wfSeqStitched, 'live: f1 overlap split, not seq-stitched');
     assert.equal(sub.turns[1]._wfSeqStitched, true, 'live: f2 seq-stitched, matches batch');
+  });
+
+  it('#238 P1: live-appended new model on main lane updates lane.models', () => {
+    const ctx = loadWfModule();
+    ctx.allEntries = [mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' })];
+    ctx.wfState = ctx.wfBuildState('s1');
+    var lane = ctx.wfState.lanes[0];
+    assert.equal(lane.key, 'main');
+    assert.equal(lane.models.join(','), 'claude-opus-4-6');
+    var newEntry = mkEntry('t2', 's1', 'claude-fable-5', 6000, 2, { agentKey: 'orchestrator', agentLabel: 'Orchestrator' });
+    ctx.allEntries.push(newEntry);
+    ctx.wfAddEntry(newEntry);
+    assert.ok(ctx.wfState.lanes[0].turns.some(function(t) { return t.id === 't2'; }), 'new turn landed in main');
+    assert.equal(ctx.wfState.lanes[0].models.join(','), 'claude-opus-4-6,claude-fable-5',
+      'live append must update lane.models (fails on old code — stays single-model)');
+    var lbl = ctx._wfLaneModelLabel(ctx.wfState.lanes[0]);
+    assert.equal(lbl.text, 'opus-4-6 +fable-5', 'label reflects the live model switch (fails on old code)');
+  });
+
+  it('#238 P2: stale _wfSeqStitched tag is cleared even for turns routed straight to an identity sublane', () => {
+    const ctx = loadWfModule();
+    var m1 = mkEntry('m1', 's1', 'claude-opus-4-6', 1000, 5,
+      { agentKey: 'orchestrator', agentLabel: 'Orchestrator', coreHash: '85771', convId: 'ebffe2' });
+    var t1 = mkEntry('t1', 's1', 'claude-sonnet-5', 2000, 3,
+      { agentKey: 'orchestrator', agentLabel: 'Orchestrator', coreHash: 'e6aa4', convId: '56a5def0' });
+    t1._wfSeqStitched = true; // stale tag from a prior wfInferLanes build
+    var lanes = ctx.wfInferLanes([m1, t1], []);
+    var teamLane = lanes.find(function(l) { return l.key === 'agent-orchestrator:56a5def0'; });
+    assert.ok(teamLane, 'expected the teammate to land in its coreHash identity lane, not main');
+    assert.equal(teamLane.turns[0].id, 't1');
+    assert.equal(teamLane.turns[0]._wfSeqStitched, false,
+      't1 never enters mainLane.turns, so a mainLane-scoped reset would miss it (fails on old code)');
   });
 });


### PR DESCRIPTION
## 摘要

#230/#232 之後,main lane 可合法含多模型(如 session 4b15c248:main = opus-4-6 ×192 + fable-5 ×73,合法 /model 切換),但 lane label 與 agent card 只顯示多數決的 `opus-4-6`。本 PR(**display 層,不動分類**)讓 label 反映 lane 內容:多模型顯示 `opus-4-6 +fable-5`(3+ 顯示 `+N`),hover 展開全列;agent card 同步。另加 R2 seq-stitched turn 的 hover 標記。

Closes #238

## Changes（`public/workflow-timeline.js`,+38 −6）

- **`lane.models`**:在既有多數決 `lane.model`(不變)旁,存 dominant-first 完整 model 列表。
- **`_wfLaneModelLabel(lane)`**:單模型→`opus-4-6`(不變);2→`opus-4-6 +fable-5`;3+→`opus-4-6 +2`;`.title` 全列。
- 接入 lane-label `<tspan>` + agent-card `wf-ac-model` span(兩者 hover title 顯示全列)。`wfLaneColor` 仍 key on `lane.model`(不變)。
- **`_wfSeqStitched`**(Part 2):R2 dip-stitch turn 加標記(batch + live,**絕不**在 R1 bracket-close 或 ADR 0008 overlap split),fixpoint 前 reset 防 stale,僅 tooltip 讀 → hover 顯示 `· seq-stitched`。

## 驗證證據

### 真實 render pipeline（隔離實例 + 合成資料）
| 項目 | 值 |
|---|---|
| `lane.model`(dominant,不變) | `claude-opus-4-6` |
| `lane.models` | `[opus-4-6, fable-5]` |
| **渲染的 lane label tspan** | **`opus-4-6 +fable-5`** ✅ |
| **agent card model** | **`opus-4-6 +fable-5`**(title `opus-4-6, fable-5`)✅ |

![mixed-model lane label + agent card](https://raw.githubusercontent.com/lis186/ccxray/evidence/pr-238/mixed-model.png)

### 機器已驗（orchestrator 親跑 + 獨立驗證 subagent）
| 項目 | 結果 |
|---|---|
| helper 輸出(single/2/3+/fallback) | 全部精確 ✅ |
| workflow-timeline 套件 | 123/123 |
| diff-check(base origin/main) | exit 0(舊 117/123、新 123/123;6 新測試 fail-on-old) |
| boot-smoke | HTTP 200 |
| 孤兒參照 | 零刪除符號 |
| `_wfSeqStitched` 讀取點 | 僅 tooltip(551 reset / 580 batch / 937 live / 2157 read) |

### AC 對照
- **AC1**(mixed-model label + 單模型不變,fail-on-old)✅
- **AC2**(ADR 0002 dirty-check):`sigParts`(miller-columns.js)不引用任何 lane model 欄位 → 本改動不影響 `renderProjectsCol` re-render ✅
- **AC3**(截圖證據)✅

`pipeline:needs-visual-review`:label 為新顯示樣式,請 owner 確認 `opus-4-6 +fable-5` 呈現與 seq-stitched hover。
