### PR TITLE
feat(ws-proxy): record compact _ts markers on WS events for Codex TTFT (#293)

### DIFF
--- a/docs/solutions/ws-ts-stamp-for-codex-ttft.md
+++ b/docs/solutions/ws-ts-stamp-for-codex-ttft.md
@@ -1,0 +1,110 @@
+# WS `_ts` stamp for Codex TTFT (#204)
+
+## Diagnosis
+
+**Question**: Can we stamp `_ts: Date.now()` on recorded WS events without perturbing the relay?
+
+**Answer: Yes — structural isolation proves it.**
+
+### Evidence (code-level, no live traffic required)
+
+`server/ws-proxy.js` upstream→client message handler (L537-568):
+
+```
+upstreamWs.on('message', (data, isBinary) => {
+  // ...
+  const parsed = JSON.parse(data.toString());     // L543: parse for recording
+  // ...
+  currentTurn.responseEvents.push(parsed);        // L554: record (parsed object)
+  ctx.responseEvents.push(parsed);                // L560: record (parsed object)
+  // ...
+  safeSend(clientWs, data, isBinary);             // L568: relay (raw buffer)
+});
+```
+
+- **Recording path**: uses `parsed` (JavaScript object) — enrichable
+- **Relay path**: uses `data` (raw buffer from upstream) — never touches `parsed`
+- **Conclusion**: adding `{ ...parsed, _ts: Date.now() }` at push sites cannot alter frames forwarded to client. The two paths are structurally independent.
+
+### Relay latency
+
+`Date.now()` itself is a syscall that takes <1μs and runs after `parsed` is
+already constructed (JSON.parse already happened), so the stamp itself adds
+nothing. But the *shape* of what gets pushed onto `responseEvents` matters:
+`response.completed` triggers `finalizeTurn()` synchronously in the same
+message handler, and `finalizeTurn` → `recordWebSocketEntry` (JSON
+serialization + credential scan over the recorded event array) runs on that
+relay path **before** `safeSend` forwards the frame (see the P1 finding
+below) — so a large recorded object on that turn's `responseEvents` array
+does sit in front of the relay, unlike the non-terminal events. The compact
+`{ type, _ts }` marker (see "Revision" below) keeps that array small
+regardless of envelope size, so this cost stays negligible in practice.
+
+## Design
+
+### Change (2 lines)
+
+```js
+// L554
+if (!WS_SKIP_EVENTS.has(parsed.type)) currentTurn.responseEvents.push({ ...parsed, _ts: Date.now() });
+// L560
+if (!turnEmitted && !WS_SKIP_EVENTS.has(parsed.type)) ctx.responseEvents.push({ ...parsed, _ts: Date.now() });
+```
+
+### TTFT derivation (downstream consumer)
+
+```
+response.created._ts     → t0 (response accepted)
+first output_text.delta._ts → first token (TTFT = Δt - t0)
+response.completed._ts   → stream end (duration = completed - created)
+```
+
+Note: existing data shows `response.created` and `response.completed` are in `WS_SKIP_EVENTS` — verify and remove from skip set if needed. Current WS_SKIP_EVENTS definition at L41.
+
+### Verification plan (for the implementation PR, not this diagnostic)
+
+1. Before/after frame bytes: `ctx.byteCounts.upstreamToClient` unchanged (already tracked)
+2. Test: existing `test/websocket-proxy.test.js` exercises the relay path — add assertion that recorded events have `_ts` while forwarded frames don't
+3. No `critical-path` browser-harness relay test needed — the isolation is structural, not empirical
+
+## Revision: codex P1 — keep anchors in WS_SKIP_EVENTS, record compact markers instead
+
+The first implementation (#293) removed `response.created`/`response.completed`
+from `WS_SKIP_EVENTS` outright so their `_ts` would get recorded — but that's
+exactly why they were in the skip set to begin with: each is a ~35KB envelope
+(full `instructions` + `tools`). Recording the full body on every turn
+measured 1,626 → 142,976 bytes per `_res.json` (88× bloat for a 2-turn
+session), and put that enlarged serialization + credential scan on the relay
+path, since `recordWebSocketEntry` runs inside `finalizeTurn`, which fires
+synchronously on `response.completed` **before** `safeSend` relays the frame.
+
+Owner-approved fix: put both anchors back in `WS_SKIP_EVENTS` (full envelope
+never recorded), but record a **compact `{ type, _ts }` marker** for exactly
+these two events via a small helper, so downstream TTFT derivation still
+works off the timestamps with no bloat and no added relay cost:
+
+```js
+const WS_TS_ANCHORS = new Set(['response.created', 'response.completed']);
+
+function wsRecordValue(parsed) {
+  if (!WS_SKIP_EVENTS.has(parsed.type)) return { ...parsed, _ts: Date.now() };
+  if (WS_TS_ANCHORS.has(parsed.type)) return { type: parsed.type, _ts: Date.now() };
+  return null;
+}
+```
+
+Both push sites call `wsRecordValue(parsed)` and only push if it returns
+non-null. `usage`/`model`/`lastResponseStatus` are still extracted from `r`
+before this check runs, so no consumed data is lost — only the raw
+`instructions`/`tools`/`response` envelope is dropped for these two event
+types.
+
+Measured after the fix (`test/fixtures/codex-ws-frames/say-hi.ndjson`):
+recorded-events serialized size back down to ~1.8KB (vs. the ~143KB
+full-envelope regression), with `response.created`/`response.completed`
+still present as `{type,_ts}` markers.
+
+## Status
+
+Implemented (#293), P1 fixed. `test/websocket-proxy.test.js` locks in both
+the `_ts` stamping and the compact-marker shape as a regression guard.

--- a/docs/solutions/ws-ts-stamp-for-codex-ttft.md
+++ b/docs/solutions/ws-ts-stamp-for-codex-ttft.md
@@ -104,7 +104,49 @@ recorded-events serialized size back down to ~1.8KB (vs. the ~143KB
 full-envelope regression), with `response.created`/`response.completed`
 still present as `{type,_ts}` markers.
 
+## Revision: codex P2 — `response.done` terminal variant
+
+Codex review round 2 flagged that `response.done` — a documented terminal-event
+variant some Codex versions emit instead of `response.completed`
+(`docs/wire-protocol-reference.md`, treated as completion in
+`public/renderers/openai.js`) — was missing from `WS_TS_ANCHORS`, so those
+sessions got no terminal `_ts`. Fix: add it as a third compact anchor.
+
+```js
+const WS_TS_ANCHORS = new Set(['response.created', 'response.completed', 'response.done']);
+```
+
+Note: `finalizeTurn()` still fires only on `response.completed`; a
+`response.done`-terminal turn finalizes via the next `response.create` or the
+socket-close path. The `_ts` marker is recorded at receive time regardless, so
+duration is derivable; changing turn-splitting on `response.done` is a separate
+concern, out of scope here.
+
+## Scope (TTFT-only — owner-defined, explicit)
+
+Captured: success-path timestamps only — `response.created` (t0) → first
+`output_text.delta` → `response.completed`/`response.done` (end). Deliberately
+**not** captured (accepted, TTFT needs none of it):
+
+- **Failure/interrupt terminals** (`response.failed` / `response.incomplete`, or
+  close-without-terminal): no `stop_ts` anchor; any such non-anchor terminal
+  envelope that reaches the recorder is stored in full, not compacted. Future
+  pure addition (extend `WS_TS_ANCHORS`).
+- **Terminal `output_tokens`**: kept in `ctx.lastUsage` for cost, but dropped
+  from the compact `{type,_ts}` markers, so a throughput consumer (#195) can't
+  read per-event tokens from a marker. Future pure addition.
+
+## Test barrier (round-2 review)
+
+The `response.done` regression test drives finalization by an **event-driven
+barrier** — it waits until the proxy relays the `response.done` frame (which
+happens *after* `wsRecordValue()` records the marker, since `safeSend` is last),
+then closes. It does **not** use a fixed `setTimeout` sleep: a fixed-sleep pass
+is a load-dependent (possibly false) green and an unreliable old-fail/new-pass
+anchor.
+
 ## Status
 
-Implemented (#293), P1 fixed. `test/websocket-proxy.test.js` locks in both
-the `_ts` stamping and the compact-marker shape as a regression guard.
+Implemented (#293), P1 + P2 fixed. `test/websocket-proxy.test.js` locks in the
+`_ts` stamping, the compact-marker shape (incl. `response.done`), and the
+relay-integrity contract as regression guards.

--- a/server/ws-proxy.js
+++ b/server/ws-proxy.js
@@ -23,13 +23,25 @@ const {
 } = require('./wire-parsers/openai');
 const detectOpenAISession = (headers, body) => _detectOpenAISession3(null, headers, body);
 
-// Large envelope events skipped from responseEvents capture (~35KB each).
-// usage and model are extracted before this filter (lines below), so skipping
-// these loses no data. Tool-call extraction uses response.output_item.done events.
+// Large envelope events skipped from responseEvents capture (~35KB each,
+// full instructions+tools). usage/model/status are extracted before this
+// filter (lines below), so skipping these loses no consumed data.
+// Tool-call extraction uses response.output_item.done events.
+// response.created/response.completed/response.done are additionally recorded
+// as compact { type, _ts } markers (see WS_TS_ANCHORS/wsRecordValue below) so a
+// downstream consumer can still derive Codex TTFT from their timestamps
+// without paying for the full envelope.
 const WS_SKIP_EVENTS = new Set([
   'response.created', 'response.in_progress', 'response.completed', 'response.done',
   'codex.rate_limits',
 ]);
+
+// TTFT anchors: large envelopes we skip from full capture, but still record as a
+// compact { type, _ts } marker so a downstream consumer can derive Codex TTFT
+// (response.created -> first output_text.delta -> response.completed/response.done).
+// response.done is a terminal-event variant some Codex versions emit instead of
+// response.completed (docs/wire-protocol-reference.md) — see #293.
+const WS_TS_ANCHORS = new Set(['response.created', 'response.completed', 'response.done']);
 
 const WS_TERMINAL_STATUSES = new Set(['completed', 'incomplete', 'failed', 'cancelled']);
 
@@ -361,6 +373,15 @@ async function recordWebSocketEntry(ctx, result, turn = null) {
   if (!turn) ctx.clientRequest = null;
 }
 
+// Value to record for a WS response event, or null to record nothing.
+// Non-skipped events keep their full body + a receive _ts; anchor events keep
+// only a compact { type, _ts } marker (their ~35KB envelope is intentionally dropped).
+function wsRecordValue(parsed) {
+  if (!WS_SKIP_EVENTS.has(parsed.type)) return { ...parsed, _ts: Date.now() };
+  if (WS_TS_ANCHORS.has(parsed.type)) return { type: parsed.type, _ts: Date.now() };
+  return null;
+}
+
 function handleWebSocketUpgrade(req, socket, head) {
   const upstream = config.getUpstreamForRequestAndHeaders(req.url, req.headers);
   if (!isOpenAIWebSocket(req, upstream)) {
@@ -585,13 +606,17 @@ function handleWebSocketUpgrade(req, socket, head) {
               if (usage) currentTurn.lastUsage = usage;
               if (model) currentTurn.lastModel = model;
               if (isTerminal) currentTurn.lastResponseStatus = r.status;
-              if (!WS_SKIP_EVENTS.has(parsed.type)) currentTurn.responseEvents.push(parsed);
+              const rec = wsRecordValue(parsed);
+              if (rec) currentTurn.responseEvents.push(rec);
             }
 
             if (usage) ctx.lastUsage = usage;
             if (model) ctx.lastModel = model;
             if (isTerminal) ctx.lastResponseStatus = r.status;
-            if (!turnEmitted && !WS_SKIP_EVENTS.has(parsed.type)) ctx.responseEvents.push(parsed);
+            if (!turnEmitted) {
+              const rec = wsRecordValue(parsed);
+              if (rec) ctx.responseEvents.push(rec);
+            }
 
             if (parsed.type === 'response.completed' && currentTurn) {
               finalizeTurn({ status: 101 });

--- a/test/websocket-proxy.test.js
+++ b/test/websocket-proxy.test.js
@@ -869,4 +869,140 @@ describe('OpenAI Responses WebSocket proxy', () => {
     assert.equal(entry.title, 'Interrupted turn');
     assert.equal(entry.status, 101);
   });
+
+  it('stamps _ts on recorded response events, keeping anchors compact but never on frames relayed to the client (#293)', async () => {
+    upstreamWss = new WebSocket.Server({ server: upstreamServer, path: '/v1/responses' });
+    upstreamWss.on('connection', ws => {
+      ws.on('message', data => {
+        const parsed = JSON.parse(data.toString());
+        if (parsed.type !== 'response.create') return;
+        ws.send(JSON.stringify({
+          type: 'response.created',
+          instructions: 'x'.repeat(500),
+          response: { status: 'in_progress', model: 'gpt-5.5' },
+        }));
+        ws.send(JSON.stringify({ type: 'response.output_text.delta', delta: 'hi' }));
+        ws.send(JSON.stringify({
+          type: 'response.completed',
+          instructions: 'x'.repeat(500),
+          response: { status: 'completed', model: 'gpt-5.5', usage: { input_tokens: 100, output_tokens: 10, total_tokens: 110 } },
+        }));
+      });
+    });
+    await startProxy();
+
+    const sessionId = 'ws-ts-stamp-test-001';
+    const ws = new WebSocket(`ws://localhost:${proxyPort}/v1/responses`, {
+      headers: { 'openai-beta': 'responses_websockets=2026-02-06', session_id: sessionId },
+    });
+    await new Promise((resolve, reject) => { ws.on('open', resolve); ws.on('error', reject); });
+
+    const forwarded = [];
+    ws.on('message', data => forwarded.push(data.toString()));
+    const done = waitForCompleted(ws);
+    ws.send(JSON.stringify({
+      type: 'response.create', model: 'gpt-5.5',
+      input: [{ role: 'user', content: [{ type: 'input_text', text: 'TTFT check' }] }],
+    }));
+    await done;
+    ws.close(1000, 'done');
+    await new Promise(r => ws.on('close', r));
+
+    // Forwarded frames must stay byte-identical to what upstream sent — no _ts leak into the relay.
+    assert.ok(forwarded.length >= 3, 'expected at least 3 relayed frames');
+    for (const raw of forwarded) {
+      const parsed = JSON.parse(raw);
+      assert.equal(parsed._ts, undefined, `relayed frame ${parsed.type} must not carry _ts`);
+    }
+
+    const entry = await waitForIndexEntry(path.join(testHome, 'logs'), e => e.sessionId === sessionId && e.title);
+    const resLog = JSON.parse(fs.readFileSync(path.join(testHome, 'logs', `${entry.id}_res.json`), 'utf8'));
+    assert.ok(Array.isArray(resLog), 'recorded res.json should be the responseEvents array');
+
+    const recordedTypes = resLog.map(ev => ev.type);
+    assert.ok(recordedTypes.includes('response.created'), 'response.created should now be recorded, not skipped');
+    assert.ok(recordedTypes.includes('response.completed'), 'response.completed should now be recorded, not skipped');
+
+    for (const ev of resLog) {
+      assert.equal(typeof ev._ts, 'number', `recorded event ${ev.type} should carry a numeric _ts`);
+    }
+
+    // P1 regression guard (codex review): response.created/response.completed must be
+    // recorded as COMPACT { type, _ts } markers, not the full ~35KB envelope.
+    for (const anchorType of ['response.created', 'response.completed']) {
+      const marker = resLog.find(ev => ev.type === anchorType);
+      assert.ok(marker, `expected a recorded ${anchorType} marker`);
+      assert.deepEqual(Object.keys(marker).sort(), ['_ts', 'type'], `${anchorType} marker must be compact ({type,_ts} only)`);
+      assert.equal(marker.response, undefined, `${anchorType} marker must not carry the full response envelope`);
+      assert.equal(marker.instructions, undefined, `${anchorType} marker must not carry instructions`);
+    }
+
+    // Non-anchor events keep their full body alongside _ts.
+    const delta = resLog.find(ev => ev.type === 'response.output_text.delta');
+    assert.ok(delta, 'expected the recorded response.output_text.delta event');
+    assert.equal(delta.delta, 'hi', 'non-anchor event should retain its full content (delta field)');
+    assert.equal(typeof delta._ts, 'number', 'non-anchor event should still carry a numeric _ts');
+  });
+
+  it('records response.done as a compact terminal _ts anchor when upstream emits it instead of response.completed (#293)', async () => {
+    upstreamWss = new WebSocket.Server({ server: upstreamServer, path: '/v1/responses' });
+    upstreamWss.on('connection', ws => {
+      ws.on('message', data => {
+        const parsed = JSON.parse(data.toString());
+        if (parsed.type !== 'response.create') return;
+        ws.send(JSON.stringify({
+          type: 'response.created',
+          response: { status: 'in_progress', model: 'gpt-5.5' },
+        }));
+        ws.send(JSON.stringify({ type: 'response.output_text.delta', delta: 'hi' }));
+        // Some Codex versions emit response.done instead of response.completed as
+        // the terminal event (docs/wire-protocol-reference.md:144) — large envelope,
+        // same shape as response.completed.
+        ws.send(JSON.stringify({
+          type: 'response.done',
+          instructions: 'x'.repeat(500),
+          response: { status: 'completed', model: 'gpt-5.5', usage: { input_tokens: 100, output_tokens: 10, total_tokens: 110 } },
+        }));
+      });
+    });
+    await startProxy();
+
+    const sessionId = 'ws-ts-stamp-test-002';
+    const ws = new WebSocket(`ws://localhost:${proxyPort}/v1/responses`, {
+      headers: { 'openai-beta': 'responses_websockets=2026-02-06', session_id: sessionId },
+    });
+    await new Promise((resolve, reject) => { ws.on('open', resolve); ws.on('error', reject); });
+
+    const forwarded = [];
+    ws.on('message', data => forwarded.push(data.toString()));
+    ws.send(JSON.stringify({
+      type: 'response.create', model: 'gpt-5.5',
+      input: [{ role: 'user', content: [{ type: 'input_text', text: 'Done-variant TTFT check' }] }],
+    }));
+
+    // response.done alone does not finalize the turn — only response.completed
+    // triggers finalizeTurn() inline (see ws-proxy.js upstreamWs 'message' handler).
+    // Close the socket to finalize via the close-path finalize() call instead of
+    // waitForCompleted(), which only resolves on response.completed.
+    await new Promise(resolve => setTimeout(resolve, 300));
+    ws.close(1000, 'done');
+    await new Promise(resolve => ws.on('close', resolve));
+
+    // Forwarded frames must stay byte-identical to what upstream sent — no _ts leak into the relay.
+    for (const raw of forwarded) {
+      const parsed = JSON.parse(raw);
+      assert.equal(parsed._ts, undefined, `relayed frame ${parsed.type} must not carry _ts`);
+    }
+
+    const entry = await waitForIndexEntry(path.join(testHome, 'logs'), e => e.sessionId === sessionId && e.title);
+    const resLog = JSON.parse(fs.readFileSync(path.join(testHome, 'logs', `${entry.id}_res.json`), 'utf8'));
+    assert.ok(Array.isArray(resLog), 'recorded res.json should be the responseEvents array');
+
+    const marker = resLog.find(ev => ev.type === 'response.done');
+    assert.ok(marker, 'expected a recorded response.done marker');
+    assert.deepEqual(Object.keys(marker).sort(), ['_ts', 'type'], 'response.done marker must be compact ({type,_ts} only)');
+    assert.equal(marker.response, undefined, 'response.done marker must not carry the full response envelope');
+    assert.equal(marker.instructions, undefined, 'response.done marker must not carry instructions');
+    assert.equal(typeof marker._ts, 'number', 'response.done marker should carry a numeric _ts');
+  });
 });

--- a/test/websocket-proxy.test.js
+++ b/test/websocket-proxy.test.js
@@ -975,16 +975,26 @@ describe('OpenAI Responses WebSocket proxy', () => {
 
     const forwarded = [];
     ws.on('message', data => forwarded.push(data.toString()));
+    // Event-driven barrier: resolve once the proxy relays response.done to the client.
+    // safeSend() runs AFTER wsRecordValue() pushes the marker, so observing the frame
+    // here guarantees the compact marker is already recorded. No fixed sleep — that
+    // would be a load-dependent "green" and an unreliable old-fail/new-pass anchor.
+    const sawDone = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('barrier timeout: no response.done relayed')), 4000);
+      const onMsg = d => {
+        if (JSON.parse(d.toString()).type === 'response.done') { clearTimeout(timer); ws.off('message', onMsg); resolve(); }
+      };
+      ws.on('message', onMsg);
+    });
     ws.send(JSON.stringify({
       type: 'response.create', model: 'gpt-5.5',
       input: [{ role: 'user', content: [{ type: 'input_text', text: 'Done-variant TTFT check' }] }],
     }));
+    await sawDone;
 
-    // response.done alone does not finalize the turn — only response.completed
-    // triggers finalizeTurn() inline (see ws-proxy.js upstreamWs 'message' handler).
-    // Close the socket to finalize via the close-path finalize() call instead of
-    // waitForCompleted(), which only resolves on response.completed.
-    await new Promise(resolve => setTimeout(resolve, 300));
+    // response.done alone does not finalize the turn — only response.completed triggers
+    // finalizeTurn() inline (see ws-proxy.js upstreamWs 'message' handler). Close the
+    // socket to finalize via the close-path finalize() call.
     ws.close(1000, 'done');
     await new Promise(resolve => ws.on('close', resolve));
 


### PR DESCRIPTION
## 摘要（繁中）

實作 #204 診斷結論：在 WS response events 上蓋 receive-time `_ts`，讓下游可推導 Codex TTFT（`response.created` → 首個 `output_text.delta` → `response.completed`）。設計文件 `docs/solutions/ws-ts-stamp-for-codex-ttft.md`（owner 已 APPROVE-DESIGN）。

**codex 二審在原設計抓到 P1**：`response.created`/`response.completed` 是 ~35KB 大信封（完整 instructions+tools，這正是它們被 skip 的原因），原設計「移出 skip set」會讓每個 `_res.json` 多存 2×35KB（實測 1,626→142,976 bytes，88×）並把放大的序列化+credential scan 放到 relay path。**owner 裁決改用 compact marker**：錨點事件保留在 skip set，只記 `{type,_ts}` 極小 marker。TTFT 不受影響、零儲存膨脹、零 relay 回歸。

**觸及 WS 擷取路徑 → 治理規則永久排除 auto-merge，僅人工 merge。**

## What changed (`server/ws-proxy.js`, purely additive vs `origin/main`)

- **`WS_SKIP_EVENTS` is unchanged from `origin/main`** (all 5 large-envelope events still skipped from full capture).
- Added `WS_TS_ANCHORS = { response.created, response.completed, response.done }` and a `wsRecordValue(parsed)` helper:
  - non-skipped events → recorded as `{ ...parsed, _ts: Date.now() }` (full body + receive timestamp)
  - anchor events → recorded as a compact `{ type, _ts }` marker (the ~35KB envelope is intentionally dropped)
  - other skipped events → not recorded
- Both `responseEvents.push` sites now go through `wsRecordValue`.

The raw-buffer relay path (`safeSend(clientWs, data, isBinary)`) and the `response.completed → finalizeTurn` trigger are untouched. `{ ...parsed, _ts }` allocates a new object, so `parsed` is never mutated.

Also commits the approved design doc (previously untracked), including the codex-P1 revision section.

## Verification evidence

**Feature works (diff-check, old-fail/new-pass):** `scripts/diff-check.sh origin/main test/websocket-proxy.test.js -- …` → **exit 0** (old FAIL / new PASS).

**P1 fixed (recorded size, measured on the real `say-hi.ndjson` fixture):** compact markers record **11 events / 1,838 bytes**, vs the original full-envelope approach's **142,976 bytes (88×)**.

**Guard test** (`test/websocket-proxy.test.js`): forwarded frames carry no `_ts`; recorded `response.created`/`response.completed` markers have keys exactly `['_ts','type']` (no `response`/`instructions` envelope — regression guard against the 88× form); non-anchor `output_text.delta` keeps its full `delta` field plus a numeric `_ts`.

**websocket-proxy suite:** 20/20 pass (isolated, twice).

**Full suite:** `node --test test/*.test.js` → **1371 / 1371 pass** on a clean (uncontended) run. Under CPU contention the WS/proxy suite has a **pre-existing, load-dependent concurrency flake unrelated to this change**: contended runs failed 1 (a websocket-proxy subtest) or 1 + 4 cancelled (`OpenAI Responses raw capture`, `Concurrent proxy requests`) — a *different* random set each time, then 0 on the clean run. Isolated with three order-controlled experiments under synthetic CPU load (6 runs/cell):

| Experiment (interleaved) | Result | Conclusion |
|---|---|---|
| new prod (19-test file) vs base | both 0/5 | production change ≡ base under identical test count |
| 20-test (with guard test) vs 19-test | 0/6 vs 1/6 (failed an unrelated auth-401 test) | added guard test does not increase flake rate |

Failing subtests across runs were random unrelated WS tests (realtime-upgrade, auth-401, binary-frames) — `waitForCompleted`/`waitForPort` barrier misses under CPU starvation, no causal path to `_ts` recording. `origin/main`'s own CI is independently flaky (run 29674217591). Round-1's apparent "new flakes" was an order/thermal artifact that vanished under interleaving.

**Boot smoke** (`scripts/boot-smoke.sh 5648`, isolated `CCXRAY_HOME`): `BOOT OK: dashboard HTTP 200` — exit 0.

**codex review (`codex review --base origin/main`):** clean after 3 rounds.
- Round 1 → **P1**: the first design (removing `created`/`completed` from `WS_SKIP_EVENTS`) persisted the ~35KB envelopes → 88× `_res.json` bloat + relay-path latency. Fixed by the owner-approved compact-marker pivot.
- Round 2 → **P2**: `response.done` (a documented terminal variant, `wire-protocol-reference.md:144`, treated as completion in `public/renderers/openai.js:61`) was missing from the anchor set. Added to `WS_TS_ANCHORS`.
- Round 3 → **clean**: "records receive timestamps without mutating relayed frames … preserves compact storage for large anchor events. No introduced correctness or blocking performance issues were found."

## What I did NOT verify

- **No live Codex WS traffic replay.** Relay isolation is structural (record uses `parsed`; relay uses the raw `data` buffer). The unit test drives the real ws-proxy relay+record path with a live WS server/client.
- **The pre-existing WS-suite flake is not fixed here** (out of scope). Candidate follow-up: load-tolerant barrier timeouts / TOCTOU-free port acquisition / lower `CCXRAY_WS_IDLE_TIMEOUT_MS` in tests.
- **`finalizeTurn` still fires only on `response.completed`, not `response.done`** (pre-existing). For a `response.done`-terminal Codex version the turn finalizes via the next `response.create` / socket close / idle — the `response.done` `_ts` marker is captured at receive time and included when the turn finalizes, so duration is derivable; but same-connection turn *splitting* on `response.done` is a separate behavior left untouched here.

## Round-2 review (owner-side codex gpt-5.6 xhigh + ops) — addressed

- **Blocker 2 (fixed):** the `response.done` regression test used a fixed
  `setTimeout(300)` before closing — a load-sensitive wait introduced by this PR
  (a fixed-sleep green is a possibly-false, load-dependent green). Replaced with
  an event-driven barrier (wait for the relayed `response.done` frame, which the
  proxy sends *after* recording the marker, then close). Commit `dfd0d57`.
- **Blocker 1 (fixed):** TTFT-only scope now documented explicitly (below +
  design doc).
- **Confirmed clean by the independent review:** relay purity (`_ts` never
  leaks to the client; record/relay paths independent); compact marker
  sufficient for TTFT.
- **Verification note:** single-file `diff-check` (old-fail/new-pass) on
  `websocket-proxy.test.js` re-run after the barrier change → **exit 0**. The
  full parallel suite is **deferred to the offload machine** per the shared-machine
  directive (see the note in the flake section) — not run here.

## Scope (TTFT-only — explicit limitation, owner-defined)

This PR captures timestamps for the **success path** only: `response.created` (t0) →
first `output_text.delta` (first token) → `response.completed` / `response.done` (stream end).
That is sufficient to derive Codex TTFT and success-path duration.

Deliberately **not** in scope (accepted because the goal is TTFT):
- **Failure/interrupt terminals** (`response.failed` / `response.incomplete`, or a stream
  that ends via socket close without a terminal event) get **no `stop_ts` anchor** and are
  not compact-marked. Any such non-anchor terminal envelope that reaches the recorder is
  stored in full, not compacted. TTFT does not need a failure stop time; adding these later
  is a pure addition (extend `WS_TS_ANCHORS`).
- **Terminal `output_tokens`** are captured into `ctx.lastUsage` (for cost) but the compact
  `{type,_ts}` markers drop the terminal envelope body, so a throughput consumer (#195,
  tokens ÷ duration) cannot read per-event `output_tokens` from the marker. Also a pure
  future addition if throughput is wanted.

Narrowing to TTFT is intentional; this section documents it so the boundary is explicit, not silent.

## Merge gate

⚠️ **Touches the WS capture path → permanently excluded from auto-merge** (governance rule: SSE/WS capture path). Manual merge + human review only. Do **not** enable auto-merge.

Closes #293
