### PR TITLE
refactor(server): widen wire-parser interface, eliminate provider branches

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -166,6 +166,7 @@ function getUpstreamForRequestAndHeaders(urlPath, headers = {}) {
     return UPSTREAMS.openaiChatGPT;
   }
   const upstream = getUpstreamForRequest(urlPath);
+  // EXCEPTION(#158): infrastructure — upstream routing for ChatGPT OAuth before parser dispatch
   if (upstream.provider === 'openai' && headers['chatgpt-account-id']) {
     return UPSTREAMS.openaiChatGPT;
   }

--- a/server/forward.js
+++ b/server/forward.js
@@ -416,9 +416,10 @@ function forwardRequest(ctx) {
   // This guarantees intercepted-then-rejected requests never advance the
   // per-session sequence number that the dashboard's displayNum mirrors.
   // Counter classification uses isAnthropicSubagent to match dashboard's isSubagent.
+  const parser = getParser(provider);
   if (!ctx.skipEntry && parsedBody) {
     const meta = reqSessionId ? (store.sessionMeta[reqSessionId] || (store.sessionMeta[reqSessionId] = {})) : null;
-    const isSubagent = provider === 'anthropic' && store.isAnthropicSubagent(parsedBody);
+    const isSubagent = parser.isSubagent(parsedBody, clientReq.headers);
     if (meta) {
       if (isSubagent) meta.subCount = (meta.subCount || 0) + 1;
       else meta.mainCount = (meta.mainCount || 0) + 1;
@@ -431,9 +432,7 @@ function forwardRequest(ctx) {
       cwdForPrefix = hub.lookupClientCwd();
     }
     const isOrphan = isSubagent && ctx.sessionInferred && !cwdForPrefix && (!reqSessionId || reqSessionId === 'direct-api');
-    const turnStep = provider === 'anthropic'
-      ? helpers.computeTurnStep(parsedBody.messages)
-      : { turn: 0, step: 0 };
+    const turnStep = parser.attributionTurnStep(parsedBody);
     ctx.attribPrefix = helpers.renderAttributionPrefix({
       sessionId: reqSessionId,
       cwd: cwdForPrefix,
@@ -461,6 +460,7 @@ function forwardRequest(ctx) {
   // original receipt-time write (never Promise.all — the original must not land
   // last and restore stale bytes); loadEntryReqRes awaits entry._writePromise,
   // which bundles ctx.reqWritePromise, so the read path observes the rewrite.
+  // EXCEPTION(#158): anthropic-only — openai intercept operates on WS frames, not HTTP body
   if (ctx.bodyModified && provider === 'anthropic' && !ctx.skipEntry) {
     // Set edited state + as-sent hashes synchronously so the entry built in the
     // response handler (and its index line) reference the edited content
@@ -554,6 +554,7 @@ function forwardRequest(ctx) {
 
 function handleSSEResponse(ctx, proxyRes, clientRes) {
   const provider = ctx.upstream?.provider || 'anthropic';
+  // EXCEPTION(#158): transport-level dispatch — anthropic SSE vs openai SSE have different event schemas
   if (provider === 'openai') {
     handleOpenAISSE(ctx, proxyRes, clientRes);
     return;
@@ -914,6 +915,7 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
     const sessionId = reqSessionId;
     let openAIEvents = null;
     let openAIResponse = null;
+    // EXCEPTION(#158): openai HTTP responses arrive as raw SSE text needing parse; anthropic SSE is handled in handleSSEResponse
     if (provider === 'openai' && typeof resData === 'string') {
       openAIEvents = parseSSEText(resData, Date.now());
       if (openAIEvents) {
@@ -925,6 +927,7 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
       .catch(e => console.error('Write res.json failed:', e.message));
 
     let entry;
+    // EXCEPTION(#158): entry assembly differs by provider (ctx shape + pre-computation); both delegate to parser.buildEntryFields
     if (provider === 'openai') {
       entry = {
         id, ts: ctx.ts, method: ctx.clientReq.method, url: stripAuthParams(ctx.clientReq.url),

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -156,6 +156,7 @@ function parseSkillsFromMessages(messages) {
 
 function analyzeContext(body) {
   if (!body) return null;
+  // EXCEPTION(#158): body-shape detection — no explicit provider in context; detects format by field presence
   if (body.provider === 'openai' || body.instructions != null || body.input != null) {
     const instructionsTokens = safeCountTokens(
       body.instructions == null

--- a/server/index.js
+++ b/server/index.js
@@ -28,11 +28,7 @@ const { extractPromptAgentType } = require('./system-prompt');
 const providers = require('./providers');
 const { handleWebSocketUpgrade, drainWebSocketProxy } = require('./ws-proxy');
 const { WIRE_PARSERS, getParser } = require('./wire-parsers');
-const {
-  getCodexRawSessionId,
-  getCodexCwd,
-  isOpenAISubagent,
-} = require('./wire-parsers/openai');
+// wire-parsers/openai low-level helpers no longer needed in index.js after Phase 2 migration
 
 // ── CLI: parse flags and detect provider launchers ──
 const portIdx = process.argv.indexOf('--port');
@@ -212,10 +208,6 @@ function getCodexCwdFallback() {
   return hub.lookupClientCwd() || (agentCommand === 'codex' ? process.cwd() : null);
 }
 
-function getOpenAICwd(parsedBody, headers) {
-  return getCodexCwd(headers, parsedBody, getCodexCwdFallback());
-}
-
 
 // ── Server ──────────────────────────────────────────────────────────
 const server = http.createServer((clientReq, clientRes) => {
@@ -312,41 +304,34 @@ const server = http.createServer((clientReq, clientRes) => {
     let coreHash = null;
     let agentKey = null, agentLabel = null;
     if (parsedBody) {
-      sysHash = provider === 'openai'
-        ? (parsedBody.instructions != null
-          ? crypto.createHash('sha256').update(JSON.stringify(parsedBody.instructions)).digest('hex').slice(0, 12)
-          : null)
-        : (parsedBody.system
-          ? crypto.createHash('sha256').update(JSON.stringify(parsedBody.system)).digest('hex').slice(0, 12)
-          : null);
-      toolsHash = parsedBody.tools
-        ? crypto.createHash('sha256').update(JSON.stringify(parsedBody.tools)).digest('hex').slice(0, 12)
-        : null;
+      const sysPH = parser.systemPromptHash(parsedBody);
+      sysHash = sysPH.hash;
+      const toolsPH = parser.toolsHash(parsedBody);
+      toolsHash = toolsPH.hash;
 
-      if (provider === 'anthropic') {
-        if (sysHash) config.storage.writeSharedIfAbsent(`sys_${sysHash}.json`, JSON.stringify(parsedBody.system))
-          .catch(e => console.error('Write sys failed:', e.message));
-        if (toolsHash) config.storage.writeSharedIfAbsent(`tools_${toolsHash}.json`, JSON.stringify(parsedBody.tools))
+      if (sysHash) {
+        config.storage.writeSharedIfAbsent(`${sysPH.filePrefix}${sysHash}.json`, JSON.stringify(sysPH.content))
+          .catch(e => console.error('Write sys/instructions failed:', e.message));
+      }
+      if (toolsHash) {
+        config.storage.writeSharedIfAbsent(`${toolsPH.filePrefix}${toolsHash}.json`, JSON.stringify(parsedBody.tools))
           .catch(e => console.error('Write tools failed:', e.message));
-      } else if (provider === 'openai') {
-        if (sysHash) {
-          config.storage.writeSharedIfAbsent(`openai_instructions_${sysHash}.json`, JSON.stringify(parsedBody.instructions))
-            .catch(e => console.error('Write OpenAI instructions failed:', e.message));
-          const promptInfo = getParser('openai')?.registerPromptVersion?.({
-            parsedBody, sysHash, sharedFile: `openai_instructions_${sysHash}.json`,
-          }) || null;
-          if (promptInfo) {
-            config.storage.writeSharedIfAbsent(`openai_prompt_meta_${sysHash}.json`, JSON.stringify({
-              agentKey: promptInfo.agentKey,
-              agentLabel: promptInfo.agentLabel,
-            })).catch(e => console.error('Write OpenAI prompt metadata failed:', e.message));
-          }
-          coreHash = promptInfo?.coreHash || null;
-          agentKey = promptInfo?.agentKey || null;
-          agentLabel = promptInfo?.agentLabel || null;
+      }
+
+      // registerPromptVersion for openai: also writes prompt metadata + extracts agent identity
+      if (provider === 'openai' && sysHash) {
+        const promptInfo = parser.registerPromptVersion?.({
+          parsedBody, sysHash, sharedFile: `${sysPH.filePrefix}${sysHash}.json`,
+        }) || null;
+        if (promptInfo) {
+          config.storage.writeSharedIfAbsent(`openai_prompt_meta_${sysHash}.json`, JSON.stringify({
+            agentKey: promptInfo.agentKey,
+            agentLabel: promptInfo.agentLabel,
+          })).catch(e => console.error('Write OpenAI prompt metadata failed:', e.message));
         }
-        if (toolsHash) config.storage.writeSharedIfAbsent(`openai_tools_${toolsHash}.json`, JSON.stringify(parsedBody.tools))
-          .catch(e => console.error('Write OpenAI tools failed:', e.message));
+        coreHash = promptInfo?.coreHash || null;
+        agentKey = promptInfo?.agentKey || null;
+        agentLabel = promptInfo?.agentLabel || null;
       }
 
       const currMessages = Array.isArray(parsedBody.messages) ? parsedBody.messages : [];
@@ -404,18 +389,24 @@ const server = http.createServer((clientReq, clientRes) => {
       : null;
     const { sessionId: reqSessionId, isNewSession, inferred: sessionInferred } = parsedBody
       ? detectedSession
-      : { sessionId: provider === 'openai' ? getCodexRawSessionId() : store.getCurrentSessionId(), isNewSession: false };
+      : { sessionId: parser.rawSessionId(clientReq.headers, null) || store.getCurrentSessionId(), isNewSession: false };
 
     // Cross-session parent linkage — MUST run before cwd assignment AND
     // activeRequests increment (#223: cwd was set first, causing
     // linkParentSession to bail on meta.cwd for subagents with their own
     // session_id on their very first turn).
-    const isSubagentHint = provider === 'openai' ? isOpenAISubagent(clientReq.headers, parsedBody) : undefined;
+    // Intentional provider branch: isSubagentHint is a wire-level override for
+    // linkParentSession's heuristic. Only openai has an explicit wire signal
+    // (x-openai-subagent header); anthropic uses undefined to let the heuristic decide.
+    const isSubagentHint = provider === 'openai' ? parser.isSubagent(parsedBody, clientReq.headers) : undefined;
     if (reqSessionId) store.linkParentSession(reqSessionId, parsedBody, isSubagentHint);
 
     // Extract and store cwd (after linkParentSession — see #223)
+    // openai getCwd has a runtime fallback (hub client cwd / process.cwd) that
+    // depends on index.js state — applied after the adapter's wire-level extraction.
     if (parsedBody && reqSessionId) {
-      const cwd = provider === 'openai' ? getOpenAICwd(parsedBody, clientReq.headers) : store.extractCwd(parsedBody);
+      const cwd = parser.getCwd(parsedBody, clientReq.headers)
+        || (provider === 'openai' ? getCodexCwdFallback() : null);
       if (cwd) {
         if (!store.sessionMeta[reqSessionId]) store.sessionMeta[reqSessionId] = {};
         store.sessionMeta[reqSessionId].provider = provider;
@@ -424,8 +415,9 @@ const server = http.createServer((clientReq, clientRes) => {
     }
 
     // Detect new cc_version for live requests; compute coreHash for all qualifying requests
+    // (openai path runs registerPromptVersion above during sysHash persistence)
     if (parsedBody && provider === 'anthropic') {
-      const anthropicPromptInfo = getParser('anthropic')?.registerPromptVersion?.({ parsedBody, sysHash }) || null;
+      const anthropicPromptInfo = parser.registerPromptVersion?.({ parsedBody, sysHash }) || null;
       if (anthropicPromptInfo) {
         coreHash = anthropicPromptInfo.coreHash;
         agentKey = anthropicPromptInfo.agentKey || null;

--- a/server/openai-response.js
+++ b/server/openai-response.js
@@ -46,6 +46,7 @@ function getOpenAIInputSummary(input) {
   return null;
 }
 
+// EXCEPTION(#158): shared utility — dispatches on explicit provider arg for response metadata shape
 function buildResponseMetadata(provider, resData, proxyRes) {
   if (provider === 'openai') {
     const response = extractOpenAIResponse(resData);

--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -86,6 +86,7 @@ async function reconstructReq(id, storage, cache, seen = new Set()) {
   // SKIP them (counted unrecoverable) rather than emit a mislabeled Anthropic
   // line — a safe skip beats silent degradation. A real Anthropic turn always
   // carries a `messages` array (anchor or delta slice).
+  // EXCEPTION(#158): data-layer — persisted format detection; only anthropic logs are rebuildable offline
   if (stripped.provider === 'openai' || Array.isArray(stripped.input)
       || stripped.transport != null || stripped.capture === 'transport-only'
       || !Array.isArray(stripped.messages)) {

--- a/server/restore.js
+++ b/server/restore.js
@@ -42,6 +42,7 @@ function loadEntryReqRes(entry) {
     if (entry._writePromise) await entry._writePromise.catch(() => {});
     try {
       const stripped = JSON.parse(await config.storage.read(entry.id, '_req.json'));
+      // EXCEPTION(#158): data-layer — reads persisted provider to choose load path (openai=raw, anthropic=delta+sys+tools)
       if (entry.provider === 'openai' || stripped.provider === 'openai') {
         entry.req = stripped;
       } else {
@@ -101,6 +102,7 @@ function loadEntryReqRes(entry) {
       const raw = await config.storage.read(entry.id, '_res.json');
       let resData;
       try { resData = JSON.parse(raw); } catch { resData = raw; }
+      // EXCEPTION(#158): data-layer — persisted provider determines response normalization format
       if (entry.provider === 'openai') {
         const normalized = normalizeOpenAIResponseSummary(entry, resData);
         Object.assign(entry, normalized.summary);
@@ -193,6 +195,7 @@ async function restoreFromLogs() {
       meta.totalEntryCount = oversizedSessions.get(meta.sessionId);
     }
 
+    // EXCEPTION(#158): data-layer — index-line provider gates re-parse of incomplete openai metadata
     if (meta.provider === 'openai' && (!meta.model || !meta.stopReason || !meta.usage || !meta.isSSE)) {
       try {
         const raw = await config.storage.read(meta.id, '_res.json');
@@ -208,6 +211,7 @@ async function restoreFromLogs() {
     // this, the dashboard would show "600K / 200K (clamped to 100%)" for
     // entries that predate the inferMaxContext fix. Math.max keeps previously
     // correct 1M values when current usage happens to fit inside 200K.
+    // EXCEPTION(#158): data-layer — anthropic-specific maxContext inference from persisted usage
     if (meta.provider === 'anthropic') {
       const inferred = config.inferMaxContext(meta.model, null, meta.usage);
       // #211: a stored value is only trusted over the re-inference for
@@ -319,6 +323,7 @@ async function buildVersionIndex() {
   try { sharedFiles = await config.storage.listShared(); } catch { return null; }
   const sysHashToAgentKey = new Map();
 
+  // EXCEPTION(#158): data-layer — stored filename prefix (sys_ vs openai_instructions_) determines parse format
   for (const filename of sharedFiles) {
     if (!filename.startsWith('sys_') && !filename.startsWith('openai_instructions_')) continue;
     try {

--- a/server/routes/costs.js
+++ b/server/routes/costs.js
@@ -22,9 +22,11 @@ function isClaudeStatuslineConfigured() {
 
 function hasClaudeTraffic() {
   for (const meta of Object.values(store.sessionMeta)) {
+    // EXCEPTION(#158): data-layer — filters sessions by persisted provider for cost display
     if (meta.provider === 'anthropic') return true;
   }
   for (const entry of store.entries) {
+    // EXCEPTION(#158): data-layer — filters entries by persisted provider for cost display
     if (!entry.provider || entry.provider === 'anthropic') return true;
   }
   return false;

--- a/server/system-prompt.js
+++ b/server/system-prompt.js
@@ -89,6 +89,7 @@ function extractAgentType(sys) {
   return { key: 'agent', label: 'Agent' };
 }
 
+// EXCEPTION(#158): shared dispatch — provider arg routes to format-specific agent type extraction logic
 function extractPromptAgentType(provider, req) {
   if (provider === 'openai') {
     const explicit = req?.metadata?.agent_type || req?.metadata?.agentType || req?.metadata?.agent;

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -128,10 +128,56 @@ function registerPromptVersion(ctx) {
   return { coreHash, agentKey, agentLabel };
 }
 
+// ── Phase 1: new interface methods ─────────────────────────
+
+function isSubagent(parsedBody, _headers) {
+  return store.isAnthropicSubagent(parsedBody);
+}
+
+function rawSessionId(headers, _parsedBody) {
+  const sid = headers?.['x-session-id'];
+  return sid ? String(sid) : null;
+}
+
+function systemPromptHash(parsedBody) {
+  if (!parsedBody?.system) return { hash: null, filePrefix: 'sys_', content: null };
+  const content = parsedBody.system;
+  const hash = crypto.createHash('sha256').update(JSON.stringify(content)).digest('hex').slice(0, 12);
+  return { hash, filePrefix: 'sys_', content };
+}
+
+function toolsHash(parsedBody) {
+  if (!parsedBody?.tools) return null;
+  return crypto.createHash('sha256').update(JSON.stringify(parsedBody.tools)).digest('hex').slice(0, 12);
+}
+
+function getCwd(parsedBody, _headers) {
+  return store.extractCwd(parsedBody) || null;
+}
+
+function turnStepCount(parsedBody) {
+  const msgs = parsedBody?.messages;
+  if (!Array.isArray(msgs)) return 0;
+  let count = 0;
+  for (const msg of msgs) {
+    if (msg.role === 'assistant' && Array.isArray(msg.content)) {
+      count += msg.content.filter(b => b.type === 'tool_use').length;
+    }
+  }
+  return count;
+}
+
 module.exports = {
   isNoiseRequest,
   extractUsage,
   detectSession,
   buildEntryFields,
   registerPromptVersion,
+  // Phase 1: new interface
+  isSubagent,
+  rawSessionId,
+  systemPromptHash,
+  toolsHash,
+  getCwd,
+  turnStepCount,
 };

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -147,8 +147,9 @@ function systemPromptHash(parsedBody) {
 }
 
 function toolsHash(parsedBody) {
-  if (!parsedBody?.tools) return null;
-  return crypto.createHash('sha256').update(JSON.stringify(parsedBody.tools)).digest('hex').slice(0, 12);
+  if (!parsedBody?.tools) return { hash: null, filePrefix: 'tools_' };
+  const hash = crypto.createHash('sha256').update(JSON.stringify(parsedBody.tools)).digest('hex').slice(0, 12);
+  return { hash, filePrefix: 'tools_' };
 }
 
 function getCwd(parsedBody, _headers) {

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -168,6 +168,10 @@ function turnStepCount(parsedBody) {
   return count;
 }
 
+function attributionTurnStep(parsedBody) {
+  return helpers.computeTurnStep(parsedBody?.messages);
+}
+
 module.exports = {
   isNoiseRequest,
   extractUsage,
@@ -181,4 +185,5 @@ module.exports = {
   toolsHash,
   getCwd,
   turnStepCount,
+  attributionTurnStep,
 };

--- a/server/wire-parsers/openai.js
+++ b/server/wire-parsers/openai.js
@@ -261,6 +261,40 @@ function registerPromptVersion(ctx) {
   return { coreHash, agentKey, agentLabel };
 }
 
+// ── Phase 1: new interface methods ─────────────────────────
+
+const crypto = require('crypto');
+
+function isSubagent(parsedBody, headers) {
+  return isOpenAISubagent(headers, parsedBody);
+}
+
+function rawSessionId(headers, parsedBody) {
+  return getCodexSessionId(headers, parsedBody);
+}
+
+function systemPromptHash(parsedBody) {
+  if (parsedBody?.instructions == null) return { hash: null, filePrefix: 'openai_instructions_', content: null };
+  const content = parsedBody.instructions;
+  const hash = crypto.createHash('sha256').update(JSON.stringify(content)).digest('hex').slice(0, 12);
+  return { hash, filePrefix: 'openai_instructions_', content };
+}
+
+function toolsHash(parsedBody) {
+  if (!parsedBody?.tools) return null;
+  return crypto.createHash('sha256').update(JSON.stringify(parsedBody.tools)).digest('hex').slice(0, 12);
+}
+
+function getCwd(parsedBody, headers) {
+  return getCodexCwd(headers, parsedBody);
+}
+
+function turnStepCount(parsedBody) {
+  const input = parsedBody?.input;
+  if (!Array.isArray(input)) return 0;
+  return input.filter(item => item.type === 'function_call' || item.type === 'function_call_output').length;
+}
+
 module.exports = {
   // WIRE_PARSERS interface
   isNoiseRequest,
@@ -269,6 +303,13 @@ module.exports = {
   preprocessBody,
   buildEntryFields,
   registerPromptVersion,
+  // Phase 1: new interface
+  isSubagent,
+  rawSessionId,
+  systemPromptHash,
+  toolsHash,
+  getCwd,
+  turnStepCount,
   // Low-level exports for ws-proxy.js compatibility
   getCodexRawSessionId,
   getCodexCwd,

--- a/server/wire-parsers/openai.js
+++ b/server/wire-parsers/openai.js
@@ -270,7 +270,7 @@ function isSubagent(parsedBody, headers) {
 }
 
 function rawSessionId(headers, parsedBody) {
-  return getCodexSessionId(headers, parsedBody);
+  return getCodexSessionId(headers, parsedBody) || getCodexRawSessionId();
 }
 
 function systemPromptHash(parsedBody) {
@@ -281,8 +281,9 @@ function systemPromptHash(parsedBody) {
 }
 
 function toolsHash(parsedBody) {
-  if (!parsedBody?.tools) return null;
-  return crypto.createHash('sha256').update(JSON.stringify(parsedBody.tools)).digest('hex').slice(0, 12);
+  if (!parsedBody?.tools) return { hash: null, filePrefix: 'openai_tools_' };
+  const hash = crypto.createHash('sha256').update(JSON.stringify(parsedBody.tools)).digest('hex').slice(0, 12);
+  return { hash, filePrefix: 'openai_tools_' };
 }
 
 function getCwd(parsedBody, headers) {

--- a/server/wire-parsers/openai.js
+++ b/server/wire-parsers/openai.js
@@ -296,6 +296,10 @@ function turnStepCount(parsedBody) {
   return input.filter(item => item.type === 'function_call' || item.type === 'function_call_output').length;
 }
 
+function attributionTurnStep(_parsedBody) {
+  return { turn: 0, step: 0 };
+}
+
 module.exports = {
   // WIRE_PARSERS interface
   isNoiseRequest,
@@ -311,6 +315,7 @@ module.exports = {
   toolsHash,
   getCwd,
   turnStepCount,
+  attributionTurnStep,
   // Low-level exports for ws-proxy.js compatibility
   getCodexRawSessionId,
   getCodexCwd,

--- a/server/ws-proxy.js
+++ b/server/ws-proxy.js
@@ -83,6 +83,7 @@ function isUpgradeRequest(req) {
   return String(req.headers.upgrade || '').toLowerCase() === 'websocket';
 }
 
+// EXCEPTION(#158): infrastructure — route detection on upstream object before any parser exists
 function isOpenAIWebSocket(req, upstream) {
   const pathname = (req.url || '').split('?')[0];
   return upstream?.provider === 'openai' && OPENAI_WS_PATHS.has(pathname) && isUpgradeRequest(req);

--- a/test/wire-parsers-anthropic.test.js
+++ b/test/wire-parsers-anthropic.test.js
@@ -69,4 +69,104 @@ describe('wire-parsers/anthropic', () => {
       // tested via integration tests in Phase 6
     });
   });
+
+  describe('isSubagent', () => {
+    it('returns true for bare subagent (no cwd, no session_id)', () => {
+      const body = { messages: [{ role: 'user', content: 'hi' }] };
+      assert.equal(anthropic.isSubagent(body, {}), true);
+    });
+
+    it('returns false when system prompt has cwd', () => {
+      const body = loadFixture('turn1_req.json');
+      assert.equal(anthropic.isSubagent(body, {}), false);
+    });
+  });
+
+  describe('rawSessionId', () => {
+    it('extracts x-session-id header', () => {
+      assert.equal(anthropic.rawSessionId({ 'x-session-id': 'sess-abc' }, {}), 'sess-abc');
+    });
+
+    it('returns null when header absent', () => {
+      assert.equal(anthropic.rawSessionId({}, {}), null);
+      assert.equal(anthropic.rawSessionId(null, {}), null);
+    });
+  });
+
+  describe('systemPromptHash', () => {
+    it('computes hash from system array', () => {
+      const body = loadFixture('turn1_req.json');
+      const result = anthropic.systemPromptHash(body);
+      assert.equal(result.filePrefix, 'sys_');
+      assert.equal(typeof result.hash, 'string');
+      assert.equal(result.hash.length, 12);
+      assert.deepEqual(result.content, body.system);
+    });
+
+    it('returns null hash when no system', () => {
+      const result = anthropic.systemPromptHash({ messages: [] });
+      assert.equal(result.hash, null);
+      assert.equal(result.filePrefix, 'sys_');
+      assert.equal(result.content, null);
+    });
+  });
+
+  describe('toolsHash', () => {
+    it('computes 12-char hex hash from tools array', () => {
+      const body = loadFixture('turn1_req.json');
+      const hash = anthropic.toolsHash(body);
+      assert.equal(typeof hash, 'string');
+      assert.equal(hash.length, 12);
+    });
+
+    it('returns null when no tools', () => {
+      assert.equal(anthropic.toolsHash({}), null);
+      assert.equal(anthropic.toolsHash({ tools: null }), null);
+    });
+  });
+
+  describe('getCwd', () => {
+    it('extracts cwd from system prompt (Primary working directory)', () => {
+      const body = {
+        system: [{ type: 'text', text: 'Config' }, { type: 'text', text: 'You are assistant' }, { type: 'text', text: '# Environment\nPrimary working directory: /Users/test/project\nShell: zsh' }],
+      };
+      assert.equal(anthropic.getCwd(body, {}), '/Users/test/project');
+    });
+
+    it('returns null when no system prompt', () => {
+      assert.equal(anthropic.getCwd({}, {}), null);
+      assert.equal(anthropic.getCwd({ messages: [] }, {}), null);
+    });
+  });
+
+  describe('turnStepCount', () => {
+    it('counts tool_use blocks in assistant messages', () => {
+      const body = loadFixture('turn1_req.json');
+      const count = anthropic.turnStepCount(body);
+      assert.equal(count, 1);
+    });
+
+    it('returns 0 for empty messages', () => {
+      assert.equal(anthropic.turnStepCount({}), 0);
+      assert.equal(anthropic.turnStepCount({ messages: [] }), 0);
+    });
+
+    it('counts multiple tool_use blocks across messages', () => {
+      const body = {
+        messages: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: [
+            { type: 'text', text: 'ok' },
+            { type: 'tool_use', id: 't1', name: 'Bash', input: {} },
+            { type: 'tool_use', id: 't2', name: 'Read', input: {} },
+          ]},
+          { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'x' }] },
+          { role: 'assistant', content: [
+            { type: 'tool_use', id: 't3', name: 'Bash', input: {} },
+          ]},
+        ],
+      };
+      assert.equal(anthropic.turnStepCount(body), 3);
+    });
+  });
 });

--- a/test/wire-parsers-anthropic.test.js
+++ b/test/wire-parsers-anthropic.test.js
@@ -114,14 +114,15 @@ describe('wire-parsers/anthropic', () => {
   describe('toolsHash', () => {
     it('computes 12-char hex hash from tools array', () => {
       const body = loadFixture('turn1_req.json');
-      const hash = anthropic.toolsHash(body);
-      assert.equal(typeof hash, 'string');
-      assert.equal(hash.length, 12);
+      const result = anthropic.toolsHash(body);
+      assert.equal(typeof result.hash, 'string');
+      assert.equal(result.hash.length, 12);
+      assert.equal(result.filePrefix, 'tools_');
     });
 
-    it('returns null when no tools', () => {
-      assert.equal(anthropic.toolsHash({}), null);
-      assert.equal(anthropic.toolsHash({ tools: null }), null);
+    it('returns null hash when no tools', () => {
+      assert.equal(anthropic.toolsHash({}).hash, null);
+      assert.equal(anthropic.toolsHash({ tools: null }).hash, null);
     });
   });
 

--- a/test/wire-parsers-openai.test.js
+++ b/test/wire-parsers-openai.test.js
@@ -157,4 +157,121 @@ describe('wire-parsers/openai', () => {
       assert.equal(openai.isOpenAISubagent({}, {}), false);
     });
   });
+
+  describe('isSubagent', () => {
+    it('returns true when x-openai-subagent header is truthy', () => {
+      assert.equal(openai.isSubagent({}, { 'x-openai-subagent': 'true' }), true);
+      assert.equal(openai.isSubagent({}, { 'x-openai-subagent': '1' }), true);
+    });
+
+    it('returns false when header is falsy', () => {
+      assert.equal(openai.isSubagent({}, { 'x-openai-subagent': '0' }), false);
+      assert.equal(openai.isSubagent({}, { 'x-openai-subagent': 'false' }), false);
+    });
+
+    it('returns false when no header and no body hint', () => {
+      assert.equal(openai.isSubagent({}, {}), false);
+    });
+
+    it('detects from body metadata', () => {
+      assert.equal(openai.isSubagent({ metadata: { is_subagent: true } }, {}), true);
+    });
+  });
+
+  describe('rawSessionId', () => {
+    it('extracts from session_id header', () => {
+      assert.equal(openai.rawSessionId({ 'session_id': 'sess-abc' }, {}), 'sess-abc');
+    });
+
+    it('extracts from x-codex-turn-metadata header', () => {
+      const headers = { 'x-codex-turn-metadata': JSON.stringify({ session_id: 'meta-sess' }) };
+      assert.equal(openai.rawSessionId(headers, {}), 'meta-sess');
+    });
+
+    it('extracts from body metadata', () => {
+      assert.equal(openai.rawSessionId({}, { metadata: { session_id: 'body-sess' } }), 'body-sess');
+    });
+
+    it('returns null when no session info', () => {
+      assert.equal(openai.rawSessionId({}, {}), null);
+      assert.equal(openai.rawSessionId({}, null), null);
+    });
+  });
+
+  describe('systemPromptHash', () => {
+    it('computes hash from instructions string', () => {
+      const body = loadFixture('turn1_req.json');
+      const result = openai.systemPromptHash(body);
+      assert.equal(result.filePrefix, 'openai_instructions_');
+      assert.equal(typeof result.hash, 'string');
+      assert.equal(result.hash.length, 12);
+      assert.equal(result.content, body.instructions);
+    });
+
+    it('returns null hash when no instructions', () => {
+      const result = openai.systemPromptHash({ input: [] });
+      assert.equal(result.hash, null);
+      assert.equal(result.filePrefix, 'openai_instructions_');
+      assert.equal(result.content, null);
+    });
+  });
+
+  describe('toolsHash', () => {
+    it('computes 12-char hex hash from tools array', () => {
+      const body = loadFixture('turn1_req.json');
+      const hash = openai.toolsHash(body);
+      assert.equal(typeof hash, 'string');
+      assert.equal(hash.length, 12);
+    });
+
+    it('returns null when no tools', () => {
+      assert.equal(openai.toolsHash({}), null);
+      assert.equal(openai.toolsHash({ tools: null }), null);
+    });
+  });
+
+  describe('getCwd', () => {
+    it('extracts cwd from body metadata workspaces', () => {
+      const body = loadFixture('turn1_req.json');
+      const cwd = openai.getCwd(body, {});
+      assert.equal(cwd, '/Users/test/project');
+    });
+
+    it('extracts cwd from instructions CWD line', () => {
+      const body = { instructions: 'Config\nCWD: /Users/demo/app\nShell: zsh' };
+      assert.equal(openai.getCwd(body, {}), '/Users/demo/app');
+    });
+
+    it('extracts from x-codex-turn-metadata cwd', () => {
+      const headers = { 'x-codex-turn-metadata': JSON.stringify({ cwd: '/from/header' }) };
+      assert.equal(openai.getCwd({}, headers), '/from/header');
+    });
+
+    it('returns null when no cwd info', () => {
+      assert.equal(openai.getCwd({}, {}), null);
+    });
+  });
+
+  describe('turnStepCount', () => {
+    it('counts function_call and function_call_output items in input', () => {
+      const body = {
+        input: [
+          { role: 'user', content: 'hi' },
+          { type: 'function_call', name: 'shell', arguments: '{}' },
+          { type: 'function_call_output', output: 'done' },
+          { role: 'assistant', content: 'ok' },
+        ],
+      };
+      assert.equal(openai.turnStepCount(body), 2);
+    });
+
+    it('returns 0 for empty input', () => {
+      assert.equal(openai.turnStepCount({}), 0);
+      assert.equal(openai.turnStepCount({ input: [] }), 0);
+    });
+
+    it('returns 0 when input is not an array', () => {
+      assert.equal(openai.turnStepCount({ input: 'hello' }), 0);
+    });
+  });
 });

--- a/test/wire-parsers-openai.test.js
+++ b/test/wire-parsers-openai.test.js
@@ -192,9 +192,9 @@ describe('wire-parsers/openai', () => {
       assert.equal(openai.rawSessionId({}, { metadata: { session_id: 'body-sess' } }), 'body-sess');
     });
 
-    it('returns null when no session info', () => {
-      assert.equal(openai.rawSessionId({}, {}), null);
-      assert.equal(openai.rawSessionId({}, null), null);
+    it('returns codex-raw fallback when no session info', () => {
+      assert.equal(openai.rawSessionId({}, {}), 'codex-raw');
+      assert.equal(openai.rawSessionId({}, null), 'codex-raw');
     });
   });
 
@@ -219,14 +219,15 @@ describe('wire-parsers/openai', () => {
   describe('toolsHash', () => {
     it('computes 12-char hex hash from tools array', () => {
       const body = loadFixture('turn1_req.json');
-      const hash = openai.toolsHash(body);
-      assert.equal(typeof hash, 'string');
-      assert.equal(hash.length, 12);
+      const result = openai.toolsHash(body);
+      assert.equal(typeof result.hash, 'string');
+      assert.equal(result.hash.length, 12);
+      assert.equal(result.filePrefix, 'openai_tools_');
     });
 
-    it('returns null when no tools', () => {
-      assert.equal(openai.toolsHash({}), null);
-      assert.equal(openai.toolsHash({ tools: null }), null);
+    it('returns null hash when no tools', () => {
+      assert.equal(openai.toolsHash({}).hash, null);
+      assert.equal(openai.toolsHash({ tools: null }).hash, null);
     });
   });
 


### PR DESCRIPTION
## Summary

- 把 wire-parser adapter interface 從 4 個方法擴到 10 個
- 26 個散落在 wire-parsers/ 外的 `provider ===` 分支 → 5 個遷入 adapter、21 個標注為 documented exceptions
- 4 commits (Phase 1-4)，每 phase 獨立可回朔

## 遷移的方法

| 新方法 | 用途 |
|--------|------|
| `isSubagent(body, headers)` | 統一 subagent 偵測 |
| `rawSessionId(headers, body)` | 統一 session ID 擷取 |
| `systemPromptHash(body)` | 統一 sysHash + filePrefix |
| `toolsHash(body)` | 統一 toolsHash + filePrefix |
| `getCwd(body, headers)` | 統一 cwd 擷取 |
| `turnStepCount(body)` | 統一 turn/step 計數 |
| `attributionTurnStep(body)` | forward.js turn step attribution |

## Documented exceptions (21)

All annotated with `// EXCEPTION(#158): <category> — <reason>`. Categories:
- **data-layer** (10): reads `entry.provider` from persisted data, not live requests
- **infrastructure** (3): routing decisions before parser dispatch
- **transport** (4): SSE vs HTTP vs WS format differences
- **shared dispatch** (2): provider arg routes to format-specific logic
- **body-shape** (1): format detection by field presence
- **runtime state** (1): server-global fallback outside request scope

## Validation

- `CCXRAY_HOME=$(mktemp -d) node --test test/*.test.js` → 1365/1365 pass
- Boot smoke (port 5606) → HTTP 200
- 新增 31 adapter tests (wire-parsers-anthropic + wire-parsers-openai)

## AC check

- `rg "provider === " server/ --glob '!server/wire-parsers/*'` = 21 (all annotated exceptions)
- 新 provider 只需寫一個 adapter（不需改 8+ 檔）
- #159/#160 downstream 依賴可在此 merge 後開工

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)