### PR TITLE
fix: sidebar toggle 後 timeline 正確重繪 + session 切換預設 L1

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -845,7 +845,15 @@ function addEntry(e) {
       const wasOnLiveEdge = followLiveTurn && !isFocusedMode &&
         (selectedTurnIdx === -1 || selectedTurnIdx === prevMainIdx);
       if (wasOnLiveEdge) {
-        selectTurn(idx);
+        // In workflow L1 mode, use the suppressed-highlight path so all
+        // selectTurn side-effects fire (prefetch, breadcrumb, step clear)
+        // but wfHighlightTurn is suppressed — L1 is preserved.
+        if (typeof wfState !== 'undefined' && wfState && wfState.selectionLevel === 'L1') {
+          if (typeof _wfShowTurnDetail === 'function') _wfShowTurnDetail(allEntries[idx]);
+          if (typeof wfDeferRender === 'function') wfDeferRender();
+        } else {
+          selectTurn(idx);
+        }
         scrollTurnsToBottom();
         sess.subPillCount = 0;
         sess.subPillErrCount = 0;

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -285,7 +285,9 @@ function _decodeStepStarId(stepId) {
 }
 
 function targetFromCurrentSelection() {
-  if (selectedTurnIdx >= 0) {
+  // Workflow L1: no turn locked — serialize at session level
+  var wfL1 = typeof wfState !== 'undefined' && wfState && wfState.selectionLevel === 'L1';
+  if (selectedTurnIdx >= 0 && !wfL1) {
     const entry = allEntries[selectedTurnIdx];
     if (entry && entry.id) {
       if (selectedSection === 'timeline' && selectedMessageIdx >= 0) {
@@ -2062,9 +2064,16 @@ function selectSessionAndLatestTurn(sid) {
     if (wfState) { wfRenderTimeline(); columnsEl.classList.add('wf-active'); }
     else { columnsEl.classList.remove('wf-active'); }
   }
-  // Auto-select latest turn in this session
-  const visible = getVisibleTurnIndices();
-  if (visible.length) selectTurn(visible[visible.length - 1]);
+  // Auto-select latest turn — but in workflow mode the timeline already
+  // defaults to L1 (whole main lane), so skip the selectTurn that would
+  // override it to L2 on the last turn.
+  if (!(wfState && columnsEl.classList.contains('wf-active'))) {
+    const visible = getVisibleTurnIndices();
+    if (visible.length) selectTurn(visible[visible.length - 1]);
+  } else {
+    // Reset stale index so follow-live's edge check starts clean
+    selectedTurnIdx = -1;
+  }
   updateRetryEmptyState(sid);
   renderSessionToolBar(sid);
   renderSessionSparkline(sid);
@@ -2127,7 +2136,10 @@ function syncUrlFromState() {
   const projName = selectedProjectName || (selectedSessionId && sessionsMap.get(selectedSessionId) && getProjectName(sessionsMap.get(selectedSessionId).cwd));
   if (projName) params.set('p', projName);
   if (selectedSessionId) params.set('s', formatSessionUrlToken(selectedSessionId));
-  if (selectedTurnIdx >= 0) {
+  // In workflow L1 (lane overview), selectedTurnIdx is set internally for
+  // the agent card but no turn is visually locked — don't serialize it.
+  var wfL1 = typeof wfState !== 'undefined' && wfState && wfState.selectionLevel === 'L1';
+  if (selectedTurnIdx >= 0 && !wfL1) {
     const e = allEntries[selectedTurnIdx];
     const turnEl = e ? colTurns.querySelector('.turn-item[data-entry-idx="' + selectedTurnIdx + '"]') : null;
     const num = turnEl ? turnEl.dataset.sessNum : String(selectedTurnIdx + 1);
@@ -2191,9 +2203,12 @@ function selectSession(id) {
     columnsEl.classList.remove('wf-active');
   }
 
-  // Auto-select latest turn so agent card + steps panel populate
-  var visible = getVisibleTurnIndices();
-  if (visible.length) selectTurn(visible[visible.length - 1]);
+  // Auto-select latest turn so agent card + steps panel populate —
+  // but in workflow mode, timeline defaults to L1 (main lane overview).
+  if (!(wfState && columnsEl.classList.contains('wf-active'))) {
+    var visible = getVisibleTurnIndices();
+    if (visible.length) selectTurn(visible[visible.length - 1]);
+  }
 
   renderBreadcrumb();
 }

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -2966,11 +2966,22 @@ function wfKeyHandler(key, e) {
   return false;
 }
 
-// ── Window Resize ─────────────────────────────────────────────────────────
-var _wfResizeTimer = 0;
-window.addEventListener('resize', function() {
-  if (!wfState) return;
-  clearTimeout(_wfResizeTimer);
-  _wfCssCache = null;
-  _wfResizeTimer = setTimeout(wfDeferRender, 200);
-});
+// ── Container Resize (covers window resize + sidebar toggle transition) ───
+// ponytail: ResizeObserver fires continuously during CSS transitions so
+// sidebar collapse/expand animates smoothly. Falls back to debounced
+// window resize for test harnesses without ResizeObserver.
+if (typeof ResizeObserver !== 'undefined') {
+  new ResizeObserver(function() {
+    if (!wfState) return;
+    _wfCssCache = null;
+    wfDeferRender();
+  }).observe(document.getElementById('col-turns'));
+} else {
+  var _wfResizeTimer = 0;
+  window.addEventListener('resize', function() {
+    if (!wfState) return;
+    clearTimeout(_wfResizeTimer);
+    _wfCssCache = null;
+    _wfResizeTimer = setTimeout(wfDeferRender, 200);
+  });
+}


### PR DESCRIPTION
## Summary
- sidebar 收合/展開時 timeline overview 和 swimlane 跟著 CSS transition 平滑重繪（ResizeObserver）
- session 切換預設停在 L1（main lane 概覽），不再鎖最後一個 turn
- L1 live-follow 保留所有 selectTurn 副作用但不觸發 L2 lock
- L1 時 URL 不 serialize turn 參數，重新整理回到 lane 概覽

## Test plan
- [x] 150 existing tests pass
- [x] codex review 3 rounds (gpt-5.6-sol) + fable round — all findings addressed

## Review trail
- R1: ResizeObserver guard, follow-live L1 preservation, deep-link serialize
- R2: selectedTurnIdx advancement for follow-live continuity
- R3: full selectTurn side-effects via _wfShowTurnDetail suppressed path
- Fable: selectedTurnIdx reset on selectSessionAndLatestTurn L1 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)