### PR TITLE
feat(workflow): adaptive overview height — viewport-proportion cap replaces 48px (#268)

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -686,7 +686,7 @@
 #columns.wf-active #col-turns .turn-item { display: none !important; }
 #columns.wf-active #col-turns .col-sticky-header { display: none; }
 #wf-timeline { display: flex; flex-direction: column; flex: 1; min-height: 0; overflow: hidden; }
-#wf-overview { flex-shrink: 0; border-bottom: 1px solid var(--border); position: relative; display: flex; align-items: center; }
+#wf-overview { flex-shrink: 0; border-bottom: 1px solid var(--border); position: relative; display: flex; align-items: flex-start; }
 #wf-overview-label { width: 240px; flex-shrink: 0; padding: 4px 10px; font-size: 10px; color: var(--dim); text-transform: uppercase; letter-spacing: 0.5px; display: flex; flex-direction: column; gap: 3px; }
 #wf-overview-label .wf-ol-row { display: flex; align-items: center; gap: 4px; }
 /* Row 2 always renders (toggle button never disappears) so the label's

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -1788,10 +1788,10 @@ function wfDeferRender() {
 // readable slot. The uncapped formula gives wfOverviewBarGeom's slot =
 // (MH-4)/laneCount = 7 + 2/laneCount, always ≥7px. #268: the old 48px hard
 // cap made 10+ lane sessions smear into ~1px slivers; the cap now scales
-// with viewport height (35% of window.innerHeight) instead. Beyond that cap
+// with viewport height (20% of window.innerHeight) instead. Beyond that cap
 // bars still compress toward 1px — per-lane analysis is the swimlane's job.
 function wfOverviewHeight(laneCount) {
-  return Math.min(window.innerHeight * 0.35, Math.max(28, laneCount * 7 + 6));
+  return Math.min(window.innerHeight * 0.20, Math.max(28, laneCount * 7 + 6));
 }
 
 // slot = px per lane; when tight (<3px) the 1px gap compresses away so

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -1784,11 +1784,14 @@ function wfDeferRender() {
 }
 
 // ── Overview Bar (Canvas) ─────────────────────────────────────────────────
-// Multi-agent legibility: canvas grows with lane count so 4-6 lanes get
-// ~6px bars instead of 2-3px slivers. Capped at 48px (#114) — beyond ~10
-// lanes bars shrink toward 1px; per-lane analysis is the swimlane's job.
+// Multi-agent legibility: canvas grows with lane count so every lane keeps a
+// readable slot. The uncapped formula gives wfOverviewBarGeom's slot =
+// (MH-4)/laneCount = 7 + 2/laneCount, always ≥7px. #268: the old 48px hard
+// cap made 10+ lane sessions smear into ~1px slivers; the cap now scales
+// with viewport height (35% of window.innerHeight) instead. Beyond that cap
+// bars still compress toward 1px — per-lane analysis is the swimlane's job.
 function wfOverviewHeight(laneCount) {
-  return Math.min(48, Math.max(28, laneCount * 7 + 6));
+  return Math.min(window.innerHeight * 0.35, Math.max(28, laneCount * 7 + 6));
 }
 
 // slot = px per lane; when tight (<3px) the 1px gap compresses away so

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -276,25 +276,26 @@ describe('workflow-timeline data layer', () => {
     assert.equal(ctx.wfLaneCostMedian(lane), 0.09);
   });
 
-  it('wfOverviewHeight scales with lane count, floors at 28, caps at 35% viewport (#268)', () => {
+  it('wfOverviewHeight scales with lane count, floors at 28, caps at 20% viewport (#268)', () => {
     const ctx = loadWfModule();
-    ctx.window.innerHeight = 900; // cap = 315
+    ctx.window.innerHeight = 900; // cap = 180
     assert.equal(ctx.wfOverviewHeight(1), 28);   // floor: single lane
     assert.equal(ctx.wfOverviewHeight(3), 28);   // 3*7+6=27 → floor
     assert.equal(ctx.wfOverviewHeight(4), 34);
     assert.equal(ctx.wfOverviewHeight(6), 48);   // 6*7+6=48, well under cap
+    assert.equal(ctx.wfOverviewHeight(15), 111); // 15*7+6=111, still under cap
     assert.equal(ctx.wfOverviewHeight(18), 132); // 18*7+6=132, still under cap
-    assert.equal(ctx.wfOverviewHeight(60), 315); // 60*7+6=426 > cap → clamped to cap
+    assert.equal(ctx.wfOverviewHeight(60), 180); // 60*7+6=426 > cap → clamped to cap
   });
 
   it('#268 old-fail/new-pass: slot never shrinks below 6px until the viewport cap is hit', () => {
     // Old formula hard-capped at 48px regardless of viewport, so 10+ lane
     // sessions smeared into ~1-2px slivers. This sweep fails against the
     // old `Math.min(48, ...)` formula (e.g. laneCount=20 → height=48 →
-    // slot=2.2px, height=48 < cap=315) and passes against the new one.
+    // slot=2.2px, height=48 < cap=180) and passes against the new one.
     const ctx = loadWfModule();
     ctx.window.innerHeight = 900;
-    const cap = 0.35 * 900;
+    const cap = 0.20 * 900;
     for (let laneCount = 4; laneCount <= 40; laneCount++) {
       const h = ctx.wfOverviewHeight(laneCount);
       const slot = (h - 4) / laneCount;
@@ -312,12 +313,12 @@ describe('workflow-timeline data layer', () => {
     }
   });
 
-  it('#268 guard: height never exceeds 35% of viewport height', () => {
+  it('#268 guard: height never exceeds 20% of viewport height', () => {
     const ctx = loadWfModule();
     ctx.window.innerHeight = 900;
     for (let laneCount = 1; laneCount <= 60; laneCount++) {
       const h = ctx.wfOverviewHeight(laneCount);
-      assert.ok(h <= 0.35 * 900, `laneCount=${laneCount} height=${h} exceeds 35% viewport cap`);
+      assert.ok(h <= 0.20 * 900, `laneCount=${laneCount} height=${h} exceeds 20% viewport cap`);
     }
   });
 

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -276,13 +276,49 @@ describe('workflow-timeline data layer', () => {
     assert.equal(ctx.wfLaneCostMedian(lane), 0.09);
   });
 
-  it('wfOverviewHeight scales with lane count, clamped 28-48', () => {
+  it('wfOverviewHeight scales with lane count, floors at 28, caps at 35% viewport (#268)', () => {
     const ctx = loadWfModule();
+    ctx.window.innerHeight = 900; // cap = 315
     assert.equal(ctx.wfOverviewHeight(1), 28);   // floor: single lane
     assert.equal(ctx.wfOverviewHeight(3), 28);   // 3*7+6=27 → floor
     assert.equal(ctx.wfOverviewHeight(4), 34);
-    assert.equal(ctx.wfOverviewHeight(6), 48);   // 6*7+6=48 → exactly cap
-    assert.equal(ctx.wfOverviewHeight(18), 48);  // cap: many lanes
+    assert.equal(ctx.wfOverviewHeight(6), 48);   // 6*7+6=48, well under cap
+    assert.equal(ctx.wfOverviewHeight(18), 132); // 18*7+6=132, still under cap
+    assert.equal(ctx.wfOverviewHeight(60), 315); // 60*7+6=426 > cap → clamped to cap
+  });
+
+  it('#268 old-fail/new-pass: slot never shrinks below 6px until the viewport cap is hit', () => {
+    // Old formula hard-capped at 48px regardless of viewport, so 10+ lane
+    // sessions smeared into ~1-2px slivers. This sweep fails against the
+    // old `Math.min(48, ...)` formula (e.g. laneCount=20 → height=48 →
+    // slot=2.2px, height=48 < cap=315) and passes against the new one.
+    const ctx = loadWfModule();
+    ctx.window.innerHeight = 900;
+    const cap = 0.35 * 900;
+    for (let laneCount = 4; laneCount <= 40; laneCount++) {
+      const h = ctx.wfOverviewHeight(laneCount);
+      const slot = (h - 4) / laneCount;
+      assert.ok(slot >= 6 || h >= cap, `laneCount=${laneCount} slot=${slot} height=${h}`);
+    }
+  });
+
+  it('#268 low-lane regression: laneCount <= 4 stays within old value + 8px', () => {
+    const ctx = loadWfModule();
+    ctx.window.innerHeight = 900;
+    const oldValues = { 1: 28, 2: 28, 3: 28, 4: 34 }; // old Math.min(48, Math.max(28, n*7+6))
+    for (const [n, oldV] of Object.entries(oldValues)) {
+      const h = ctx.wfOverviewHeight(Number(n));
+      assert.ok(h <= oldV + 8, `laneCount=${n} height=${h} exceeds old=${oldV}+8`);
+    }
+  });
+
+  it('#268 guard: height never exceeds 35% of viewport height', () => {
+    const ctx = loadWfModule();
+    ctx.window.innerHeight = 900;
+    for (let laneCount = 1; laneCount <= 60; laneCount++) {
+      const h = ctx.wfOverviewHeight(laneCount);
+      assert.ok(h <= 0.35 * 900, `laneCount=${laneCount} height=${h} exceeds 35% viewport cap`);
+    }
   });
 
   it('wfOverviewBarGeom keeps every lane inside the canvas (no clipping)', () => {


### PR DESCRIPTION
## 摘要（繁中）

解除 overview 小地圖 48px 高度硬上限：`wfOverviewHeight` 的 cap 改為 **20% 視窗高度**（`window.innerHeight * 0.20`，round 2 依 owner 視覺驗收反饋自 35% 調降），線性成長項（每 lane 7px）不變。多 agent session 的 overview 從糊成一片變成每條 lane 有可讀 slot；低 lane 數（≤6）行為與現行完全相同。同輪反饋：overview 控制項改靠齊左上（`#wf-overview` `align-items: flex-start`），不再於變高的條帶中垂直置中。超過 cap 後維持既有壓縮退化（不引入捲動——#269 範圍）。

Closes #268

## Change

`public/workflow-timeline.js` (`wfOverviewHeight`) + one CSS property (`public/style.css`):

```js
- return Math.min(48, Math.max(28, laneCount * 7 + 6));
+ return Math.min(window.innerHeight * 0.20, Math.max(28, laneCount * 7 + 6));
```

```css
- #wf-overview { ... align-items: center; }
+ #wf-overview { ... align-items: flex-start; }
```

`wfOverviewBarGeom`, minimap brush/pan interaction, and the only call site are untouched (slot math already yields `7 + 2/n ≥ 7px` whenever uncapped). Commits: `400df43` (adaptive cap) + `904f6ba` (owner feedback round: 20% cap + top-left controls).

## Evidence

**diff-check (old-fail/new-pass)** — orchestrator re-run:

```
scripts/diff-check.sh origin/main test/workflow-timeline.test.js -- node --test test/workflow-timeline.test.js
→ exit 0 ✅ old FAIL / new PASS
```

**Unit tests** (3 new + 1 updated in `test/workflow-timeline.test.js`): old-fail/new-pass sweep (innerHeight=900, laneCount 4–40: slot ≥ 6px OR height at 20% cap = 180px); low-lane regression (laneCount 1–4 exactly equals old values 28/28/28/34; 15 lanes → 111px asserted); guard (laneCount 1–60: height ≤ 20% viewport; cap first binds at laneCount=25). File: 130/130 pass.

**Real-data browser measurement** (isolated CCXRAY_HOME, real multi-agent sessions, 1440×900, before=main / after=this branch, puppeteer guards exit 0, re-run after round 2):

| session | lanes | height before → after | slot before → after | lanesTop / stepsTop (after) |
|---|---|---|---|---|
| mid | 15 | 48px → 111px | 2.93px → **7.13px** | 190 / 603 (first screen ✓) |
| extreme | 75 | 48px → 180px (= 20% cap) | 0.59px → 2.35px (capped degradation) | 259 / 672 (first screen ✓) |

**Screenshots** (de-identified; red box = overview region):

15-lane before / after (the headline use case — slot crosses the ≥6px readability floor):

![15-lane before overview](https://raw.githubusercontent.com/lis186/ccxray/evidence/pr-268/268mid-before-overview.png)
![15-lane after overview](https://raw.githubusercontent.com/lis186/ccxray/evidence/pr-268/268bmid-after-overview.png)
![15-lane after full](https://raw.githubusercontent.com/lis186/ccxray/evidence/pr-268/268bmid-after-full.png)

75-lane cap case (before / after — note controls now top-left):

![75-lane before overview](https://raw.githubusercontent.com/lis186/ccxray/evidence/pr-268/268-before-overview.png)
![75-lane after overview](https://raw.githubusercontent.com/lis186/ccxray/evidence/pr-268/268b-after-overview.png)

## Gates

- Full suite: 1297/1299 pass locally (re-run after round 2); the 2 fails (`dashboard-codex-e2e`, `rebuild-index.e2e`) are a pre-existing local puppeteer Chrome-binary environment issue (identical on unmodified origin/main); CI is the authoritative green — round-1 CI passed test(20)/test(22), round 2 re-runs on push.
- Boot smoke (`scripts/boot-smoke.sh`, isolated home with real-data restore): `BOOT OK: dashboard HTTP 200` → exit 0.
- Orphan scan (`git diff origin/main`): 0 deleted/renamed symbols.
- Codex second review (round 1 diff): pass — "The adaptive height calculation preserves existing low-lane behavior, caps growth relative to the viewport, and is covered by focused regression tests. No actionable correctness issues were found." Round 2 delta (cap constant + one CSS property + test constants) re-reviewed after push.

## Verified / not verified

Verified: formula behavior (unit sweep + real-data measurement, both rounds), layout first-screen guard at 1440×900, boot with real-data restore, low-lane no-regression, controls top-left alignment (screenshot). Not verified: final perceptual sign-off — owner visual gate in progress (`pipeline:needs-visual-review`); round-1 feedback (cap 20%, top-left controls) applied in `904f6ba`; acceptance report at `.visual-review/268/index.html` (untracked, in the fix worktree). No video: no new interaction (brush/pan read `clientHeight` and were not modified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
