### PR TITLE
fix(dashboard): abort previous cold session fetch on session switch

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2261,6 +2261,7 @@ function selectSession(id) {
           if (childEl && childSess) childEl.innerHTML = renderSessionItem(childSess, sid, childEl);
         }
         // Render — use _renderSelectedSession to avoid selectSession's id===selected guard
+        _coldFetchController = null;
         if (spinner.parentNode) spinner.remove();
         _renderSelectedSession(id);
       })

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1305,6 +1305,7 @@ function _applyStatsToggleUI() {
 
 let selectedProjectName = null; // null = (all)
 let selectedSessionId = null;
+let _coldFetchController = null; // AbortController for in-flight cold session fetch (#317)
 let selectedTurnIdx = -1;
 let selectedSection = null;
 let selectedMessageIdx = -1;
@@ -2207,7 +2208,9 @@ function selectSession(id) {
     renderSessionToolBar(id);
     document.getElementById('columns').classList.remove('wf-active');
     renderBreadcrumb();
-    fetch('/_api/session/' + encodeURIComponent(id) + '/entries')
+    if (_coldFetchController) _coldFetchController.abort();
+    _coldFetchController = new AbortController();
+    fetch('/_api/session/' + encodeURIComponent(id) + '/entries', { signal: _coldFetchController.signal })
       .then(r => r.json())
       .then(data => {
         if (selectedSessionId !== id) return;
@@ -2261,7 +2264,8 @@ function selectSession(id) {
         if (spinner.parentNode) spinner.remove();
         _renderSelectedSession(id);
       })
-      .catch(() => {
+      .catch(err => {
+        if (err && err.name === 'AbortError') return;
         if (spinner.parentNode) spinner.innerHTML = '<div style="opacity:0.5">Failed to load entries</div>';
       });
     return;


### PR DESCRIPTION
## Summary

Fixes #317 — rapid session switching during cold lazy-load caused spinner stacking and UI hangs from concurrent addEntry() calls.

## Fix

Add module-level `AbortController` (`_coldFetchController`). Each cold fetch aborts the previous in-flight one via `signal`, so only the latest session loads.

## Changes

- `public/miller-columns.js`: +4 lines (controller declaration + abort-before-fetch + signal param)

## Evidence

- full-test: 1391 pass, 0 fail
- boot-smoke: server started on port 18317, exit 0

<!-- GATE-MANIFEST
issue-lint=pass @836b6e2e6be603a6efda3e72a0a6dc57c5db07c1
full-test=0 @836b6e2e6be603a6efda3e72a0a6dc57c5db07c1
boot-smoke=0 @836b6e2e6be603a6efda3e72a0a6dc57c5db07c1
-->