### PR TITLE
fix(client): cold replay child session + project migration recompute edge cases

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -919,9 +919,7 @@ function addEntry(e) {
 function recomputeSessionStats(sid) {
   const sess = sessionsMap.get(sid);
   if (!sess) return;
-  sess.count = 0; sess.mainCount = 0; sess.subCount = 0; sess.retryCount = 0;
-  sess.totalCost = 0; sess.inputTokens = 0; sess.outputTokens = 0;
-  sess.toolCalls = {}; sess.toolCallTurns = 0; sess.toolFailTurns = 0;
+  zeroSessionStats(sess);
   for (var i = 0; i < allEntries.length; i++) {
     var en = allEntries[i];
     if (en.sessionId !== sid) continue;

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -635,7 +635,7 @@ function addEntry(e) {
   // Live (hot): full recompute from allEntries (idempotent, O(n) per entry).
   // Batch: increment counts for displayNum; defer full recompute to post-batch.
   // Cold: increment all stats (entries not in allEntries; full recompute on activation).
-  if (!_loading && !sess._cold) {
+  if (!_loading && !sess._cold && !window._coldActivating) {
     recomputeSessionStats(sid);
     recomputeProjectCost(projName);
     if (prevProjectName && prevProjectName !== projName) recomputeProjectCost(prevProjectName);

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2212,16 +2212,21 @@ function selectSession(id) {
         sess.totalCost = 0; sess.inputTokens = 0; sess.outputTokens = 0;
         sess.toolCalls = {}; sess.toolCallTurns = 0; sess.toolFailTurns = 0;
         const entries = data.entries || [];
+        // Track all sessions touched during replay (child sessions, migrations)
+        const replaySids = new Set([id]);
         window._coldActivating = true;
-        for (const e of entries) addEntry(e);
+        for (const e of entries) {
+          if (e.sessionId) replaySids.add(e.sessionId);
+          addEntry(e);
+        }
         window._coldActivating = false;
-        sess._cold = false;
+        // Clear _cold for all replayed sessions (parent + children)
+        for (const sid of replaySids) {
+          const s = sessionsMap.get(sid);
+          if (s) s._cold = false;
+        }
         if (typeof recomputeSessionStats === 'function') {
-          recomputeSessionStats(id);
-          // Child sessions created during cold replay also need full recompute
-          for (const [childId, childSess] of sessionsMap) {
-            if (childSess.parentSessionId === id) recomputeSessionStats(childId);
-          }
+          for (const sid of replaySids) recomputeSessionStats(sid);
         }
         // Recompute all projects — cwd migration means old project needs update too
         if (typeof recomputeProjectCost === 'function') {

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2217,7 +2217,16 @@ function selectSession(id) {
         window._coldActivating = true;
         try {
           for (const e of entries) {
-            if (e.sessionId) replaySids.add(e.sessionId);
+            if (e.sessionId && !replaySids.has(e.sessionId)) {
+              replaySids.add(e.sessionId);
+              // Zero child session stats seeded by mergeColdSessions (same reason as parent above)
+              const cs = sessionsMap.get(e.sessionId);
+              if (cs && cs._cold) {
+                cs.count = 0; cs.mainCount = 0; cs.subCount = 0; cs.retryCount = 0;
+                cs.totalCost = 0; cs.inputTokens = 0; cs.outputTokens = 0;
+                cs.toolCalls = {}; cs.toolCallTurns = 0; cs.toolFailTurns = 0;
+              }
+            }
             addEntry(e);
           }
         } finally {

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2215,11 +2215,14 @@ function selectSession(id) {
         // Track all sessions touched during replay (child sessions, migrations)
         const replaySids = new Set([id]);
         window._coldActivating = true;
-        for (const e of entries) {
-          if (e.sessionId) replaySids.add(e.sessionId);
-          addEntry(e);
+        try {
+          for (const e of entries) {
+            if (e.sessionId) replaySids.add(e.sessionId);
+            addEntry(e);
+          }
+        } finally {
+          window._coldActivating = false;
         }
-        window._coldActivating = false;
         // Clear _cold for all replayed sessions (parent + children)
         for (const sid of replaySids) {
           const s = sessionsMap.get(sid);
@@ -2237,6 +2240,13 @@ function selectSession(id) {
             const s = sessionsMap.get(sid);
             if (s && !s.title) s.title = title;
           }
+        }
+        // Re-render child session cards to reflect recomputed stats
+        for (const sid of replaySids) {
+          if (sid === id) continue;
+          const childEl = document.getElementById('sess-' + sid.slice(0, 8));
+          const childSess = sessionsMap.get(sid);
+          if (childEl && childSess) childEl.innerHTML = renderSessionItem(childSess, sid, childEl);
         }
         // Render — use _renderSelectedSession to avoid selectSession's id===selected guard
         if (spinner.parentNode) spinner.remove();

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2216,9 +2216,17 @@ function selectSession(id) {
         for (const e of entries) addEntry(e);
         window._coldActivating = false;
         sess._cold = false;
-        if (typeof recomputeSessionStats === 'function') recomputeSessionStats(id);
-        const projName = getProjectName(sess.cwd);
-        if (typeof recomputeProjectCost === 'function') recomputeProjectCost(projName);
+        if (typeof recomputeSessionStats === 'function') {
+          recomputeSessionStats(id);
+          // Child sessions created during cold replay also need full recompute
+          for (const [childId, childSess] of sessionsMap) {
+            if (childSess.parentSessionId === id) recomputeSessionStats(childId);
+          }
+        }
+        // Recompute all projects — cwd migration means old project needs update too
+        if (typeof recomputeProjectCost === 'function') {
+          for (const [name] of projectsMap) recomputeProjectCost(name);
+        }
         if (data.sessionTitles) {
           for (const [sid, title] of Object.entries(data.sessionTitles)) {
             const s = sessionsMap.get(sid);

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2166,6 +2166,12 @@ function formatCurrentStepBreadcrumb() {
   return 'step #' + (step.stepIdx + 1) + subLabel;
 }
 
+function zeroSessionStats(s) {
+  s.count = 0; s.mainCount = 0; s.subCount = 0; s.retryCount = 0;
+  s.totalCost = 0; s.inputTokens = 0; s.outputTokens = 0;
+  s.toolCalls = {}; s.toolCallTurns = 0; s.toolFailTurns = 0;
+}
+
 function selectSession(id) {
   setFocus('sessions');
   if (id === selectedSessionId) return;
@@ -2208,9 +2214,7 @@ function selectSession(id) {
         // #308: zero stats before replay — sessions.json seeded them; addEntry
         // increments on top (cold path), so without zeroing = double-count.
         // Replay with _cold still true → incremental counts, not O(n²) recompute.
-        sess.count = 0; sess.mainCount = 0; sess.subCount = 0; sess.retryCount = 0;
-        sess.totalCost = 0; sess.inputTokens = 0; sess.outputTokens = 0;
-        sess.toolCalls = {}; sess.toolCallTurns = 0; sess.toolFailTurns = 0;
+        zeroSessionStats(sess);
         const entries = data.entries || [];
         // Track all sessions touched during replay (child sessions, migrations)
         const replaySids = new Set([id]);
@@ -2219,13 +2223,9 @@ function selectSession(id) {
           for (const e of entries) {
             if (e.sessionId && !replaySids.has(e.sessionId)) {
               replaySids.add(e.sessionId);
-              // Zero child session stats seeded by mergeColdSessions (same reason as parent above)
+              // Zero child session stats seeded by mergeColdSessions (same reason as parent)
               const cs = sessionsMap.get(e.sessionId);
-              if (cs && cs._cold) {
-                cs.count = 0; cs.mainCount = 0; cs.subCount = 0; cs.retryCount = 0;
-                cs.totalCost = 0; cs.inputTokens = 0; cs.outputTokens = 0;
-                cs.toolCalls = {}; cs.toolCallTurns = 0; cs.toolFailTurns = 0;
-              }
+              if (cs && cs._cold) zeroSessionStats(cs);
             }
             addEntry(e);
           }


### PR DESCRIPTION
## Summary

Fixes #314 — two perf edge cases from PR #312 codex review:

1. **Child sessions O(n²)**: During cold activation, child sessions created via `addEntry()` lacked `_cold` flag → hit the hot path with per-entry `recomputeSessionStats` + `recomputeProjectCost`. Fix: add `!window._coldActivating` guard at entry-rendering.js:638.

2. **Project cost stale after cwd migration**: Post-activation recompute only covered the current project. If a session migrated from project A→B during replay, A's cost was never updated. Fix: recompute all projects after activation.

## Changes

- `public/entry-rendering.js`: +1 condition to line 638 guard
- `public/miller-columns.js`: child session recompute loop + full projectsMap recompute after cold activation

## Evidence

- full-test: 1391 pass, 0 fail
- boot-smoke: server started on port 18314, exit 0
- codex-review: pending (agmsg reviewer dispatched)

<!-- GATE-MANIFEST
issue-lint=pass @193131118165e13cdc550b1b3cf54e424fb98aea
full-test=0 @193131118165e13cdc550b1b3cf54e424fb98aea
boot-smoke=0 @193131118165e13cdc550b1b3cf54e424fb98aea
-->