### PR TITLE
fix(server): clamp SESSION_ENTRY_CAP to min 1

### DIFF
--- a/server/restore.js
+++ b/server/restore.js
@@ -159,7 +159,8 @@ async function restoreFromLogs() {
     retentionSets = computeRetentionSets(lightweight, stars);
   }
 
-  // Pre-count entries per session to identify oversized sessions
+  // Pre-count entries per session to identify oversized sessions.
+  // Separate loop because it needs retentionSets (built above) for the cutoff filter.
   const sessionTotals = new Map();
   for (const line of lines) {
     try {

--- a/server/store.js
+++ b/server/store.js
@@ -8,7 +8,7 @@ const NON_RESUMABLE_SESSIONS = new Set(['direct-api', 'codex-raw', 'unknown']);
 
 // ── In-memory store & SSE clients ───────────────────────────────────
 const MAX_ENTRIES = parseInt(process.env.CCXRAY_MAX_ENTRIES || '5000', 10);
-const SESSION_ENTRY_CAP = parseInt(process.env.CCXRAY_SESSION_ENTRY_CAP || '500', 10);
+const SESSION_ENTRY_CAP = Math.max(1, parseInt(process.env.CCXRAY_SESSION_ENTRY_CAP || '500', 10) || 1);
 const entries = [];
 // INVARIANT: entryIndex must mirror entries[] — see docs/decisions/0003-entry-index-map.md
 const entryIndex = new Map();


### PR DESCRIPTION
## 摘要

- `CCXRAY_SESSION_ENTRY_CAP=0` 或無法 parse 的值會讓 restore 把每個 session 都視為 oversized，只載 1 entry — 加 `Math.max(1, …)` + NaN guard
- pre-count loop 加註解說明為何不合併到 star pre-pass（retentionSets 依賴）

## Detail

Follow-up to PR #276 code review findings. Two changes:

**server/store.js**: `Math.max(1, parseInt(…) || 1)` — env=0 → 1, env=garbage → NaN → 1.

**server/restore.js**: Comment clarifying the pre-count loop is separate because it needs `retentionSets` (built by the star pre-pass above). Merging them would regress the common `cutoffStr + no stars` case from 2 to 3 full parses.

## Test plan

- [x] `CCXRAY_HOME=$(mktemp -d) node --test test/restore-session-cap.test.js` — 2/2 pass
- [x] `CCXRAY_HOME=$(mktemp -d) node --test test/*.test.js` — 1312/1313 pass (1 pre-existing flaky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)