### PR TITLE
fix(server): log-first session index + startup reconciliation (#309)

### DIFF
--- a/server/forward.js
+++ b/server/forward.js
@@ -763,8 +763,10 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
 
     // Persist to index (fire-and-forget after broadcast)
     const indexLine = buildIndexLine(entry);
-    config.storage.appendIndex(indexLine + '\n').catch(e => console.error('Write index failed:', e.message));
-    sessionIdx.updateFromEntry(entry);
+    // Log-first: only update session index after index.ndjson write succeeds (#309)
+    config.storage.appendIndex(indexLine + '\n').then(() => {
+      sessionIdx.updateFromEntry(entry);
+    }).catch(e => console.error('Write index failed:', e.message));
 
     // Release req/res from memory — data is on disk (or being written), lazy-load on demand
     entry.req = null;
@@ -862,8 +864,10 @@ function handleOpenAISSE(ctx, proxyRes, clientRes) {
     broadcast(entry);
 
     const indexLine = buildIndexLine(entry);
-    config.storage.appendIndex(indexLine + '\n').catch(e => console.error('Write index failed:', e.message));
-    sessionIdx.updateFromEntry(entry);
+    // Log-first: only update session index after index.ndjson write succeeds (#309)
+    config.storage.appendIndex(indexLine + '\n').then(() => {
+      sessionIdx.updateFromEntry(entry);
+    }).catch(e => console.error('Write index failed:', e.message));
 
     entry.req = null;
     entry.res = null;
@@ -994,8 +998,10 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
     broadcast(entry);
 
     const indexLine = buildIndexLine(entry);
-    config.storage.appendIndex(indexLine + '\n').catch(e => console.error('Write index failed:', e.message));
-    sessionIdx.updateFromEntry(entry);
+    // Log-first: only update session index after index.ndjson write succeeds (#309)
+    config.storage.appendIndex(indexLine + '\n').then(() => {
+      sessionIdx.updateFromEntry(entry);
+    }).catch(e => console.error('Write index failed:', e.message));
 
     // Release req/res from memory — data is on disk (or being written), lazy-load on demand
     entry.req = null;

--- a/server/importer.js
+++ b/server/importer.js
@@ -294,8 +294,10 @@ function pushImportedEntry(entry, existingIds) {
   // broadcast to avoid 158K memory spike + client SSE flood. Imported sessions
   // are cold; their entries load on-demand via /_api/session/:sid/entries.
   const indexLine = buildIndexLine(entry);
-  _pendingIndexWrites.push(config.storage.appendIndex(indexLine + '\n').catch(() => {}));
-  sessionIdx.updateFromEntry(entry);
+  // Log-first: only update session index after index.ndjson write succeeds (#309)
+  _pendingIndexWrites.push(config.storage.appendIndex(indexLine + '\n').then(() => {
+    sessionIdx.updateFromEntry(entry);
+  }).catch(e => console.error('Write import index failed:', e.message)));
   return true;
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -630,8 +630,10 @@ async function gracefulExit(code) {
   const deadline = new Promise(resolve => setTimeout(resolve, 5000));
   const drain = (async () => {
     try { await drainWebSocketProxy(); } catch (e) { console.error('WS drain failed:', e.message); }
-    try { await sessionIdx.flush(); } catch (e) { console.error('Session index flush failed:', e.message); }
+    // drain() before flush(): in-flight appendIndex .then(updateFromEntry) callbacks
+    // must fire before flush persists the session Map to disk (#309)
     try { await config.storage.drain(); } catch (e) { console.error('Storage drain failed:', e.message); }
+    try { await sessionIdx.flush(); } catch (e) { console.error('Session index flush failed:', e.message); }
   })();
   await Promise.race([drain, deadline]);
   process.exit(code);

--- a/server/restore.js
+++ b/server/restore.js
@@ -141,6 +141,13 @@ async function restoreFromLogs() {
     return;
   }
 
+  // 1b. Reconcile sessions.json against index.ndjson if loaded (#309)
+  if (sessionIndexLoaded && indexContent) {
+    if (sessionIdx.reconcile(indexContent)) {
+      console.log(`\x1b[90m   Session index reconciled: ${sessionIdx.size()} sessions\x1b[0m`);
+    }
+  }
+
   // 2. Parse index lines and filter by RESTORE_DAYS
   console.time('restore:parse');
   let cutoffStr = null;

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -62,6 +62,30 @@ function rebuildFromIndexContent(indexContent) {
   dirty = true;
 }
 
+// Compare loaded sessions.json against index.ndjson content. Returns true if
+// drift detected (and rebuilds). Checks both unique session count and total
+// entry count — the latter catches appendIndex failures for existing sessions
+// where session count stays the same but per-session counts diverge. (#309)
+function reconcile(indexContent) {
+  if (!indexContent || !sessionIndex.size) return false;
+  let indexSessions = 0, indexEntries = 0;
+  const seen = new Set();
+  const re = /"sessionId":"([^"]+)"/;
+  for (const line of indexContent.split('\n')) {
+    if (!line) continue;
+    const m = re.exec(line);
+    if (!m) continue;
+    indexEntries++;
+    if (!seen.has(m[1])) { seen.add(m[1]); indexSessions++; }
+  }
+  let totalEntries = 0;
+  for (const s of sessionIndex.values()) totalEntries += s.count;
+  if (indexSessions === sessionIndex.size && indexEntries === totalEntries) return false;
+  console.warn(`\x1b[33m[session-index] drift detected: sessions.json has ${sessionIndex.size} sessions / ${totalEntries} entries, index.ndjson has ${indexSessions} sessions / ${indexEntries} entries — rebuilding\x1b[0m`);
+  rebuildFromIndexContent(indexContent);
+  return true;
+}
+
 // Upsert a session summary from an entry's index fields.
 function updateFromEntry(entry) {
   if (!entry || !entry.sessionId) return;
@@ -125,4 +149,4 @@ function size() {
   return sessionIndex.size;
 }
 
-module.exports = { loadSessionIndex, rebuildFromIndexContent, updateFromEntry, setTitle, flush, getAll, size };
+module.exports = { loadSessionIndex, rebuildFromIndexContent, reconcile, updateFromEntry, setTitle, flush, getAll, size };

--- a/server/ws-proxy.js
+++ b/server/ws-proxy.js
@@ -367,8 +367,10 @@ async function recordWebSocketEntry(ctx, result, turn = null) {
   broadcast(entry);
 
   const indexLine = buildIndexLine(entry);
-  config.storage.appendIndex(indexLine + '\n').catch(e => console.error('Write ws index failed:', e.message));
-  sessionIdx.updateFromEntry(entry);
+  // Log-first: only update session index after index.ndjson write succeeds (#309)
+  config.storage.appendIndex(indexLine + '\n').then(() => {
+    sessionIdx.updateFromEntry(entry);
+  }).catch(e => console.error('Write ws index failed:', e.message));
   entry.req = null;
   entry.res = null;
   entry._loaded = false;

--- a/test/session-index.test.js
+++ b/test/session-index.test.js
@@ -101,4 +101,57 @@ describe('session-index', () => {
     }
     assert.equal(si.size(), 5);
   });
+
+  it('reconcile detects session-count drift and rebuilds', async () => {
+    const si = require('../server/session-index');
+    // Seed sessions.json with 2 sessions
+    si.updateFromEntry({ sessionId: 'sa', id: 't1', model: 'x', cost: { cost: 1 }, receivedAt: 1 });
+    si.updateFromEntry({ sessionId: 'sb', id: 't2', model: 'x', cost: { cost: 2 }, receivedAt: 2 });
+    await si.flush();
+    assert.equal(si.size(), 2);
+
+    // index.ndjson has 3 sessions
+    const indexContent = [
+      JSON.stringify({ id: 't1', sessionId: 'sa', model: 'x', cost: { cost: 1 }, receivedAt: 1 }),
+      JSON.stringify({ id: 't2', sessionId: 'sb', model: 'x', cost: { cost: 2 }, receivedAt: 2 }),
+      JSON.stringify({ id: 't3', sessionId: 'sc', model: 'x', cost: { cost: 3 }, receivedAt: 3 }),
+    ].join('\n');
+
+    const drifted = si.reconcile(indexContent);
+    assert.ok(drifted, 'should detect session-count drift');
+    assert.equal(si.size(), 3, 'should rebuild with 3 sessions');
+  });
+
+  it('reconcile detects entry-count drift and rebuilds', async () => {
+    const si = require('../server/session-index');
+    // Seed with 1 session / 1 entry
+    si.updateFromEntry({ sessionId: 'sa', id: 't1', model: 'x', cost: { cost: 1 }, receivedAt: 1 });
+    await si.flush();
+    assert.equal(si.getAll()[0].count, 1);
+
+    // index.ndjson has same 1 session but 2 entries
+    const indexContent = [
+      JSON.stringify({ id: 't1', sessionId: 'sa', model: 'x', cost: { cost: 1 }, receivedAt: 1 }),
+      JSON.stringify({ id: 't2', sessionId: 'sa', model: 'x', cost: { cost: 2 }, receivedAt: 2 }),
+    ].join('\n');
+
+    const drifted = si.reconcile(indexContent);
+    assert.ok(drifted, 'should detect entry-count drift');
+    assert.equal(si.getAll()[0].count, 2, 'should rebuild with correct count');
+  });
+
+  it('reconcile passes when counts match', () => {
+    const si = require('../server/session-index');
+    si.updateFromEntry({ sessionId: 'sa', id: 't1', model: 'x', cost: { cost: 1 }, receivedAt: 1 });
+    si.updateFromEntry({ sessionId: 'sb', id: 't2', model: 'x', cost: { cost: 2 }, receivedAt: 2 });
+
+    const indexContent = [
+      JSON.stringify({ id: 't1', sessionId: 'sa', model: 'x', cost: { cost: 1 }, receivedAt: 1 }),
+      JSON.stringify({ id: 't2', sessionId: 'sb', model: 'x', cost: { cost: 2 }, receivedAt: 2 }),
+    ].join('\n');
+
+    const drifted = si.reconcile(indexContent);
+    assert.equal(drifted, false, 'should not detect drift');
+    assert.equal(si.size(), 2, 'should keep existing sessions');
+  });
 });


### PR DESCRIPTION
## 摘要

- appendIndex 失敗時不再更新 sessionIdx（log-first 原則）
- 啟動時比對 sessions.json 與 index.ndjson 的 session 數 + entry 總數，漂移時自動重建 + console.warn
- gracefulExit 中 `storage.drain()` 移到 `sessionIdx.flush()` 前面，確保 in-flight `.then(updateFromEntry)` 在 flush 前完成

## Detail

### A. Log-first (5 sites)

`sessionIdx.updateFromEntry(entry)` chained inside `.then()` of `appendIndex()` — if the append fails, the session index is not updated. Prevents sessions.json from leading index.ndjson.

Sites: `forward.js` ×3, `ws-proxy.js` ×1, `importer.js` ×1 (full chain pushed into `_pendingIndexWrites`).

### B. gracefulExit ordering

Swap `storage.drain()` before `sessionIdx.flush()` so in-flight appendIndex `.then(updateFromEntry)` callbacks fire before flush persists the Map to disk.

### C. Startup reconciliation

`reconcile(indexContent)` in `session-index.js` compares both unique session count AND total entry count against the loaded sessions.json. Catches drift from appendIndex failures for both new and existing sessions. Called in `restore.js` after loading sessions.json and reading index.ndjson.

### D. Tests

3 new tests: session-count drift, entry-count drift, no-drift pass.

## Test plan

- [x] `CCXRAY_HOME=$(mktemp -d) npm test` — 1391 pass, 0 fail
- [x] Smoke test startup with isolated CCXRAY_HOME — no errors

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)