### PR TITLE
fix: prevent MaxListenersExceeded warning on keep-alive TLSSocket

### DIFF
--- a/server/forward.js
+++ b/server/forward.js
@@ -540,7 +540,7 @@ function forwardRequest(ctx) {
     // Late socket errors (EPIPE / ECONNRESET after response received) may not
     // re-emit on the ClientRequest. Listener prevents uncaught-exception crash.
     // Deferred check avoids duplicate logging when proxyReq 'error' already fired.
-    // ponytail: WeakSet guards against stacking listeners on keep-alive sockets
+    // Keep-alive sockets are reused across requests; guard prevents stacking listeners
     proxyReq.on('socket', (socket) => {
       if (_socketErrorGuard.has(socket)) return;
       _socketErrorGuard.add(socket);

--- a/server/forward.js
+++ b/server/forward.js
@@ -22,6 +22,8 @@ const {
   getOpenAIOutputSummary, getOpenAIInputSummary, buildResponseMetadata,
 } = require('./openai-response');
 
+const _socketErrorGuard = new WeakSet();
+
 // For title-generator subagent responses, extract the clean title from the
 // JSON payload and (when attribution succeeds) stamp it onto the parent
 // session. Returns the clean title string or null.
@@ -538,7 +540,10 @@ function forwardRequest(ctx) {
     // Late socket errors (EPIPE / ECONNRESET after response received) may not
     // re-emit on the ClientRequest. Listener prevents uncaught-exception crash.
     // Deferred check avoids duplicate logging when proxyReq 'error' already fired.
+    // ponytail: WeakSet guards against stacking listeners on keep-alive sockets
     proxyReq.on('socket', (socket) => {
+      if (_socketErrorGuard.has(socket)) return;
+      _socketErrorGuard.add(socket);
       socket.on('error', (err) => {
         setImmediate(() => {
           if (!reqErrorHandled) {

--- a/test/socket-listener-leak.e2e.test.js
+++ b/test/socket-listener-leak.e2e.test.js
@@ -80,6 +80,7 @@ describe('keep-alive socket listener leak', () => {
 
     await waitForPort(proxyPort);
 
+    // 15 > Node's default maxListeners (10) — triggers the warning on unfixed code
     const agent = new http.Agent({ keepAlive: true });
     for (let i = 0; i < 15; i++) {
       await new Promise((resolve, reject) => {

--- a/test/socket-listener-leak.test.js
+++ b/test/socket-listener-leak.test.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const SERVER_SCRIPT = path.join(__dirname, '..', 'server', 'index.js');
+
+async function findFreePort() {
+  return new Promise(resolve => {
+    const s = http.createServer();
+    s.listen(0, () => { const p = s.address().port; s.close(() => resolve(p)); });
+  });
+}
+
+function waitForPort(port, timeoutMs = 8000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      const req = http.get(`http://localhost:${port}/_api/health`, { timeout: 1000 }, res => {
+        res.resume();
+        res.on('end', () => resolve());
+      });
+      req.on('error', () => {
+        if (Date.now() - start > timeoutMs) return reject(new Error('proxy did not start'));
+        setTimeout(check, 200);
+      });
+      req.on('timeout', () => {
+        req.destroy();
+        if (Date.now() - start > timeoutMs) return reject(new Error('proxy did not start'));
+        setTimeout(check, 200);
+      });
+    };
+    check();
+  });
+}
+
+describe('keep-alive socket listener leak', () => {
+  let child, mockUpstream;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-leak-'));
+
+  after(async () => {
+    if (mockUpstream) await new Promise(r => mockUpstream.close(r));
+    if (child && child.exitCode === null) {
+      child.kill('SIGTERM');
+      await new Promise(r => { child.on('exit', r); setTimeout(() => { try { child.kill('SIGKILL'); } catch {} r(); }, 3000); });
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('no MaxListenersExceededWarning after 15 requests on same keep-alive socket', async () => {
+    const [proxyPort, upstreamPort] = await Promise.all([findFreePort(), findFreePort()]);
+
+    mockUpstream = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Connection': 'keep-alive' });
+      res.end(JSON.stringify({ id: 'msg_test', type: 'message', role: 'assistant',
+        content: [{ type: 'text', text: 'ok' }], model: 'test',
+        usage: { input_tokens: 1, output_tokens: 1 } }));
+    });
+    await new Promise(r => mockUpstream.listen(upstreamPort, '127.0.0.1', r));
+
+    let stderr = '';
+    child = spawn(process.execPath, [SERVER_SCRIPT, '--port', String(proxyPort), '--no-browser'], {
+      env: {
+        ...process.env,
+        CCXRAY_HOME: tmpDir,
+        ANTHROPIC_TEST_HOST: '127.0.0.1',
+        ANTHROPIC_TEST_PORT: String(upstreamPort),
+        ANTHROPIC_TEST_PROTOCOL: 'http',
+        BROWSER: 'none',
+        RESTORE_DAYS: '0',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    child.stderr.on('data', d => { stderr += d.toString(); });
+
+    await waitForPort(proxyPort);
+
+    const agent = new http.Agent({ keepAlive: true });
+    for (let i = 0; i < 15; i++) {
+      await new Promise((resolve, reject) => {
+        const body = JSON.stringify({
+          model: 'test', max_tokens: 10,
+          messages: [{ role: 'user', content: [{ type: 'text', text: `req ${i}` }] }],
+        });
+        const req = http.request({
+          hostname: 'localhost', port: proxyPort,
+          method: 'POST', path: '/v1/messages',
+          headers: {
+            'content-type': 'application/json',
+            'content-length': Buffer.byteLength(body),
+            'x-api-key': 'sk-fake',
+            'anthropic-version': '2023-06-01',
+          },
+          agent,
+        }, res => {
+          res.resume();
+          res.on('end', resolve);
+        });
+        req.on('error', reject);
+        req.end(body);
+      });
+    }
+    agent.destroy();
+
+    // Give the proxy a moment to flush any deferred warnings
+    await new Promise(r => setTimeout(r, 500));
+
+    assert.ok(
+      !stderr.includes('MaxListenersExceededWarning'),
+      `Expected no MaxListenersExceededWarning in stderr:\n${stderr.slice(0, 800)}`
+    );
+  });
+});


### PR DESCRIPTION
## 摘要
- keep-alive socket 被重用時，每個 request 都無條件加 `error` listener，超過 10 個後 Node 噴 `MaxListenersExceededWarning`
- 用 module-level `WeakSet` guard 防止重複掛 listener，socket GC 時自動清除
- 附差異測試：舊碼 FAIL（warning 觸發）、新碼 PASS

## Detail

Node 19+ defaults `keepAlive: true` on the global `https.Agent`. The proxy's
`proxyReq.on('socket', ...)` handler in `forward.js` unconditionally added a new
`error` listener to whatever socket was assigned — but with keep-alive, the same
TLSSocket is reused across requests. After 11 requests on one connection, Node's
default `maxListeners=10` threshold fires a warning.

### Fix

A module-level `WeakSet` (`_socketErrorGuard`) tracks sockets that already have
the error listener. On keep-alive socket reuse, the guard skips adding a
duplicate. WeakSet entries are automatically GC'd when the socket is reclaimed.

```
BEFORE                          AFTER
req1  → socket.on('error')     req1  → socket.on('error')
req2  → socket.on('error')     req2  → guard.has → skip
...                             ...
req11 → ⚠️ MaxListeners        req15 → guard.has → skip  ✓
```

### Alternatives considered

- `socket.once('error')` — only catches the first error per socket lifetime
- `removeListener` per request — handler closes over per-request `reqErrorHandled`,
  so cleanup is complex; the listener's job is crash prevention (always catches),
  the closure only gates logging
- `setMaxListeners(0)` — masks the symptom without bounding growth

### Verification (差異檢查)

| Code | Result |
|------|--------|
| Old (1da80fc) | FAIL — `MaxListenersExceededWarning: 11 error listeners added to [Socket]` |
| New | PASS — no warning after 15 requests on same keep-alive socket |

### Code review

Codex review: clean (no blocker/major/minor).
Standards review: 3 findings accepted and fixed (ponytail tag stripped, test
renamed to `.e2e.test.js`, magic number `15` documented).

## Test plan
- [x] Difference test: `test/socket-listener-leak.e2e.test.js` — 15 requests on keep-alive, assert no MaxListenersExceededWarning
- [x] Verified old code FAIL / new code PASS via disposable worktree
- [x] Full test suite passes (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)