### PR TITLE
feat(importer): Codex local transcript → dashboard entries (degraded)

### DIFF
--- a/server/entry.js
+++ b/server/entry.js
@@ -6,6 +6,7 @@ const INDEX_FIELDS = [
   'stopReason','title','thinkingDuration','toolFail','elapsed','status','receivedAt',
   'sysHash','toolsHash','coreHash','agentKey','agentLabel','convId','thinkingStripped','hasCredential','toolSources',
   'edited','editSummary',
+  'imported','importSource',
 ];
 
 function buildIndexLine(entry) {

--- a/server/importer.js
+++ b/server/importer.js
@@ -10,12 +10,20 @@ const { broadcast } = require('./sse-broadcast');
 const { buildIndexLine } = require('./entry');
 
 const DEFAULT_CONTEXT_WINDOW = 200000;
+const CODEX_CONTEXT_WINDOW = 400000;
 
 const RATES = {
   'claude-sonnet-4-5': { input: 3e-6, output: 15e-6, cache_read: 0.3e-6, cache_create: 3.75e-6 },
   'claude-opus-4': { input: 15e-6, output: 75e-6, cache_read: 1.5e-6, cache_create: 18.75e-6 },
   'claude-haiku-3-5': { input: 0.8e-6, output: 4e-6, cache_read: 0.08e-6, cache_create: 1e-6 },
   'claude-fable-5': { input: 5e-6, output: 25e-6, cache_read: 0.5e-6, cache_create: 6.25e-6 },
+  // gpt-5.5 must precede gpt-5 — "gpt-5.5-..." startsWith("gpt-5") would
+  // otherwise match the less specific key first (same ordering as cost-worker.js).
+  'gpt-5.5': { input: 2e-6, output: 10e-6, cache_read: 1e-6, cache_create: 0 },
+  'gpt-5': { input: 2e-6, output: 10e-6, cache_read: 1e-6, cache_create: 0 },
+  'gpt-4o': { input: 2.5e-6, output: 10e-6, cache_read: 1.25e-6, cache_create: 0 },
+  'o3': { input: 2e-6, output: 8e-6, cache_read: 0.5e-6, cache_create: 0 },
+  'o4-mini': { input: 1.1e-6, output: 4.4e-6, cache_read: 0.55e-6, cache_create: 0 },
 };
 
 function calculateCostSimple(usage, model) {
@@ -69,6 +77,30 @@ function discoverHomes() {
   return results;
 }
 
+function discoverCodexHomes() {
+  if (process.env.CCXRAY_IMPORT_CODEX_HOMES) {
+    return [{ dir: process.env.CCXRAY_IMPORT_CODEX_HOMES }];
+  }
+  const home = os.homedir();
+  const results = [];
+  const inodes = new Set();
+  let items;
+  try { items = fs.readdirSync(home); } catch { return results; }
+  for (const d of items) {
+    if (!d.startsWith('.codex') || d.includes('.bak')) continue;
+    const isNamed = d.startsWith('.codex-');
+    if (d !== '.codex' && !isNamed) continue;
+    const subdir = path.join(home, d, 'sessions');
+    try {
+      const ino = fs.statSync(subdir).ino;
+      if (inodes.has(ino)) continue;
+      inodes.add(ino);
+      results.push({ dir: subdir });
+    } catch {}
+  }
+  return results;
+}
+
 async function collectJsonlFiles(dir) {
   const results = [];
   let items;
@@ -80,13 +112,27 @@ async function collectJsonlFiles(dir) {
   return results;
 }
 
-function buildTokens(usage) {
+// Codex sessions live nested under sessions/YYYY/MM/DD/*.jsonl, unlike
+// Claude's flat projects/<slug>/*.jsonl — needs a recursive walk.
+async function collectJsonlFilesRecursive(dir, results = []) {
+  let items;
+  try { items = await fs.promises.readdir(dir); } catch { return results; }
+  for (const item of items) {
+    const fullPath = path.join(dir, item);
+    let stat;
+    try { stat = await fs.promises.stat(fullPath); } catch { continue; }
+    if (stat.isDirectory()) await collectJsonlFilesRecursive(fullPath, results);
+    else if (item.endsWith('.jsonl')) results.push(fullPath);
+  }
+  return results;
+}
+
+function buildTokens(usage, contextWindow = DEFAULT_CONTEXT_WINDOW) {
   const input = usage.input_tokens || 0;
   const output = usage.output_tokens || 0;
   const cacheRead = usage.cache_read_input_tokens || 0;
   const cacheCreate = usage.cache_creation_input_tokens || 0;
   const total = input + output + cacheRead + cacheCreate;
-  const contextWindow = DEFAULT_CONTEXT_WINDOW;
   const contextPct = contextWindow > 0 ? Math.round(((input + cacheRead + cacheCreate) / contextWindow) * 100) : 0;
   return { input, output, cacheRead, cacheCreate, contextPct, contextWindow };
 }
@@ -165,6 +211,89 @@ async function parseSessionFile(filePath, projectSlug) {
   return entries;
 }
 
+// Codex transcript lines are {timestamp, type, payload}. `payload.model` and
+// `payload.cwd` show up opportunistically on turn_context/session_meta lines;
+// usage lives on event_msg lines where payload.type === 'token_count'.
+// Mirrors server/cost-worker.js's processCodexFile against real ~/.codex*/sessions data.
+async function parseCodexSessionFile(filePath) {
+  const entries = [];
+  let sessionId = path.basename(filePath, '.jsonl');
+  let cwd = null;
+  let lastModel = 'unknown';
+
+  const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  for await (const line of rl) {
+    let obj;
+    try { obj = JSON.parse(line); } catch { continue; }
+    const payload = obj.payload;
+    if (!payload) continue;
+
+    if (payload.cwd && !cwd) cwd = payload.cwd;
+    if (payload.model) lastModel = payload.model;
+    if (obj.type === 'session_meta' && typeof payload.session_id === 'string') sessionId = payload.session_id;
+
+    if (payload.type !== 'token_count') continue;
+    const tu = payload.info && payload.info.last_token_usage;
+    if (!tu) continue;
+
+    const cached = tu.cached_input_tokens || 0;
+    const usage = {
+      input_tokens: Math.max(0, (tu.input_tokens || 0) - cached),
+      output_tokens: (tu.output_tokens || 0) + (tu.reasoning_output_tokens || 0),
+      cache_read_input_tokens: cached,
+      cache_creation_input_tokens: 0,
+    };
+    const totalTokens = usage.input_tokens + usage.output_tokens + usage.cache_read_input_tokens;
+    if (totalTokens === 0) continue;
+
+    const id = tsToId(obj.timestamp);
+    if (!id) continue;
+
+    const contextWindow = (payload.info && payload.info.model_context_window) || CODEX_CONTEXT_WINDOW;
+    const cost = calculateCostSimple(usage, lastModel);
+    const tokens = buildTokens(usage, contextWindow);
+    const receivedAt = new Date(obj.timestamp).getTime();
+
+    entries.push({
+      id,
+      ts: obj.timestamp,
+      method: 'POST',
+      url: '/v1/responses',
+      req: null,
+      res: null,
+      _loaded: false,
+      elapsed: null,
+      status: 200,
+      isSSE: false,
+      receivedAt,
+      tokens,
+      cost: { cost },
+      model: lastModel,
+      sessionId,
+      title: '(imported)',
+      stopReason: null,
+      imported: true,
+      importSource: 'codex',
+      provider: 'openai',
+      cwd,
+      usage,
+    });
+  }
+  return entries;
+}
+
+function pushImportedEntry(entry, existingIds) {
+  if (existingIds.has(entry.id)) return false;
+  existingIds.add(entry.id);
+  // INVARIANT: push + entryIndex.set must pair — see docs/decisions/0003-entry-index-map.md
+  store.entries.push(entry);
+  store.entryIndex.set(entry.id, entry);
+  broadcast(entry);
+  return true;
+}
+
 async function scanAndImport() {
   if (process.env.CCXRAY_IMPORT_DISABLE === '1') return { imported: 0, skipped: 0 };
 
@@ -187,14 +316,19 @@ async function scanAndImport() {
       for (const filePath of jsonlFiles) {
         const entries = await parseSessionFile(filePath, slug);
         for (const entry of entries) {
-          if (existingIds.has(entry.id)) { skipped++; continue; }
-          existingIds.add(entry.id);
-          // INVARIANT: push + entryIndex.set must pair — see docs/decisions/0003-entry-index-map.md
-          store.entries.push(entry);
-          store.entryIndex.set(entry.id, entry);
-          broadcast(entry);
-          imported++;
+          if (pushImportedEntry(entry, existingIds)) imported++; else skipped++;
         }
+      }
+    }
+  }
+
+  const codexHomes = discoverCodexHomes();
+  for (const { dir } of codexHomes) {
+    const jsonlFiles = await collectJsonlFilesRecursive(dir);
+    for (const filePath of jsonlFiles) {
+      const entries = await parseCodexSessionFile(filePath);
+      for (const entry of entries) {
+        if (pushImportedEntry(entry, existingIds)) imported++; else skipped++;
       }
     }
   }
@@ -206,4 +340,12 @@ async function scanAndImport() {
   return { imported, skipped };
 }
 
-module.exports = { scanAndImport, parseSessionFile, discoverHomes, slugToProject, tsToId };
+module.exports = {
+  scanAndImport,
+  parseSessionFile,
+  parseCodexSessionFile,
+  discoverHomes,
+  discoverCodexHomes,
+  slugToProject,
+  tsToId,
+};

--- a/server/sse-broadcast.js
+++ b/server/sse-broadcast.js
@@ -39,6 +39,8 @@ function summarizeEntry(entry) {
     convId: entry.convId || null,
     toolsHash: entry.toolsHash || null,
     thinkingStripped: entry.thinkingStripped || false,
+    imported: entry.imported || undefined,
+    importSource: entry.importSource || undefined,
     parentSessionId: store.sessionMeta[entry.sessionId]?.parentSessionId || null,
     tokens: tok ? {
       system: tok.system, tools: tok.tools, messages: tok.messages, total: tok.total,

--- a/test/importer.test.js
+++ b/test/importer.test.js
@@ -13,7 +13,7 @@ fs.mkdirSync(path.join(tmpHome, 'logs'), { recursive: true });
 fs.writeFileSync(path.join(tmpHome, 'logs', 'index.ndjson'), '');
 
 const store = require('../server/store');
-const { scanAndImport, parseSessionFile, slugToProject, tsToId } = require('../server/importer');
+const { scanAndImport, parseSessionFile, parseCodexSessionFile, slugToProject, tsToId } = require('../server/importer');
 
 function makeLine(type, extra = {}) {
   const base = {
@@ -56,17 +56,24 @@ function makeUser(text = 'Hello world') {
 
 describe('importer', () => {
   let importDir;
+  let codexImportDir;
 
   beforeEach(() => {
     store.entries.length = 0;
     store.entryIndex.clear();
     importDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-import-'));
     process.env.CCXRAY_IMPORT_HOMES = importDir;
+    // scanAndImport() also scans Codex homes — isolate it here too, or it
+    // falls back to the real ~/.codex*/sessions and imports actual data.
+    codexImportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-import-codex-'));
+    process.env.CCXRAY_IMPORT_CODEX_HOMES = codexImportDir;
   });
 
   afterEach(() => {
     delete process.env.CCXRAY_IMPORT_HOMES;
+    delete process.env.CCXRAY_IMPORT_CODEX_HOMES;
     fs.rmSync(importDir, { recursive: true, force: true });
+    fs.rmSync(codexImportDir, { recursive: true, force: true });
   });
 
   describe('tsToId', () => {
@@ -182,6 +189,165 @@ describe('importer', () => {
       assert.strictEqual(result.imported, 0);
       assert.strictEqual(store.entries.length, 0);
       delete process.env.CCXRAY_IMPORT_DISABLE;
+    });
+  });
+});
+
+// Codex JSONL lines: {timestamp, type, payload}. session_meta carries
+// session_id/cwd directly on payload; token_count is nested inside an
+// event_msg line as payload.type === 'token_count'. Verified against real
+// ~/.codex*/sessions/**/*.jsonl data — see server/cost-worker.js's
+// processCodexFile, the reference implementation this mirrors.
+function makeCodexSessionMeta(opts = {}) {
+  return JSON.stringify({
+    timestamp: opts.timestamp || '2026-07-15T10:30:00.000Z',
+    type: 'session_meta',
+    payload: {
+      session_id: opts.sessionId || 'codex-sess-1',
+      cwd: opts.cwd || '/tmp/codex-project',
+      originator: 'codex_exec',
+    },
+  });
+}
+
+function makeCodexTurnContext(opts = {}) {
+  return JSON.stringify({
+    timestamp: opts.timestamp || '2026-07-15T10:30:01.000Z',
+    type: 'turn_context',
+    payload: {
+      turn_id: opts.turnId || 'turn-1',
+      cwd: opts.cwd || '/tmp/codex-project',
+      model: opts.model || 'gpt-5.5',
+    },
+  });
+}
+
+function makeCodexTokenCount(opts = {}) {
+  return JSON.stringify({
+    timestamp: opts.timestamp || '2026-07-15T10:30:05.000Z',
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: {
+        model_context_window: opts.contextWindow ?? 258400,
+        last_token_usage: {
+          input_tokens: opts.input ?? 17172,
+          cached_input_tokens: opts.cachedInput ?? 4992,
+          output_tokens: opts.output ?? 35,
+          reasoning_output_tokens: opts.reasoningOutput ?? 28,
+          total_tokens: opts.total ?? 17207,
+        },
+      },
+    },
+  });
+}
+
+describe('codex importer', () => {
+  let codexDir;
+  let claudeHomeDir;
+
+  beforeEach(() => {
+    store.entries.length = 0;
+    store.entryIndex.clear();
+    codexDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-codex-import-'));
+    claudeHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-empty-claude-'));
+    process.env.CCXRAY_IMPORT_CODEX_HOMES = codexDir;
+    process.env.CCXRAY_IMPORT_HOMES = claudeHomeDir;
+  });
+
+  afterEach(() => {
+    delete process.env.CCXRAY_IMPORT_CODEX_HOMES;
+    delete process.env.CCXRAY_IMPORT_HOMES;
+    fs.rmSync(codexDir, { recursive: true, force: true });
+    fs.rmSync(claudeHomeDir, { recursive: true, force: true });
+  });
+
+  describe('parseCodexSessionFile', () => {
+    it('extracts entries from token_count events', async () => {
+      const sessDir = path.join(codexDir, '2026', '07', '15');
+      fs.mkdirSync(sessDir, { recursive: true });
+      const file = path.join(sessDir, 'rollout-2026-07-15T10-30-00-abc.jsonl');
+      fs.writeFileSync(file, [
+        makeCodexSessionMeta({ sessionId: 'codex-sess-1', cwd: '/tmp/codex-project' }),
+        makeCodexTurnContext({ model: 'gpt-5.5' }),
+        makeCodexTokenCount({ timestamp: '2026-07-15T10:30:05.000Z' }),
+      ].join('\n'));
+
+      const entries = await parseCodexSessionFile(file);
+      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries[0].imported, true);
+      assert.strictEqual(entries[0].importSource, 'codex');
+      assert.strictEqual(entries[0].provider, 'openai');
+      assert.strictEqual(entries[0].sessionId, 'codex-sess-1');
+      assert.strictEqual(entries[0].cwd, '/tmp/codex-project');
+      assert.strictEqual(entries[0].model, 'gpt-5.5');
+      assert.strictEqual(entries[0].url, '/v1/responses');
+      assert.strictEqual(entries[0].tokens.input, 17172 - 4992);
+      assert.strictEqual(entries[0].tokens.cacheRead, 4992);
+      assert.strictEqual(entries[0].tokens.output, 35 + 28);
+      assert.strictEqual(entries[0].tokens.contextWindow, 258400);
+    });
+
+    it('skips token_count events with zero usage', async () => {
+      const sessDir = path.join(codexDir, '2026', '07', '15');
+      fs.mkdirSync(sessDir, { recursive: true });
+      const file = path.join(sessDir, 'rollout-zero.jsonl');
+      fs.writeFileSync(file, [
+        makeCodexSessionMeta(),
+        makeCodexTokenCount({ input: 0, cachedInput: 0, output: 0, reasoningOutput: 0, total: 0 }),
+      ].join('\n'));
+
+      const entries = await parseCodexSessionFile(file);
+      assert.strictEqual(entries.length, 0);
+    });
+  });
+
+  describe('scanAndImport (codex)', () => {
+    it('imports codex entries alongside claude entries', async () => {
+      const sessDir = path.join(codexDir, '2026', '07', '15');
+      fs.mkdirSync(sessDir, { recursive: true });
+      fs.writeFileSync(path.join(sessDir, 'rollout-1.jsonl'), [
+        makeCodexSessionMeta({ sessionId: 'codex-sess-2' }),
+        makeCodexTurnContext({ model: 'gpt-5.5' }),
+        makeCodexTokenCount({ timestamp: '2026-07-15T11:00:00.000Z' }),
+      ].join('\n'));
+
+      const claudeProjectDir = path.join(claudeHomeDir, '-tmp-myproject');
+      fs.mkdirSync(claudeProjectDir, { recursive: true });
+      fs.writeFileSync(path.join(claudeProjectDir, 'session-xyz.jsonl'), [
+        makeUser('Test'),
+        makeAssistant({ timestamp: '2026-07-15T11:05:00.000Z' }),
+      ].join('\n'));
+
+      const result = await scanAndImport();
+      assert.strictEqual(result.imported, 2);
+      assert.strictEqual(store.entries.length, 2);
+
+      const codexEntry = store.entries.find(e => e.importSource === 'codex');
+      assert.ok(codexEntry);
+      assert.strictEqual(codexEntry.provider, 'openai');
+      const claudeEntry = store.entries.find(e => e.importSource === 'claude-code');
+      assert.ok(claudeEntry);
+      assert.strictEqual(claudeEntry.provider, 'anthropic');
+    });
+
+    it('deduplicates codex entries on second scan', async () => {
+      const sessDir = path.join(codexDir, '2026', '07', '15');
+      fs.mkdirSync(sessDir, { recursive: true });
+      fs.writeFileSync(path.join(sessDir, 'rollout-dedup.jsonl'), [
+        makeCodexSessionMeta({ sessionId: 'codex-sess-3' }),
+        makeCodexTurnContext({ model: 'gpt-5.5' }),
+        makeCodexTokenCount({ timestamp: '2026-07-15T12:00:00.000Z' }),
+      ].join('\n'));
+
+      const result1 = await scanAndImport();
+      assert.strictEqual(result1.imported, 1);
+      assert.strictEqual(store.entries.length, 1);
+
+      const result2 = await scanAndImport();
+      assert.strictEqual(result2.imported, 0);
+      assert.strictEqual(result2.skipped, 1);
+      assert.strictEqual(store.entries.length, 1);
     });
   });
 });


### PR DESCRIPTION
## Summary

- 從 `~/.codex*/sessions/**/*.jsonl` 匯入 Codex session 到 dashboard
- Entry 帶 `imported: true` + `importSource: "codex"` + `provider: "openai"`
- 復用 #284 的 import 基礎設施 + UI guard（降級提示自動適用）
- 支援 recursive session 目錄結構（`sessions/YYYY/MM/DD/`）

## Changes

- `server/importer.js`: +`parseCodexSessionFile`, +`discoverCodexHomes`, +`collectJsonlFilesRecursive`, refactored `pushImportedEntry` shared helper (ADR 0003)
- `test/importer.test.js`: +4 codex tests, fix test isolation (CCXRAY_IMPORT_CODEX_HOMES)

## Validation

- `CCXRAY_HOME=$(mktemp -d) node --test test/*.test.js` → 1369/1369 pass
- Codex usage math matches `cost-worker.js` (input - cached, output + reasoning)

## Not implemented (per support matrix)

- Context %、thinking、cache breakdown、stop_reason — Codex transcript 不含
- 降級提示由 #284 的 UI guard 自動顯示

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)