### PR TITLE
feat(dashboard): port #332 dashboard improvements to main

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -369,6 +369,7 @@ function _attachColdPrefetch(el, sid) {
 function addEntry(e) {
   // Dedup: SSE + on-demand fetch race can deliver the same entry twice
   if (e.id && window.entryById && window.entryById.has(e.id)) return;
+  if (e.imported && window.ccxraySettings?.hideImported) return;
   const idx = entryCount++;
 
   const sid = e.sessionId || 'unknown';
@@ -822,6 +823,7 @@ window.recomputeProjectCost = recomputeProjectCost;
 function mergeColdSessions(sessions) {
   for (const s of sessions) {
     if (!s || !s.sid) continue;
+    if (s.importedOnly && window.ccxraySettings?.hideImported) continue;
     if (sessionsMap.has(s.sid)) {
       var existing = sessionsMap.get(s.sid);
       if (!existing.title && s.title) existing.title = s.title;

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -1133,6 +1133,9 @@ function _setLoadingStatus(text) {
   window._entriesLoadingText = text;
   const el = document.getElementById('entries-loading-status');
   if (el) el.textContent = text;
+  // ponytail: always show restore progress in breadcrumb, not just deep-link (#332)
+  const breadcrumb = document.getElementById('breadcrumb');
+  if (breadcrumb && _loading) breadcrumb.textContent = text;
   if (_deepLinkLoadingActive) _renderDeepLinkLoading(text);
 }
 

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -1180,6 +1180,7 @@ function _setLoadingStatus(text) {
   const breadcrumb = document.getElementById('breadcrumb');
   if (breadcrumb && _loading) breadcrumb.textContent = text;
   if (_deepLinkLoadingActive) _renderDeepLinkLoading(text);
+  if (typeof renderProjectsCol === 'function') renderProjectsCol();
 }
 
 function _setDeepLinkProgress(text) {

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -530,7 +530,7 @@ function addEntry(e) {
   proj.sessionIds.add(sid);
   proj.lastId = entryId;
   proj.lastSeenAt = Date.now();
-  if (!_loading) renderProjectsCol();
+  if (!_loading && !window._coldActivating) renderProjectsCol();
 
   const statusClass = isHttpStatusOk(e.status) ? 'status-ok' : 'status-err';
   const displayModel = (model && model !== '?') ? model : (sess.model || '?');
@@ -548,8 +548,10 @@ function addEntry(e) {
     const ctxInputTotal = ctxCacheRead + ctxCacheCreate + (usage ? (usage.input_tokens || 0) : 0);
     sess.latestCacheHitRatio = ctxInputTotal > 0 ? ctxCacheRead / ctxInputTotal : 0;
     sess.latestMaxContext = e.maxContext || DEFAULT_MAX_CTX;
-    const sessElCtx = document.getElementById('sess-' + sid.slice(0, 8));
-    if (sessElCtx) sessElCtx.innerHTML = renderSessionItem(sess, sid, sessElCtx);
+    if (!window._coldActivating) {
+      const sessElCtx = document.getElementById('sess-' + sid.slice(0, 8));
+      if (sessElCtx) sessElCtx.innerHTML = renderSessionItem(sess, sid, sessElCtx);
+    }
   }
 
   // Gap timing: idle time from end of previous turn to start of this turn
@@ -664,7 +666,7 @@ function addEntry(e) {
     window.entryById.set(entryId, { id: entryId, sessionId: sid, cwd: entryCwd, receivedAt: e.receivedAt || null, displayNum });
   }
   // Re-render session card after stats are fresh (suppressed during batch)
-  if (!_loading) {
+  if (!_loading && !window._coldActivating) {
     const sessEl = document.getElementById('sess-' + sid.slice(0, 8));
     if (sessEl) {
       sessEl.innerHTML = renderSessionItem(sess, sid, sessEl);
@@ -706,7 +708,7 @@ function addEntry(e) {
   // viewing the just-loaded latest turn genuinely is on it.
   const prevMainIdx = sess.latestMainTurnIdx;
   if (!isSubagent) sess.latestMainTurnIdx = idx;
-  if (!_loading && selectedSessionId === sid) {
+  if (!_loading && !window._coldActivating && selectedSessionId === sid) {
     // Only auto-follow if toggle is on AND user is currently on the live edge
     // Never interrupt focused mode (drill-down); workflow split view is the default
     // state and must keep following live turns.

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -612,8 +612,18 @@ function addEntry(e) {
   }
   if (isCompacted) sess.compactCount = (sess.compactCount || 0) + 1;
 
+  // Per-turn severity (context / HTTP status / abnormal stop). #332 removed the
+  // turn-column DOM that used to carry `.risk-*`, so severity now lives on the
+  // entry (data-layer single source) and is surfaced on the swimlane turn bar
+  // (data-severity + wf-b-<sev>) — critical turns stay visible without the column.
+  const _dupes = e.duplicateToolCalls || null;
+  const _dupesMax = _dupes ? Math.max(...Object.values(_dupes)) : 0;
+  const _ctxPct = ctxUsed > 0 ? Math.min(100, ctxUsed / (e.maxContext || DEFAULT_MAX_CTX) * 100) : 0;
+  const severity = classifySeverity({ status: e.status, stopReason, hasCredential: e.hasCredential || false, toolFail: e.toolFail || false }, _ctxPct, _dupesMax);
+
   allEntries.push({
     tokens: tok, usage, ts: e.ts, model, maxContext: e.maxContext, cost: turnCost, sessionId: sid,
+    severity,
     req: e.req || null, res: e.res || null, reqLoaded: !!(e.req || e.res),
     msgCount, toolCount, toolCalls: e.toolCalls || {}, stopReason,
     status: e.status, elapsed: e.elapsed, method: e.method, id: e.id,

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -381,21 +381,17 @@ function addEntry(e) {
     sessEl.dataset.sessionId = sid;
     sessEl.id = 'sess-' + shortSid;
     sessEl.onclick = () => selectSession(sid);
-    sessEl.innerHTML = renderSessionItem(sessionsMap.get(sid), sid, sessEl);
-    // Insert at top (after col-title) — newest sessions first
-    const firstSession = colSessions.querySelector('.session-item');
-    if (firstSession) colSessions.insertBefore(sessEl, firstSession);
-    else colSessions.appendChild(sessEl);
-    // Apply visibility to this element immediately to prevent flash-in during batch load.
-    // During non-deeplink loading: O(1) inline check instead of O(N) applySessionFilter call.
-    // sessionStatusMap is populated by SSE session_status events which arrive before the
-    // batch payload resolves, so getStatusClass is already accurate for most sessions.
-    if (!_loading || window._entriesLoadingProjectName || window._entriesLoadingSessionPrefix) {
+    if (_loading) {
+      // ponytail: defer rendering to post-batch pass (#332) — just create the
+      // DOM node so getElementById finds it; post-batch overwrites innerHTML
+      sessEl.style.display = 'none';
+      colSessions.appendChild(sessEl);
+    } else {
+      sessEl.innerHTML = renderSessionItem(sessionsMap.get(sid), sid, sessEl);
+      const firstSession = colSessions.querySelector('.session-item');
+      if (firstSession) colSessions.insertBefore(sessEl, firstSession);
+      else colSessions.appendChild(sessEl);
       applySessionFilter();
-    } else if (sessionFilterMode !== 'all') {
-      const status = getStatusClass(sid);
-      const hidden = sessionFilterMode === 'streaming' ? status !== 'sdot-stream' : status === 'sdot-off';
-      if (hidden) sessEl.style.display = 'none';
     }
   }
   const sess = sessionsMap.get(sid);
@@ -1085,6 +1081,18 @@ window._entriesLoadingProjectName = _pendingDeepLink.p || null;
 window._entriesLoadingSessionPrefix = _pendingDeepLink.s || null;
 window._entriesLoadingText = _hasDeepLink ? 'Resolving link…' : 'Loading…';
 if (typeof renderProjectsCol === 'function') renderProjectsCol();
+// ponytail: scaffold rows during restore (#332) — replaced by post-batch render
+(function _insertScaffold() {
+  var projCol = document.getElementById('col-projects');
+  var sessCol = document.getElementById('col-sessions');
+  var projHtml = '', sessHtml = '';
+  for (var i = 0; i < 8; i++) projHtml += '<div class="scaffold-row scaffold-proj"><div></div><div></div><div></div></div>';
+  for (var j = 0; j < 5; j++) sessHtml += '<div class="scaffold-row scaffold-sess"><div></div><div></div><div></div><div></div><div></div></div>';
+  if (projCol) projCol.insertAdjacentHTML('beforeend', projHtml);
+  if (sessCol) sessCol.insertAdjacentHTML('beforeend', sessHtml);
+  var cols = document.getElementById('columns');
+  if (cols) cols.classList.add('restoring');
+})();
 const _starsReady = (typeof loadStars === 'function') ? loadStars() : Promise.resolve();
 const _sessionsReady = (async function _fetchSessionsWhenReady() {
   for (;;) {
@@ -1145,13 +1153,9 @@ function _setDeepLinkProgress(text) {
 }
 
 function _renderDeepLinkLoading(text) {
-  const safeText = typeof escapeHtml === 'function' ? escapeHtml(text) : String(text || '');
+  // ponytail: restore progress shown in breadcrumb only (#332) — no column spinners
   const breadcrumb = document.getElementById('breadcrumb');
   if (breadcrumb && _loading) breadcrumb.textContent = 'Loading link · ' + text;
-  if (selectedTurnIdx >= 0) return;
-  const html = '<div class="col-empty loading-state"><div class="loading-spinner"></div><div>' + safeText + '</div></div>';
-  if (colSections && !selectedSection) colSections.innerHTML = html;
-  if (colDetail && !selectedSection) colDetail.innerHTML = html;
 }
 
 function _clearDeepLinkProgress() {
@@ -1259,6 +1263,10 @@ Promise.all([_entriesReady, _starsReady, _sessionsReady]).then(async ([data, , s
     _dirtySessions = null;
     for (const [name] of projectsMap) recomputeProjectCost(name);
   }
+  // ponytail: remove scaffold rows + restoring state before real render (#332)
+  document.querySelectorAll('.scaffold-row').forEach(el => el.remove());
+  var colsEl = document.getElementById('columns');
+  if (colsEl) colsEl.classList.remove('restoring');
   const colSessEl = document.getElementById('col-sessions');
   if (colSessEl) {
     const sortedSids = [...sessionsMap.entries()]
@@ -1268,6 +1276,7 @@ Promise.all([_entriesReady, _starsReady, _sessionsReady]).then(async ([data, , s
       const el = document.getElementById('sess-' + sid.slice(0, 8));
       if (!el) continue;
       el.innerHTML = renderSessionItem(sessionsMap.get(sid), sid, el);
+      el.style.display = '';
       colSessEl.appendChild(el); // appendChild in desc order → most-recent rises to top
     }
   }

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -348,6 +348,24 @@ function _seqRecomputeSession(sid, sess, currentSeqTurn) {
   return currentPlace;
 }
 
+// ponytail: hover-prefetch cold session entries (#332)
+var _coldPrefetchTimer = null;
+function _attachColdPrefetch(el, sid) {
+  el.onmouseenter = function() {
+    clearTimeout(_coldPrefetchTimer);
+    _coldPrefetchTimer = setTimeout(function() {
+      var sess = sessionsMap.get(sid);
+      if (!sess || !sess._cold || sess._prefetching || sess._prefetchedEntries) return;
+      sess._prefetching = true;
+      fetch('/_api/session/' + encodeURIComponent(sid) + '/entries')
+        .then(function(r) { return r.json(); })
+        .then(function(data) { sess._prefetchedEntries = data; sess._prefetching = false; })
+        .catch(function() { sess._prefetching = false; });
+    }, 150);
+  };
+  el.onmouseleave = function() { clearTimeout(_coldPrefetchTimer); };
+}
+
 function addEntry(e) {
   // Dedup: SSE + on-demand fetch race can deliver the same entry twice
   if (e.id && window.entryById && window.entryById.has(e.id)) return;
@@ -381,6 +399,7 @@ function addEntry(e) {
     sessEl.dataset.sessionId = sid;
     sessEl.id = 'sess-' + shortSid;
     sessEl.onclick = () => selectSession(sid);
+    _attachColdPrefetch(sessEl, sid);
     if (_loading) {
       // ponytail: defer rendering to post-batch pass (#332) — just create the
       // DOM node so getElementById finds it; post-batch overwrites innerHTML
@@ -811,6 +830,7 @@ function mergeColdSessions(sessions) {
     sessEl.dataset.sessionId = s.sid;
     sessEl.id = 'sess-' + shortSid;
     sessEl.onclick = (function(sid) { return function() { selectSession(sid); }; })(s.sid);
+    _attachColdPrefetch(sessEl, s.sid);
     sessEl.innerHTML = renderSessionItem(sessionsMap.get(s.sid), s.sid, sessEl);
     colSessions.appendChild(sessEl);
     var projName = getProjectName(s.cwd);
@@ -1277,6 +1297,7 @@ Promise.all([_entriesReady, _starsReady, _sessionsReady]).then(async ([data, , s
       if (!el) continue;
       el.innerHTML = renderSessionItem(sessionsMap.get(sid), sid, el);
       el.style.display = '';
+      _attachColdPrefetch(el, sid);
       colSessEl.appendChild(el); // appendChild in desc order → most-recent rises to top
     }
   }

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -619,7 +619,10 @@ function addEntry(e) {
   const _dupes = e.duplicateToolCalls || null;
   const _dupesMax = _dupes ? Math.max(...Object.values(_dupes)) : 0;
   const _ctxPct = ctxUsed > 0 ? Math.min(100, ctxUsed / (e.maxContext || DEFAULT_MAX_CTX) * 100) : 0;
-  const severity = classifySeverity({ status: e.status, stopReason, hasCredential: e.hasCredential || false, toolFail: e.toolFail || false }, _ctxPct, _dupesMax);
+  // Pass the whole entry (with the normalized stopReason) so every field
+  // classifySeverity/isProxyLifecycleShutdown reads is present — a synthetic
+  // subset would silently drop a field a future severity rule starts using.
+  const severity = classifySeverity({ ...e, stopReason }, _ctxPct, _dupesMax);
 
   allEntries.push({
     tokens: tok, usage, ts: e.ts, model, maxContext: e.maxContext, cost: turnCost, sessionId: sid,

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -34,7 +34,6 @@ function showNewTurnPill(count) {
     selectTurn(targetIdx);
     scrollTurnsToBottom();
   };
-  // colTurns.appendChild(pill);  // ponytail: turn column removed
 }
 
 function hideNewTurnPill() {
@@ -67,7 +66,6 @@ function showSubagentPill(count, errCount, sinceNum) {
     scrollTurnsToBottom();
     hideSubagentPill();
   };
-  // colTurns.appendChild(pill);  // ponytail: turn column removed
 }
 
 // sid defaults to selectedSessionId, but callers leaving a session (e.g.
@@ -620,9 +618,7 @@ function addEntry(e) {
   const _dupes = e.duplicateToolCalls || null;
   const _dupesMax = _dupes ? Math.max(...Object.values(_dupes)) : 0;
   const _ctxPct = ctxUsed > 0 ? Math.min(100, ctxUsed / (e.maxContext || DEFAULT_MAX_CTX) * 100) : 0;
-  // Pass the whole entry (with the normalized stopReason) so every field
-  // classifySeverity/isProxyLifecycleShutdown reads is present — a synthetic
-  // subset would silently drop a field a future severity rule starts using.
+  // INVARIANT: severity field consumed by workflow-timeline.js wfRenderLaneSvg
   const severity = classifySeverity({ ...e, stopReason }, _ctxPct, _dupesMax);
 
   allEntries.push({
@@ -724,10 +720,6 @@ function addEntry(e) {
   }
 
   if (isRetry) return;
-
-  // ponytail: turn-item DOM creation removed — turn column no longer rendered
-  // Data-only variables kept above (ctxUsed, turnCost, etc.) feed session stats.
-  // ponytail: turn-item DOM removed (L707-864 original); data logic above preserved
 
   if (selectedSessionId === sid) renderSessionSparkline(sid);
   // Track unconditionally (not gated by !_loading) — codex review: this was
@@ -1116,18 +1108,6 @@ window._entriesLoadingProjectName = _pendingDeepLink.p || null;
 window._entriesLoadingSessionPrefix = _pendingDeepLink.s || null;
 window._entriesLoadingText = _hasDeepLink ? 'Resolving link…' : 'Loading…';
 if (typeof renderProjectsCol === 'function') renderProjectsCol();
-// ponytail: scaffold rows during restore (#332) — replaced by post-batch render
-(function _insertScaffold() {
-  var projCol = document.getElementById('col-projects');
-  var sessCol = document.getElementById('col-sessions');
-  var projHtml = '', sessHtml = '';
-  for (var i = 0; i < 8; i++) projHtml += '<div class="scaffold-row scaffold-proj"><div></div><div></div><div></div></div>';
-  for (var j = 0; j < 5; j++) sessHtml += '<div class="scaffold-row scaffold-sess"><div></div><div></div><div></div><div></div><div></div></div>';
-  if (projCol) projCol.insertAdjacentHTML('beforeend', projHtml);
-  if (sessCol) sessCol.insertAdjacentHTML('beforeend', sessHtml);
-  var cols = document.getElementById('columns');
-  if (cols) cols.classList.add('restoring');
-})();
 const _starsReady = (typeof loadStars === 'function') ? loadStars() : Promise.resolve();
 const _sessionsReady = (async function _fetchSessionsWhenReady() {
   for (;;) {
@@ -1174,9 +1154,6 @@ async function _fetchEntriesWhenReady() {
 
 function _setLoadingStatus(text) {
   window._entriesLoadingText = text;
-  const el = document.getElementById('entries-loading-status');
-  if (el) el.textContent = text;
-  // ponytail: always show restore progress in breadcrumb, not just deep-link (#332)
   const breadcrumb = document.getElementById('breadcrumb');
   if (breadcrumb && _loading) breadcrumb.textContent = text;
   if (_deepLinkLoadingActive) _renderDeepLinkLoading(text);
@@ -1299,10 +1276,6 @@ Promise.all([_entriesReady, _starsReady, _sessionsReady]).then(async ([data, , s
     _dirtySessions = null;
     for (const [name] of projectsMap) recomputeProjectCost(name);
   }
-  // ponytail: remove scaffold rows + restoring state before real render (#332)
-  document.querySelectorAll('.scaffold-row').forEach(el => el.remove());
-  var colsEl = document.getElementById('columns');
-  if (colsEl) colsEl.classList.remove('restoring');
   const colSessEl = document.getElementById('col-sessions');
   if (colSessEl) {
     const sortedSids = [...sessionsMap.entries()]

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -357,7 +357,7 @@ function _attachColdPrefetch(el, sid) {
       var sess = sessionsMap.get(sid);
       if (!sess || !sess._cold || sess._prefetching || sess._prefetchedEntries) return;
       sess._prefetching = true;
-      fetch('/_api/session/' + encodeURIComponent(sid) + '/entries')
+      fetch(_apiQ('/_api/session/' + encodeURIComponent(sid) + '/entries'))
         .then(function(r) { return r.json(); })
         .then(function(data) { sess._prefetchedEntries = data; sess._prefetching = false; })
         .catch(function() { sess._prefetching = false; });
@@ -941,7 +941,7 @@ evtSource.onmessage = (ev) => {
       // Server ring buffer evicted or hub restarted — full re-fetch
       console.log('[ccxray] SSE stale — re-fetching entries + sessions');
       Promise.all([
-        fetch('/_api/entries', { cache: 'no-store' }).then(r => r.json()).catch(() => ({ entries: [] })),
+        fetch(_apiQ('/_api/entries'), { cache: 'no-store' }).then(r => r.json()).catch(() => ({ entries: [] })),
         fetch('/_api/sessions', { cache: 'no-store' }).then(r => r.json()).catch(() => ({ sessions: [] })),
       ]).then(([entriesData, sessionsData]) => {
         for (const e of (entriesData.entries || [])) addEntry(e);
@@ -1153,7 +1153,7 @@ async function _fetchEntriesWhenReady() {
   if (_pendingDeepLink.s) qs = '?sid=' + encodeURIComponent(_pendingDeepLink.s);
   else if (_pendingDeepLink.e) qs = '?e=' + encodeURIComponent(_pendingDeepLink.e);
   for (;;) {
-    const r = await fetch('/_api/entries' + qs, { cache: 'no-store' });
+    const r = await fetch(_apiQ('/_api/entries' + qs), { cache: 'no-store' });
     if (firstResponse) {
       _markLoad('entries-response');
       _measureLoad('entries-fetch', 'entries-start', 'entries-response');

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -34,7 +34,7 @@ function showNewTurnPill(count) {
     selectTurn(targetIdx);
     scrollTurnsToBottom();
   };
-  colTurns.appendChild(pill);
+  // colTurns.appendChild(pill);  // ponytail: turn column removed
 }
 
 function hideNewTurnPill() {
@@ -67,7 +67,7 @@ function showSubagentPill(count, errCount, sinceNum) {
     scrollTurnsToBottom();
     hideSubagentPill();
   };
-  colTurns.appendChild(pill);
+  // colTurns.appendChild(pill);  // ponytail: turn column removed
 }
 
 // sid defaults to selectedSessionId, but callers leaving a session (e.g.
@@ -286,15 +286,6 @@ function _seqApplyFlips(sid, sess, flipIds, unflipIds) {
     if (en.displayNum === num) continue;
     en.displayNum = num;
     if (window.entryById && window.entryById.has(en.id)) window.entryById.get(en.id).displayNum = num;
-    if (!_loading) {
-      const card = colTurns.querySelector('.turn-item[data-entry-idx="' + i + '"]');
-      if (card) {
-        card.classList.toggle('turn-sub', !!en.isSubagent);
-        card.dataset.sessNum = num;
-        const numEl = card.querySelector('.turn-num');
-        if (numEl) numEl.textContent = en.isSubagent ? '↳' + num : '#' + num;
-      }
-    }
   }
   sess.mainCount = mainN; sess.subCount = subN; sess.retryCount = retryN;
 }
@@ -360,7 +351,6 @@ function _seqRecomputeSession(sid, sess, currentSeqTurn) {
 function addEntry(e) {
   // Dedup: SSE + on-demand fetch race can deliver the same entry twice
   if (e.id && window.entryById && window.entryById.has(e.id)) return;
-  if (entryCount === 0) colTurns.innerHTML = '<div class="col-sticky-header"><div class="col-title" style="display:flex;align-items:center">Turns<span id="scroll-toggle" onclick="toggleFollowLive()" style="cursor:pointer;font-size:10px;margin-left:auto"><span class="scroll-on active">ON</span> <span class="scroll-off">OFF</span></span></div><div id="session-tool-bar" style="display:none"></div><div id="ctx-legend"><span><span class="ctx-legend-dot" style="background:var(--color-cache-read)"></span>cache read</span><span><span class="ctx-legend-dot" style="background:var(--color-cache-write)"></span>cache write</span><span><span class="ctx-legend-dot" style="background:var(--color-input)"></span>input</span></div><div id="session-sparkline"></div></div>';
   const idx = entryCount++;
 
   const sid = e.sessionId || 'unknown';
@@ -704,164 +694,9 @@ function addEntry(e) {
 
   if (isRetry) return;
 
-  // ── V3 turn card: five-line layout ──
-  const toolFail = e.toolFail || false;
-  const hasCred = e.hasCredential || false;
-  const dupes = e.duplicateToolCalls || null;
-  const dupesMax = dupes ? Math.max(...Object.values(dupes)) : 0;
-
-  const ctxMax = e.maxContext || DEFAULT_MAX_CTX;
-  const ctxPct = ctxUsed > 0 ? Math.min(100, ctxUsed / ctxMax * 100) : 0;
-  const severity = classifySeverity({ status: e.status, stopReason, hasCredential: hasCred, toolFail }, ctxPct, dupesMax);
-
-  const el = document.createElement('div');
-  el.className = 'turn-item' + (isSubagent ? ' turn-sub' : '') + (severity ? ' risk-' + severity : '');
-  el.dataset.entryIdx = idx;
-  el.dataset.sessionId = sid;
-  el.dataset.sessNum = displayNum;
-  el.onclick = (event) => {
-    const starEl = event && event.target && event.target.closest && event.target.closest('.turn-star');
-    if (starEl && el.contains(starEl)) {
-      event.stopPropagation();
-      const isChipClick = event.target.classList.contains('pin-btn-count');
-      if (isChipClick && typeof openDerivedPopover === 'function') {
-        openDerivedPopover('turn', starEl.dataset.id, starEl);
-        return;
-      }
-      if (typeof window.toggleStar === 'function') {
-        window.toggleStar('turn', starEl.dataset.id, !starEl.classList.contains('starred'));
-      }
-      return;
-    }
-    setFocus('turns');
-    selectTurn(idx);
-  };
-  el.onmouseenter = () => { clearTimeout(_hoverTimer); _hoverTimer = setTimeout(() => prefetchEntry(idx), 150); };
-  el.onmouseleave = () => clearTimeout(_hoverTimer);
-
-  // Line 1: identity + critical marker + star toggle
-  const prefix = isSubagent ? '↳s' + sess.subCount : '#' + displayNum;
-  const modelHtml = '<span class="turn-model">' + escapeHtml(shortModelStr) + '</span>';
-  const dotClass = (isHttpStatusOk(e.status) || isProxyLifecycleShutdown(e)) ? 'status-dot status-dot-ok' : 'status-dot status-dot-err';
-  const waitMark = stopReason === 'end_turn' ? '<span class="turn-wait" title="Waiting for user">↵</span>' : '';
-  const critMarker = getCriticalMarker(stopReason, e.status, ctxPct);
-  const critMarkerHtml = critMarker ? '<span class="turn-critical-marker">' + critMarker + '</span>' : '';
-  const isTurnStarred = !!(window.xrayStars && window.xrayStars.turns && window.xrayStars.turns.has(entryId));
-  const derivedStepStars = (typeof countDescendantStars === 'function') ? countDescendantStars('turn', entryId) : 0;
-  const starClass = isTurnStarred ? ' starred' : (derivedStepStars > 0 ? ' derived' : '');
-  const starTitle = isTurnStarred && derivedStepStars > 0
-    ? 'Starred — click ★ to unstar, click [' + derivedStepStars + '] to view starred items inside'
-    : isTurnStarred
-      ? 'Starred — click to unstar'
-      : (derivedStepStars > 0 ? 'Retained because ' + derivedStepStars + ' starred steps below — click to view' : 'Star this turn (keeps log forever)');
-  const starGlyph = isTurnStarred && derivedStepStars > 0
-    ? '★<span class="pin-btn-count" aria-hidden="true">' + derivedStepStars + '</span>'
-    : isTurnStarred
-      ? '★'
-      : (derivedStepStars > 0 ? '☆<span class="pin-btn-count" aria-hidden="true">' + derivedStepStars + '</span>' : '☆');
-  const starHtml = '<span class="turn-star' + starClass + '" data-kind="turn" data-id="' + escapeHtml(entryId) + '" title="' + escapeHtml(starTitle) + '">' + starGlyph + '</span>';
-  const identityTooltip = [
-    isCompacted ? 'Context compacted' : null,
-    e.sessionInferred ? 'Session inferred (no explicit session ID)' : null,
-  ].filter(Boolean).join(' · ');
-  const identityAttr = identityTooltip ? ' title="' + escapeHtml(identityTooltip) + '"' : '';
-  const importBadge = e.imported ? '<span class="turn-imported-badge" title="Imported from local transcript">⇐</span>' : '';
-  const identityLine =
-    '<div class="turn-identity"' + identityAttr + '>' +
-      '<span class="' + dotClass + '" title="HTTP ' + e.status + '">●</span>' +
-      '<span class="turn-num">' + prefix + '</span>' +
-      modelHtml +
-      importBadge +
-      waitMark +
-      critMarkerHtml +
-      starHtml +
-    '</div>';
-
-  // Line 2: title (omit if null or noise)
-  const cleanedTitle = cleanTitle(e.title);
-  const titleLine = cleanedTitle ? '<div class="turn-title">' + escapeHtml(cleanedTitle) + '</div>' : '';
-
-  // Line 2.5: cost (own line; right-aligned dim 11px). Omitted when null OR
-  // when the rounded display would read $0.00 (cache-hit turns are the
-  // ~80% case and a column of "$0.00" lines is just noise — session cards
-  // still aggregate the cost, so the information is not lost).
-  const costFmt = turnCost != null ? turnCost.toFixed(2) : null;
-  const costLine = (costFmt != null && costFmt !== '0.00')
-    ? '<div class="turn-cost-line">$' + costFmt + '</div>'
-    : '';
-
-  // Line 3: ctx bar (original segment proportions) + ctx:/hit: labels
-  const seg = (tokens, color) => tokens > 0
-    ? '<div style="width:' + (tokens / ctxMax * 100).toFixed(2) + '%;background:' + color + ';min-width:1px"></div>'
-    : '';
-  const totalUsed = ctxCacheRead + ctxCacheCreate + ctxInput;
-  // Per-turn anomaly-detection thresholds — see Decision D11. Do NOT unify
-  // with L1/L3's 83.5/75 thresholds; L2 scans turns for spikes, not absolute
-  // proximity to auto-compact. Changing these to 83.5/75 produces a wall of
-  // red in late-session turns (pre-mortem F1).
-  const ctxPctClass = ctxPct > 95 ? 'ctx-critical' : ctxPct > 85 ? 'ctx-warning' : '';
-  const ctxPctLabel = '<span class="turn-ctx-pct' + (ctxPctClass ? ' ' + ctxPctClass : '') + '">ctx:' + ctxPct.toFixed(0) + '%</span>';
-  const hitPct = totalUsed > 0 ? Math.round(ctxCacheRead / totalUsed * 100) : null;
-  const hitPctClass = hitPct !== null && hitPct < 10 ? ' hit-cold' : '';
-  const hitLabel = hitPct !== null ? '<span class="turn-hit-pct' + hitPctClass + '">cache:' + hitPct + '%</span>' : '';
-  const ctxBarHtml = ctxUsed > 0
-    ? '<div class="turn-ctx turn-ctx-bar" title="auto-compact at ~' + (((window.ccxraySettings?.autoCompactPct) || 0.835) * 100).toFixed(1) + '%">' +
-        '<div class="turn-ctx-bar-bg">' +
-          seg(ctxCacheRead,   'var(--color-cache-read)') +
-          seg(ctxCacheCreate, 'var(--color-cache-write)') +
-          seg(ctxInput,       'var(--color-input)') +
-        '</div>' +
-        '<div class="turn-ctx-labels">' + hitLabel + ctxPctLabel + '</div>' +
-      '</div>'
-    : '';
-
-  // Line 4: [time-info] [tools]
-  // time-info: elapsed [wait:gap] [think:N] — flex:1, can clip; tools: flex-shrink:0, always visible
-  const elapsedMs = parseFloat(e.elapsed || 0) * 1000;
-  const thinkPart = (e.thinkingDuration && e.thinkingDuration >= 0.05)
-    ? 'think:' + e.thinkingDuration.toFixed(1) + 's'
-    : '';
-  const waitPart = (gapMs != null && gapMs >= 500) ? 'wait:' + formatGap(gapMs) : '';
-  const secondaryParts = [waitPart, thinkPart].filter(Boolean).join(' · ');
-  const secondaryHtml = secondaryParts
-    ? ' <span class="turn-elapsed-secondary" title="' + escapeHtml(gapTitle) + '">(' + secondaryParts + ')</span>'
-    : '';
-  const timeHtml = elapsedMs > 0
-    ? '<span class="turn-elapsed">dur:' + formatGap(elapsedMs) + '</span>' + secondaryHtml
-    : '';
-  let chipsHtml = '';
-  for (const n of Object.keys(e.toolCalls || {})) {
-    chipsHtml += '<span class="tool-chip">' + escapeHtml(n.replace(/^mcp__[^_]+__/, '')) + '</span>';
-  }
-  const secondaryLine = '<div class="turn-secondary">' +
-    (chipsHtml ? '<div class="turn-tools-row">' + chipsHtml + '</div>' : '') +
-    '<div class="turn-time-row">' + timeHtml + '</div>' +
-    '</div>';
-
-  // Line 5: warning/notice risk (no emoji, plain text)
-  const riskMarkers = [];
-  if (hasCred) riskMarkers.push('cred');
-  if (toolFail) riskMarkers.push('tool-fail');
-  if (dupesMax >= 2) riskMarkers.push('dupes\xD7' + dupesMax);
-  if (e.thinkingStripped === true) riskMarkers.push('thinking-stripped');
-  if (e.coreHash || e.toolsHash) {
-    for (let i = allEntries.length - 2; i >= 0; i--) {
-      const prev = allEntries[i];
-      if (prev.sessionId === sid && !prev.isSubagent) {
-        if (prev.coreHash && e.coreHash && prev.coreHash !== e.coreHash) riskMarkers.push('sys-changed');
-        if (prev.toolsHash && e.toolsHash && prev.toolsHash !== e.toolsHash) riskMarkers.push('tools-changed');
-        break;
-      }
-    }
-  }
-  const riskLine = riskMarkers.length ? '<div class="turn-risk-line">' + riskMarkers.join(' ') + '</div>' : '';
-
-  el.innerHTML = identityLine + titleLine + costLine + ctxBarHtml + secondaryLine + riskLine;
-
-  // Hide turn if no session selected, or if it belongs to a different session
-  if (!selectedSessionId || selectedSessionId !== sid) el.style.display = 'none';
-  // Append: chronological order — oldest at top, newest at bottom
-  colTurns.appendChild(el);
+  // ponytail: turn-item DOM creation removed — turn column no longer rendered
+  // Data-only variables kept above (ctxUsed, turnCost, etc.) feed session stats.
+  // ponytail: turn-item DOM removed (L707-864 original); data logic above preserved
 
   if (selectedSessionId === sid) renderSessionSparkline(sid);
   // Track unconditionally (not gated by !_loading) — codex review: this was

--- a/public/index.html
+++ b/public/index.html
@@ -118,10 +118,10 @@
   </div>
   <div id="columns">
     <div id="col-projects" class="col"><div class="col-title">Projects</div></div>
-    <div id="col-sessions" class="col"><div class="col-title" style="display:flex;align-items:center;gap:6px">Sessions <select id="sess-filter-select" onchange="setSessionFilter(this.value)" style="background:var(--surface);color:var(--dim);border:1px solid var(--border);border-radius:3px;font-size:10px;padding:1px 4px;cursor:pointer"><option value="streaming" title="Only projects with in-flight API calls">Streaming</option><option value="recent" selected title="Projects active within the last 5 minutes">Recent</option><option value="all">All</option></select><span id="sess-filter-count" style="color:var(--dim);font-size:10px"></span></div></div>
-    <div id="col-turns" class="col"><div class="col-sticky-header"><div class="col-title" style="display:flex;align-items:center">Turns<span id="scroll-toggle" onclick="toggleFollowLive()" style="cursor:pointer;font-size:10px;margin-left:auto"><span class="scroll-on active">ON</span> <span class="scroll-off">OFF</span></span></div><div id="session-tool-bar" style="display:none"></div><div id="ctx-legend"><span><span class="ctx-legend-dot" style="background:var(--color-cache-read)"></span>cache read</span><span><span class="ctx-legend-dot" style="background:var(--color-cache-write)"></span>cache write</span><span><span class="ctx-legend-dot" style="background:var(--color-input)"></span>input</span></div><div id="session-sparkline"></div></div></div>
-    <div id="col-sections" class="col"><div class="col-empty">←</div></div>
-    <div id="col-detail" class="col"><div class="col-empty">←</div></div>
+    <div id="col-sessions" class="col"><div class="col-title" style="display:flex;align-items:center;gap:6px">Sessions <select id="sess-filter-select" onchange="setSessionFilter(this.value)" style="background:var(--surface);color:var(--dim);border:1px solid var(--border);border-radius:3px;font-size:10px;padding:1px 4px;cursor:pointer"><option value="streaming" title="Only projects with in-flight API calls">Streaming</option><option value="recent" selected title="Sessions active within the last 24 hours">Recent</option><option value="all">All</option></select><span id="sess-filter-count" style="color:var(--dim);font-size:10px"></span></div></div>
+    <div id="col-turns" class="col"></div>
+    <div id="col-sections" class="col"></div>
+    <div id="col-detail" class="col"></div>
   </div>
   <div id="cmd-bar" class="hidden">
     <div id="cmd-bar-row1"></div>

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1205,7 +1205,7 @@ function applySessionFilter() {
 
   // Placeholder when a project is selected but no sessions are visible
   let placeholder = colSessions.querySelector('.sessions-empty');
-  if (!anyVisible && projectBoundary) {
+  if (!anyVisible && projectBoundary && !window._entriesLoading) {
     if (!placeholder) {
       placeholder = document.createElement('div');
       placeholder.className = 'sessions-empty col-empty';

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1592,6 +1592,18 @@ function _renderProjectsColInner() {
     '<option value="all"' + (projectFilterMode === 'all' ? ' selected' : '') + '>All</option>' +
     '</select><span id="proj-filter-count" style="color:var(--dim);font-size:10px"></span></div>';
 
+  if (window._entriesLoading && projectsMap.size === 0) {
+    var skel = '';
+    for (var si = 0; si < 6; si++) {
+      skel += '<div class="project-item" style="pointer-events:none;opacity:0.5">' +
+        '<div class="skeleton skeleton-text" style="width:' + (50 + si * 12 % 40) + 'px;margin-bottom:6px"></div>' +
+        '<div class="skeleton skeleton-text" style="width:90px;height:10px;margin-bottom:4px"></div>' +
+        '<div class="skeleton skeleton-text" style="width:60px;height:10px"></div></div>';
+    }
+    colProjects.innerHTML = html + skel;
+    return;
+  }
+
   const sorted = [...projectsMap.values()].sort((a, b) => {
     // Sort by: starred (or star-protected) first, then status, then last activity.
     const pa = isStarredOrDerived('project', a.name) ? 0 : 1;

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2142,6 +2142,7 @@ function zeroSessionStats(s) {
 }
 
 function selectSession(id) {
+  if (sidebarCollapsed) toggleSidebar();
   setFocus('sessions');
   if (id === selectedSessionId) return;
   cancelColdLoad();

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2178,9 +2178,11 @@ function selectSession(id) {
     columnsEl.classList.add('cold-loading');
     renderBreadcrumb();
     const token = _coldLoad = { id, controller: new AbortController(), spinner, columnsEl };
-    fetch('/_api/session/' + encodeURIComponent(id) + '/entries', { signal: token.controller.signal })
-      .then(r => r.json())
-      .then(data => {
+    // ponytail: use hover-prefetched data if available, otherwise fetch (#332)
+    var dataPromise = sess._prefetchedEntries
+      ? Promise.resolve(sess._prefetchedEntries).then(d => { delete sess._prefetchedEntries; return d; })
+      : fetch('/_api/session/' + encodeURIComponent(id) + '/entries', { signal: token.controller.signal }).then(r => r.json());
+    dataPromise.then(data => {
         if (_coldLoad !== token) return;
         // #308: zero stats before replay — sessions.json seeded them; addEntry
         // increments on top (cold path), so without zeroing = double-count.

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2182,7 +2182,7 @@ function selectSession(id) {
     // ponytail: use hover-prefetched data if available, otherwise fetch (#332)
     var dataPromise = sess._prefetchedEntries
       ? Promise.resolve(sess._prefetchedEntries).then(d => { delete sess._prefetchedEntries; return d; })
-      : fetch('/_api/session/' + encodeURIComponent(id) + '/entries', { signal: token.controller.signal }).then(r => r.json());
+      : fetch(_apiQ('/_api/session/' + encodeURIComponent(id) + '/entries'), { signal: token.controller.signal }).then(r => r.json());
     dataPromise.then(data => {
         if (_coldLoad !== token) return;
         // #308: zero stats before replay — sessions.json seeded them; addEntry

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1019,24 +1019,6 @@ function rerenderColumnsAfterStar() {
     if (sessEl && sess) sessEl.innerHTML = renderSessionItem(sess, sid, sessEl);
   }
   applySessionFilter();
-  // Turn cards: only the directly affected turn changes glyph; cheap to redraw all
-  // visible turn star buttons in current selection.
-  document.querySelectorAll('.turn-item .turn-star').forEach(btn => {
-    const id = btn.dataset.id;
-    const starred = id && xrayStars.turns.has(id);
-    const derived = id ? countDescendantStars('turn', id) : 0;
-    btn.classList.toggle('starred', !!starred);
-    btn.classList.toggle('derived', !starred && derived > 0);
-    if (starred && derived > 0) {
-      btn.innerHTML = '★<span class="pin-btn-count" aria-hidden="true">' + derived + '</span>';
-      btn.title = 'Starred — click ★ to unstar, click [' + derived + '] to view starred items inside';
-    } else {
-      btn.innerHTML = starred ? '★' : (derived > 0 ? '☆<span class="pin-btn-count" aria-hidden="true">' + derived + '</span>' : '☆');
-      btn.title = starred
-        ? 'Starred — click to unstar'
-        : (derived > 0 ? 'Retained because ' + derived + ' starred steps below — click to view' : 'Star this turn (keeps log forever)');
-    }
-  });
   document.querySelectorAll('.tl-step-star').forEach(btn => {
     const id = btn.dataset.id;
     const starred = id && xrayStars.steps.has(id);
@@ -1230,11 +1212,17 @@ function applySessionFilter() {
   }
 }
 
+var RECENT_MS = 24 * 60 * 60 * 1000; // 24h rolling window for "Recent" filter
 function getStatusClass(sid) {
   const s = sessionStatusMap.get(sid);
-  if (!s) return 'sdot-off';
-  if (s.active) return 'sdot-stream';
-  if (s.lastSeenAt && Date.now() - s.lastSeenAt < 5 * 60 * 1000) return 'sdot-idle';
+  if (s) {
+    if (s.active) return 'sdot-stream';
+    if (s.lastSeenAt && Date.now() - s.lastSeenAt < RECENT_MS) return 'sdot-idle';
+    return 'sdot-off';
+  }
+  // ponytail: fallback to sessionsMap for restored sessions without SSE events (#292)
+  const sess = sessionsMap.get(sid);
+  if (sess && sess.lastReceivedAt && Date.now() - sess.lastReceivedAt < RECENT_MS) return 'sdot-idle';
   return 'sdot-off';
 }
 function getProjectStatusClass(proj) {
@@ -1251,7 +1239,7 @@ function getStatusPriority(statusClass) {
 function updateTopbarStatus() {
   const streaming = [...sessionStatusMap.values()].filter(s => s.active).length;
   const idle = [...sessionStatusMap.values()].filter(s =>
-    !s.active && s.lastSeenAt && Date.now() - s.lastSeenAt < 5 * 60 * 1000
+    !s.active && s.lastSeenAt && Date.now() - s.lastSeenAt < RECENT_MS
   ).length;
   let txt = '';
   if (streaming) txt += '<span style="color:var(--green)">●' + streaming + ' streaming</span>  ';
@@ -1267,17 +1255,8 @@ let countdownInterval = null;
 
 // ── Follow live turn state ──
 let followLiveTurn = true;
-function toggleFollowLive() {
-  followLiveTurn = !followLiveTurn;
-  const btn = document.getElementById('scroll-toggle');
-  if (btn) {
-    btn.querySelector('.scroll-on').classList.toggle('active', followLiveTurn);
-    btn.querySelector('.scroll-off').classList.toggle('active', !followLiveTurn);
-  }
-}
-function scrollTurnsToBottom() {
-  if (followLiveTurn) colTurns.scrollTop = colTurns.scrollHeight;
-}
+function toggleFollowLive() { followLiveTurn = !followLiveTurn; }
+function scrollTurnsToBottom() {}
 
 // ── Status line injection state ──
 // eslint-disable-next-line no-undef
@@ -1320,7 +1299,7 @@ let selectedStepSub = null;
 let selectedStepSubExplicit = false;
 // Start focus on the leftmost visible column — Projects/Sessions are hidden
 // when the sidebar loads collapsed (#206).
-let focusedCol = (typeof isSidebarCollapsed === 'function' && isSidebarCollapsed()) ? 'turns' : 'projects'; // 'projects' | 'sessions' | 'turns' | 'sections' | 'messages'
+let focusedCol = (typeof isSidebarCollapsed === 'function' && isSidebarCollapsed()) ? 'sessions' : 'projects'; // 'projects' | 'sessions' | 'sections' | 'messages'
 let isFocusedMode = false;
 // ponytail: "split pane active" — classic focused OR workflow timeline (P16: workflow never uses isFocusedMode)
 function inSplitView() { return isFocusedMode || (typeof wfState !== 'undefined' && !!wfState && selectedSection === 'timeline'); }
@@ -1391,7 +1370,7 @@ function copyCurrentUrl(btn) {
 function clearAll() { // kept for console use if needed
   colProjects.innerHTML = '<div class="col-title">Projects</div>';
   colSessions.innerHTML = '<div class="col-title">Sessions</div>';
-  colTurns.innerHTML = '<div class="col-sticky-header"><div class="col-title" style="display:flex;align-items:center">Turns<span id="scroll-toggle" onclick="toggleFollowLive()" style="cursor:pointer;font-size:10px;margin-left:auto"><span class="scroll-on active">ON</span> <span class="scroll-off">OFF</span></span></div><div id="session-tool-bar" style="display:none"></div><div id="ctx-legend"><span><span class="ctx-legend-dot" style="background:var(--color-cache-read)"></span>cache read</span><span><span class="ctx-legend-dot" style="background:var(--color-cache-write)"></span>cache write</span><span><span class="ctx-legend-dot" style="background:var(--color-input)"></span>input</span></div><div id="session-sparkline"></div></div>';
+  colTurns.innerHTML = '';
   colSections.innerHTML = '<div class="col-empty">←</div>';
   colDetail.innerHTML = '<div class="col-empty">←</div>';
   allEntries.length = 0;
@@ -1603,7 +1582,7 @@ function _renderProjectsColInner() {
   let html = '<div class="col-title" style="display:flex;align-items:center;gap:6px">Projects' +
     '<select id="proj-filter-select" onchange="setProjectFilter(this.value)" style="background:var(--surface);color:var(--dim);border:1px solid var(--border);border-radius:3px;font-size:10px;padding:1px 4px;cursor:pointer">' +
     '<option value="streaming"' + (projectFilterMode === 'streaming' ? ' selected' : '') + ' title="Only projects with in-flight API calls">Streaming</option>' +
-    '<option value="recent"' + (projectFilterMode === 'recent' ? ' selected' : '') + ' title="Projects active within the last 5 minutes">Recent</option>' +
+    '<option value="recent"' + (projectFilterMode === 'recent' ? ' selected' : '') + ' title="Projects active within the last 24 hours">Recent</option>' +
     '<option value="all"' + (projectFilterMode === 'all' ? ' selected' : '') + '>All</option>' +
     '</select><span id="proj-filter-count" style="color:var(--dim);font-size:10px"></span></div>';
 
@@ -1730,7 +1709,6 @@ function selectProject(name) {
   selectedTurnIdx = -1;
   selectedSection = null;
   clearSelectedStepSelection();
-  colTurns.querySelectorAll('.turn-item').forEach(el => { el.style.display = 'none'; });
   colSections.innerHTML = '';
   colDetail.innerHTML = '';
   // Clear workflow timeline
@@ -1753,7 +1731,6 @@ function setFocus(col) {
   focusedCol = col;
   colProjects.classList.toggle('col-focused', col === 'projects');
   colSessions.classList.toggle('col-focused', col === 'sessions');
-  colTurns.classList.toggle('col-focused', col === 'turns');
   colSections.classList.toggle('col-focused', col === 'sections');
   if (typeof renderCmdBar === 'function') renderCmdBar();
 }
@@ -1764,23 +1741,7 @@ function getVisibleTurnIndices() {
     .filter(i => selectedSessionId && allEntries[i].sessionId === selectedSessionId && !allEntries[i].isRetry);
 }
 
-function updateRetryEmptyState(sid) {
-  let el = colTurns.querySelector('.retry-empty-state');
-  if (!sid) { if (el) el.remove(); return; }
-  const sess = sessionsMap.get(sid);
-  const hasVisibleTurns = colTurns.querySelector('.turn-item[style=""]') || colTurns.querySelector('.turn-item:not([style*="display: none"])');
-  if (!hasVisibleTurns && sess && sess.retryCount > 0) {
-    if (!el) { el = document.createElement('div'); el.className = 'retry-empty-state col-empty'; colTurns.appendChild(el); }
-    const rc = sess.retryCount;
-    const codes = [];
-    for (let i = 0; i < allEntries.length; i++) {
-      if (allEntries[i].sessionId === sid && allEntries[i].isRetry) codes.push(allEntries[i].status);
-    }
-    const summary = Object.entries(codes.reduce((a, c) => { a[c] = (a[c] || 0) + 1; return a; }, {})).map(([k, v]) => v > 1 ? v + '× ' + k : k).join(', ');
-    el.textContent = 'No turns — ' + rc + ' failed request' + (rc > 1 ? 's' : '') + ' (' + summary + ')';
-    el.style.display = '';
-  } else { if (el) el.remove(); }
-}
+function updateRetryEmptyState() {}
 
 function renderSessionToolBar(sid) {
   const bar = document.getElementById('session-tool-bar');
@@ -2065,9 +2026,6 @@ function selectSessionAndLatestTurn(sid) {
   colSessions.querySelectorAll('.session-item').forEach(el => {
     el.classList.toggle('selected', el.dataset.sessionId === sid);
   });
-  colTurns.querySelectorAll('.turn-item').forEach(el => {
-    el.style.display = (sid && el.dataset.sessionId === sid) ? '' : 'none';
-  });
   // Workflow view
   var columnsEl = document.getElementById('columns');
   if (typeof wfBuildState === 'function' && sid) {
@@ -2202,18 +2160,9 @@ function selectSession(id) {
   // Cold session: fetch entries on demand, then render
   const sess = sessionsMap.get(id);
   if (sess && sess._cold) {
-    colTurns.querySelectorAll('.turn-item').forEach(el => { el.style.display = 'none'; });
     colSections.innerHTML = '';
     colDetail.innerHTML = '';
-    colTurns.querySelectorAll('.col-empty').forEach(el => el.remove());
-    const turnsColHeader = colTurns.querySelector('.col-sticky-header');
-    if (!turnsColHeader) {
-      colTurns.innerHTML = '<div class="col-sticky-header"><div class="col-title">Turns</div></div>';
-    }
-    const spinner = document.createElement('div');
-    spinner.className = 'col-empty loading-state';
-    spinner.innerHTML = '<div class="loading-spinner"></div><div>Loading ' + (sess.count || '') + ' turns…</div>';
-    colTurns.appendChild(spinner);
+    const spinner = document.createElement('div'); // ponytail: kept for cancelColdLoad token identity, not rendered
     renderSessionToolBar(id);
     const columnsEl = document.getElementById('columns');
     columnsEl.classList.remove('wf-active');
@@ -2283,10 +2232,6 @@ function selectSession(id) {
         if (_coldLoad !== token) return;
         console.error('[cold-load]', err);
         cancelColdLoad();
-        const errEl = document.createElement('div');
-        errEl.className = 'col-empty';
-        errEl.innerHTML = '<div style="opacity:0.5">Failed to load entries</div>';
-        colTurns.appendChild(errEl);
       });
     return;
   }
@@ -2295,11 +2240,6 @@ function selectSession(id) {
 }
 
 function _renderSelectedSession(id) {
-  colTurns.querySelectorAll('.col-empty').forEach(el => el.remove());
-  // Show turns for this session
-  colTurns.querySelectorAll('.turn-item').forEach(el => {
-    el.style.display = (id && el.dataset.sessionId === id) ? '' : 'none';
-  });
   // Clear downstream — Miller column rule: N+2 onwards must clear
   colSections.innerHTML = '';
   colDetail.innerHTML = '';
@@ -2417,32 +2357,6 @@ function selectTurn(idx, opts) {
   selectedTurnIdx = idx;
   clearSelectedStepSelection();
   if (typeof wfHighlightTurn === 'function' && wfState) wfHighlightTurn(allEntries[idx]?.id);
-  colTurns.querySelectorAll('.turn-item').forEach(el => {
-    el.classList.toggle('selected', parseInt(el.dataset.entryIdx) === idx);
-  });
-  const selEl = colTurns.querySelector('.turn-item[data-entry-idx="' + idx + '"]');
-  if (selEl) {
-    // scrollIntoView({block:'nearest'}) aligns to the column's scroll
-    // container top, but col-sticky-header overlays that area — the turn
-    // ends up tucked behind the header. Compute the header's height and
-    // nudge the column scroll so the selected card sits clear of it.
-    const stickyHeader = colTurns.querySelector('.col-sticky-header');
-    const headerH = stickyHeader ? stickyHeader.getBoundingClientRect().height : 0;
-    const colRect = colTurns.getBoundingClientRect();
-    const elRect = selEl.getBoundingClientRect();
-    const elTopInCol = elRect.top - colRect.top;
-    const elBottomInCol = elRect.bottom - colRect.top;
-    let delta = 0;
-    if (elTopInCol < headerH + 4) {
-      delta = elTopInCol - headerH - 8;
-    } else if (elBottomInCol > colRect.height - 4) {
-      delta = elBottomInCol - colRect.height + 8;
-    }
-    if (delta !== 0) {
-      if (opts && opts.smooth) _smoothScrollBy(colTurns, delta, 300);
-      else colTurns.scrollBy({ top: delta, behavior: 'auto' });
-    }
-  }
   // Auto-highlight the session this turn belongs to (read-only indicator, not a gate)
   const sid = allEntries[idx]?.sessionId;
   colSessions.querySelectorAll('.session-item').forEach(el => {

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1585,22 +1585,25 @@ function renderProjectsCol() {
 }
 
 function _renderProjectsColInner() {
-  let html = '<div class="col-title" style="display:flex;align-items:center;gap:6px">Projects' +
-    '<select id="proj-filter-select" onchange="setProjectFilter(this.value)" style="background:var(--surface);color:var(--dim);border:1px solid var(--border);border-radius:3px;font-size:10px;padding:1px 4px;cursor:pointer">' +
+  var filterHtml = '<select id="proj-filter-select" onchange="setProjectFilter(this.value)" style="background:var(--surface);color:var(--dim);border:1px solid var(--border);border-radius:3px;font-size:10px;padding:1px 4px;cursor:pointer">' +
     '<option value="streaming"' + (projectFilterMode === 'streaming' ? ' selected' : '') + ' title="Only projects with in-flight API calls">Streaming</option>' +
     '<option value="recent"' + (projectFilterMode === 'recent' ? ' selected' : '') + ' title="Projects active within the last 24 hours">Recent</option>' +
     '<option value="all"' + (projectFilterMode === 'all' ? ' selected' : '') + '>All</option>' +
-    '</select><span id="proj-filter-count" style="color:var(--dim);font-size:10px"></span></div>';
+    '</select>';
+  let html = '<div class="col-title" style="display:flex;align-items:center;gap:6px">Projects' +
+    filterHtml + '<span id="proj-filter-count" style="color:var(--dim);font-size:10px"></span></div>';
 
   if (window._entriesLoading && projectsMap.size === 0) {
-    var skel = '';
+    var loadText = window._entriesLoadingText || 'Loading…';
+    html += '<div style="padding:8px 12px;font-size:11px;color:var(--dim)">' + loadText + '</div>';
     for (var si = 0; si < 6; si++) {
-      skel += '<div class="project-item" style="pointer-events:none;opacity:0.5">' +
-        '<div class="skeleton skeleton-text" style="width:' + (50 + si * 12 % 40) + 'px;margin-bottom:6px"></div>' +
-        '<div class="skeleton skeleton-text" style="width:90px;height:10px;margin-bottom:4px"></div>' +
-        '<div class="skeleton skeleton-text" style="width:60px;height:10px"></div></div>';
+      html += '<div class="project-item" style="pointer-events:none">' +
+        '<div class="pi-name"><span class="skeleton skeleton-text" style="width:' + (60 + si * 15 % 40) + 'px"></span></div>' +
+        '<div class="pi-meta"><span class="skeleton skeleton-text" style="width:80px"></span></div>' +
+        '<div class="pi-meta pi-cost"><span class="skeleton skeleton-text" style="width:50px"></span></div>' +
+        '</div>';
     }
-    colProjects.innerHTML = html + skel;
+    colProjects.innerHTML = html;
     return;
   }
 

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -437,12 +437,18 @@ function _ensureEntryLoadedByIndex(idx) {
     .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
     .then(data => {
       if (!data) { entry._loadFailed = true; return { ok: false, reason: 'load-failed' }; }
-      entry.req = data.req;
-      entry.res = data.res;
-      entry.reqLoaded = true;
-      entry.toolSources = data.toolSources || null;
+      if (data.req || data.res) {
+        entry.req = data.req;
+        entry.res = data.res;
+        entry.reqLoaded = true;
+        entry.toolSources = data.toolSources || null;
+        if (data.receivedAt) entry.receivedAt = data.receivedAt;
+      } else {
+        entry._loadFailed = true;
+        entry._prefetching = false;
+        return { ok: false, reason: 'load-failed' };
+      }
       entry._prefetching = false;
-      if (data.receivedAt) entry.receivedAt = data.receivedAt;
       return { ok: true };
     })
     .catch(() => {
@@ -2160,9 +2166,15 @@ function selectSession(id) {
   // Cold session: fetch entries on demand, then render
   const sess = sessionsMap.get(id);
   if (sess && sess._cold) {
+    if (typeof wfState !== 'undefined') wfState = null;
+    var oldTimeline = document.getElementById('wf-timeline');
+    if (oldTimeline) oldTimeline.remove();
     colSections.innerHTML = '';
     colDetail.innerHTML = '';
-    const spinner = document.createElement('div'); // ponytail: kept for cancelColdLoad token identity, not rendered
+    const spinner = document.createElement('div');
+    spinner.className = 'loading-state';
+    spinner.innerHTML = '<div class="loading-spinner"></div><div>Loading ' + (sess.count || '') + ' turns…</div>';
+    colTurns.appendChild(spinner);
     renderSessionToolBar(id);
     const columnsEl = document.getElementById('columns');
     columnsEl.classList.remove('wf-active');
@@ -2306,13 +2318,17 @@ function prefetchEntry(idx) {
         if (selectedTurnIdx === idx) scheduleRender();
         return;
       }
-      allEntries[idx].req = data.req;
-      allEntries[idx].res = data.res;
-      allEntries[idx].reqLoaded = true;
-      allEntries[idx].toolSources = data.toolSources || null;
+      if (data.req || data.res) {
+        allEntries[idx].req = data.req;
+        allEntries[idx].res = data.res;
+        allEntries[idx].reqLoaded = true;
+        allEntries[idx].toolSources = data.toolSources || null;
+        if (data.receivedAt) allEntries[idx].receivedAt = data.receivedAt;
+      } else {
+        allEntries[idx]._loadFailed = true;
+      }
       allEntries[idx]._prefetching = false;
       allEntries[idx]._prefetchPromise = null;
-      if (data.receivedAt) allEntries[idx].receivedAt = data.receivedAt;
       if (selectedTurnIdx === idx) {
         scheduleRender(() => {
           // Apply deferred deep link sec/msg after lazy-load completes

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1559,7 +1559,6 @@ function renderProjectsCol() {
     projectFilterMode,
     selectedProjectName || '',
     window._entriesLoading ? '1' : '0',
-    window._entriesLoadingText || '',
     (window.ccxraySettings?.hiddenProjects || []).join(','),
   ];
   for (const [name, proj] of projectsMap) {
@@ -1594,8 +1593,6 @@ function _renderProjectsColInner() {
     filterHtml + '<span id="proj-filter-count" style="color:var(--dim);font-size:10px"></span></div>';
 
   if (window._entriesLoading && projectsMap.size === 0) {
-    var loadText = window._entriesLoadingText || 'Loading…';
-    html += '<div style="padding:8px 12px;font-size:11px;color:var(--dim)">' + loadText + '</div>';
     for (var si = 0; si < 6; si++) {
       html += '<div class="project-item" style="pointer-events:none">' +
         '<div class="pi-name"><span class="skeleton skeleton-text" style="width:' + (60 + si * 15 % 40) + 'px"></span></div>' +
@@ -1741,7 +1738,6 @@ function selectProject(name) {
 function fmt(n) { return n != null ? n.toLocaleString() : '—'; }
 
 // ── Miller Columns: Selection ──
-let _hoverTimer = null;
 
 function setFocus(col) {
   // #206: never focus a column hidden by sidebar collapse

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -434,7 +434,7 @@ function _ensureEntryLoadedByIndex(idx) {
   if (entry._prefetching) return _waitForEntryLoaded(idx, 300);
   entry._prefetching = true;
   entry._prefetchPromise = fetch('/_api/entry/' + encodeURIComponent(entry.id))
-    .then(r => r.json())
+    .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
     .then(data => {
       if (!data) { entry._loadFailed = true; return { ok: false, reason: 'load-failed' }; }
       entry.req = data.req;
@@ -2297,7 +2297,7 @@ function prefetchEntry(idx) {
   if (!e || e.reqLoaded || e._prefetching || e._prefetchPromise) return;
   e._prefetching = true;
   e._prefetchPromise = fetch('/_api/entry/' + encodeURIComponent(e.id))
-    .then(r => r.json())
+    .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
     .then(data => {
       if (!data) {
         allEntries[idx]._loadFailed = true;

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1211,7 +1211,7 @@ function applySessionFilter() {
       placeholder.className = 'sessions-empty col-empty';
       colSessions.appendChild(placeholder);
     }
-    placeholder.textContent = window._entriesLoading ? (window._entriesLoadingText || 'Loading…') : 'No sessions yet';
+    placeholder.textContent = 'No sessions yet';
     placeholder.style.display = '';
   } else if (placeholder) {
     placeholder.style.display = 'none';
@@ -1630,9 +1630,6 @@ function _renderProjectsColInner() {
       '<div class="pi-meta pi-cost">$' + proj.totalCost.toFixed(2) + '</div>' +
       (rangeStr ? '<div class="pi-range">' + escapeHtml(rangeStr) + '</div>' : '') +
       '</div>';
-  }
-  if (visibleProjCount === 0 && window._entriesLoading) {
-    html += '<div id="entries-loading-status" class="col-empty loading-state" style="padding-top:16px;opacity:0.75"><div class="loading-spinner"></div><div>' + escapeHtml(window._entriesLoadingText || 'Loading…') + '</div></div>';
   }
   colProjects.innerHTML = html;
   const projCountEl = document.getElementById('proj-filter-count');

--- a/public/settings.js
+++ b/public/settings.js
@@ -20,6 +20,11 @@ window.ccxraySettings = {
   hideImported: !new URLSearchParams(window.location.search).has('imported'),
 };
 
+function _apiQ(url) {
+  if (!window.ccxraySettings?.hideImported) return url;
+  return url + (url.includes('?') ? '&' : '?') + 'hideImported';
+}
+
 function getCacheMode(provider) {
   return window.ccxraySettings?.providerProfiles?.[provider]?.cache
       || window.ccxraySettings?.providerProfiles?.anthropic?.cache

--- a/public/settings.js
+++ b/public/settings.js
@@ -15,6 +15,9 @@ window.ccxraySettings = {
   visibleProviders: [],
   providerProfiles: {},
   loaded: false,
+  // ponytail: hide imported entries by default (no req/res, missing identity
+  // fields → sawtooth + load-failed). ?imported=1 in URL to show them.
+  hideImported: !new URLSearchParams(window.location.search).has('imported'),
 };
 
 function getCacheMode(provider) {

--- a/public/style.css
+++ b/public/style.css
@@ -212,6 +212,20 @@
   .si-meta-row .si-cache { margin-top: 0; }
   .si-time { font-size: 10px; color: var(--fg); white-space: nowrap; }
   .session-item .si-cost { color: var(--yellow); }
+  /* Restore scaffold — static placeholder rows during entry restore (#332) */
+  .scaffold-row { border-bottom: 1px solid var(--border); padding: 10px; }
+  .scaffold-row > div { background: var(--border); border-radius: 3px; }
+  .scaffold-proj { height: 68px; }
+  .scaffold-proj > div:nth-child(1) { width: 60%; height: 12px; margin-bottom: 6px; }
+  .scaffold-proj > div:nth-child(2) { width: 40%; height: 10px; margin-bottom: 4px; }
+  .scaffold-proj > div:nth-child(3) { width: 30%; height: 10px; }
+  .scaffold-sess { height: 120px; }
+  .scaffold-sess > div:nth-child(1) { width: 50%; height: 12px; margin-bottom: 6px; }
+  .scaffold-sess > div:nth-child(2) { width: 80%; height: 10px; margin-bottom: 4px; }
+  .scaffold-sess > div:nth-child(3) { width: 45%; height: 10px; margin-bottom: 6px; }
+  .scaffold-sess > div:nth-child(4) { width: 100%; height: 6px; margin-bottom: 6px; }
+  .scaffold-sess > div:nth-child(5) { width: 35%; height: 10px; }
+
   .ctx-alert { font-size: 10px; font-weight: bold; }
   .ctx-alert-yellow { color: var(--yellow); }
   .ctx-alert-red { color: var(--red); }
@@ -678,6 +692,11 @@
 .sysprompt-breadcrumb { padding: 6px 12px; font-size: 11px; border-bottom: 1px solid var(--border); background: var(--surface); }
 .sysprompt-breadcrumb a { color: var(--accent); text-decoration: none; cursor: pointer; }
 .sysprompt-breadcrumb a:hover { text-decoration: underline; }
+
+/* Restore: hide empty right-side columns (#332) */
+#columns.restoring #col-turns,
+#columns.restoring #col-sections,
+#columns.restoring #col-detail { display: none; }
 
 /* Cold-loading: hide empty sections/detail, let turns fill the space (#316) */
 #columns.cold-loading #col-sections,

--- a/public/style.css
+++ b/public/style.css
@@ -166,7 +166,7 @@
   #col-sections { width: 220px; }
 
   .col-empty { color: var(--dim); text-align: center; padding: 40px 12px; font-size: 12px; }
-  .loading-state { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+  .loading-state { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; flex: 1; }
   .loading-spinner { width: 14px; height: 14px; border: 2px solid var(--border); border-top-color: var(--accent); border-radius: 50%; animation: ccxray-spin 0.8s linear infinite; }
   @keyframes ccxray-spin { to { transform: rotate(360deg); } }
   .col-title { padding: 10px 12px; font-size: 10px; font-weight: 600; color: var(--dim); letter-spacing: 0.08em; text-transform: uppercase; border-bottom: 2px solid var(--border); position: sticky; top: 0; background: var(--surface); z-index: 1; }
@@ -682,7 +682,7 @@
 /* Cold-loading: hide empty sections/detail, let turns fill the space (#316) */
 #columns.cold-loading #col-sections,
 #columns.cold-loading #col-detail { display: none; }
-#columns.cold-loading #col-turns { flex: 1; }
+#columns.cold-loading #col-turns { flex: 1; overflow: hidden; }
 
 /* ── Workflow Swimlane Timeline (#91) ── */
 /* When workflow is active, col-turns becomes the full-width right area;
@@ -726,7 +726,7 @@
 #wf-resize.wf-resize-expand { height: 15px; cursor: pointer; }
 #wf-resize.wf-resize-expand::after { content: '▾ show all agents'; width: auto; height: auto; border-radius: 0; background: none; color: var(--dim); font-size: 10px; letter-spacing: 0.2px; }
 #wf-resize.wf-resize-expand:hover::after { color: var(--text); }
-#wf-detail-area { flex: 1; display: flex; min-height: 0; overflow: hidden; }
+#wf-detail-area { flex: 1; display: flex; min-height: 180px; overflow: hidden; }
 #wf-agent-card-panel { width: 240px; flex-shrink: 0; overflow-y: auto; border-right: 1px solid var(--border); background: var(--surface); }
 #wf-steps-panel { flex: 1; overflow-y: auto; min-width: 0; }
 .wf-tooltip { position: fixed; display: none; background: var(--surface); border: 1px solid var(--border); border-radius: 4px; padding: 6px 10px; font-size: 11px; color: var(--text); z-index: 100; pointer-events: none; max-width: 300px; box-shadow: 0 2px 8px rgba(0,0,0,0.3); line-height: 1.6; }

--- a/public/style.css
+++ b/public/style.css
@@ -212,19 +212,7 @@
   .si-meta-row .si-cache { margin-top: 0; }
   .si-time { font-size: 10px; color: var(--fg); white-space: nowrap; }
   .session-item .si-cost { color: var(--yellow); }
-  /* Restore scaffold — static placeholder rows during entry restore (#332) */
-  .scaffold-row { border-bottom: 1px solid var(--border); padding: 10px; }
-  .scaffold-row > div { background: var(--border); border-radius: 3px; }
-  .scaffold-proj { height: 68px; }
-  .scaffold-proj > div:nth-child(1) { width: 60%; height: 12px; margin-bottom: 6px; }
-  .scaffold-proj > div:nth-child(2) { width: 40%; height: 10px; margin-bottom: 4px; }
-  .scaffold-proj > div:nth-child(3) { width: 30%; height: 10px; }
-  .scaffold-sess { height: 120px; }
-  .scaffold-sess > div:nth-child(1) { width: 50%; height: 12px; margin-bottom: 6px; }
-  .scaffold-sess > div:nth-child(2) { width: 80%; height: 10px; margin-bottom: 4px; }
-  .scaffold-sess > div:nth-child(3) { width: 45%; height: 10px; margin-bottom: 6px; }
-  .scaffold-sess > div:nth-child(4) { width: 100%; height: 6px; margin-bottom: 6px; }
-  .scaffold-sess > div:nth-child(5) { width: 35%; height: 10px; }
+
 
   .ctx-alert { font-size: 10px; font-weight: bold; }
   .ctx-alert-yellow { color: var(--yellow); }
@@ -316,12 +304,8 @@
   .turn-item { padding: 7px 10px; cursor: pointer; border-left: 2px solid transparent; border-bottom: 1px solid var(--border); }
   .turn-item:hover { background: var(--surface-hover); }
   .turn-item.selected { border-left-color: var(--accent); background: var(--surface-hover); }
-  .turn-item.risk-critical { border-left-color: var(--red); }
-  .turn-item.risk-warning { border-left-color: var(--orange); }
-  .turn-item.risk-notice { border-left-color: var(--yellow); }
   /* Line 1: identity */
   .turn-item .turn-identity { display: flex; gap: 6px; align-items: center; font-size: 12px; flex-wrap: nowrap; }
-  .turn-item .turn-num { color: var(--dim); flex-shrink: 0; }
   .turn-model { color: var(--purple); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .turn-item .status-dot { font-size: 10px; line-height: 1; flex-shrink: 0; }
   .turn-item .status-dot-ok { color: var(--green); }
@@ -339,7 +323,6 @@
   /* Line 2: title */
   .turn-item .turn-title { font-size: 11px; color: var(--text); margin-top: 2px; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; }
   /* Line 3: ctx bar */
-  .turn-item .turn-ctx { margin-top: 4px; }
   /* Line 4: secondary — time + tools */
   .turn-item .turn-secondary { display: flex; flex-direction: column; gap: 3px; font-size: 9px; color: var(--dim); margin-top: 3px; }
   .turn-item .turn-time-row { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
@@ -694,9 +677,6 @@
 .sysprompt-breadcrumb a:hover { text-decoration: underline; }
 
 /* Restore: hide empty right-side columns (#332) */
-#columns.restoring #col-turns,
-#columns.restoring #col-sections,
-#columns.restoring #col-detail { display: none; }
 
 /* Cold-loading: hide empty sections/detail, let turns fill the space (#316) */
 #columns.cold-loading #col-sections,

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -1496,26 +1496,30 @@ function wfRenderTimeline() {
   container.appendChild(detailArea);
 
   colTurns.appendChild(container);
-  _wfLoadVersions();
 
-  // P1: content-driven height (selected lane is taller)
-  var contentH = WF_PAD + WF_AXIS_H + _wfTotalLanesHeight() + WF_PAD;
-  var maxH = window.innerHeight * 0.45;
-  lanesSection.style.maxHeight = Math.min(contentH, maxH) + 'px';
+  // ponytail: defer render to next frame — flex layout must settle before
+  // reading colTurns.clientWidth, otherwise SVG gets wrong dimensions
+  requestAnimationFrame(function() {
+    _wfLoadVersions();
 
-  _wfRenderSvgContent(mainSvg, subSvg, canvas);
-  wfSetupInteractions(mainSvg, subSvg);
-  wfInitResize(lanesSection, resizeHandle);
-  resizeHandle.classList.toggle('wf-resize-expand', !!wfState.laneFocusMode);
-  if (wfState.selectionLevel === 'L2' && wfState.selectedTurnId) {
-    var hit = wfState.turnIndex && wfState.turnIndex.get(wfState.selectedTurnId);
-    if (hit) wfRenderTurnCard(hit.turn);
-    else wfRenderAgentCard(wfState.selectedLane);
-  } else {
-    wfRenderAgentCard(wfState.selectedLane);
-  }
-  // ponytail: charts now inline in selected lane SVG, no separate header
-  wfRenderCurrentSection();
+    // P1: content-driven height (selected lane is taller)
+    var contentH = WF_PAD + WF_AXIS_H + _wfTotalLanesHeight() + WF_PAD;
+    var maxH = window.innerHeight * 0.45;
+    lanesSection.style.maxHeight = Math.min(contentH, maxH) + 'px';
+
+    _wfRenderSvgContent(mainSvg, subSvg, canvas);
+    wfSetupInteractions(mainSvg, subSvg);
+    wfInitResize(lanesSection, resizeHandle);
+    resizeHandle.classList.toggle('wf-resize-expand', !!wfState.laneFocusMode);
+    if (wfState.selectionLevel === 'L2' && wfState.selectedTurnId) {
+      var hit = wfState.turnIndex && wfState.turnIndex.get(wfState.selectedTurnId);
+      if (hit) wfRenderTurnCard(hit.turn);
+      else wfRenderAgentCard(wfState.selectedLane);
+    } else {
+      wfRenderAgentCard(wfState.selectedLane);
+    }
+    wfRenderCurrentSection();
+  });
 }
 
 function _wfRenderSvgContent(mainSvg, subSvg, canvas) {

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -1366,10 +1366,15 @@ function wfRenderLaneSvg(lane, laneIdx, W, xFn, mainConvs) {
     var cwH = inT > 0 ? Math.round(h * cc / inT) : 0;
     if (cc > 0 && cwH < 1) cwH = 1;
     var riH = Math.max(0, h - crH - cwH);
-    svg += '<g class="wf-b" data-i="' + i + '" data-turn-id="' + t.id + '">';
+    svg += '<g class="wf-b' + (t.severity ? ' wf-b-' + t.severity : '') + '" data-i="' + i + '" data-turn-id="' + t.id + '"' + (t.severity ? ' data-severity="' + t.severity + '"' : '') + '>';
     if (riH > 0) svg += '<rect x="' + tx.toFixed(1) + '" y="' + (WF_BAR_H - h) + '" width="' + tw.toFixed(1) + '" height="' + riH + '" fill="' + WF_V8_INPUT + '"/>';
     if (cwH > 0) svg += '<rect x="' + tx.toFixed(1) + '" y="' + (WF_BAR_H - crH - cwH) + '" width="' + tw.toFixed(1) + '" height="' + cwH + '" fill="' + WF_V8_CACHE_WRITE + '"/>';
     if (crH > 0) svg += '<rect x="' + tx.toFixed(1) + '" y="' + (WF_BAR_H - crH) + '" width="' + tw.toFixed(1) + '" height="' + crH + '" fill="' + WF_V8_CACHE_READ + '"/>';
+    // #332 severity marker: 2px baseline in risk colour (mirrors the pre-#332
+    // turn-item left border). data-severity above is the machine-readable source.
+    if (t.severity === 'critical' || t.severity === 'warning') {
+      svg += '<rect x="' + tx.toFixed(1) + '" y="' + (WF_BAR_H - 2) + '" width="' + tw.toFixed(1) + '" height="2" fill="' + (t.severity === 'critical' ? '#f85149' : '#d29922') + '"/>';
+    }
     svg += '</g>';
   }
 

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -1502,9 +1502,13 @@ function wfRenderTimeline() {
   requestAnimationFrame(function() {
     _wfLoadVersions();
 
-    // P1: content-driven height (selected lane is taller)
+    // P1: content-driven height — budget from actual column, not viewport
+    var DETAIL_MIN = 180;
     var contentH = WF_PAD + WF_AXIS_H + _wfTotalLanesHeight() + WF_PAD;
-    var maxH = window.innerHeight * 0.45;
+    var overviewH = overviewDiv.offsetHeight || 48;
+    var resizeH = 8;
+    var availForLanes = (colTurns.clientHeight || window.innerHeight) - overviewH - resizeH - DETAIL_MIN;
+    var maxH = Math.max(60, availForLanes);
     lanesSection.style.maxHeight = Math.min(contentH, maxH) + 'px';
 
     _wfRenderSvgContent(mainSvg, subSvg, canvas);
@@ -1663,8 +1667,12 @@ function _wfRefreshLaneFocusUI() {
   // broken (ux-heuristic-analysis: drags that don't stick read as a bug).
   var lanesSection = document.getElementById('wf-lanes-section');
   if (lanesSection && !(wfState && wfState.laneHeightManual)) {
+    var DETAIL_MIN = 180;
     var contentH = WF_PAD + WF_AXIS_H + _wfTotalLanesHeight() + WF_PAD;
-    var maxH = window.innerHeight * 0.45;
+    var ov = document.getElementById('wf-overview');
+    var overviewH = ov ? ov.offsetHeight : 48;
+    var availForLanes = (colTurns.clientHeight || window.innerHeight) - overviewH - 8 - DETAIL_MIN;
+    var maxH = Math.max(60, availForLanes);
     lanesSection.style.maxHeight = Math.min(contentH, maxH) + 'px';
   }
   var resizeHandle = document.getElementById('wf-resize');
@@ -2300,9 +2308,11 @@ function wfInitResize(subScroll, handle) {
     // (_wfRefreshLaneFocusUI) — otherwise the next toggle/cycle/click
     // silently overwrites their resize with no feedback (ux-heuristic-analysis).
     if (wfState) wfState.laneHeightManual = true;
+    var ov = document.getElementById('wf-overview');
+    var maxDrag = (colTurns.clientHeight || 600) - (ov ? ov.offsetHeight : 48) - 8 - 180;
     var onMove = function(ev) {
       var delta = ev.clientY - startY;
-      var newH = Math.max(60, startH + delta);
+      var newH = Math.max(60, Math.min(startH + delta, maxDrag));
       subScroll.style.maxHeight = newH + 'px';
     };
     var onUp = function() {

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -2337,6 +2337,18 @@ function wfInitResize(subScroll, handle) {
 }
 
 // ── Highlight Turn (without full re-render) ───────────────────────────────
+function _wfLastProxyTurn(lane) {
+  // Find the proxy turn with the highest msgCount — that one holds the most
+  // complete conversation history for the "full range" timeline view.
+  // Compaction/resume turns have low msgCount despite being recent.
+  var best = null;
+  for (var i = 0; i < lane.turns.length; i++) {
+    if (lane.turns[i].imported) continue;
+    if (!best || (lane.turns[i].msgCount || 0) > (best.msgCount || 0)) best = lane.turns[i];
+  }
+  return best || lane.turns[lane.turns.length - 1];
+}
+
 // Render a turn's detail into the steps panel without locking it in the
 // swimlane (used by lane selection: last turn = full conversation range).
 // selectTurn feeds back into wfHighlightTurn, so suppress that echo.
@@ -2799,7 +2811,7 @@ function wfSelectSection(name) {
   if (!lane || !lane.turns.length) return;
   // No turn selected: timeline = last turn's detail (full range), no lock
   if (!wfState.selectedTurnId) {
-    if (name === 'timeline') { _wfShowTurnDetail(lane.turns[lane.turns.length - 1]); return; }
+    if (name === 'timeline') { _wfShowTurnDetail(_wfLastProxyTurn(lane)); return; }
     _wfRenderLaneSummary(lane, name); return;
   }
   for (var i = 0; i < allEntries.length; i++) {
@@ -2817,7 +2829,7 @@ function wfRenderCurrentSection() {
   if (!wfState.selectedTurnId) {
     // Timeline with no lock = last turn's detail (its request holds the whole
     // conversation = full range) without lock visuals; other sections keep summary
-    if (sec === 'timeline') { _wfShowTurnDetail(lane.turns[lane.turns.length - 1]); return; }
+    if (sec === 'timeline') { _wfShowTurnDetail(_wfLastProxyTurn(lane)); return; }
     _wfRenderLaneSummary(lane, sec); return;
   }
   for (var i = 0; i < allEntries.length; i++) {

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -1359,21 +1359,25 @@ function wfRenderLaneSvg(lane, laneIdx, W, xFn, mainConvs) {
     var tx = Math.max(WF_LABEL_W, xFn(ts));
     var tw = Math.max(WF_MIN_TURN_PX, xFn(tend) - tx);
     var h = Math.max(2, Math.round(wfCtxPct(t) / 100 * WF_BAR_H));
+    // Reserve 2px at top for severity marker so it never overlaps the ctx bar
+    var hasSev = t.severity === 'critical' || t.severity === 'warning';
+    if (hasSev) h = Math.min(h, WF_BAR_H - 2);
     var u = t.usage || {};
     var cr = u.cache_read_input_tokens || 0, cc = u.cache_creation_input_tokens || 0;
     var inT = (u.input_tokens || 0) + cr + cc;
     var crH = inT > 0 ? Math.round(h * cr / inT) : 0;
     var cwH = inT > 0 ? Math.round(h * cc / inT) : 0;
     if (cc > 0 && cwH < 1) cwH = 1;
+    if (crH + cwH > h) cwH = Math.max(0, h - crH);
     var riH = Math.max(0, h - crH - cwH);
     svg += '<g class="wf-b' + (t.severity ? ' wf-b-' + t.severity : '') + '" data-i="' + i + '" data-turn-id="' + t.id + '"' + (t.severity ? ' data-severity="' + t.severity + '"' : '') + '>';
     if (riH > 0) svg += '<rect x="' + tx.toFixed(1) + '" y="' + (WF_BAR_H - h) + '" width="' + tw.toFixed(1) + '" height="' + riH + '" fill="' + WF_V8_INPUT + '"/>';
     if (cwH > 0) svg += '<rect x="' + tx.toFixed(1) + '" y="' + (WF_BAR_H - crH - cwH) + '" width="' + tw.toFixed(1) + '" height="' + cwH + '" fill="' + WF_V8_CACHE_WRITE + '"/>';
     if (crH > 0) svg += '<rect x="' + tx.toFixed(1) + '" y="' + (WF_BAR_H - crH) + '" width="' + tw.toFixed(1) + '" height="' + crH + '" fill="' + WF_V8_CACHE_READ + '"/>';
-    // #332 severity marker: 2px baseline in risk colour (mirrors the pre-#332
-    // turn-item left border). data-severity above is the machine-readable source.
-    if (t.severity === 'critical' || t.severity === 'warning') {
-      svg += '<rect x="' + tx.toFixed(1) + '" y="' + (WF_BAR_H - 2) + '" width="' + tw.toFixed(1) + '" height="2" fill="' + (t.severity === 'critical' ? '#f85149' : '#d29922') + '"/>';
+    // #332 severity marker: 2px cap above the ctx bar; h was capped to WF_BAR_H-2
+    // so sevY is always ≥ 0 and never overlaps the encoding.
+    if (hasSev) {
+      svg += '<rect x="' + tx.toFixed(1) + '" y="' + (WF_BAR_H - h - 2) + '" width="' + tw.toFixed(1) + '" height="2" fill="' + (t.severity === 'critical' ? '#f85149' : '#d29922') + '"/>';
     }
     svg += '</g>';
   }

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -95,7 +95,7 @@ function normalizeIndexEntry(meta) {
 
 // Scan index.ndjson for entries of the given session ids (cold sessions have
 // no store.entries presence — index.ndjson is their durable source).
-async function loadSessionEntriesFromIndex(targetSids) {
+async function loadSessionEntriesFromIndex(targetSids, opts) {
   const indexContent = await config.storage.readIndex();
   if (!indexContent) return [];
   // String pre-filter before JSON.parse: parsing all ~150K lines costs
@@ -111,6 +111,7 @@ async function loadSessionEntriesFromIndex(targetSids) {
     let meta;
     try { meta = JSON.parse(line); } catch { continue; }
     if (!meta.sessionId || !targetSids.has(meta.sessionId)) continue;
+    if (meta.imported && opts?.hideImported) continue;
     metas.push(meta);
   }
   // #333 (load-bearing): a shared ~/.ccxray written by chained proxies holds
@@ -154,6 +155,7 @@ function handleApiRoutes(clientReq, clientRes) {
     const params = new URLSearchParams(clientReq.url.split('?')[1] || '');
     const sidParam = params.get('sid');
     const entryParam = params.get('e');
+    const hideImported = params.has('hideImported');
     // Scope resolution: ?sid= (id or prefix) > ?e= (entry id → its session)
     // > default (N most recently active sessions). Sessions outside the scope
     // arrive cold via /_api/sessions and load on demand.
@@ -184,10 +186,11 @@ function handleApiRoutes(clientReq, clientRes) {
     addChildSessions(scopeSids);
     (async () => {
       let scoped = store.entries.filter(e => e.sessionId && scopeSids.has(e.sessionId));
+      if (hideImported) scoped = scoped.filter(e => !e.imported);
       let entries = scoped.map(summarizeEntry);
       // Cold fallback: scoped session not in store.entries (trimmed or imported) — serve from index.ndjson
       if (!entries.length && sidParam) {
-        entries = await loadSessionEntriesFromIndex(scopeSids);
+        entries = await loadSessionEntriesFromIndex(scopeSids, { hideImported });
       }
       const sessionTitles = Object.fromEntries(
         Object.entries(store.sessionMeta).filter(([, m]) => m.title).map(([sid, m]) => [sid, m.title])
@@ -213,9 +216,11 @@ function handleApiRoutes(clientReq, clientRes) {
   const sessionEntriesMatch = pathname.match(/^\/\_api\/session\/([^/]+)\/entries$/);
   if (sessionEntriesMatch) {
     const sid = decodeURIComponent(sessionEntriesMatch[1]);
+    const sesParams = new URLSearchParams(clientReq.url.split('?')[1] || '');
+    const sesHideImported = sesParams.has('hideImported');
     (async () => {
       const targetSids = addChildSessions(new Set([sid]));
-      const entries = await loadSessionEntriesFromIndex(targetSids);
+      const entries = await loadSessionEntriesFromIndex(targetSids, { hideImported: sesHideImported });
       const sessionTitles = {};
       for (const s of targetSids) {
         const title = store.sessionMeta[s]?.title || sessionIdx.getAll().find(x => x.sid === s)?.title;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -344,7 +344,7 @@ function handleApiRoutes(clientReq, clientRes) {
     const id = decodeURIComponent(entryMatch[1]);
     (async () => {
       const entry = store.getEntryById(id) || await loadColdEntry(id);
-      if (!entry) { clientRes.writeHead(404); clientRes.end('Not found'); return; }
+      if (!entry) { clientRes.writeHead(404, { 'Content-Type': 'application/json' }); clientRes.end(JSON.stringify({ error: 'not found' })); return; }
       await loadEntryReqRes(entry);
       const snapshot = { req: entry.req, res: entry.res, receivedAt: entry.receivedAt || null, toolSources: entry.toolSources || null };
       if (entry.elapsed === '?') { entry.req = null; entry.res = null; entry._loaded = false; }
@@ -363,7 +363,7 @@ function handleApiRoutes(clientReq, clientRes) {
     const id = decodeURIComponent(tokMatch[1]);
     (async () => {
       const entry = store.getEntryById(id) || await loadColdEntry(id);
-      if (!entry) { clientRes.writeHead(404); clientRes.end('Not found'); return; }
+      if (!entry) { clientRes.writeHead(404, { 'Content-Type': 'application/json' }); clientRes.end(JSON.stringify({ error: 'not found' })); return; }
       if (!entry.tokens) {
         await loadEntryReqRes(entry);
         if (entry.req) entry.tokens = tokenizeRequest(entry.req);

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -203,6 +203,9 @@ function _upsert(sid, entry) {
   if (recvAt > (s.lastReceivedAt || 0)) s.lastReceivedAt = recvAt;
   if (entry.provider) s.provider = entry.provider;
   if (entry.agent) s.agent = entry.agent;
+  // Track whether session has any non-imported entries
+  if (entry.imported) { if (s.importedOnly === undefined) s.importedOnly = true; }
+  else s.importedOnly = false;
 }
 
 function setTitle(sid, title) {

--- a/test/dashboard-codex-e2e.test.js
+++ b/test/dashboard-codex-e2e.test.js
@@ -195,28 +195,32 @@ describe('Codex dashboard status E2E', () => {
       await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 1 });
       await page.goto(`http://localhost:${port}/?p=${encodeURIComponent(PROJECT_NAME)}&s=codex-raw`, { waitUntil: 'domcontentloaded' });
       await page.waitForFunction(() => {
-        const turn = document.querySelector('.turn-item[data-session-id="codex-raw"]');
+        // #332: turn column removed — the selected session card, the sections
+        // header, and the swimlane turn bar carry what the old .turn-item did.
+        // Wait on all three (header + projLabel are rAF-coalesced, ADR 0002; the
+        // swimlane SVG paints on the next frame, so wait for its bar too).
+        const session = document.querySelector('.session-item[data-session-id="codex-raw"]');
         const header = document.querySelector('#col-sections .ch-line2');
-        // Also wait for the selected project label to be painted: it renders via the
-        // rAF-coalesced dirty-check (ADR 0002), so page.evaluate can otherwise read it
-        // empty before the frame lands under CPU contention (the CI flake, #294 CI red).
         const projLabel = document.querySelector('.project-item.selected .pi-label');
-        return !!turn && !!header && header.textContent.includes('completed')
-          && !!projLabel && projLabel.textContent.trim().length > 0;
+        const bar = document.querySelector('#wf-main-svg .wf-b[data-turn-id="2026-05-03T23-38-05-284"]');
+        return !!session && !!header && header.textContent.includes('completed')
+          && !!projLabel && projLabel.textContent.trim().length > 0 && !!bar;
       });
 
       const state = await page.evaluate(() => {
-        const turn = document.querySelector('.turn-item[data-session-id="codex-raw"]');
+        // sections header (ch-line1/ch-line2) reflects the deep-link-selected turn #1;
+        // severity now lives on that turn's swimlane bar (data-severity), not a turn card.
         const header = document.querySelector('#col-sections .ch-line2');
-        const model = turn?.querySelector('.turn-model');
+        const line1 = document.querySelector('#col-sections .ch-line1');
+        const bar = document.querySelector('#wf-main-svg .wf-b[data-turn-id="2026-05-03T23-38-05-284"]');
         return {
           projectText: document.querySelector('.project-item.selected .pi-label')?.textContent || '',
           sessionText: document.querySelector('.session-item.selected .sid')?.textContent || '',
           url: location.search,
-          hasOkDot: !!turn?.querySelector('.status-dot-ok'),
-          hasErrDot: !!turn?.querySelector('.status-dot-err'),
-          isCritical: turn?.classList.contains('risk-critical') || false,
-          modelText: model?.textContent || '',
+          hasOkDot: !!header?.querySelector('.status-ok'),
+          hasErrDot: !!header?.querySelector('.status-err'),
+          severity: bar?.getAttribute('data-severity') || null,
+          modelText: line1?.textContent || '',
           sectionText: header?.textContent || '',
         };
       });
@@ -226,7 +230,7 @@ describe('Codex dashboard status E2E', () => {
       assert.match(state.url, /s=codex-raw/);
       assert.equal(state.hasOkDot, true);
       assert.equal(state.hasErrDot, false);
-      assert.equal(state.isCritical, false);
+      assert.notEqual(state.severity, 'critical');
       assert.match(state.modelText, /gpt-5\.5/);
       assert.match(state.sectionText, /200/);
       assert.match(state.sectionText, /completed/);
@@ -251,12 +255,12 @@ describe('Codex dashboard status E2E', () => {
       await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 1 });
       await page.goto(`http://localhost:${port}/?p=${encodeURIComponent(PROJECT_NAME)}&s=${encodeURIComponent(sessionId)}`, { waitUntil: 'domcontentloaded' });
       await page.waitForFunction((sid) => {
-        const turn = document.querySelector(`.turn-item[data-session-id="${sid}"]`);
+        // #332: turn column removed — assert on the selected session card instead.
         const session = document.querySelector(`.session-item[data-session-id="${sid}"]`);
         // Wait for the rAF-coalesced selected project label too (ADR 0002) — same race
         // as the first test: this subtest also asserts projectText.
         const projLabel = document.querySelector('.project-item.selected .pi-label');
-        return !!turn && !!session && !!projLabel && projLabel.textContent.trim().length > 0;
+        return !!session && !!projLabel && projLabel.textContent.trim().length > 0;
       }, {}, sessionId);
 
       const state = await page.evaluate(() => ({

--- a/test/dashboard-codex-e2e.test.js
+++ b/test/dashboard-codex-e2e.test.js
@@ -230,7 +230,7 @@ describe('Codex dashboard status E2E', () => {
       assert.match(state.url, /s=codex-raw/);
       assert.equal(state.hasOkDot, true);
       assert.equal(state.hasErrDot, false);
-      assert.notEqual(state.severity, 'critical');
+      assert.equal(state.severity, null); // 200/completed → no severity marker at all
       assert.match(state.modelText, /gpt-5\.5/);
       assert.match(state.sectionText, /200/);
       assert.match(state.sectionText, /completed/);

--- a/test/image-xss.test.js
+++ b/test/image-xss.test.js
@@ -12,7 +12,7 @@ function loadImageHelpers() {
       style: {}, dataset: {}, innerHTML: '', textContent: '',
       classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
       addEventListener() {}, appendChild(c) { this._children = this._children || []; this._children.push(c); return c; },
-      insertBefore() {}, querySelector: () => el(), querySelectorAll: () => [],
+      insertBefore() {}, insertAdjacentHTML() {}, querySelector: () => el(), querySelectorAll: () => [],
       remove() {},
     };
   }

--- a/test/rebuild-index.browser-harness.e2e.sh
+++ b/test/rebuild-index.browser-harness.e2e.sh
@@ -66,13 +66,12 @@ browser-harness -c "
 ensure_real_tab()
 goto_url('http://localhost:$PORT/?p=ccxray&s=BH-DEMO')
 wait_for_load()
-wait_for_element('.turn-item[data-session-id=\"BH-DEMO\"]', timeout=20)
-counts = js('JSON.stringify({turns:document.querySelectorAll(\".turn-item\").length,project:(document.querySelector(\".project-item.selected .pi-label\")||{}).textContent||\"\",turnText:(document.querySelector(\".turn-item[data-session-id=\x27BH-DEMO\x27]\")||{}).innerText||\"\"})')
+wait_for_element('.session-item[data-session-id=\"BH-DEMO\"]', timeout=20)
+counts = js('JSON.stringify({sessions:document.querySelectorAll(\".session-item\").length,project:(document.querySelector(\".project-item.selected .pi-label\")||{}).textContent||\"\"})')
 import json
 d = json.loads(counts)
-assert d['turns'] == 2, 'expected 2 recovered turns, got %r' % d['turns']
+assert d['sessions'] >= 1, 'expected at least 1 recovered session, got %r' % d['sessions']
 assert d['project'] == 'ccxray', 'expected project ccxray, got %r' % d['project']
-assert 'rebuild index from logs' in d['turnText'], 'recovered title missing: %r' % d['turnText']
 capture_screenshot('$SHOT', full=True)
 print('BROWSER-HARNESS E2E PASS:', counts)
 "

--- a/test/rebuild-index.e2e.test.js
+++ b/test/rebuild-index.e2e.test.js
@@ -148,22 +148,28 @@ describe('rebuild-index E2E — self-heal a lost index to a real browser render'
       // Projects column render is rAF-coalesced (docs/decisions/0002-dirty-check-signature.md),
       // so wait for it too — the turn-item can commit a frame before it does.
       await page.waitForFunction(
-        (sid) => !!document.querySelector(`.turn-item[data-session-id="${sid}"]`) &&
-                 !!document.querySelector('.project-item.selected .pi-label')?.textContent,
-        { timeout: 8000 }, SESSION_ID,
+        (sid, tid) => !!document.querySelector(`.session-item[data-session-id="${sid}"]`) &&
+                 !!document.querySelector('.project-item.selected .pi-label')?.textContent &&
+                 !!document.querySelector(`#wf-main-svg .wf-b[data-turn-id="${tid}"]`),
+        { timeout: 8000 }, SESSION_ID, id,
       );
 
-      const state = await page.evaluate((sid) => {
-        const turn = document.querySelector(`.turn-item[data-session-id="${sid}"]`);
+      const state = await page.evaluate((sid, tid) => {
+        // #332: turn column removed. The recovered turn proves it flowed through
+        // restore → SSE → render by appearing as its own swimlane bar (exact
+        // data-turn-id, not a bare rect the legend/lane background could satisfy);
+        // model shows in the sections header for the deep-link-selected turn.
+        const bar = document.querySelector(`#wf-main-svg .wf-b[data-turn-id="${tid}"]`);
+        const line1 = document.querySelector('#col-sections .ch-line1');
         return {
           projectText: document.querySelector('.project-item.selected .pi-label')?.textContent || '',
           sessionVisible: !!document.querySelector('.session-item.selected'),
-          turnVisible: !!turn,
-          model: turn?.querySelector('.turn-model')?.textContent || '',
+          turnVisible: !!bar,
+          model: line1?.textContent || '',
         };
-      }, SESSION_ID);
+      }, SESSION_ID, id);
 
-      assert.equal(state.turnVisible, true, 'recovered turn renders in the dashboard');
+      assert.equal(state.turnVisible, true, 'recovered turn renders in the dashboard (swimlane bar)');
       assert.equal(state.sessionVisible, true, 'recovered session column populated');
       assert.equal(state.projectText, truncateMiddle(PROJECT_NAME, 20), 'recovered project (cwd) renders');
       assert.match(state.model, /sonnet-4-6/); // dashboard strips the claude- prefix for display

--- a/test/retry-grouping.test.js
+++ b/test/retry-grouping.test.js
@@ -374,3 +374,4 @@ describe('#332 per-turn severity (data layer → swimlane data-severity)', () =>
     assert.equal(ctx.allEntries[0].severity, null);
   });
 });
+

--- a/test/retry-grouping.test.js
+++ b/test/retry-grouping.test.js
@@ -41,6 +41,7 @@ function loadDashboardContext() {
     function setInterval() { return 0; }
     function clearInterval() {}
     window.ccxraySettings = { visibleProviders: [] };
+    function _apiQ(url) { return url; }
     function fetch() { return Promise.resolve({ ok: false, json() { return Promise.resolve({}); } }); }
   `, context);
   for (const f of ['format.js', 'session-label.js', 'miller-columns.js', 'entry-rendering.js']) {

--- a/test/retry-grouping.test.js
+++ b/test/retry-grouping.test.js
@@ -15,6 +15,7 @@ function loadDashboardContext() {
       style: {}, dataset: {}, innerHTML: '', textContent: '',
       classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
       addEventListener() {}, appendChild() {}, insertBefore() {},
+      insertAdjacentHTML() {},
       querySelector: () => el(), querySelectorAll: () => [],
       remove() {},
     };
@@ -340,5 +341,36 @@ describe('Issue #222: entry-rendering temporal overlap classifies parallel fork 
     const sess = ctx.sessionsMap.get('seq-sess');
     assert.equal(sess.mainCount, 2, 'both sequential turns are main');
     assert.equal(sess.subCount || 0, 0, 'no subagent classification');
+  });
+});
+
+// #332 removed the turn-column DOM that used to carry `.risk-*`. Severity is now
+// a data-layer property on the entry, surfaced on the swimlane turn bar as
+// data-severity (see workflow-timeline.js). These lock the classifier + the
+// addEntry hand-off so a future refactor can't silently drop critical marking.
+describe('#332 per-turn severity (data layer → swimlane data-severity)', () => {
+  it('classifySeverity flags the three critical triggers, warnings, and healthy turns', () => {
+    const ctx = loadDashboardContext();
+    assert.equal(ctx.classifySeverity({ status: 500 }, 0, 0), 'critical', 'HTTP non-ok → critical');
+    assert.equal(ctx.classifySeverity({ status: 200, stopReason: 'max_tokens' }, 0, 0), 'critical', 'abnormal stop → critical');
+    assert.equal(ctx.classifySeverity({ status: 200, stopReason: 'end_turn' }, 96, 0), 'critical', 'context > 95% → critical');
+    assert.equal(ctx.classifySeverity({ status: 200, stopReason: 'end_turn', toolFail: true }, 0, 0), 'warning', 'tool failure → warning');
+    assert.equal(ctx.classifySeverity({ status: 200, stopReason: 'end_turn' }, 10, 0), null, 'healthy turn → no severity');
+  });
+
+  it('addEntry stamps severity onto the entry the swimlane reads', () => {
+    const ctx = loadDashboardContext();
+    // HTTP 500 WITH output tokens → a real (non-retry) turn that must still show critical.
+    ctx.addEntry(makeEntry({ id: 'sev-crit', sessionId: SID, status: 500, stopReason: 'error',
+      usage: { input_tokens: 5000, output_tokens: 200 } }));
+    const e = ctx.allEntries[0];
+    assert.equal(e.isRetry, false, 'a 500 with output tokens is a real turn, not a retry');
+    assert.equal(e.severity, 'critical', 'entry.severity is what workflow-timeline renders as data-severity');
+  });
+
+  it('healthy 200/end_turn turn carries no severity (no false critical marker)', () => {
+    const ctx = loadDashboardContext();
+    ctx.addEntry(makeEntry({ id: 'sev-ok', sessionId: SID, status: 200, stopReason: 'end_turn' }));
+    assert.equal(ctx.allEntries[0].severity, null);
   });
 });

--- a/test/seq-interleave-rendering.test.js
+++ b/test/seq-interleave-rendering.test.js
@@ -19,6 +19,7 @@ function loadDashboardContext() {
       style: {}, dataset: {}, innerHTML: '', textContent: '',
       classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
       addEventListener() {}, appendChild() {}, insertBefore() {},
+      insertAdjacentHTML() {},
       querySelector: () => el(), querySelectorAll: () => [],
       remove() {},
     };

--- a/test/session-filter.test.js
+++ b/test/session-filter.test.js
@@ -1,0 +1,61 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const RECENT_MS = 24 * 60 * 60 * 1000;
+
+// Mirrors public/miller-columns.js getStatusClass (post-fix with sessionsMap fallback)
+function makeGetStatusClass(sessionStatusMap, sessionsMap) {
+  return function getStatusClass(sid) {
+    const s = sessionStatusMap.get(sid);
+    if (s) {
+      if (s.active) return 'sdot-stream';
+      if (s.lastSeenAt && Date.now() - s.lastSeenAt < RECENT_MS) return 'sdot-idle';
+      return 'sdot-off';
+    }
+    const sess = sessionsMap.get(sid);
+    if (sess && sess.lastReceivedAt && Date.now() - sess.lastReceivedAt < RECENT_MS) return 'sdot-idle';
+    return 'sdot-off';
+  };
+}
+
+describe('getStatusClass — session filter fallback', () => {
+  it('restored session with recent lastReceivedAt should not be sdot-off', () => {
+    const sessionStatusMap = new Map();
+    const sessionsMap = new Map();
+    sessionsMap.set('sess-1', { lastReceivedAt: Date.now() - 3600_000 }); // 1h ago
+
+    const getStatusClass = makeGetStatusClass(sessionStatusMap, sessionsMap);
+    assert.notEqual(getStatusClass('sess-1'), 'sdot-off',
+      'restored session within 24h should not be sdot-off');
+  });
+
+  it('restored session older than 24h returns sdot-off', () => {
+    const sessionStatusMap = new Map();
+    const sessionsMap = new Map();
+    sessionsMap.set('sess-1', { lastReceivedAt: Date.now() - 25 * 60 * 60 * 1000 });
+
+    const getStatusClass = makeGetStatusClass(sessionStatusMap, sessionsMap);
+    assert.equal(getStatusClass('sess-1'), 'sdot-off');
+  });
+
+  it('active session via sessionStatusMap returns sdot-stream', () => {
+    const sessionStatusMap = new Map();
+    sessionStatusMap.set('sess-1', { active: true, lastSeenAt: Date.now() });
+
+    const getStatusClass = makeGetStatusClass(sessionStatusMap, new Map());
+    assert.equal(getStatusClass('sess-1'), 'sdot-stream');
+  });
+
+  it('recently-idle session via sessionStatusMap returns sdot-idle', () => {
+    const sessionStatusMap = new Map();
+    sessionStatusMap.set('sess-1', { active: false, lastSeenAt: Date.now() - 60_000 });
+
+    const getStatusClass = makeGetStatusClass(sessionStatusMap, new Map());
+    assert.equal(getStatusClass('sess-1'), 'sdot-idle');
+  });
+
+  it('unknown session returns sdot-off', () => {
+    const getStatusClass = makeGetStatusClass(new Map(), new Map());
+    assert.equal(getStatusClass('nonexistent'), 'sdot-off');
+  });
+});

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -2355,3 +2355,82 @@ describe('#251 L1/L2 selection state machine', () => {
     assert.equal(ctx.wfState.hoverTurnId, 'e1');
   });
 });
+
+describe('#332 severity marker geometry (SVG output)', () => {
+  function renderSvgForTurn(ctxPct, severity, cacheRatio) {
+    var ctx = loadWfModule();
+    var cr = cacheRatio || 0;
+    var inTokens = 100000;
+    var entry = mkEntry('sev1', 's1', 'opus', 1000, 10, {
+      severity: severity,
+      maxContext: 200000,
+      ctxUsed: Math.round(ctxPct / 100 * 200000),
+      usage: {
+        input_tokens: Math.round(inTokens * (1 - cr)),
+        output_tokens: 5000,
+        cache_read_input_tokens: Math.round(inTokens * cr),
+        cache_creation_input_tokens: 0,
+      },
+    });
+    var lane = { key: 'main', name: 'main', turns: [entry], spawnParent: null };
+    ctx.wfState = { viewT0: 0, viewT1: 20000, selectedLane: null, selectionLevel: 'L1', lanes: [lane] };
+    var xFn = function(t) { return t * 0.1; };
+    return ctx.wfRenderLaneSvg(lane, 0, 600, xFn, new Set());
+  }
+
+  function extractTurnBarRects(svg) {
+    var group = svg.match(/<g class="wf-b[^"]*"[^>]*>([\s\S]*?)<\/g>/);
+    if (!group) return [];
+    var rects = [];
+    var re = /<rect\s+([^>]+)>/g, m;
+    while ((m = re.exec(group[1])) !== null) {
+      var attrs = {};
+      m[1].replace(/([\w-]+)="([^"]*)"/g, function(_, k, v) { attrs[k] = v; });
+      rects.push({ y: parseFloat(attrs.y), h: parseFloat(attrs.height), fill: attrs.fill });
+    }
+    return rects;
+  }
+
+  it('severity marker sits above ctx bar at 100% context', () => {
+    var svg = renderSvgForTurn(100, 'critical', 0);
+    var rects = extractTurnBarRects(svg);
+    var marker = rects.find(r => r.fill === '#f85149');
+    var ctxRects = rects.filter(r => r.fill !== '#f85149');
+    assert.ok(marker, 'should have a red severity marker');
+    assert.ok(ctxRects.length > 0, 'should have ctx bar rects');
+    var barTop = Math.min(...ctxRects.map(r => r.y));
+    assert.ok(marker.y + marker.h <= barTop,
+      'marker bottom (' + (marker.y + marker.h) + ') must not exceed bar top (' + barTop + ')');
+  });
+
+  it('severity marker sits above ctx bar at 95% context', () => {
+    var svg = renderSvgForTurn(95, 'warning', 0);
+    var rects = extractTurnBarRects(svg);
+    var marker = rects.find(r => r.fill === '#d29922');
+    var ctxRects = rects.filter(r => r.fill !== '#d29922');
+    assert.ok(marker, 'should have an orange severity marker');
+    var barTop = Math.min(...ctxRects.map(r => r.y));
+    assert.ok(marker.y + marker.h <= barTop,
+      'marker bottom (' + (marker.y + marker.h) + ') must not exceed bar top (' + barTop + ')');
+  });
+
+  it('no marker rect for healthy turns', () => {
+    var svg = renderSvgForTurn(50, null, 0);
+    var rects = extractTurnBarRects(svg);
+    var marker = rects.find(r => r.fill === '#f85149' || r.fill === '#d29922');
+    assert.equal(marker, undefined, 'healthy turn should have no severity marker');
+  });
+
+  it('rounding overflow: stacked sub-bars never exceed h even with high cache ratio', () => {
+    var svg = renderSvgForTurn(98, 'critical', 0.99);
+    var rects = extractTurnBarRects(svg);
+    var marker = rects.find(r => r.fill === '#f85149');
+    var ctxRects = rects.filter(r => r.fill !== '#f85149');
+    assert.ok(marker, 'should have a red severity marker');
+    if (ctxRects.length > 0) {
+      var barTop = Math.min(...ctxRects.map(r => r.y));
+      assert.ok(marker.y + marker.h <= barTop,
+        'marker bottom (' + (marker.y + marker.h) + ') must not exceed bar top (' + barTop + ') with 99% cache');
+    }
+  });
+});


### PR DESCRIPTION
## 摘要

將 release 分支的 dashboard 改進 port 回 main，包含冷載入 UX 修正、batched render、hover prefetch、per-turn severity marker，以及 codex review 後的 geometry 修正。

## Detail

**Phase 0 — Port release branch changes** (`8136ec1`)
- Reconcile release-branch dashboard fixes with main's current state

**Cold-load UX — 7 fixes** (`acc450d`)
- Replay, layout, and entry loading reliability for cold-loaded sessions

**API 404 guard** (`0a9862e`)
- Return JSON on `/_api/entry` 404, guard client fetch with `r.ok`

**Step 1 — Single restore progress source** (`630e05c`)
- Breadcrumb progress indicator uses one source of truth

**Steps 2-3 — Stable scaffold + batched session render** (`a822159`)
- `requestAnimationFrame`-deferred render, height calculation from actual column

**Step 5 — Hover prefetch** (`1010cc1`)
- Prefetch cold session data on hover for faster navigation

**Test alignment** (`e70c05b`)
- DOM mocks + dashboard e2e adapted to #332 turn-column removal

**Per-turn severity** (`abe4d3e`)
- `classifySeverity` stamps severity on entry data layer
- Swimlane renders `data-severity` + 2px color cap marker (red=critical, orange=warning)

**Codex review fixes** (`2f3a579`)
- Full entry spread to `classifySeverity` (future-proof)
- Severity marker drawn above ctx bar with `h` cap (`WF_BAR_H - 2`)
- Rounding overflow clamp (`crH + cwH > h`)
- SVG-based geometry tests via `wfRenderLaneSvg` at 95/100% context + 99% cache edge case
- Strict `severity === null` e2e assertion

```
main lane context bar (44px track)
┌─────────────────────────────────┐
│ severity marker (2px, red/orange)│ ← only on critical/warning turns
├─────────────────────────────────┤
│                                 │
│  ctx bar (h ≤ 42px)             │
│  ┌─ input ──────────────┐      │
│  ├─ cache_write ────────┤      │
│  └─ cache_read ─────────┘      │
│                                 │
└─────────────────────────────────┘
```

## Test plan

- [x] Unit: `classifySeverity` flags 3 critical triggers + warning + null (retry-grouping.test.js)
- [x] Unit: `addEntry` stamps severity onto entry data layer
- [x] SVG geometry: marker never overlaps ctx bar at 95/98/100% context (workflow-timeline.test.js)
- [x] SVG geometry: rounding overflow with 99% cache ratio
- [x] E2E: codex dashboard status — healthy turn carries `severity === null`
- [x] Browser smoke: critical turn shows `data-severity="critical"` + red marker
- [x] All tests: 1427/1428 pass (1 flaky `P0: proxy e2e` timeout, pre-existing, passes solo)
- [x] Codex review: APPROVE (round 4, gpt-5.5)

## Related

- Closes #332
- #342 — pre-existing sawtooth in main lane (legacy imported lines without identity fields, not a #332 regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)