### PR TITLE
fix(server): add disk fallback for cold session entry/tokens endpoints

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -17,6 +17,35 @@ const sessionIdx = require('../session-index');
 
 const AUTO_COMPACT_PCT = 0.835;
 
+// ── Bounded LRU for cold-session entries (disk fallback) ────────────
+const COLD_LRU_CAP = 200;
+const coldEntryCache = new Map(); // Map preserves insertion order → LRU via delete+re-set
+
+async function loadColdEntry(id) {
+  if (coldEntryCache.has(id)) {
+    const e = coldEntryCache.get(id);
+    coldEntryCache.delete(id); coldEntryCache.set(id, e); // touch
+    return e;
+  }
+  const indexContent = await config.storage.readIndex();
+  if (!indexContent) return null;
+  const needle = '"id":"' + id + '"';
+  for (const line of indexContent.split('\n')) {
+    if (!line || !line.includes(needle)) continue;
+    let meta;
+    try { meta = JSON.parse(line); } catch { continue; }
+    if (meta.id !== id) continue;
+    const entry = normalizeIndexEntry(meta);
+    // Evict oldest if at capacity
+    if (coldEntryCache.size >= COLD_LRU_CAP) {
+      coldEntryCache.delete(coldEntryCache.keys().next().value);
+    }
+    coldEntryCache.set(id, entry);
+    return entry;
+  }
+  return null;
+}
+
 function computeSettings() {
   const recentUsages = store.entries
     .filter(e => e && e.usage)
@@ -303,13 +332,13 @@ function handleApiRoutes(clientReq, clientRes) {
     return true;
   }
 
-  // Full entry data (req + res) — lazy loaded
+  // Full entry data (req + res) — lazy loaded; cold-session disk fallback
   const entryMatch = pathname.match(/^\/_api\/entry\/(.+)$/);
   if (entryMatch) {
     const id = decodeURIComponent(entryMatch[1]);
-    const entry = store.getEntryById(id);
-    if (!entry) { clientRes.writeHead(404); clientRes.end('Not found'); return true; }
     (async () => {
+      const entry = store.getEntryById(id) || await loadColdEntry(id);
+      if (!entry) { clientRes.writeHead(404); clientRes.end('Not found'); return; }
       await loadEntryReqRes(entry);
       const snapshot = { req: entry.req, res: entry.res, receivedAt: entry.receivedAt || null, toolSources: entry.toolSources || null };
       if (entry.elapsed === '?') { entry.req = null; entry.res = null; entry._loaded = false; }
@@ -322,13 +351,13 @@ function handleApiRoutes(clientReq, clientRes) {
     return true;
   }
 
-  // Lazy tokenization endpoint
+  // Lazy tokenization endpoint; cold-session disk fallback
   const tokMatch = pathname.match(/^\/_api\/tokens\/(.+)$/);
   if (tokMatch) {
     const id = decodeURIComponent(tokMatch[1]);
-    const entry = store.getEntryById(id);
-    if (!entry) { clientRes.writeHead(404); clientRes.end('Not found'); return true; }
     (async () => {
+      const entry = store.getEntryById(id) || await loadColdEntry(id);
+      if (!entry) { clientRes.writeHead(404); clientRes.end('Not found'); return; }
       if (!entry.tokens) {
         await loadEntryReqRes(entry);
         if (entry.req) entry.tokens = tokenizeRequest(entry.req);


### PR DESCRIPTION
## Summary

Cold session entries are not in server memory — `/_api/entry/:id` and `/_api/tokens/:id` returned 404, causing \"turn data could not be loaded\" on every cold session turn. This is the root cause of the widespread red text reported after #303 Phase 2.

## Fix

Add `loadColdEntry(id)`: scans index.ndjson for the entry, loads body files from disk. Uses bounded Map-based LRU (200 entries) to avoid repeated disk reads. Both `/_api/entry/:id` and `/_api/tokens/:id` now fall back to this on memory miss.

## Changes

- `server/routes/api.js`: +35/-6 — loadColdEntry + LRU + fallback in both endpoints

## Evidence

- full-test: 1391 pass, 0 fail

## Known limitation

Each LRU miss reads the full index file to find the entry. Acceptable for now (LRU prevents repeated reads for same entry), but a byte-offset index would eliminate this for Phase 3.

<!-- GATE-MANIFEST
issue-lint=pass @748793fcb7ca565ad3d98f3d809b2f37c009f393
full-test=0 @748793fcb7ca565ad3d98f3d809b2f37c009f393
boot-smoke=0 @748793fcb7ca565ad3d98f3d809b2f37c009f393
-->