### PR TITLE
fix(dashboard): stabilize detail panel width during cold session loading

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2205,7 +2205,9 @@ function selectSession(id) {
     spinner.innerHTML = '<div class="loading-spinner"></div><div>Loading ' + (sess.count || '') + ' turns…</div>';
     colTurns.appendChild(spinner);
     renderSessionToolBar(id);
-    document.getElementById('columns').classList.remove('wf-active');
+    const columnsEl = document.getElementById('columns');
+    columnsEl.classList.remove('wf-active');
+    columnsEl.classList.add('cold-loading');
     renderBreadcrumb();
     fetch('/_api/session/' + encodeURIComponent(id) + '/entries')
       .then(r => r.json())
@@ -2259,9 +2261,11 @@ function selectSession(id) {
         }
         // Render — use _renderSelectedSession to avoid selectSession's id===selected guard
         if (spinner.parentNode) spinner.remove();
+        columnsEl.classList.remove('cold-loading');
         _renderSelectedSession(id);
       })
       .catch(() => {
+        columnsEl.classList.remove('cold-loading');
         if (spinner.parentNode) spinner.innerHTML = '<div style="opacity:0.5">Failed to load entries</div>';
       });
     return;

--- a/public/style.css
+++ b/public/style.css
@@ -679,6 +679,11 @@
 .sysprompt-breadcrumb a { color: var(--accent); text-decoration: none; cursor: pointer; }
 .sysprompt-breadcrumb a:hover { text-decoration: underline; }
 
+/* Cold-loading: hide empty sections/detail, let turns fill the space (#316) */
+#columns.cold-loading #col-sections,
+#columns.cold-loading #col-detail { display: none; }
+#columns.cold-loading #col-turns { flex: 1; }
+
 /* ── Workflow Swimlane Timeline (#91) ── */
 /* When workflow is active, col-turns becomes the full-width right area;
    col-sections and col-detail are hidden (agent card + steps live inside col-turns) */


### PR DESCRIPTION
## Summary

Fixes #316 — cold session loading caused layout jump: empty sections/detail columns had fixed widths during spinner phase, then toggled to wf-active on completion (hiding them and expanding turns to flex:1).

## Fix

Add `cold-loading` CSS class during fetch that hides sections/detail and lets turns expand, matching the final layout from the start. Class removed on fetch complete or error.

## Changes

- `public/miller-columns.js`: add/remove `cold-loading` class around cold fetch
- `public/style.css`: `cold-loading` rules to hide sections/detail and flex turns

## Evidence

- full-test: 1391 pass, 0 fail
- boot-smoke: server started on port 18316, exit 0

<!-- GATE-MANIFEST
issue-lint=pass @faa16345baae67e9e67186e05b4d25aa5e3bb66a
full-test=0 @faa16345baae67e9e67186e05b4d25aa5e3bb66a
boot-smoke=0 @faa16345baae67e9e67186e05b4d25aa5e3bb66a
-->