### PR TITLE
feat(sse): reconnect-safe delta sync with broadcast sequence ring buffer

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -937,6 +937,45 @@ function recomputeProjectCost(projName) {
 window.recomputeSessionStats = recomputeSessionStats;
 window.recomputeProjectCost = recomputeProjectCost;
 
+// ── Merge cold sessions from session index into sessionsMap + DOM + projectsMap ──
+function mergeColdSessions(sessions) {
+  for (const s of sessions) {
+    if (!s || !s.sid) continue;
+    if (sessionsMap.has(s.sid)) {
+      var existing = sessionsMap.get(s.sid);
+      if (!existing.title && s.title) existing.title = s.title;
+      continue;
+    }
+    sessionsMap.set(s.sid, {
+      id: s.sid, firstTs: null, firstId: s.firstId || '', lastId: s.lastId || '',
+      count: s.count || 0, mainCount: s.count || 0, subCount: 0, retryCount: 0,
+      model: s.model || '?', totalCost: s.totalCost || 0, cwd: s.cwd || null,
+      title: s.title || null, titleReqTs: 0, lastAssistantText: null,
+      agent: s.agent || 'claude', provider: s.provider || 'anthropic',
+      latestCacheHitRatio: 0, latestCacheReadTokens: 0,
+      resumeCommand: null, parentSessionId: null,
+      lastReceivedAt: s.lastReceivedAt || 0, _cold: true,
+    });
+    var shortSid = s.sid.slice(0, 8);
+    var sessEl = document.createElement('div');
+    sessEl.className = 'session-item';
+    sessEl.dataset.sessionId = s.sid;
+    sessEl.id = 'sess-' + shortSid;
+    sessEl.onclick = (function(sid) { return function() { selectSession(sid); }; })(s.sid);
+    sessEl.innerHTML = renderSessionItem(sessionsMap.get(s.sid), s.sid, sessEl);
+    colSessions.appendChild(sessEl);
+    var projName = getProjectName(s.cwd);
+    if (!projectsMap.has(projName)) {
+      projectsMap.set(projName, { name: projName, totalCost: 0, sessionIds: new Set(), firstId: s.firstId || '', lastId: s.lastId || '', lastSeenAt: 0 });
+    }
+    var proj = projectsMap.get(projName);
+    proj.sessionIds.add(s.sid);
+    if (s.totalCost) proj.totalCost += s.totalCost;
+    if (s.lastId && s.lastId > (proj.lastId || '')) proj.lastId = s.lastId;
+    if (s.lastReceivedAt && s.lastReceivedAt > (proj.lastSeenAt || 0)) proj.lastSeenAt = s.lastReceivedAt;
+  }
+}
+
 // Initialize badge on load
 setTimeout(() => updateSysPromptBadge('orchestrator'), 500);
 startQuotaTicker();
@@ -947,7 +986,18 @@ const evtSource = new EventSource('/_events');
 evtSource.onmessage = (ev) => {
   try {
     const data = JSON.parse(ev.data);
-    if (data._type === 'session_status') {
+    if (data._type === 'stale') {
+      // Server ring buffer evicted or hub restarted — full re-fetch
+      console.log('[ccxray] SSE stale — re-fetching entries + sessions');
+      Promise.all([
+        fetch('/_api/entries', { cache: 'no-store' }).then(r => r.json()).catch(() => ({ entries: [] })),
+        fetch('/_api/sessions', { cache: 'no-store' }).then(r => r.json()).catch(() => ({ sessions: [] })),
+      ]).then(([entriesData, sessionsData]) => {
+        for (const e of (entriesData.entries || [])) addEntry(e);
+        mergeColdSessions(sessionsData.sessions || []);
+        renderProjectsCol();
+      });
+    } else if (data._type === 'session_status') {
       sessionStatusMap.set(data.sessionId, { active: data.active, lastSeenAt: data.lastSeenAt });
       const sid = data.sessionId;
       const sessEl = document.getElementById('sess-' + sid.slice(0, 8));
@@ -959,33 +1009,7 @@ evtSource.onmessage = (ev) => {
     } else if (data._type === 'sessions_updated') {
       // Importer finished — re-fetch session index to pick up new cold sessions
       fetch('/_api/sessions', { cache: 'no-store' }).then(r => r.json()).then(sd => {
-        const cold = (sd && sd.sessions) || [];
-        for (const s of cold) {
-          if (!s || !s.sid || sessionsMap.has(s.sid)) continue;
-          sessionsMap.set(s.sid, {
-            id: s.sid, firstTs: null, firstId: s.firstId || '', lastId: s.lastId || '',
-            count: s.count || 0, mainCount: s.count || 0, subCount: 0, retryCount: 0,
-            model: s.model || '?', totalCost: s.totalCost || 0, cwd: s.cwd || null,
-            title: s.title || null, titleReqTs: 0, lastAssistantText: null,
-            agent: s.agent || 'claude', provider: s.provider || 'anthropic',
-            latestCacheHitRatio: 0, latestCacheReadTokens: 0,
-            resumeCommand: null, parentSessionId: null,
-            lastReceivedAt: s.lastReceivedAt || 0, _cold: true,
-          });
-          const shortSid = s.sid.slice(0, 8);
-          const sessEl = document.createElement('div');
-          sessEl.className = 'session-item';
-          sessEl.dataset.sessionId = s.sid;
-          sessEl.id = 'sess-' + shortSid;
-          sessEl.onclick = () => selectSession(s.sid);
-          sessEl.innerHTML = renderSessionItem(sessionsMap.get(s.sid), s.sid, sessEl);
-          colSessions.appendChild(sessEl);
-          const projName = getProjectName(s.cwd);
-          if (!projectsMap.has(projName)) projectsMap.set(projName, { name: projName, totalCost: 0, sessionIds: new Set(), firstId: s.firstId || '', lastId: s.lastId || '', lastSeenAt: 0 });
-          const proj = projectsMap.get(projName);
-          proj.sessionIds.add(s.sid);
-          if (s.totalCost) proj.totalCost += s.totalCost;
-        }
+        mergeColdSessions((sd && sd.sessions) || []);
         renderProjectsCol();
         applySessionFilter();
       }).catch(() => {});
@@ -1144,7 +1168,10 @@ const _sessionsReady = (async function _fetchSessionsWhenReady() {
     const r = await fetch('/_api/sessions', { cache: 'no-store' }).catch(() => null);
     if (!r) return { sessions: [] };
     const d = await r.json();
-    if (!d.restore || !d.restore.restoring) return d;
+    // Wait until restore is fully complete — not just !restoring (initial
+    // state is restoring:false,complete:false before setRestoreState runs)
+    if (d.restore && d.restore.complete) return d;
+    if (!d.restore) return d;
     await new Promise(r => setTimeout(r, 500));
   }
 })();
@@ -1287,43 +1314,7 @@ Promise.all([_entriesReady, _starsReady, _sessionsReady]).then(async ([data, , s
   }
 
   // Merge cold sessions from the full session index (#303).
-  const coldSessions = (sessionsData && sessionsData.sessions) || [];
-  for (const s of coldSessions) {
-    if (!s || !s.sid) continue;
-    if (sessionsMap.has(s.sid)) {
-      const existing = sessionsMap.get(s.sid);
-      if (!existing.title && s.title) existing.title = s.title;
-      continue;
-    }
-    sessionsMap.set(s.sid, {
-      id: s.sid, firstTs: null, firstId: s.firstId || '', lastId: s.lastId || '',
-      count: s.count || 0, mainCount: s.count || 0, subCount: 0, retryCount: 0,
-      model: s.model || '?', totalCost: s.totalCost || 0, cwd: s.cwd || null,
-      title: s.title || null, titleReqTs: 0, lastAssistantText: null,
-      agent: s.agent || 'claude', provider: s.provider || 'anthropic',
-      latestCacheHitRatio: 0, latestCacheReadTokens: 0,
-      resumeCommand: null, parentSessionId: null,
-      lastReceivedAt: s.lastReceivedAt || 0,
-      _cold: true,
-    });
-    const shortSid = s.sid.slice(0, 8);
-    const sessEl = document.createElement('div');
-    sessEl.className = 'session-item';
-    sessEl.dataset.sessionId = s.sid;
-    sessEl.id = 'sess-' + shortSid;
-    sessEl.onclick = () => selectSession(s.sid);
-    sessEl.innerHTML = renderSessionItem(sessionsMap.get(s.sid), s.sid, sessEl);
-    colSessions.appendChild(sessEl);
-    const projName = getProjectName(s.cwd);
-    if (!projectsMap.has(projName)) {
-      projectsMap.set(projName, { name: projName, totalCost: 0, sessionIds: new Set(), firstId: s.firstId || '', lastId: s.lastId || '', lastSeenAt: 0 });
-    }
-    const proj = projectsMap.get(projName);
-    proj.sessionIds.add(s.sid);
-    if (s.totalCost) proj.totalCost += s.totalCost;
-    if (s.lastId && s.lastId > (proj.lastId || '')) proj.lastId = s.lastId;
-    if (s.lastReceivedAt && s.lastReceivedAt > (proj.lastSeenAt || 0)) proj.lastSeenAt = s.lastReceivedAt;
-  }
+  mergeColdSessions((sessionsData && sessionsData.sessions) || []);
 
   // Post-batch: one final render pass — sort sessions by most-recently-active then
   // rerender each item with accumulated data. colSessions + renderSessionItem are

--- a/server/routes/sse.js
+++ b/server/routes/sse.js
@@ -2,6 +2,7 @@
 
 const store = require('../store');
 const { MAX_SSE_PER_IP } = require('../config');
+const { getEpoch, getRing } = require('../sse-broadcast');
 
 function normalizeIp(raw) {
   if (!raw) return '';
@@ -28,6 +29,26 @@ function handleSSERoute(clientReq, clientRes) {
     'Connection': 'keep-alive',
   });
   clientRes.write(':\n\n');
+
+  // ── Reconnect replay via Last-Event-ID ──
+  // Format: "<epoch>:<seq>". Epoch matches + seq in ring → replay after seq.
+  // Epoch mismatch or seq evicted → stale signal → client full re-fetch.
+  const lastId = clientReq.headers && clientReq.headers['last-event-id'];
+  if (lastId) {
+    const sep = lastId.indexOf(':');
+    const reqEpoch = sep > 0 ? Number(lastId.slice(0, sep)) : 0;
+    const reqSeq = sep > 0 ? Number(lastId.slice(sep + 1)) : 0;
+    const ring = getRing();
+    if (reqEpoch === getEpoch() && ring.length > 0 && reqSeq >= ring[0].seq) {
+      for (const item of ring) {
+        if (item.seq > reqSeq) {
+          clientRes.write(`id: ${getEpoch()}:${item.seq}\ndata: ${item.data}\n\n`);
+        }
+      }
+    } else {
+      clientRes.write(`data: ${JSON.stringify({ _type: 'stale' })}\n\n`);
+    }
+  }
 
   // Send current session statuses
   for (const [sid, meta] of Object.entries(store.sessionMeta)) {

--- a/server/sse-broadcast.js
+++ b/server/sse-broadcast.js
@@ -3,6 +3,28 @@
 const store = require('./store');
 const { agentForProvider } = require('./providers');
 
+// ── Broadcast sequence + ring buffer for reconnect replay ──────────
+// Monotonic seq (not entry.id — entry.id is request-start time, broadcast
+// happens at completion; long turns would have id < watermark). Epoch
+// distinguishes hub restarts; ring buffer holds recent events for replay.
+let _broadcastSeq = 0;
+const _epoch = Date.now();
+const RING_SIZE = parseInt(process.env.CCXRAY_SSE_RING_SIZE || '2000', 10);
+const _ring = [];
+
+function _broadcastAll(data) {
+  const seq = ++_broadcastSeq;
+  const sseId = `${_epoch}:${seq}`;
+  _ring.push({ seq, data });
+  if (_ring.length > RING_SIZE) _ring.shift();
+  for (const res of store.sseClients) {
+    res.write(`id: ${sseId}\ndata: ${data}\n\n`);
+  }
+}
+
+function getEpoch() { return _epoch; }
+function getRing() { return _ring; }
+
 // Strip req/res from broadcast — browser only needs summary for the turn list
 function summarizeEntry(entry) {
   const tok = entry.tokens;
@@ -51,37 +73,25 @@ function summarizeEntry(entry) {
 }
 
 function broadcast(entry) {
-  const data = JSON.stringify(summarizeEntry(entry));
-  for (const res of store.sseClients) {
-    res.write(`data: ${data}\n\n`);
-  }
+  _broadcastAll(JSON.stringify(summarizeEntry(entry)));
 }
 
 function broadcastSessionStatus(sessionId) {
   const active = (store.activeRequests[sessionId] || 0) > 0;
   const lastSeenAt = store.sessionMeta[sessionId]?.lastSeenAt || null;
-  const data = JSON.stringify({ _type: 'session_status', sessionId, active, lastSeenAt });
-  for (const res of store.sseClients) {
-    res.write(`data: ${data}\n\n`);
-  }
+  _broadcastAll(JSON.stringify({ _type: 'session_status', sessionId, active, lastSeenAt }));
 }
 
 function broadcastPendingRequest(requestId, parsedBody, sessionId) {
-  const data = JSON.stringify({
-    _type: 'pending_request', requestId, sessionId,
-    body: parsedBody,
-  });
-  for (const res of store.sseClients) res.write(`data: ${data}\n\n`);
+  _broadcastAll(JSON.stringify({ _type: 'pending_request', requestId, sessionId, body: parsedBody }));
 }
 
 function broadcastInterceptToggle(sessionId, enabled) {
-  const data = JSON.stringify({ _type: 'intercept_toggled', sessionId, enabled });
-  for (const res of store.sseClients) res.write(`data: ${data}\n\n`);
+  _broadcastAll(JSON.stringify({ _type: 'intercept_toggled', sessionId, enabled }));
 }
 
 function broadcastInterceptRemoved(requestId) {
-  const data = JSON.stringify({ _type: 'intercept_removed', requestId });
-  for (const res of store.sseClients) res.write(`data: ${data}\n\n`);
+  _broadcastAll(JSON.stringify({ _type: 'intercept_removed', requestId }));
 }
 
 // Per-session debounced title-update broadcast. Bursts within the window
@@ -95,8 +105,7 @@ function flushSessionTitleUpdate(sessionId) {
   const title = store.getSessionTitle(sessionId);
   if (!title) return;
   const titleReqTs = store.sessionMeta[sessionId]?.titleReqTs || null;
-  const data = JSON.stringify({ _type: 'session_title_update', sessionId, title, titleReqTs });
-  for (const res of store.sseClients) res.write(`data: ${data}\n\n`);
+  _broadcastAll(JSON.stringify({ _type: 'session_title_update', sessionId, title, titleReqTs }));
 }
 
 function broadcastSessionTitleUpdate(sessionId, { immediate = false } = {}) {
@@ -119,8 +128,7 @@ function _resetTitleDebounce() {
 }
 
 function broadcastRaw(obj) {
-  const data = JSON.stringify(obj);
-  for (const res of store.sseClients) res.write(`data: ${data}\n\n`);
+  _broadcastAll(JSON.stringify(obj));
 }
 
 module.exports = {
@@ -134,4 +142,6 @@ module.exports = {
   broadcastSessionTitleUpdate,
   TITLE_DEBOUNCE_MS,
   _resetTitleDebounce,
+  getEpoch,
+  getRing,
 };

--- a/test/session-title-broadcast.test.js
+++ b/test/session-title-broadcast.test.js
@@ -26,7 +26,7 @@ describe('broadcastSessionTitleUpdate', () => {
     store.sseClients.push(client);
     sse.broadcastSessionTitleUpdate('sA', { immediate: true });
     assert.equal(client.written.length, 1);
-    const parsed = JSON.parse(client.written[0].replace(/^data: /, '').trim());
+    const parsed = JSON.parse(client.written[0].split('\n').find(l => l.startsWith('data: ')).replace(/^data: /, ''));
     assert.equal(parsed._type, 'session_title_update');
     assert.equal(parsed.sessionId, 'sA');
     assert.equal(parsed.title, 'first');
@@ -47,7 +47,7 @@ describe('broadcastSessionTitleUpdate', () => {
 
     setTimeout(() => {
       assert.equal(client.written.length, 1, 'exactly one event after debounce window');
-      const parsed = JSON.parse(client.written[0].replace(/^data: /, '').trim());
+      const parsed = JSON.parse(client.written[0].split('\n').find(l => l.startsWith('data: ')).replace(/^data: /, ''));
       assert.equal(parsed.title, 'third');
       done();
     }, sse.TITLE_DEBOUNCE_MS + 100);

--- a/test/sse-ring-buffer.test.js
+++ b/test/sse-ring-buffer.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('SSE ring buffer', () => {
+  let mod;
+  beforeEach(() => {
+    // Fresh module for each test
+    delete require.cache[require.resolve('../server/sse-broadcast')];
+    mod = require('../server/sse-broadcast');
+  });
+
+  it('getEpoch returns a number', () => {
+    assert.equal(typeof mod.getEpoch(), 'number');
+    assert.ok(mod.getEpoch() > 0);
+  });
+
+  it('getRing starts empty', () => {
+    assert.deepEqual(mod.getRing(), []);
+  });
+
+  it('broadcast populates ring with monotonic seq', () => {
+    const store = require('../server/store');
+    // Add a fake SSE client to capture output
+    const chunks = [];
+    const fakeRes = { write(d) { chunks.push(d); } };
+    store.sseClients.push(fakeRes);
+
+    mod.broadcastRaw({ _type: 'test', v: 1 });
+    mod.broadcastRaw({ _type: 'test', v: 2 });
+
+    const ring = mod.getRing();
+    assert.equal(ring.length, 2);
+    assert.ok(ring[1].seq > ring[0].seq);
+
+    // SSE frames should have id: field
+    assert.ok(chunks[0].startsWith('id: '));
+    assert.ok(chunks[0].includes('data: '));
+
+    // Parse the id
+    const idLine = chunks[0].split('\n')[0];
+    const [epoch, seq] = idLine.replace('id: ', '').split(':').map(Number);
+    assert.equal(epoch, mod.getEpoch());
+    assert.equal(seq, ring[0].seq);
+
+    store.sseClients.splice(store.sseClients.indexOf(fakeRes), 1);
+  });
+
+  it('ring evicts oldest when full', () => {
+    // Use a small ring size for testing — env var is read at require time,
+    // so we test eviction behavior by filling the ring
+    const ring = mod.getRing();
+    const store = require('../server/store');
+    const fakeRes = { write() {} };
+    store.sseClients.push(fakeRes);
+
+    for (let i = 0; i < 2010; i++) {
+      mod.broadcastRaw({ i });
+    }
+    // Default RING_SIZE=2000
+    assert.ok(ring.length <= 2000);
+    assert.ok(ring[0].seq > 1); // oldest was evicted
+
+    store.sseClients.splice(store.sseClients.indexOf(fakeRes), 1);
+  });
+});


### PR DESCRIPTION
## Summary

- SSE 斷線重連自動補漏：broadcast sequence ring buffer + Last-Event-ID 原生重連重放
- 覆蓋所有事件類型（entries、session_status、title、intercept）
- Hub 重啟/ring 逐出 → stale 訊號 → 前端全量重抓

## 設計

```
broadcast(entry) ──┐
broadcastStatus ───┤
broadcastTitle ────┤──► _broadcastAll(data)
broadcastRaw ──────┘       │
                           ├─ seq++ (monotonic)
                           ├─ ring.push({seq, data})
                           └─ SSE frame: id: <epoch>:<seq>\ndata: ...\n\n

reconnect:
  Last-Event-ID: <epoch>:<seq>
  ├─ epoch match + seq in ring → replay after seq
  └─ epoch mismatch / evicted → stale → client re-fetch
```

## Test plan

- [x] Ring buffer unit tests (4 tests): monotonic seq, eviction, id field format
- [x] Title broadcast tests: adapted for new SSE frame format
- [x] SSE connection tests: headers guard for mock clients
- [ ] `npm test` — running (all affected tests pass individually)

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)