### PR TITLE
feat(dashboard): hiddenProjects — settings.json 設定隱藏特定專案 (#275)

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1642,7 +1642,8 @@ function _renderProjectsColInner() {
 
 // Returns the first project in sorted order (starred → streaming → active → lastId)
 function getFirstProject() {
-  return [...projectsMap.values()].sort((a, b) => {
+  const hidden = new Set(window.ccxraySettings?.hiddenProjects || []);
+  return [...projectsMap.values()].filter(p => !hidden.has(p.name)).sort((a, b) => {
     const pa = isStarredOrDerived('project', a.name) ? 0 : 1;
     const pb = isStarredOrDerived('project', b.name) ? 0 : 1;
     if (pa !== pb) return pa - pb;
@@ -1933,6 +1934,8 @@ if (document.readyState === 'loading') {
   initScorecardHover();
   _applyStatsToggleUI();
 }
+
+document.addEventListener('ccxray:settings-loaded', () => { _lastProjectsSignature = ''; renderProjectsCol(); });
 
 function renderStackedAreaChart(el, turns) {
   const W = 400, H = 56, PAD = 4;

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1561,6 +1561,7 @@ function renderProjectsCol() {
     selectedProjectName || '',
     window._entriesLoading ? '1' : '0',
     window._entriesLoadingText || '',
+    (window.ccxraySettings?.hiddenProjects || []).join(','),
   ];
   for (const [name, proj] of projectsMap) {
     const statusClass = getProjectStatusClass(proj);
@@ -1602,8 +1603,10 @@ function _renderProjectsColInner() {
     if (sa !== sb) return sa - sb;
     return (b.lastId || '').localeCompare(a.lastId || '');
   });
+  const hiddenSet = new Set(window.ccxraySettings?.hiddenProjects || []);
   let visibleProjCount = 0;
   for (const proj of sorted) {
+    if (hiddenSet.has(proj.name)) continue;
     const isStarred = isStarredOrDerived('project', proj.name);
     const statusClass = getProjectStatusClass(proj);
     // Filter by activity (unless star-protected or selected)

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -62,7 +62,7 @@ function handleApiRoutes(clientReq, clientRes) {
   if (clientReq.method === 'GET' && pathname === '/_api/settings') {
     const s = readSettings();
     clientRes.writeHead(200, { 'Content-Type': 'application/json' });
-    clientRes.end(JSON.stringify({ ...computeSettings(), statusLine: s.statusLine }));
+    clientRes.end(JSON.stringify({ ...computeSettings(), statusLine: s.statusLine, hiddenProjects: s.hiddenProjects }));
     return true;
   }
 

--- a/server/settings.js
+++ b/server/settings.js
@@ -13,6 +13,7 @@ const DEFAULTS = {
   starredSessions: [],
   starredTurns: [],
   starredSteps: [],
+  hiddenProjects: [],
 };
 
 // Coerce a settings field to a string array, dropping non-strings. Returns a
@@ -34,6 +35,7 @@ function cloneSettings(s) {
     starredSessions: [...(s.starredSessions || [])],
     starredTurns: [...(s.starredTurns || [])],
     starredSteps: [...(s.starredSteps || [])],
+    hiddenProjects: [...(s.hiddenProjects || [])],
   };
 }
 
@@ -59,6 +61,7 @@ function readSettings() {
         starredSessions: coerceStringArray(parsed.starredSessions),
         starredTurns: coerceStringArray(parsed.starredTurns),
         starredSteps: coerceStringArray(parsed.starredSteps),
+        hiddenProjects: coerceStringArray(parsed.hiddenProjects),
       };
     } else {
       console.error(`[ccxray] settings.json at ${SETTINGS_PATH} did not parse to an object — using defaults.`);

--- a/test/settings-hidden.test.js
+++ b/test/settings-hidden.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+describe('hiddenProjects in settings', () => {
+  let tmpDir, prevHome;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-test-'));
+    prevHome = process.env.CCXRAY_HOME;
+    process.env.CCXRAY_HOME = tmpDir;
+    delete require.cache[require.resolve('../server/settings')];
+    delete require.cache[require.resolve('../server/paths')];
+  });
+
+  afterEach(() => {
+    if (prevHome != null) process.env.CCXRAY_HOME = prevHome;
+    else delete process.env.CCXRAY_HOME;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete require.cache[require.resolve('../server/settings')];
+    delete require.cache[require.resolve('../server/paths')];
+  });
+
+  it('defaults to empty array when no settings file', () => {
+    const { readSettings } = require('../server/settings');
+    const s = readSettings();
+    assert.deepStrictEqual(s.hiddenProjects, []);
+  });
+
+  it('reads hiddenProjects from settings.json', () => {
+    fs.writeFileSync(path.join(tmpDir, 'settings.json'), JSON.stringify({
+      hiddenProjects: ['secret-project', 'personal']
+    }));
+    const { readSettings } = require('../server/settings');
+    const s = readSettings();
+    assert.deepStrictEqual(s.hiddenProjects, ['secret-project', 'personal']);
+  });
+
+  it('coerces non-array hiddenProjects to empty array', () => {
+    fs.writeFileSync(path.join(tmpDir, 'settings.json'), JSON.stringify({
+      hiddenProjects: 'not-an-array'
+    }));
+    const { readSettings } = require('../server/settings');
+    const s = readSettings();
+    assert.deepStrictEqual(s.hiddenProjects, []);
+  });
+
+  it('filters non-string entries', () => {
+    fs.writeFileSync(path.join(tmpDir, 'settings.json'), JSON.stringify({
+      hiddenProjects: ['valid', 42, null, 'also-valid']
+    }));
+    const { readSettings } = require('../server/settings');
+    const s = readSettings();
+    assert.deepStrictEqual(s.hiddenProjects, ['valid', 'also-valid']);
+  });
+
+  it('clone does not share reference', () => {
+    fs.writeFileSync(path.join(tmpDir, 'settings.json'), JSON.stringify({
+      hiddenProjects: ['secret']
+    }));
+    const { readSettings } = require('../server/settings');
+    const a = readSettings();
+    const b = readSettings();
+    a.hiddenProjects.push('mutated');
+    assert.deepStrictEqual(b.hiddenProjects, ['secret']);
+  });
+});


### PR DESCRIPTION
## 摘要

- `settings.json` 新增 `hiddenProjects` 字串陣列，列入的專案名完全不出現在 dashboard project list
- 隱藏 = UI 層過濾，entry 資料仍在 store（deep link 仍可存取）
- 與 `starredProjects` 同格式、同層級

## 改動

| 檔案 | 變更 |
|------|------|
| `server/settings.js` | DEFAULTS + readSettings + cloneSettings 加 `hiddenProjects` |
| `server/routes/api.js` | GET `/_api/settings` 回傳 `hiddenProjects` |
| `public/miller-columns.js` | sigParts (ADR 0002)、`_renderProjectsColInner` 過濾、`getFirstProject` 排除、settings-loaded re-render |
| `test/settings-hidden.test.js` | 5 個 unit tests 覆蓋 default/read/coerce/filter/clone |

## 證據

### Unit tests (11/11 pass)
```
settings-hidden.test.js: 5/5 pass
settings-endpoint.test.js: 6/6 pass
```

### Smoke boot
```
boot: OK (pid=50878, HTTP=200)
hiddenProjects in settings: []
```

### Codex review
- P1 (getFirstProject 排除 hidden): 已修
- P2 (settings async load 後 re-render): 已修

### 未驗證
- 瀏覽器端實際隱藏效果（需 visual review — PR 動 `public/`，標 `pipeline:needs-visual-review`）

## Test plan

- [ ] 在 `~/.ccxray/settings.json` 加 `"hiddenProjects": ["<project-name>"]`，重新整理 dashboard 確認該專案消失
- [ ] 確認 `starredProjects` 中的專案若同時在 `hiddenProjects` 也會消失（hidden 優先）
- [ ] 確認移除 `hiddenProjects` 後專案恢復出現
- [ ] 確認空陣列或欄位不存在時行為不變

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>