### PR TITLE
fix(server): reverse buildVersionIndex query — read by hash, don't scan shared/

### DIFF
--- a/server/restore.js
+++ b/server/restore.js
@@ -293,9 +293,12 @@ async function restoreFromLogs() {
   store.trimEntries();
   console.timeEnd('restore:parse');
 
-  // 3. Build version index from shared/ system prompts (scans a handful of small files)
+  // 3. Build version index from shared/ system prompts — driven by hashes seen
+  //    during parse, NOT by scanning shared/ (which may have 100K+ files).
   console.time('restore:versions');
-  const sysHashToAgentKey = await buildVersionIndex();
+  const knownHashes = store._sysHashDates ? [...store._sysHashDates.keys()] : [];
+  console.log(`   buildVersionIndex: ${knownHashes.length} distinct sysHash from parsed entries`);
+  const sysHashToAgentKey = await buildVersionIndex(knownHashes);
   console.timeEnd('restore:versions');
 
   // Backfill agent identity for index lines written before agentKey landed —
@@ -347,22 +350,21 @@ async function restoreFromLogs() {
   }
 }
 
-async function buildVersionIndex() {
-  let sharedFiles;
-  try { sharedFiles = await config.storage.listShared(); } catch { return null; }
+async function buildVersionIndex(knownHashes) {
+  if (!knownHashes || knownHashes.length === 0) return null;
   const sysHashToAgentKey = new Map();
 
-  // EXCEPTION(#158): data-layer — stored filename prefix (sys_ vs openai_instructions_) determines parse format
-  for (const filename of sharedFiles) {
-    if (!filename.startsWith('sys_') && !filename.startsWith('openai_instructions_')) continue;
-    try {
-      const sys = JSON.parse(await config.storage.readShared(filename));
-      const isOpenAI = filename.startsWith('openai_instructions_');
+  for (const sysHash of knownHashes) {
+    // Try both prefixes — anthropic (sys_) and openai (openai_instructions_)
+    for (const prefix of ['sys_', 'openai_instructions_']) {
+      const filename = `${prefix}${sysHash}.json`;
+      const isOpenAI = prefix === 'openai_instructions_';
+      let sys;
+      try { sys = JSON.parse(await config.storage.readShared(filename)); } catch { continue; }
       if (!isOpenAI && (!Array.isArray(sys) || sys.length < 3)) continue;
       const b0 = isOpenAI ? '' : (sys[0]?.text || '');
       const b2 = isOpenAI ? (typeof sys === 'string' ? sys : JSON.stringify(sys, null, 2)) : (sys[2]?.text || '');
       const m = b0.match(/cc_version=(\S+?)[; ]/);
-      const sysHash = filename.replace(/^sys_/, '').replace(/^openai_instructions_/, '').replace(/\.json$/, '');
       let agentInfo = null;
       if (isOpenAI) {
         const meta = await config.storage.readShared(`openai_prompt_meta_${sysHash}.json`)
@@ -379,15 +381,12 @@ async function buildVersionIndex() {
       if (b2.length >= (isOpenAI ? 1 : 500)) {
         const coreText = isOpenAI ? b2 : (splitB2IntoBlocks(b2).coreInstructions || '');
         const coreLen = coreText.length;
-        // INVARIANT: anthropic coreHash via computeCoreHash (platform-normalized) — see system-prompt.js (#219).
-        // OpenAI/Codex keeps the raw hash (no platform-token split there).
         const coreHash = isOpenAI ? rawCoreHash(coreText) : computeCoreHash(coreText);
         const ver = isOpenAI ? coreHash : (m ? m[1] : null);
         if (!ver) continue;
         const idxKey = `${agentKey}::${coreHash}`;
         const existing = store.versionIndex.get(idxKey);
         if (!existing || b2.length > existing.b2Len) {
-          // Get file mtime as firstSeen date
           const stat = config.storage.statShared ? await config.storage.statShared(filename) : null;
           const firstSeen = stat?.mtime ? stat.mtime.toISOString().slice(0, 10) : null;
           store.versionIndex.set(idxKey, {
@@ -399,7 +398,8 @@ async function buildVersionIndex() {
           if (ver > existing.version) existing.version = ver;
         }
       }
-    } catch {}
+      break; // found for this hash, skip other prefix
+    }
   }
   return sysHashToAgentKey;
 }

--- a/server/restore.js
+++ b/server/restore.js
@@ -297,7 +297,6 @@ async function restoreFromLogs() {
   //    during parse, NOT by scanning shared/ (which may have 100K+ files).
   console.time('restore:versions');
   const knownHashes = store._sysHashDates ? [...store._sysHashDates.keys()] : [];
-  console.log(`   buildVersionIndex: ${knownHashes.length} distinct sysHash from parsed entries`);
   const sysHashToAgentKey = await buildVersionIndex(knownHashes);
   console.timeEnd('restore:versions');
 
@@ -354,8 +353,7 @@ async function buildVersionIndex(knownHashes) {
   if (!knownHashes || knownHashes.length === 0) return null;
   const sysHashToAgentKey = new Map();
 
-  for (const sysHash of knownHashes) {
-    // Try both prefixes — anthropic (sys_) and openai (openai_instructions_)
+  async function processHash(sysHash) {
     for (const prefix of ['sys_', 'openai_instructions_']) {
       const filename = `${prefix}${sysHash}.json`;
       const isOpenAI = prefix === 'openai_instructions_';
@@ -377,6 +375,19 @@ async function buildVersionIndex(knownHashes) {
       const { key: agentKey, label: agentLabel } = agentInfo || (isOpenAI
         ? extractPromptAgentType('openai', { instructions: b2 })
         : extractAgentType(sys));
+      return { sysHash, filename, isOpenAI, b0, b2, m, agentKey, agentLabel };
+    }
+    return null;
+  }
+
+  // Parallel read in batches of 50 to limit open file descriptors
+  const BATCH = 50;
+  for (let i = 0; i < knownHashes.length; i += BATCH) {
+    const batch = knownHashes.slice(i, i + BATCH);
+    const results = await Promise.all(batch.map(h => processHash(h).catch(() => null)));
+    for (const r of results) {
+      if (!r) continue;
+      const { sysHash, filename, isOpenAI, b2, m, agentKey, agentLabel } = r;
       if (sysHash && agentKey) sysHashToAgentKey.set(sysHash, { key: agentKey, label: agentLabel });
       if (b2.length >= (isOpenAI ? 1 : 500)) {
         const coreText = isOpenAI ? b2 : (splitB2IntoBlocks(b2).coreInstructions || '');
@@ -398,7 +409,6 @@ async function buildVersionIndex(knownHashes) {
           if (ver > existing.version) existing.version = ver;
         }
       }
-      break; // found for this hash, skip other prefix
     }
   }
   return sysHashToAgentKey;


### PR DESCRIPTION
## Summary

Fixes #321 — `buildVersionIndex()` was scanning all 114K+ files in shared/ via `listShared()`, causing server startup to hang on large homes.

## Fix

Drive the version index from the sysHash set already collected during parse (~15K hashes), reading files directly by name in parallel batches of 50. Eliminates the 114K-entry readdir entirely.

**Before**: restore:versions hung (114K readdir + serial reads)
**After**: restore:versions 3s (15K parallel reads), total startup 16s

## Changes

- `server/restore.js`: pass knownHashes to buildVersionIndex, replace listShared scan with direct reads, batch 50 concurrent

## Evidence

- full-test: 1391 pass, 0 fail
- boot-smoke: server started with real 114K shared/ home, restore:total 15.8s

<!-- GATE-MANIFEST
issue-lint=pass @184e9c1a74ce9e847758916f71a1fa42d9829bd3
full-test=0 @184e9c1a74ce9e847758916f71a1fa42d9829bd3
boot-smoke=0 @184e9c1a74ce9e847758916f71a1fa42d9829bd3
-->