### PR TITLE
feat(importer): Claude Code local transcript → dashboard entries

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -720,11 +720,13 @@ function addEntry(e) {
     e.sessionInferred ? 'Session inferred (no explicit session ID)' : null,
   ].filter(Boolean).join(' · ');
   const identityAttr = identityTooltip ? ' title="' + escapeHtml(identityTooltip) + '"' : '';
+  const importBadge = e.imported ? '<span class="turn-imported-badge" title="Imported from local transcript">⇐</span>' : '';
   const identityLine =
     '<div class="turn-identity"' + identityAttr + '>' +
       '<span class="' + dotClass + '" title="HTTP ' + e.status + '">●</span>' +
       '<span class="turn-num">' + prefix + '</span>' +
       modelHtml +
+      importBadge +
       waitMark +
       critMarkerHtml +
       starHtml +

--- a/public/messages.js
+++ b/public/messages.js
@@ -415,6 +415,11 @@ function getCachedSteps(messages, resEvents, provider) {
 
 function prepareTimelineSteps(messages, resEvents, provider) {
   if ((!messages || !messages.length) && (!resEvents || !resEvents.length)) {
+    const entry = typeof selectedTurnIdx !== 'undefined' && selectedTurnIdx >= 0 ? allEntries[selectedTurnIdx] : null;
+    if (entry && entry.imported) {
+      currentSteps = [{ type: 'assistant-text', text: 'Wire capture unavailable — imported from local transcript (' + (entry.importSource || 'unknown') + ').\nTurn list, cost, and context data are available. System Prompt, Request, TTFT, and streaming timeline are not recorded in local transcripts.' }];
+      return;
+    }
     currentSteps = [];
     return;
   }

--- a/public/style.css
+++ b/public/style.css
@@ -314,6 +314,7 @@
   .turn-item .status-dot-err { color: var(--red); }
   .turn-item .turn-wait { color: var(--dim); font-size: 11px; flex-shrink: 0; }
   .turn-item .turn-critical-marker { font-size: 10px; color: var(--red); font-weight: bold; flex-shrink: 0; }
+  .turn-item .turn-imported-badge { font-size: 10px; color: var(--cyan); margin-left: 4px; flex-shrink: 0; opacity: 0.7; }
   .turn-item .turn-star { margin-left: auto; flex-shrink: 0; cursor: pointer; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-size: 15px; line-height: 1; padding: 0 2px; user-select: none; opacity: 0.6; }
   .turn-item .turn-star:hover { opacity: 1; }
   .turn-item .turn-star.starred { color: var(--yellow); opacity: 1; }

--- a/server/importer.js
+++ b/server/importer.js
@@ -1,0 +1,209 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const os = require('os');
+const store = require('./store');
+const config = require('./config');
+const { broadcast } = require('./sse-broadcast');
+const { buildIndexLine } = require('./entry');
+
+const DEFAULT_CONTEXT_WINDOW = 200000;
+
+const RATES = {
+  'claude-sonnet-4-5': { input: 3e-6, output: 15e-6, cache_read: 0.3e-6, cache_create: 3.75e-6 },
+  'claude-opus-4': { input: 15e-6, output: 75e-6, cache_read: 1.5e-6, cache_create: 18.75e-6 },
+  'claude-haiku-3-5': { input: 0.8e-6, output: 4e-6, cache_read: 0.08e-6, cache_create: 1e-6 },
+  'claude-fable-5': { input: 5e-6, output: 25e-6, cache_read: 0.5e-6, cache_create: 6.25e-6 },
+};
+
+function calculateCostSimple(usage, model) {
+  let r = null;
+  for (const [k, v] of Object.entries(RATES)) {
+    if (model && model.startsWith(k)) { r = v; break; }
+  }
+  if (!r) r = RATES['claude-sonnet-4-5'];
+  return (usage.input_tokens || 0) * r.input
+    + (usage.output_tokens || 0) * r.output
+    + (usage.cache_read_input_tokens || 0) * r.cache_read
+    + (usage.cache_creation_input_tokens || 0) * r.cache_create;
+}
+
+function tsToId(timestamp) {
+  const d = new Date(timestamp);
+  if (isNaN(d.getTime())) return null;
+  return d.toISOString().replace(/[:.]/g, '-').slice(0, -2);
+}
+
+function slugToProject(slug) {
+  return slug.replace(/^-/, '/').replace(/-/g, '/').replace(/\/\//g, '/-');
+}
+
+function discoverHomes() {
+  if (process.env.CCXRAY_IMPORT_HOMES) {
+    return [{ dir: process.env.CCXRAY_IMPORT_HOMES }];
+  }
+  const home = os.homedir();
+  const results = [];
+  const inodes = new Set();
+  let items;
+  try { items = fs.readdirSync(home); } catch { return results; }
+  for (const d of items) {
+    if (!d.startsWith('.claude') || d.includes('.bak')) continue;
+    const isNamed = d.startsWith('.claude-');
+    if (d !== '.claude' && !isNamed) continue;
+    const subdir = path.join(home, d, 'projects');
+    try {
+      const ino = fs.statSync(subdir).ino;
+      if (inodes.has(ino)) continue;
+      inodes.add(ino);
+      results.push({ dir: subdir });
+    } catch {}
+  }
+  const xdg = path.join(home, '.config', 'claude', 'projects');
+  try {
+    const ino = fs.statSync(xdg).ino;
+    if (!inodes.has(ino)) results.push({ dir: xdg });
+  } catch {}
+  return results;
+}
+
+async function collectJsonlFiles(dir) {
+  const results = [];
+  let items;
+  try { items = await fs.promises.readdir(dir); } catch { return results; }
+  for (const item of items) {
+    if (!item.endsWith('.jsonl')) continue;
+    results.push(path.join(dir, item));
+  }
+  return results;
+}
+
+function buildTokens(usage) {
+  const input = usage.input_tokens || 0;
+  const output = usage.output_tokens || 0;
+  const cacheRead = usage.cache_read_input_tokens || 0;
+  const cacheCreate = usage.cache_creation_input_tokens || 0;
+  const total = input + output + cacheRead + cacheCreate;
+  const contextWindow = DEFAULT_CONTEXT_WINDOW;
+  const contextPct = contextWindow > 0 ? Math.round(((input + cacheRead + cacheCreate) / contextWindow) * 100) : 0;
+  return { input, output, cacheRead, cacheCreate, contextPct, contextWindow };
+}
+
+async function parseSessionFile(filePath, projectSlug) {
+  const entries = [];
+  const sessionId = path.basename(filePath, '.jsonl');
+  let lastUserText = null;
+  let cwd = null;
+
+  const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  for await (const line of rl) {
+    let obj;
+    try { obj = JSON.parse(line); } catch { continue; }
+
+    if (obj.cwd && !cwd) cwd = obj.cwd;
+
+    if (obj.type === 'user' && obj.message) {
+      const content = obj.message.content;
+      if (typeof content === 'string') {
+        lastUserText = content.slice(0, 120);
+      } else if (Array.isArray(content)) {
+        const textBlock = content.find(b => b.type === 'text');
+        if (textBlock) lastUserText = (textBlock.text || '').slice(0, 120);
+      }
+      continue;
+    }
+
+    if (obj.type !== 'assistant') continue;
+    const msg = obj.message;
+    if (!msg || !msg.usage) continue;
+    const usage = msg.usage;
+    const totalTokens = (usage.input_tokens || 0) + (usage.output_tokens || 0);
+    if (totalTokens === 0) continue;
+
+    const id = tsToId(obj.timestamp);
+    if (!id) continue;
+
+    const model = msg.model || 'unknown';
+    const cost = calculateCostSimple(usage, model);
+    const tokens = buildTokens(usage);
+    const receivedAt = new Date(obj.timestamp).getTime();
+
+    entries.push({
+      id,
+      ts: obj.timestamp,
+      method: 'POST',
+      url: '/v1/messages',
+      req: null,
+      res: null,
+      _loaded: false,
+      elapsed: null,
+      status: 200,
+      isSSE: false,
+      receivedAt,
+      tokens,
+      cost: { cost },
+      model,
+      sessionId,
+      title: lastUserText || '(imported)',
+      stopReason: msg.stop_reason || null,
+      imported: true,
+      importSource: 'claude-code',
+      provider: 'anthropic',
+      cwd: obj.cwd || cwd || slugToProject(projectSlug),
+      usage: {
+        input_tokens: usage.input_tokens || 0,
+        output_tokens: usage.output_tokens || 0,
+        cache_read_input_tokens: usage.cache_read_input_tokens || 0,
+        cache_creation_input_tokens: usage.cache_creation_input_tokens || 0,
+      },
+    });
+  }
+  return entries;
+}
+
+async function scanAndImport() {
+  if (process.env.CCXRAY_IMPORT_DISABLE === '1') return { imported: 0, skipped: 0 };
+
+  const homes = discoverHomes();
+  let imported = 0;
+  let skipped = 0;
+  const existingIds = new Set(store.entries.map(e => e.id));
+
+  for (const { dir } of homes) {
+    let projectDirs;
+    try { projectDirs = await fs.promises.readdir(dir); } catch { continue; }
+
+    for (const slug of projectDirs) {
+      const projectPath = path.join(dir, slug);
+      let stat;
+      try { stat = await fs.promises.stat(projectPath); } catch { continue; }
+      if (!stat.isDirectory()) continue;
+
+      const jsonlFiles = await collectJsonlFiles(projectPath);
+      for (const filePath of jsonlFiles) {
+        const entries = await parseSessionFile(filePath, slug);
+        for (const entry of entries) {
+          if (existingIds.has(entry.id)) { skipped++; continue; }
+          existingIds.add(entry.id);
+          // INVARIANT: push + entryIndex.set must pair — see docs/decisions/0003-entry-index-map.md
+          store.entries.push(entry);
+          store.entryIndex.set(entry.id, entry);
+          broadcast(entry);
+          imported++;
+        }
+      }
+    }
+  }
+
+  if (imported > 0) {
+    store.trimEntries();
+    console.log(`[importer] Imported ${imported} turns from local transcripts (${skipped} duplicates skipped)`);
+  }
+  return { imported, skipped };
+}
+
+module.exports = { scanAndImport, parseSessionFile, discoverHomes, slugToProject, tsToId };

--- a/server/index.js
+++ b/server/index.js
@@ -1006,6 +1006,12 @@ async function runPostListenStartupTasks() {
     await pruneLogs();
     warmUpCosts();
   }
+
+  // Import local Claude Code transcripts (non-blocking, after restore)
+  if (restoreOk && process.env.CCXRAY_IMPORT_DISABLE !== '1') {
+    const { scanAndImport } = require('./importer');
+    scanAndImport().catch(err => console.error('[importer] Scan failed:', err.message));
+  }
 }
 
 async function startServer() {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -285,6 +285,18 @@ function handleApiRoutes(clientReq, clientRes) {
     return true;
   }
 
+  if (clientReq.method === 'POST' && pathname === '/api/import/rescan') {
+    const { scanAndImport } = require('../importer');
+    scanAndImport().then(result => {
+      clientRes.writeHead(200, { 'Content-Type': 'application/json' });
+      clientRes.end(JSON.stringify(result));
+    }).catch(err => {
+      clientRes.writeHead(500, { 'Content-Type': 'application/json' });
+      clientRes.end(JSON.stringify({ error: err.message }));
+    });
+    return true;
+  }
+
   return false;
 }
 

--- a/test/importer.test.js
+++ b/test/importer.test.js
@@ -1,0 +1,187 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Set isolated CCXRAY_HOME before requiring store
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-import-test-'));
+process.env.CCXRAY_HOME = tmpHome;
+fs.mkdirSync(path.join(tmpHome, 'logs'), { recursive: true });
+fs.writeFileSync(path.join(tmpHome, 'logs', 'index.ndjson'), '');
+
+const store = require('../server/store');
+const { scanAndImport, parseSessionFile, slugToProject, tsToId } = require('../server/importer');
+
+function makeLine(type, extra = {}) {
+  const base = {
+    type,
+    uuid: `uuid-${Math.random().toString(36).slice(2)}`,
+    parentUuid: 'parent-1',
+    timestamp: '2026-07-15T10:30:00.000Z',
+    sessionId: 'test-session-1',
+    cwd: '/tmp/test-project',
+  };
+  return JSON.stringify({ ...base, ...extra });
+}
+
+function makeAssistant(opts = {}) {
+  return makeLine('assistant', {
+    timestamp: opts.timestamp || '2026-07-15T10:30:00.000Z',
+    message: {
+      model: opts.model || 'claude-sonnet-4-5-20250514',
+      role: 'assistant',
+      content: [{ type: 'text', text: opts.text || 'Hello' }],
+      stop_reason: opts.stop_reason || 'end_turn',
+      usage: {
+        input_tokens: opts.input ?? 5000,
+        output_tokens: opts.output ?? 500,
+        cache_read_input_tokens: opts.cacheRead ?? 1000,
+        cache_creation_input_tokens: opts.cacheCreate ?? 2000,
+        cache_creation: { ephemeral_1h_input_tokens: opts.cacheCreate ?? 2000, ephemeral_5m_input_tokens: 0 },
+      },
+    },
+    ...opts.extra,
+  });
+}
+
+function makeUser(text = 'Hello world') {
+  return makeLine('user', {
+    timestamp: '2026-07-15T10:29:50.000Z',
+    message: { role: 'user', content: [{ type: 'text', text }] },
+  });
+}
+
+describe('importer', () => {
+  let importDir;
+
+  beforeEach(() => {
+    store.entries.length = 0;
+    store.entryIndex.clear();
+    importDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-import-'));
+    process.env.CCXRAY_IMPORT_HOMES = importDir;
+  });
+
+  afterEach(() => {
+    delete process.env.CCXRAY_IMPORT_HOMES;
+    fs.rmSync(importDir, { recursive: true, force: true });
+  });
+
+  describe('tsToId', () => {
+    it('converts ISO timestamp to ID format', () => {
+      assert.strictEqual(tsToId('2026-07-15T10:30:00.123Z'), '2026-07-15T10-30-00-12');
+    });
+
+    it('returns null for invalid timestamps', () => {
+      assert.strictEqual(tsToId('invalid'), null);
+    });
+  });
+
+  describe('slugToProject', () => {
+    it('converts directory slug to cwd path', () => {
+      assert.strictEqual(slugToProject('-Users-justinlee-dev-ccxray'), '/Users/justinlee/dev/ccxray');
+    });
+  });
+
+  describe('parseSessionFile', () => {
+    it('extracts entries from JSONL with usage', async () => {
+      const sessionDir = path.join(importDir, 'test-project');
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const file = path.join(sessionDir, 'sess-1.jsonl');
+      const lines = [
+        makeUser('What is 2+2?'),
+        makeAssistant({ timestamp: '2026-07-15T10:30:05.000Z', input: 3000, output: 200 }),
+      ];
+      fs.writeFileSync(file, lines.join('\n'));
+
+      const entries = await parseSessionFile(file, 'test-project');
+      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries[0].imported, true);
+      assert.strictEqual(entries[0].importSource, 'claude-code');
+      assert.strictEqual(entries[0].title, 'What is 2+2?');
+      assert.strictEqual(entries[0].tokens.input, 3000);
+      assert.strictEqual(entries[0].tokens.output, 200);
+      assert.strictEqual(entries[0].model, 'claude-sonnet-4-5-20250514');
+      assert.strictEqual(entries[0].stopReason, 'end_turn');
+    });
+
+    it('skips entries with zero usage', async () => {
+      const sessionDir = path.join(importDir, 'test-project');
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const file = path.join(sessionDir, 'sess-2.jsonl');
+      const lines = [
+        makeAssistant({ input: 0, output: 0, cacheRead: 0, cacheCreate: 0 }),
+      ];
+      fs.writeFileSync(file, lines.join('\n'));
+
+      const entries = await parseSessionFile(file, 'test-project');
+      assert.strictEqual(entries.length, 0);
+    });
+
+    it('skips non-assistant lines', async () => {
+      const sessionDir = path.join(importDir, 'test-project');
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const file = path.join(sessionDir, 'sess-3.jsonl');
+      const lines = [
+        makeLine('mode', { mode: 'normal' }),
+        makeLine('system', { content: 'system msg' }),
+        makeUser('hi'),
+      ];
+      fs.writeFileSync(file, lines.join('\n'));
+
+      const entries = await parseSessionFile(file, 'test-project');
+      assert.strictEqual(entries.length, 0);
+    });
+  });
+
+  describe('scanAndImport', () => {
+    it('imports entries from project directories', async () => {
+      const projectDir = path.join(importDir, '-tmp-myproject');
+      fs.mkdirSync(projectDir, { recursive: true });
+      const file = path.join(projectDir, 'session-abc.jsonl');
+      fs.writeFileSync(file, [
+        makeUser('Test prompt'),
+        makeAssistant({ timestamp: '2026-07-15T10:31:00.000Z' }),
+      ].join('\n'));
+
+      const result = await scanAndImport();
+      assert.strictEqual(result.imported, 1);
+      assert.strictEqual(store.entries.length, 1);
+      assert.strictEqual(store.entryIndex.size, 1);
+      assert.strictEqual(store.entries[0].imported, true);
+      assert.strictEqual(store.entries[0].sessionId, 'session-abc');
+    });
+
+    it('deduplicates on second scan', async () => {
+      const projectDir = path.join(importDir, '-tmp-myproject');
+      fs.mkdirSync(projectDir, { recursive: true });
+      const file = path.join(projectDir, 'session-abc.jsonl');
+      fs.writeFileSync(file, [
+        makeUser('Test'),
+        makeAssistant({ timestamp: '2026-07-15T10:32:00.000Z' }),
+      ].join('\n'));
+
+      await scanAndImport();
+      assert.strictEqual(store.entries.length, 1);
+
+      const result2 = await scanAndImport();
+      assert.strictEqual(result2.imported, 0);
+      assert.strictEqual(result2.skipped, 1);
+      assert.strictEqual(store.entries.length, 1);
+    });
+
+    it('respects CCXRAY_IMPORT_DISABLE', async () => {
+      process.env.CCXRAY_IMPORT_DISABLE = '1';
+      const projectDir = path.join(importDir, '-tmp-myproject');
+      fs.mkdirSync(projectDir, { recursive: true });
+      fs.writeFileSync(path.join(projectDir, 'sess.jsonl'), makeAssistant());
+
+      const result = await scanAndImport();
+      assert.strictEqual(result.imported, 0);
+      assert.strictEqual(store.entries.length, 0);
+      delete process.env.CCXRAY_IMPORT_DISABLE;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- 從 `~/.claude/projects/<slug>/<session>.jsonl` 匯入 session 到 dashboard
- Entry 帶 `imported: true` + `importSource: "claude-code"`
- 啟動時自動掃描（restore 之後），`CCXRAY_IMPORT_DISABLE=1` 關閉
- `POST /api/import/rescan` 手動觸發重掃
- Turn list ⇐ badge 標記 imported turns
- Detail view 空的 imported entry 顯示降級提示

## Validation

- `CCXRAY_HOME=$(mktemp -d) node --test test/*.test.js` → 1327/1327 pass (含 9 個新 importer 測試)
- Boot smoke (port 5604) → HTTP 200, server 正常啟動

## Not implemented (per spec)

- System Prompt tab 仍只顯示文字提示（本機 transcript 未存 system prompt）
- TTFT / streaming timeline 無法重建（無 SSE 資料）
- 支援表詳見 `docs/import-provider-support.md`

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)