### PR TITLE
feat(server): add COLD_SESSIONS_ENABLED kill-switch (default off)

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -193,6 +193,7 @@ const MAX_SSE_PER_IP = parseInt(process.env.CCXRAY_SSE_MAX_PER_IP || '20', 10);
 const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || String(LOG_RETENTION_DAYS), 10);
 // 0 = only session-start anchor; N>0 = force full snapshot every N delta writes
 const DELTA_SNAPSHOT_N = parseInt(process.env.CCXRAY_DELTA_SNAPSHOT_N || '0', 10);
+const COLD_SESSIONS_ENABLED = process.env.CCXRAY_COLD_SESSIONS === '1';
 const REWRITE_MODEL_PREFIX = process.env.CCXRAY_MODEL_PREFIX || '';
 const MAX_BODY_BYTES = parseInt(process.env.CCXRAY_MAX_BODY_MB || '50', 10) * 1024 * 1024;
 
@@ -340,6 +341,7 @@ module.exports = {
   UPSTREAMS,
   LOGS_DIR,
   RESTORE_DAYS,
+  COLD_SESSIONS_ENABLED,
   LOG_RETENTION_DAYS,
   DELTA_SNAPSHOT_N,
   MAX_SSE_PER_IP,

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -169,8 +169,12 @@ function handleApiRoutes(clientReq, clientRes) {
 
   if (pathname === '/_api/sessions') {
     const restore = store.restoreState;
+    let sessions = sessionIdx.getAll();
+    if (!config.COLD_SESSIONS_ENABLED) {
+      sessions = sessions.filter(s => store.sessionMeta[s.sid]);
+    }
     clientRes.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
-    clientRes.end(JSON.stringify({ sessions: sessionIdx.getAll(), restore: { restoring: restore.restoring, complete: restore.complete } }));
+    clientRes.end(JSON.stringify({ sessions, restore: { restoring: restore.restoring, complete: restore.complete } }));
     return true;
   }
 

--- a/test/cold-session-killswitch.test.js
+++ b/test/cold-session-killswitch.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('COLD_SESSIONS_ENABLED kill-switch', () => {
+  it('defaults to false', () => {
+    const config = require('../server/config');
+    assert.equal(config.COLD_SESSIONS_ENABLED, false);
+  });
+
+  it('filters cold sessions from /_api/sessions when disabled', () => {
+    const store = require('../server/store');
+    const sessionIdx = require('../server/session-index');
+
+    // Seed session index with two sessions
+    sessionIdx.updateFromEntry({ sessionId: 'hot-1', id: 't1', model: 'm', cwd: '/', cost: { cost: 0 }, receivedAt: 1 });
+    sessionIdx.updateFromEntry({ sessionId: 'cold-1', id: 't2', model: 'm', cwd: '/', cost: { cost: 0 }, receivedAt: 2 });
+
+    // Only hot-1 is in store.sessionMeta (hot)
+    store.sessionMeta['hot-1'] = { provider: 'anthropic' };
+
+    const config = require('../server/config');
+    const allSessions = sessionIdx.getAll();
+    assert.equal(allSessions.length >= 2, true, 'index has both sessions');
+
+    // Simulate the API filter logic
+    let sessions = allSessions;
+    if (!config.COLD_SESSIONS_ENABLED) {
+      sessions = sessions.filter(s => store.sessionMeta[s.sid]);
+    }
+
+    assert.equal(sessions.length, 1);
+    assert.equal(sessions[0].sid, 'hot-1');
+
+    // Cleanup
+    delete store.sessionMeta['hot-1'];
+  });
+});


### PR DESCRIPTION
## 摘要
- 新增 `COLD_SESSIONS_ENABLED` server-side flag（預設 `false`），透過 `CCXRAY_COLD_SESSIONS=1` 環境變數開啟
- Flag off 時，`/_api/sessions` 只回傳 hot session（已在記憶體的 session），client cold loading 機器自動休眠
- 2.0 release 先關閉 cold session 避免效能/UX 問題，post-2.0 優化後再開啟

## 改動
- `server/config.js`: 新增 `COLD_SESSIONS_ENABLED` config
- `server/routes/api.js`: `/_api/sessions` 依 flag 過濾 cold session
- `test/cold-session-killswitch.test.js`: 驗證 flag 預設值及過濾邏輯

## Test plan
- [x] 新測試通過
- [x] 全 1393 測試通過（`CCXRAY_HOME=$(mktemp -d) node --test test/*.test.js`）
- [ ] Smoke: 預設啟動 → dashboard 無 cold session spinner
- [ ] Smoke: `CCXRAY_COLD_SESSIONS=1` → cold session 可見

🤖 Generated with [Claude Code](https://claude.com/claude-code)