### PR TITLE
feat(dashboard): session weather score — pure function + tests (#320 Phase 1)

### DIFF
--- a/docs/solutions/session-weather.md
+++ b/docs/solutions/session-weather.md
@@ -1,0 +1,164 @@
+# Session Weather Score — Design
+
+> Diagnostic output for #315. Design settled in owner conversation 2026-07-20.
+
+## Problem
+
+ccxray already computes per-turn quality signals (context pressure, compaction,
+truncation, stuck detection) but they exist only as visual cues scattered across
+the dashboard. No single scalar answers "is this session healthy?" — and no
+programmatic interface lets an agent (Claude Code / Codex) self-diagnose.
+
+Jenkins solved the equivalent problem for CI with a 5-level weather icon
+(sunny → stormy) aggregated from recent build results. Same metaphor applies
+to LLM sessions.
+
+## Signals (all wire-level, language-agnostic)
+
+Existing per-turn fields consumed (no new server computation):
+
+| Field | Source | Already on SSE entry |
+|-------|--------|---------------------|
+| `ctxPct` | `computeCtxUsed(usage) / maxContext * 100` | yes (via `wfCtxPct`) |
+| `isCompacted` | server-side detection | yes |
+| `stopReason` | API response | yes |
+| `usage.output_tokens` | API response | yes |
+| `toolFail` | server-side detection | yes |
+
+`ctxZone(pct)` in `format.js` (safe <40% / warn 40-80% / danger >80%)
+already exists — weather consumes ctxPct directly, does not replace ctxZone.
+
+## Weather scale
+
+| Level | Icon | Key | Meaning |
+|-------|------|-----|---------|
+| 0 | ☀️ | `clear` | healthy |
+| 1 | 🌤️ | `fair` | context entering warn zone |
+| 2 | ⛅ | `cloudy` | context danger zone, or compaction happened |
+| 3 | 🌧️ | `rainy` | stuck detected, or multiple compactions |
+| 4 | ⛈️ | `stormy` | critically degraded |
+
+## Algorithm
+
+Single priority-ordered degradation pass. Context zone sets the base; events
+push upward; the highest level wins.
+
+```js
+function assessWeather(turns) {
+  let level = 0;
+  const factors = [];
+
+  // 1. context zone (base) — last turn's ctxPct
+  const last = turns[turns.length - 1];
+  const ctxPct = last
+    ? Math.min(100, computeCtxUsed(last.usage) / (last.maxContext || 200000) * 100)
+    : 0;
+  if (ctxPct > 80)       { level = Math.max(level, 2); factors.push('ctx_danger'); }
+  else if (ctxPct >= 40)  { level = Math.max(level, 1); factors.push('ctx_warn'); }
+
+  // 2. compaction scar (permanent, cumulative)
+  const compactions = turns.filter(t => t.isCompacted).length;
+  if (compactions >= 2)      { level = Math.max(level, 3); factors.push('compaction_multi'); }
+  else if (compactions >= 1) { level = Math.max(level, 2); factors.push('compaction'); }
+
+  // 3. truncation: stopReason=max_tokens AND output_tokens≥16000
+  const truncations = turns.filter(
+    t => t.stopReason === 'max_tokens' && (t.usage?.output_tokens ?? 0) >= 16000
+  ).length;
+  if (truncations > 0) { level = Math.min(level + 1, 4); factors.push('truncation'); }
+
+  // 4. stuck detector: ≥10 consecutive tool_use with >25% error rate
+  let streak = 0, errors = 0, maxStuck = 0;
+  for (const t of turns) {
+    if (t.stopReason === 'tool_use') {
+      streak++;
+      if (t.toolFail) errors++;
+      if (streak >= 10 && errors / streak > 0.25) maxStuck = Math.max(maxStuck, streak);
+    } else { streak = 0; errors = 0; }
+  }
+  if (maxStuck >= 10) { level = Math.max(level, 3); factors.push('stuck'); }
+
+  // 5. elevated tool error rate (non-stuck, threshold 15%)
+  const toolTurns = turns.filter(t => t.stopReason === 'tool_use');
+  if (toolTurns.length >= 5) {
+    const rate = toolTurns.filter(t => t.toolFail).length / toolTurns.length;
+    if (rate > 0.15 && maxStuck < 10) {
+      level = Math.min(level + 1, 4);
+      factors.push('tool_error_elevated');
+    }
+  }
+
+  const ICONS = ['☀️', '🌤️', '⛅', '🌧️', '⛈️'];
+  const KEYS  = ['clear', 'fair', 'cloudy', 'rainy', 'stormy'];
+  const i = Math.min(level, 4);
+  return { weather: ICONS[i], level: KEYS[i], factors };
+}
+```
+
+### Threshold rationale
+
+| Threshold | Source |
+|-----------|--------|
+| 40% / 80% context zones | existing `ctxZone()`, aligns with practitioner consensus (Anthropic team recommends compacting at 50-60%; Hermes dual-layer 50%+85%) |
+| 16000 output_tokens for truncation | #306 definition — filters low-risk subagent kicks |
+| 10-turn streak + 25% error | #306 stuck detector definition |
+| 15% tool error rate | owner decision 2026-07-20 (below stuck threshold, above noise floor) |
+
+## Scoping rules
+
+Weather is scope-dependent — same function, different `turns` input:
+
+| Consumer | turns = |
+|----------|---------|
+| Session card | all turns in session |
+| Agent card (swimlane lane title) | turns in that lane |
+| Turn card | turns[0..N] (prefix to selected turn) |
+| API / CLI / skill | parameterized (see below) |
+
+### Design decision: compaction scar is permanent
+
+A compaction event means context filled to the point the system had to
+intervene. This structurally changes what the agent can recall — the session
+never fully recovers. Weather cap: 1 compaction → max ⛅; 2+ → max 🌧️.
+
+## Architecture
+
+### One file: `public/weather.js`
+
+Pure function, zero dependencies on other ccxray modules. Reads only plain
+object fields present on every SSE entry. Isomorphic (browser script tag +
+Node require).
+
+### Two interfaces (design decision: separate)
+
+**Dashboard** (descriptive): weather emoji on session card, agent card, turn
+card. Prefix weather for turns is precomputed as `turnWeathers[]` on session
+load (one sequential scan), not recomputed per hover.
+
+**Agent API** (prescriptive):
+
+```
+GET /api/sessions/:id/weather                  → whole session
+GET /api/sessions/:id/weather?agent=<laneKey>  → specific lane
+GET /api/sessions/:id/weather?until=<turnId>   → prefix
+```
+
+Response:
+```json
+{
+  "weather": "⛅",
+  "level": "cloudy",
+  "factors": ["compaction", "ctx_warn"],
+  "turnCount": 47,
+  "ctxPct": 62.3
+}
+```
+
+CLI: `ccxray health [session-id] [--json]`
+Skill: `/session-health` — adds prescriptive `recommendation` field.
+
+## Deferred
+
+- **Security signals** — needs request body inspection, different magnitude
+- **Customizable thresholds** — YAGNI until proven otherwise
+- **Weather trend / sparkline** — after core lands

--- a/public/index.html
+++ b/public/index.html
@@ -183,6 +183,7 @@
 <script src="/cost-budget-ui.js"></script>
 <script src="/quota-ticker.js"></script>
 <script src="/format.js"></script>
+<script src="/weather.js"></script>
 <script src="/miller-columns.js"></script>
 <script src="/workflow-timeline.js"></script>
 <script src="/keyboard-nav.js"></script>

--- a/public/weather.js
+++ b/public/weather.js
@@ -1,0 +1,56 @@
+// Session weather score — single-scalar health indicator
+// Design: docs/solutions/session-weather.md
+
+function assessWeather(turns) {
+  if (!turns || !turns.length) return { weather: '☀️', level: 'clear', factors: [] };
+
+  let level = 0;
+  const factors = [];
+
+  // 1. context zone (base) — last turn's ctxPct
+  const last = turns[turns.length - 1];
+  const u = last.usage || {};
+  const ctxUsed = (u.cache_creation_input_tokens || 0) + (u.cache_read_input_tokens || 0) + (u.input_tokens || 0) + (u.output_tokens || 0);
+  const ctxPct = Math.min(100, ctxUsed / (last.maxContext || 200000) * 100);
+  if (ctxPct > 80)       { level = Math.max(level, 2); factors.push('ctx_danger'); }
+  else if (ctxPct >= 40)  { level = Math.max(level, 1); factors.push('ctx_warn'); }
+
+  // 2. compaction scar (permanent, cumulative)
+  const compactions = turns.filter(t => t.isCompacted).length;
+  if (compactions >= 2)      { level = Math.max(level, 3); factors.push('compaction_multi'); }
+  else if (compactions >= 1) { level = Math.max(level, 2); factors.push('compaction'); }
+
+  // 3. truncation: stopReason=max_tokens AND output_tokens>=16000
+  const truncations = turns.filter(
+    t => t.stopReason === 'max_tokens' && (t.usage?.output_tokens ?? 0) >= 16000
+  ).length;
+  if (truncations > 0) { level = Math.min(level + 1, 4); factors.push('truncation'); }
+
+  // 4. stuck detector: >=10 consecutive tool_use with >25% error rate
+  let streak = 0, errors = 0, maxStuck = 0;
+  for (const t of turns) {
+    if (t.stopReason === 'tool_use') {
+      streak++;
+      if (t.toolFail) errors++;
+      if (streak >= 10 && errors / streak > 0.25) maxStuck = Math.max(maxStuck, streak);
+    } else { streak = 0; errors = 0; }
+  }
+  if (maxStuck >= 10) { level = Math.max(level, 3); factors.push('stuck'); }
+
+  // 5. elevated tool error rate (non-stuck, threshold 15%)
+  const toolTurns = turns.filter(t => t.stopReason === 'tool_use');
+  if (toolTurns.length >= 5) {
+    const rate = toolTurns.filter(t => t.toolFail).length / toolTurns.length;
+    if (rate > 0.15 && maxStuck < 10) {
+      level = Math.min(level + 1, 4);
+      factors.push('tool_error_elevated');
+    }
+  }
+
+  const ICONS = ['☀️', '🌤️', '⛅', '🌧️', '⛈️'];
+  const KEYS  = ['clear', 'fair', 'cloudy', 'rainy', 'stormy'];
+  const i = Math.min(level, 4);
+  return { weather: ICONS[i], level: KEYS[i], factors };
+}
+
+if (typeof module !== 'undefined') module.exports = { assessWeather };

--- a/test/weather.test.js
+++ b/test/weather.test.js
@@ -1,0 +1,167 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { assessWeather } = require('../public/weather.js');
+
+// Helper to create a minimal turn object
+function turn(overrides = {}) {
+  return {
+    usage: { input_tokens: 10000, output_tokens: 1000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+    maxContext: 200000,
+    stopReason: 'end_turn',
+    isCompacted: false,
+    toolFail: false,
+    ...overrides
+  };
+}
+
+// ctx% fixtures (maxContext = 200000)
+const CTX10 = { input_tokens: 15000, output_tokens: 5000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 };  // 10%
+const CTX50 = { input_tokens: 80000, output_tokens: 20000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }; // 50%
+const CTX90 = { input_tokens: 150000, output_tokens: 30000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 };// 90%
+
+// n consecutive tool_use turns, first `failCount` of them failing
+function toolRun(n, failCount) {
+  const arr = [];
+  for (let i = 0; i < n; i++) arr.push(turn({ stopReason: 'tool_use', toolFail: i < failCount }));
+  return arr;
+}
+
+describe('assessWeather', () => {
+  it('1. empty turns → clear', () => {
+    for (const empty of [[], null, undefined]) {
+      const r = assessWeather(empty);
+      assert.equal(r.level, 'clear');
+      assert.equal(r.weather, '☀️');
+      assert.deepEqual(r.factors, []);
+    }
+  });
+
+  it('2. clear — low ctx, no events → clear', () => {
+    const r = assessWeather([turn({ usage: CTX10 }), turn({ usage: CTX10 })]);
+    assert.equal(r.level, 'clear');
+    assert.equal(r.weather, '☀️');
+    assert.deepEqual(r.factors, []);
+  });
+
+  it('3. ctx_warn — ctxPct between 40-80% → fair', () => {
+    const r = assessWeather([turn({ usage: CTX50 })]);
+    assert.equal(r.level, 'fair');
+    assert.equal(r.weather, '🌤️');
+    assert.deepEqual(r.factors, ['ctx_warn']);
+  });
+
+  it('4. ctx_danger — ctxPct > 80% → cloudy', () => {
+    const r = assessWeather([turn({ usage: CTX90 })]);
+    assert.equal(r.level, 'cloudy');
+    assert.equal(r.weather, '⛅');
+    assert.deepEqual(r.factors, ['ctx_danger']);
+  });
+
+  it('5. single compaction → cloudy (level 2)', () => {
+    const r = assessWeather([turn({ isCompacted: true }), turn({ usage: CTX10 })]);
+    assert.equal(r.level, 'cloudy');
+    assert.deepEqual(r.factors, ['compaction']);
+  });
+
+  it('6. multi compaction (2+) → rainy (level 3)', () => {
+    const r = assessWeather([turn({ isCompacted: true }), turn({ isCompacted: true }), turn({ usage: CTX10 })]);
+    assert.equal(r.level, 'rainy');
+    assert.equal(r.weather, '🌧️');
+    assert.deepEqual(r.factors, ['compaction_multi']);
+  });
+
+  it('7. truncation (max_tokens + output >= 16000) → bumps level by 1', () => {
+    const r = assessWeather([turn({
+      stopReason: 'max_tokens',
+      usage: { input_tokens: 10000, output_tokens: 16000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
+    })]);
+    assert.equal(r.level, 'fair');
+    assert.deepEqual(r.factors, ['truncation']);
+  });
+
+  it('8. truncation with low output (< 16000) → no effect', () => {
+    const r = assessWeather([turn({
+      stopReason: 'max_tokens',
+      usage: { input_tokens: 10000, output_tokens: 10000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
+    })]);
+    assert.equal(r.level, 'clear');
+    assert.deepEqual(r.factors, []);
+  });
+
+  it('9. stuck — 10+ consecutive tool_use with >25% error → rainy', () => {
+    const r = assessWeather(toolRun(10, 3)); // 3/10 = 30% > 25%
+    assert.equal(r.level, 'rainy');
+    assert.deepEqual(r.factors, ['stuck']);
+  });
+
+  it('10. stuck resets — streak broken by non-tool_use → no stuck', () => {
+    // run A: 9 tool_use (4 fail), break, run B: 5 tool_use (0 fail).
+    // max consecutive streak = 9 (< 10) → stuck never fires.
+    const turns = [...toolRun(9, 4), turn({ stopReason: 'end_turn' }), ...toolRun(5, 0)];
+    const r = assessWeather(turns);
+    assert.ok(!r.factors.includes('stuck'));
+    // 4 fails / 14 tool turns = 28.5% > 15%, not stuck → elevated fires instead
+    assert.equal(r.level, 'fair');
+    assert.deepEqual(r.factors, ['tool_error_elevated']);
+  });
+
+  it('11. tool_error_elevated — >15% error, 5+ tool turns, not stuck → bumps level by 1', () => {
+    const r = assessWeather(toolRun(5, 1)); // 1/5 = 20% > 15%, streak 5 < 10
+    assert.equal(r.level, 'fair');
+    assert.deepEqual(r.factors, ['tool_error_elevated']);
+  });
+
+  it('12. tool_error_below_threshold — <15% → no effect', () => {
+    const r = assessWeather(toolRun(10, 1)); // 1/10 = 10%, not stuck, not elevated
+    assert.equal(r.level, 'clear');
+    assert.deepEqual(r.factors, []);
+  });
+
+  it('13. combined: ctx_warn + compaction + truncation → cumulative', () => {
+    const turns = [
+      turn({ isCompacted: true }),
+      turn({
+        stopReason: 'max_tokens',
+        usage: { input_tokens: 10000, output_tokens: 16000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
+      }),
+      turn({ usage: CTX50 }) // last turn drives ctx → ctx_warn
+    ];
+    const r = assessWeather(turns);
+    // ctx_warn(1) → compaction(2) → truncation(min(2+1,4)=3)
+    assert.equal(r.level, 'rainy');
+    assert.deepEqual(r.factors, ['ctx_warn', 'compaction', 'truncation']);
+  });
+
+  it('14. combined: compaction_multi + stuck → max level (rainy, not additive)', () => {
+    const turns = [turn({ isCompacted: true }), turn({ isCompacted: true }), ...toolRun(10, 3)];
+    const r = assessWeather(turns);
+    // both contribute level 3 via Math.max → stays rainy, does not stack to stormy
+    assert.equal(r.level, 'rainy');
+    assert.deepEqual(r.factors, ['compaction_multi', 'stuck']);
+  });
+
+  it('15. level capped at 4 (stormy) — multiple degradations do not exceed stormy', () => {
+    const turns = [
+      turn({ isCompacted: true }),
+      turn({ isCompacted: true }),
+      turn({
+        stopReason: 'max_tokens',
+        usage: { input_tokens: 10000, output_tokens: 16000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
+      }),
+      ...toolRun(10, 3),        // stuck
+      turn({ usage: CTX90 })    // last turn → ctx_danger
+    ];
+    const r = assessWeather(turns);
+    // ctx_danger(2) → compaction_multi(3) → truncation(min(3+1,4)=4) → stuck(max(4,3)=4)
+    assert.equal(r.level, 'stormy');
+    assert.equal(r.weather, '⛈️');
+    assert.deepEqual(r.factors, ['ctx_danger', 'compaction_multi', 'truncation', 'stuck']);
+  });
+
+  it('16. compaction scar permanence — early compaction, rest clear → still cloudy', () => {
+    const turns = [turn({ isCompacted: true }), turn({ usage: CTX10 }), turn({ usage: CTX10 }), turn({ usage: CTX10 })];
+    const r = assessWeather(turns);
+    assert.equal(r.level, 'cloudy');
+    assert.deepEqual(r.factors, ['compaction']);
+  });
+});


### PR DESCRIPTION
## 摘要

Jenkins 天氣隱喻：`assessWeather(turns)` 純函數從既有 wire-level 信號算出 5 級健康分數（☀️→⛈️）。Phase 1 = 函數 + 測試，不碰 dashboard rendering。

- `public/weather.js` — zero-dep isomorphic 純函數，browser global + Node module
- `test/weather.test.js` — 16 個合成 fixture 覆蓋所有降級路徑
- `public/index.html` — 加 script tag
- `docs/solutions/session-weather.md` — 設計文件

設計：owner conversation 2026-07-20，定案於 docs/solutions/session-weather.md。

## 驗證

- weather.test.js: 16/16 pass
- 全量 npm test: 1407/1407 pass, 0 fail
- boot smoke: HTTP 200 on :5602

## 沒驗什麼

- Dashboard rendering（Phase 2）
- API endpoint / CLI（Phase 3）
- Skill（Phase 4）

## evidence-check 說明

PR 動 `public/` 兩檔（`weather.js` 新增純函數、`index.html` 加 script tag），但 Phase 1 無視覺變更——weather.js 只定義函數不渲染任何 DOM。截圖 n/a，待 owner 確認。

<!-- GATE-MANIFEST
issue-lint=pass @d231073b1a8100a6d5c6df6caa96de9c8dc30d21
full-test=0 @d231073b1a8100a6d5c6df6caa96de9c8dc30d21
boot-smoke=0 @d231073b1a8100a6d5c6df6caa96de9c8dc30d21
-->

Closes #320 (Phase 1 of 4)