### PR TITLE
feat(workflow): birdseye overview mode — magnified minimap + wfRangeSummary (#269)

### DIFF
--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -1845,7 +1845,9 @@ function wfOverviewHeight(laneCount) {
 // every lane stays inside the canvas instead of clipping the last rows
 function wfOverviewBarGeom(MH, laneCount) {
   var slot = (MH - 4) / laneCount;
-  var barH = Math.max(1, Math.min(8, slot - 1));
+  // ponytail: birdseye needs fatter bars (≥10px slot); normal caps at 8px
+  var maxBarH = (wfState && wfState.birdsEyeMode) ? 20 : 8;
+  var barH = Math.max(1, Math.min(maxBarH, slot - 1));
   return { barH: barH, laneStep: Math.min(slot, barH + 1) };
 }
 

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -783,7 +783,32 @@ function wfBuildState(sessionId) {
     selectedSection: 'timeline',
     laneFocusMode: false,
     laneHeightManual: false,
+    birdsEyeMode: false,
   };
+}
+
+// Pure data summary for a time range — no UI. For #256 (brush-range detail
+// panel) to consume; not wired into any render path yet.
+function wfRangeSummary(t0, t1) {
+  if (!wfState) return null;
+  var turns = [], cost = 0, models = {}, tools = {}, lanes = {};
+  for (var li = 0; li < wfState.lanes.length; li++) {
+    var lane = wfState.lanes[li];
+    for (var ti = 0; ti < lane.turns.length; ti++) {
+      var turn = lane.turns[ti];
+      var ts = Number(turn.receivedAt) || 0;
+      if (ts >= t0 && ts <= t1) {
+        turns.push(turn);
+        cost += (turn.cost || 0);
+        models[turn.model] = (models[turn.model] || 0) + 1;
+        lanes[lane.key] = (lanes[lane.key] || 0) + 1;
+        if (turn.toolCalls) {
+          for (var tk in turn.toolCalls) tools[tk] = (tools[tk] || 0) + turn.toolCalls[tk];
+        }
+      }
+    }
+  }
+  return { turns: turns.length, cost: cost, models: models, tools: tools, lanes: lanes, duration: t1 - t0 };
 }
 
 // tail-follow slop, aligned with wfIsZoomed's 100ms so a following-but-unzoomed
@@ -1016,6 +1041,7 @@ function _wfSeqRebuild(oldTMax) {
   fresh.selectedSection = old.selectedSection;
   fresh.laneFocusMode = old.laneFocusMode;
   fresh.laneHeightManual = old.laneHeightManual;
+  fresh.birdsEyeMode = old.birdsEyeMode;
   if (old.selectedLane) {
     fresh.selectedLane = fresh.lanes.find(function(l) { return l.key === old.selectedLane.key; }) || fresh.lanes[0];
   }
@@ -1587,6 +1613,8 @@ function _wfOverviewLabelHtml() {
     '<button onclick="wfZoomBy(0.5)">+</button>' +
     '<button onclick="wfZoomBy(2)">−</button>' +
     '<button onclick="wfState.viewT0=wfState.tMin;wfState.viewT1=wfState.tMax;wfDeferRender()">⟲</button>' +
+    '<button onclick="wfToggleBirdsEye()" title="' + (wfState.birdsEyeMode ? 'Exit birdseye' : 'Birdseye') +
+      '" class="' + (wfState.birdsEyeMode ? 'active' : '') + '">' + (wfState.birdsEyeMode ? '⤡' : '⤢') + '</button>' +
     '</div>';
   var pagerHtml = wfState.laneFocusMode
     ? '<button onclick="wfCycleLane(-1)" title="Previous agent">▲</button>' +
@@ -1622,6 +1650,23 @@ function wfToggleLaneFocus() {
   if (!wfState) return;
   wfState.laneFocusMode = !wfState.laneFocusMode;
   _wfRefreshLaneFocusUI();
+}
+
+// ── Birdseye overview mode (#269) ──────────────────────────────────────────
+// In-place expands the overview minimap so each lane gets a readable ≥10px
+// slot (vs. the #268 compact 20%-viewport cap), capped at 80% viewport height.
+function wfToggleBirdsEye() {
+  if (!wfState) return;
+  wfState.birdsEyeMode = !wfState.birdsEyeMode;
+  _wfRefreshBirdsEye();
+}
+
+function _wfRefreshBirdsEye() {
+  var canvas = document.getElementById('wf-minimap-canvas');
+  if (canvas && wfState) canvas.style.height = wfOverviewHeight(wfState.lanes.length) + 'px';
+  var overviewLabel = document.getElementById('wf-overview-label');
+  if (overviewLabel) overviewLabel.innerHTML = _wfOverviewLabelHtml();
+  wfDeferRender();
 }
 
 // Shared by the ▲/▼ buttons and the Tab/Shift+Tab keyboard shortcut.
@@ -1791,7 +1836,9 @@ function wfDeferRender() {
 // with viewport height (20% of window.innerHeight) instead. Beyond that cap
 // bars still compress toward 1px — per-lane analysis is the swimlane's job.
 function wfOverviewHeight(laneCount) {
-  return Math.min(window.innerHeight * 0.20, Math.max(28, laneCount * 7 + 6));
+  var normal = Math.min(window.innerHeight * 0.20, Math.max(28, laneCount * 7 + 6));
+  if (!(wfState && wfState.birdsEyeMode)) return normal;
+  return Math.min(window.innerHeight * 0.80, Math.max(normal, laneCount * 10 + 6));
 }
 
 // slot = px per lane; when tight (<3px) the 1px gap compresses away so
@@ -2675,8 +2722,13 @@ function wfKeyHandler(key, e) {
     return true;
   }
 
-  // Esc: unlock turn, then zoom reset, then back to main lane
+  // Esc: exit birdseye, then unlock turn, then zoom reset, then back to main lane
   if (key === 'Escape') {
+    if (wfState.birdsEyeMode) {
+      wfState.birdsEyeMode = false;
+      _wfRefreshBirdsEye();
+      return true;
+    }
     if (wfState.selectedTurnId) {
       wfState.selectedTurnId = null;
       wfDeferRender();

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -322,6 +322,72 @@ describe('workflow-timeline data layer', () => {
     }
   });
 
+  it('wfOverviewHeight birdseye mode: ≥10px/lane slot, capped at 80% viewport (#269)', () => {
+    const ctx = loadWfModule();
+    ctx.window.innerHeight = 900; // 80% cap = 720
+    ctx.wfState = { birdsEyeMode: true };
+    assert.equal(ctx.wfOverviewHeight(20), 206); // 20*10+6=206, under cap
+    assert.equal(ctx.wfOverviewHeight(4), 46);   // normal(4)=34, floor to 46
+    assert.equal(ctx.wfOverviewHeight(80), 720); // 80*10+6=806 > cap → clamped to 720
+  });
+
+  it('birdseye mode: slot ≥ 10px for laneCount 4-40 (old-fail/new-pass)', () => {
+    const ctx = loadWfModule();
+    ctx.window.innerHeight = 900;
+    ctx.wfState = { birdsEyeMode: true };
+    for (let n = 4; n <= 40; n++) {
+      const h = ctx.wfOverviewHeight(n);
+      const slot = (h - 4) / n;
+      const atCap = h >= 900 * 0.80 - 1;
+      assert.ok(slot >= 10 || atCap, `laneCount=${n}: slot=${slot.toFixed(1)}, h=${h}, atCap=${atCap}`);
+    }
+  });
+
+  it('birdseye mode: low-lane count never shorter than normal height', () => {
+    const ctx = loadWfModule();
+    ctx.window.innerHeight = 900;
+    ctx.wfState = { birdsEyeMode: false };
+    for (let n = 1; n <= 4; n++) {
+      const normal = ctx.wfOverviewHeight(n);
+      ctx.wfState.birdsEyeMode = true;
+      const birdseye = ctx.wfOverviewHeight(n);
+      ctx.wfState.birdsEyeMode = false;
+      assert.ok(birdseye >= normal, `laneCount=${n}: birdseye=${birdseye} < normal=${normal}`);
+    }
+  });
+
+  it('birdseye mode guard: height never exceeds 80% of viewport height', () => {
+    const ctx = loadWfModule();
+    ctx.window.innerHeight = 900;
+    ctx.wfState = { birdsEyeMode: true };
+    for (let laneCount = 1; laneCount <= 100; laneCount++) {
+      const h = ctx.wfOverviewHeight(laneCount);
+      assert.ok(h <= 0.80 * 900, `laneCount=${laneCount} height=${h} exceeds 80% viewport cap`);
+    }
+  });
+
+  it('wfRangeSummary aggregates turns, cost, models, tools, lanes within a range', () => {
+    const ctx = loadWfModule();
+    const t1 = mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 10, { cost: 0.1, toolCalls: { Bash: 2 } });
+    const t2 = mkEntry('t2', 's1', 'claude-opus-4-6', 2000, 10, { cost: 0.2, toolCalls: { Read: 1 } });
+    const t3 = mkEntry('t3', 's1', 'claude-sonnet-5', 3000, 10, { cost: 0.3, toolCalls: { Bash: 1 } });
+    const t4 = mkEntry('t4', 's1', 'claude-sonnet-5', 9000, 10, { cost: 0.4, toolCalls: {} }); // outside range
+    ctx.wfState = {
+      lanes: [
+        { key: 'main', turns: [t1, t2] },
+        { key: 'agent-x:c1', turns: [t3, t4] },
+      ],
+    };
+    const summary = ctx.wfRangeSummary(500, 3500);
+    assert.equal(summary.turns, 3);
+    assert.ok(Math.abs(summary.cost - 0.6) < 1e-9);
+    // vm realm objects fail deepStrictEqual prototype check → compare via JSON
+    assert.equal(JSON.stringify(summary.models), JSON.stringify({ 'claude-opus-4-6': 2, 'claude-sonnet-5': 1 }));
+    assert.equal(JSON.stringify(summary.tools), JSON.stringify({ Bash: 3, Read: 1 }));
+    assert.equal(JSON.stringify(summary.lanes), JSON.stringify({ main: 2, 'agent-x:c1': 1 }));
+    assert.equal(summary.duration, 3000);
+  });
+
   it('wfOverviewBarGeom keeps every lane inside the canvas (no clipping)', () => {
     const ctx = loadWfModule();
     // codex R1: old formula (barH floor 2 + fixed 1px gap) clipped trailing

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -356,6 +356,18 @@ describe('workflow-timeline data layer', () => {
     }
   });
 
+  it('birdseye mode: rendered laneStep ≥ 10px (codex P2 — barH cap fix)', () => {
+    const ctx = loadWfModule();
+    ctx.window.innerHeight = 900;
+    ctx.wfState = { birdsEyeMode: true };
+    for (let n = 4; n <= 40; n++) {
+      const h = ctx.wfOverviewHeight(n);
+      const g = ctx.wfOverviewBarGeom(h, n);
+      const atCap = h >= 900 * 0.80 - 1;
+      assert.ok(g.laneStep >= 10 || atCap, `laneCount=${n}: laneStep=${g.laneStep.toFixed(1)}, h=${h}`);
+    }
+  });
+
   it('birdseye mode guard: height never exceeds 80% of viewport height', () => {
     const ctx = loadWfModule();
     ctx.window.innerHeight = 900;


### PR DESCRIPTION
## Summary

- overview 小地圖加 birdseye 放大模式（[⤢]/[⤡] toggle），in-place 撐高讓每條 lane 可讀（≥10px slot），80% viewport 上限
- Esc 優先退出 birdseye（在 unlock turn / zoom reset 之前）
- `wfRangeSummary(t0, t1)` pure function 為 #256 前置（不做 UI）
- codex review P2 修正：birdseye 下放寬 `wfOverviewBarGeom` 的 `barH` cap（8→20），確保 rendered laneStep 真正 ≥10px

## 驗證證據

- diff-check exit 0：old FAIL / new PASS 成立（4 個 birdseye 測試在舊碼 fail）
- test suite 136/136（workflow-timeline）；全套 1302/1304（2 fail 為 Puppeteer Chrome binary 既存環境問題，CI 為權威）
- boot smoke exit 0（隔離 CCXRAY_HOME + port 5619）
- 孤兒掃描 0 symbol 刪除
- codex review pass（P2 finding 已修正：barH cap 放寬）

## 未驗證（知覺殘量）

- 放大後全貌是否「看得清楚」、in-place 撐開手感——待 owner 視覺驗收
- 動 `public/` → `pipeline:needs-visual-review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)