### PR TITLE
perf(server): merge three-pass index scan into single pass

### DIFF
--- a/server/restore.js
+++ b/server/restore.js
@@ -157,37 +157,32 @@ async function restoreFromLogs() {
     cutoffStr = cutoff.toLocaleString('sv-SE', { timeZone: 'Asia/Taipei' }).slice(0, 10);
   }
 
-  const lines = indexContent.split('\n').filter(Boolean);
+  // ponytail: parse JSON once instead of three times per line
+  const parsed = [];
+  for (const line of indexContent.split('\n')) {
+    if (!line) continue;
+    try { parsed.push(JSON.parse(line)); } catch {}
+  }
   let restored = 0;
 
-  // Pre-pass: parse minimal fields once and build star-protection sets so
-  // entries older than RESTORE_DAYS that are protected by stars are still
-  // restored. Single allocation; reused below in the main loop.
+  // Star-protection + session pre-count in one pass over pre-parsed data.
   const stars = readStarsSafe();
   const hasAnyStar = stars.projects.length || stars.sessions.length || stars.turns.length || stars.steps.length;
   let retentionSets = null;
   if (hasAnyStar && cutoffStr) {
     const lightweight = [];
-    for (const line of lines) {
-      try {
-        const m = JSON.parse(line);
-        if (m && m.id) lightweight.push({ id: m.id, sessionId: m.sessionId, cwd: m.cwd });
-      } catch {}
+    for (const m of parsed) {
+      if (m && m.id) lightweight.push({ id: m.id, sessionId: m.sessionId, cwd: m.cwd });
     }
     retentionSets = computeRetentionSets(lightweight, stars);
   }
 
-  // Pre-count entries per session to identify oversized sessions.
-  // Separate loop because it needs retentionSets (built above) for the cutoff filter.
   const sessionTotals = new Map();
-  for (const line of lines) {
-    try {
-      const m = JSON.parse(line);
-      if (cutoffStr && m.id && m.id.slice(0, 10) < cutoffStr) {
-        if (!retentionSets || !isProtectedByStar(m, retentionSets)) continue;
-      }
-      if (m.sessionId) sessionTotals.set(m.sessionId, (sessionTotals.get(m.sessionId) || 0) + 1);
-    } catch { continue; }
+  for (const m of parsed) {
+    if (cutoffStr && m.id && m.id.slice(0, 10) < cutoffStr) {
+      if (!retentionSets || !isProtectedByStar(m, retentionSets)) continue;
+    }
+    if (m.sessionId) sessionTotals.set(m.sessionId, (sessionTotals.get(m.sessionId) || 0) + 1);
   }
   const oversizedSessions = new Map();
   for (const [sid, count] of sessionTotals) {
@@ -195,9 +190,7 @@ async function restoreFromLogs() {
   }
   const sessionLoadedFirst = new Set();
 
-  for (const line of lines) {
-    let meta;
-    try { meta = JSON.parse(line); } catch { continue; }
+  for (let meta of parsed) {
 
     if (cutoffStr && meta.id.slice(0, 10) < cutoffStr) {
       if (!retentionSets || !isProtectedByStar(meta, retentionSets)) continue;


### PR DESCRIPTION
## 摘要
- `restore:parse` 原本對 index.ndjson 做 3 遍 `JSON.parse`（star pre-pass、session count、main loop）
- 改為 parse 一次存 array，後續 pass 迭代 parsed data（無 re-parse）
- 150K 行場景下 JSON.parse 呼叫數從 ~450K 降到 ~150K

## 改動
- `server/restore.js`: 三遍 `JSON.parse(line)` loop → 一次 parse + 迭代 parsed array

## Test plan
- [x] 全 1391 測試通過（`CCXRAY_HOME=$(mktemp -d) node --test test/*.test.js`）
- [ ] Smoke: 對比 `restore:parse` timing before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)