### PR TITLE
fix(test): wait for rAF-deferred project label in dashboard-codex-e2e; ci fail-fast:false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      # Don't cancel the sibling Node version when one flakes: a single-job flake
+      # otherwise fails the whole run and renders the cancelled job's in-flight
+      # tests as false failures (CI reliability analysis, 2026-07-19).
+      fail-fast: false
       matrix:
         node-version: [20, 22]
     steps:

--- a/test/dashboard-codex-e2e.test.js
+++ b/test/dashboard-codex-e2e.test.js
@@ -197,7 +197,12 @@ describe('Codex dashboard status E2E', () => {
       await page.waitForFunction(() => {
         const turn = document.querySelector('.turn-item[data-session-id="codex-raw"]');
         const header = document.querySelector('#col-sections .ch-line2');
-        return !!turn && !!header && header.textContent.includes('completed');
+        // Also wait for the selected project label to be painted: it renders via the
+        // rAF-coalesced dirty-check (ADR 0002), so page.evaluate can otherwise read it
+        // empty before the frame lands under CPU contention (the CI flake, #294 CI red).
+        const projLabel = document.querySelector('.project-item.selected .pi-label');
+        return !!turn && !!header && header.textContent.includes('completed')
+          && !!projLabel && projLabel.textContent.trim().length > 0;
       });
 
       const state = await page.evaluate(() => {
@@ -248,7 +253,10 @@ describe('Codex dashboard status E2E', () => {
       await page.waitForFunction((sid) => {
         const turn = document.querySelector(`.turn-item[data-session-id="${sid}"]`);
         const session = document.querySelector(`.session-item[data-session-id="${sid}"]`);
-        return !!turn && !!session;
+        // Wait for the rAF-coalesced selected project label too (ADR 0002) — same race
+        // as the first test: this subtest also asserts projectText.
+        const projLabel = document.querySelector('.project-item.selected .pi-label');
+        return !!turn && !!session && !!projLabel && projLabel.textContent.trim().length > 0;
       }, {}, sessionId);
 
       const state = await page.evaluate(() => ({


### PR DESCRIPTION
## 摘要（繁中）

CI hotfix（ops 裁示插隊）：修正目前 100% 的 CI 失敗根因。近 40 次 CI 的 4 次 failure **全是同一條** `dashboard-codex-e2e.test.js` 的 `'' !== 'ccxray'` projectText assertion——測試漏等 rAF-coalesced 的 project label（ADR 0002 dirty-check）就 `page.evaluate` 讀取，CPU 競爭下讀到空字串。**非產品 bug**。同 PR 帶 `fail-fast: false` 消除「單軌 flake 拖垮整 run + 被取消軌 in-flight 測試呈現假失敗」。

## What changed

**F1 — `test/dashboard-codex-e2e.test.js`** (both subtests): the `page.waitForFunction` gate now also waits for `.project-item.selected .pi-label` to be non-empty before `page.evaluate` reads it. The label renders via the rAF-coalesced dirty-check (ADR 0002); CDP `Runtime.evaluate` does not wait for a frame, so under CPU contention it could read the label empty → `'' !== 'ccxray'`. Waiting for the painted label closes the race.

**F2 — `.github/workflows/ci.yml`**: added `strategy.fail-fast: false` so one Node-version job's flake no longer cancels the sibling and renders its in-flight tests as false failures.

## Evidence

This is a flake fix — there is no single old-fail/new-pass diff-check. Evidence is layered:

1. **Real before-baseline (production CI):** the last 4 CI failures across `ci.yml` (runs incl. 29674217591, 29682737472 — the latter is PR #294's own red) are **all** this one assertion (`'' !== 'ccxray'`, durations 1.8–3.2s, not timeouts), on unrelated PRs (incl. a docs-only PR). ~4/40 runs.
2. **Mechanism proof (deterministic):** under CDP CPU throttling (`Emulation.setCPUThrottlingRate`, rate 40) the **fixed** test fails with `Waiting failed: 30000ms exceeded` — i.e. it now *blocks waiting for the label* rather than reading it empty. So the fix structurally cannot produce the silent wrong-value flake: it either gets the painted label or fails loudly on a visible timeout.
3. **Throttle stress (low-CPU, sequential CDP-throttle, no busy loops):** OLD reproduced the empty-projectText race under rate-20 throttle (1 occurrence in a 12-run batch; the race is ~8% and stochastic, so a second 12-run batch caught none). NEW **never** produced an empty-projectText in any throttle run. At extreme throttle (rate 40) NEW fails *loudly* with `Waiting failed: 30000ms exceeded` — confirming it now blocks on the label rather than reading it empty; OLD at rate 40 reads empty/asserts. A clean high-N `OLD X% / NEW 0%` statistic needs many runs and is **deferred to the offload machine** (this machine is quota-constrained — see note).

> **Note on verification method:** the full parallel `node --test test/*.test.js` suite and multi-instance smoke were **not** run on this machine — it is shared with a time-sensitive overnight job and high load there burns an irreplaceable external quota. Per owner directive, evidence uses only low-CPU CDP-throttle + sequential single runs. Full-suite verification is deferred to the offload machine / after the window.

## Merge gate

⚠️ **Stop at manual merge gate** — `ci.yml` change; owner wants to eyeball. Do not auto-merge. Once this lands, re-running #294's CI should clear its (unrelated) red.

Refs: CI reliability analysis 2026-07-19 (F1+F2). Follow-ups F3–F6 filed as #295/#296/#297/#298 (batch-23).
