### PR TITLE
fix(index): streaming reads, ghost prune, context% sawtooth (#347 #344 #342)

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -555,13 +555,27 @@ function addEntry(e) {
   const ctxInput       = usage ? (usage.input_tokens || 0) : 0;
   const ctxUsed = computeCtxUsed(usage);
 
+  // #342: session-level context-window consensus. inferMaxContext gives a turn
+  // whose usage stayed ≤200K the 200K base while a >200K turn in the SAME session
+  // gets the stored 1M, so dividing each turn by its own value makes adjacent
+  // same-usage main turns sawtooth 100%↔20%. Divide main turns by the session's
+  // widest main window instead (mirrors the swimlane wfCtxPctRender lane rescope).
+  // Eventually consistent on this incremental path: the latest-turn card value is
+  // correct once the session is loaded; subagents keep their own window. The
+  // isCompacted heuristic below deliberately keeps prev.maxContext (classification
+  // wants the raw per-turn value) — only these render fields use the consensus.
+  if (!isSubagent && e.maxContext) sess.maxWindow = Math.max(sess.maxWindow || 0, e.maxContext);
+  const _ctxWin = (!isSubagent && (sess.maxWindow || 0) > (e.maxContext || 0))
+    ? sess.maxWindow
+    : (e.maxContext || DEFAULT_MAX_CTX);
+
   // Update session context alert badge + cache stats for main turns
   if (!isSubagent && ctxUsed > 0) {
-    sess.latestMainCtxPct = Math.min(100, ctxUsed / (e.maxContext || DEFAULT_MAX_CTX) * 100);
+    sess.latestMainCtxPct = Math.min(100, ctxUsed / _ctxWin * 100);
     sess.latestCacheReadTokens = ctxCacheRead;
     const ctxInputTotal = ctxCacheRead + ctxCacheCreate + (usage ? (usage.input_tokens || 0) : 0);
     sess.latestCacheHitRatio = ctxInputTotal > 0 ? ctxCacheRead / ctxInputTotal : 0;
-    sess.latestMaxContext = e.maxContext || DEFAULT_MAX_CTX;
+    sess.latestMaxContext = _ctxWin;
     if (!window._coldActivating) {
       const sessElCtx = document.getElementById('sess-' + sid.slice(0, 8));
       if (sessElCtx) sessElCtx.innerHTML = renderSessionItem(sess, sid, sessElCtx);
@@ -617,7 +631,7 @@ function addEntry(e) {
   // (data-severity + wf-b-<sev>) — critical turns stay visible without the column.
   const _dupes = e.duplicateToolCalls || null;
   const _dupesMax = _dupes ? Math.max(...Object.values(_dupes)) : 0;
-  const _ctxPct = ctxUsed > 0 ? Math.min(100, ctxUsed / (e.maxContext || DEFAULT_MAX_CTX) * 100) : 0;
+  const _ctxPct = ctxUsed > 0 ? Math.min(100, ctxUsed / _ctxWin * 100) : 0;
   // INVARIANT: severity field consumed by workflow-timeline.js wfRenderLaneSvg
   const severity = classifySeverity({ ...e, stopReason }, _ctxPct, _dupesMax);
 

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -555,27 +555,13 @@ function addEntry(e) {
   const ctxInput       = usage ? (usage.input_tokens || 0) : 0;
   const ctxUsed = computeCtxUsed(usage);
 
-  // #342: session-level context-window consensus. inferMaxContext gives a turn
-  // whose usage stayed ≤200K the 200K base while a >200K turn in the SAME session
-  // gets the stored 1M, so dividing each turn by its own value makes adjacent
-  // same-usage main turns sawtooth 100%↔20%. Divide main turns by the session's
-  // widest main window instead (mirrors the swimlane wfCtxPctRender lane rescope).
-  // Eventually consistent on this incremental path: the latest-turn card value is
-  // correct once the session is loaded; subagents keep their own window. The
-  // isCompacted heuristic below deliberately keeps prev.maxContext (classification
-  // wants the raw per-turn value) — only these render fields use the consensus.
-  if (!isSubagent && e.maxContext) sess.maxWindow = Math.max(sess.maxWindow || 0, e.maxContext);
-  const _ctxWin = (!isSubagent && (sess.maxWindow || 0) > (e.maxContext || 0))
-    ? sess.maxWindow
-    : (e.maxContext || DEFAULT_MAX_CTX);
-
   // Update session context alert badge + cache stats for main turns
   if (!isSubagent && ctxUsed > 0) {
-    sess.latestMainCtxPct = Math.min(100, ctxUsed / _ctxWin * 100);
+    sess.latestMainCtxPct = Math.min(100, ctxUsed / (e.maxContext || DEFAULT_MAX_CTX) * 100);
     sess.latestCacheReadTokens = ctxCacheRead;
     const ctxInputTotal = ctxCacheRead + ctxCacheCreate + (usage ? (usage.input_tokens || 0) : 0);
     sess.latestCacheHitRatio = ctxInputTotal > 0 ? ctxCacheRead / ctxInputTotal : 0;
-    sess.latestMaxContext = _ctxWin;
+    sess.latestMaxContext = e.maxContext || DEFAULT_MAX_CTX;
     if (!window._coldActivating) {
       const sessElCtx = document.getElementById('sess-' + sid.slice(0, 8));
       if (sessElCtx) sessElCtx.innerHTML = renderSessionItem(sess, sid, sessElCtx);
@@ -631,7 +617,7 @@ function addEntry(e) {
   // (data-severity + wf-b-<sev>) — critical turns stay visible without the column.
   const _dupes = e.duplicateToolCalls || null;
   const _dupesMax = _dupes ? Math.max(...Object.values(_dupes)) : 0;
-  const _ctxPct = ctxUsed > 0 ? Math.min(100, ctxUsed / _ctxWin * 100) : 0;
+  const _ctxPct = ctxUsed > 0 ? Math.min(100, ctxUsed / (e.maxContext || DEFAULT_MAX_CTX) * 100) : 0;
   // INVARIANT: severity field consumed by workflow-timeline.js wfRenderLaneSvg
   const severity = classifySeverity({ ...e, stopReason }, _ctxPct, _dupesMax);
 

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -165,6 +165,37 @@ function wfCtxPct(e) {
   return Math.min(100, (e.ctxUsed || 0) / win * 100);
 }
 
+// #342: RENDER-time context%. A turn with no maxContext (imported turns never
+// carry one) is divided by its LANE's context window instead of the hardcoded
+// 200000 above — otherwise an imported main turn shows ctxUsed/200K while the
+// proxy main turns around it show ctxUsed/1M, i.e. the context% sawtooth.
+// INVARIANT: classification (wfInferLanes ~L505/L515) deliberately keeps the
+// plain wfCtxPct 200K default so lane decisions never shift with this render
+// fallback — only rendering reads the lane window. The turnId→laneWindow map is
+// memoized on wfState and invalidated on lane change (wfAddEntry) / rebuild
+// (fresh wfState). laneWindow = max maxContext among the lane's turns (the proxy
+// turns supply it); 0 when a lane is purely imported → falls back to 200000.
+function _wfWinByTurn() {
+  if (!wfState) return null;
+  if (wfState._winByTurn) return wfState._winByTurn;
+  var map = new Map();
+  var lanes = wfState.lanes || [];
+  for (var i = 0; i < lanes.length; i++) {
+    var turns = lanes[i].turns || [];
+    var laneWin = 0;
+    for (var j = 0; j < turns.length; j++) if ((turns[j].maxContext || 0) > laneWin) laneWin = turns[j].maxContext;
+    for (var k = 0; k < turns.length; k++) map.set(turns[k].id, laneWin);
+  }
+  wfState._winByTurn = map;
+  return map;
+}
+function wfCtxPctRender(e) {
+  var win = e.maxContext;
+  if (!win) { var m = _wfWinByTurn(); win = (m && m.get(e.id)) || 0; }
+  if (!win) win = 200000;
+  return Math.min(100, (e.ctxUsed || 0) / win * 100);
+}
+
 // #156: moved to format.js — kept as a thin wrapper (old signature took the turn, not pct).
 function wfCtxZoneColor(t) {
   return ctxZone(wfCtxPct(t)).hex;
@@ -180,7 +211,7 @@ function wfDetectEvents(t, prev) {
   else if ((t.status && !isHttpStatusOk(t.status)) || t.toolFail) evts.push('error');
   if (t.isCompacted) evts.push('compaction');
   if (inT > 1000 && (u.cache_read_input_tokens || 0) / inT < 0.5) evts.push('cache-miss');
-  if (wfCtxPct(t) >= 80 && (!prev || wfCtxPct(prev) < 80)) evts.push('ctx80');
+  if (wfCtxPctRender(t) >= 80 && (!prev || wfCtxPctRender(prev) < 80)) evts.push('ctx80');
   var tc = t.toolCalls || {};
   if (tc.Write || tc.Edit || tc.MultiEdit || tc.NotebookEdit) evts.push('file-write');
   if (t.hasCredential) evts.push('credential');
@@ -840,6 +871,7 @@ function _wfFollowTail(oldTMax) {
 // (entry-rendering.js pushes at its allEntries.push site, then calls here).
 function wfAddEntry(entry) {
   if (!wfState) return { lanesChanged: false };
+  wfState._winByTurn = null; // #342: lanes about to change — invalidate the render ctx-window memo
   var prevCount = wfState.lanes.length;
 
   var ts = Number(entry.receivedAt) || 0;
@@ -1130,7 +1162,7 @@ function wfLaneSummary(lane) {
   var peakCtx = 0, totalCacheR = 0, totalCacheAll = 0, totalCost = 0, totalIn = 0, totalOut = 0;
   for (var i = 0; i < turns.length; i++) {
     var t = turns[i];
-    var pct = wfCtxPct(t);
+    var pct = wfCtxPctRender(t);
     if (pct > peakCtx) peakCtx = pct;
     var cr = (t.usage?.cache_read_input_tokens || 0);
     var cc = (t.usage?.cache_creation_input_tokens || 0);
@@ -1358,7 +1390,7 @@ function wfRenderLaneSvg(lane, laneIdx, W, xFn, mainConvs) {
     if (tend < wfState.viewT0 || ts > wfState.viewT1) continue;
     var tx = Math.max(WF_LABEL_W, xFn(ts));
     var tw = Math.max(WF_MIN_TURN_PX, xFn(tend) - tx);
-    var h = Math.max(2, Math.round(wfCtxPct(t) / 100 * WF_BAR_H));
+    var h = Math.max(2, Math.round(wfCtxPctRender(t) / 100 * WF_BAR_H));
     // Reserve 2px at top for severity marker so it never overlaps the ctx bar
     var hasSev = t.severity === 'critical' || t.severity === 'warning';
     if (hasSev) h = Math.min(h, WF_BAR_H - 2);
@@ -1925,7 +1957,7 @@ function wfRenderOverview(canvas) {
       var t = lanes[li].turns[ti];
       var ts = Number(t.receivedAt) || 0;
       var dur = (parseFloat(t.elapsed) || 0) * 1000;
-      ctx.fillStyle = ctxZone(wfCtxPct(t)).hex;
+      ctx.fillStyle = ctxZone(wfCtxPctRender(t)).hex;
       // 0.5 alpha sank into the dark bg (lesson: low-luminance signals drown)
       ctx.globalAlpha = isSel ? 0.9 : 0.65;
       ctx.fillRect(x(ts), ly, Math.max(1, (dur / totalRange) * MW), barH);
@@ -2272,7 +2304,7 @@ function _wfShowTooltip(e, t, lane) {
   var u = t.usage || {};
   var cr = u.cache_read_input_tokens || 0, cc = u.cache_creation_input_tokens || 0;
   var inT = (u.input_tokens || 0) + cr + cc;
-  var pct = wfCtxPct(t);
+  var pct = wfCtxPctRender(t);
   var cz = ctxZone(pct);
   var zone = cz.zone;
   var zoneCls = 'wf-tt-' + (zone === 'safe' ? 'good' : zone);
@@ -2604,7 +2636,7 @@ function wfRenderTurnCard(turnEntry) {
   var cacheRead = u.cache_read_input_tokens || 0;
   var cacheCreate = u.cache_creation_input_tokens || 0;
   var cachePct = inTok > 0 ? (cacheRead / inTok * 100).toFixed(1) : '0.0';
-  var pct = wfCtxPct(turnEntry);
+  var pct = wfCtxPctRender(turnEntry);
   var cz = ctxZone(pct);
   var dur = parseFloat(turnEntry.elapsed) || 0;
   var thinkDur = turnEntry.thinkingDuration || 0;
@@ -2728,7 +2760,7 @@ function _wfRenderHoverPreview(turn, lane) {
   var u = turn.usage || {};
   var inTok = (u.input_tokens || 0) + (u.cache_read_input_tokens || 0) + (u.cache_creation_input_tokens || 0);
   var outTok = u.output_tokens || 0;
-  var pct = wfCtxPct(turn);
+  var pct = wfCtxPctRender(turn);
   var cz = ctxZone(pct);
   var dur = parseFloat(turn.elapsed) || 0;
   var laneSummary = wfLaneSummary(lane);
@@ -2862,7 +2894,7 @@ function wfRenderSteps(scrollToId) {
     var isSel = wfState.selectedTurnId === t.id;
     var tools = Object.entries(t.toolCalls || {});
     var mc = wfModelColor(t.model);
-    var pct = wfCtxPct(t);
+    var pct = wfCtxPctRender(t);
     var u = t.usage || {};
     var cr = u.cache_read_input_tokens || 0, cc = u.cache_creation_input_tokens || 0;
     var cacheRate = (cr + cc) > 0 ? cr / (cr + cc) * 100 : 0;

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -175,6 +175,10 @@ function wfCtxPct(e) {
 // memoized on wfState and invalidated on lane change (wfAddEntry) / rebuild
 // (fresh wfState). laneWindow = max maxContext among the lane's turns (the proxy
 // turns supply it); 0 when a lane is purely imported → falls back to 200000.
+// Known limit (accepted): in a rare mixed-window lane an imported turn inherits
+// the lane MAX, so its ctx% is under-reported and a `ctx80` badge could be
+// suppressed. There is no per-imported-turn window to do better client-side, and
+// under-warning is the safe failure — not worth per-model inference here.
 function _wfWinByTurn() {
   if (!wfState) return null;
   if (wfState._winByTurn) return wfState._winByTurn;

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -165,20 +165,24 @@ function wfCtxPct(e) {
   return Math.min(100, (e.ctxUsed || 0) / win * 100);
 }
 
-// #342: RENDER-time context%. A turn with no maxContext (imported turns never
-// carry one) is divided by its LANE's context window instead of the hardcoded
-// 200000 above — otherwise an imported main turn shows ctxUsed/200K while the
-// proxy main turns around it show ctxUsed/1M, i.e. the context% sawtooth.
-// INVARIANT: classification (wfInferLanes ~L505/L515) deliberately keeps the
+// #342: RENDER-time context%. Turns in one session can carry DIFFERENT
+// maxContext values though they share one real context window: the server
+// infers maxContext per-turn (config.inferMaxContext) and returns the 200K base
+// for a turn whose usage stayed under 200K, but the stored 1M for a turn that
+// exceeded it. So two adjacent main turns with the same ~199K ctxUsed render
+// 100% (÷200K) next to 20% (÷1M) — the context% sawtooth. Fix: divide by the
+// LANE's context window (the max maxContext among the lane's turns — the >200K
+// turns supply the real 1M) whenever it EXCEEDS the turn's own inferred value.
+// A lane whose turns are all ≤200K keeps 200K.
+// INVARIANT: classification (wfInferLanes ~L540/L550) deliberately keeps the
 // plain wfCtxPct 200K default so lane decisions never shift with this render
-// fallback — only rendering reads the lane window. The turnId→laneWindow map is
+// rescope — only rendering reads the lane window. The turnId→laneWindow map is
 // memoized on wfState and invalidated on lane change (wfAddEntry) / rebuild
-// (fresh wfState). laneWindow = max maxContext among the lane's turns (the proxy
-// turns supply it); 0 when a lane is purely imported → falls back to 200000.
-// Known limit (accepted): in a rare mixed-window lane an imported turn inherits
-// the lane MAX, so its ctx% is under-reported and a `ctx80` badge could be
-// suppressed. There is no per-imported-turn window to do better client-side, and
-// under-warning is the safe failure — not worth per-model inference here.
+// (fresh wfState).
+// Known limit (accepted): a lane that genuinely mixed a real 200K-window model
+// with a 1M one over-scales the 200K turns to 1M, so their ctx% is under-reported
+// and a `ctx80` badge could be suppressed. Under-warning is the safe failure;
+// there is no per-turn wire signal to do better client-side.
 function _wfWinByTurn() {
   if (!wfState) return null;
   if (wfState._winByTurn) return wfState._winByTurn;
@@ -194,8 +198,10 @@ function _wfWinByTurn() {
   return map;
 }
 function wfCtxPctRender(e) {
-  var win = e.maxContext;
-  if (!win) { var m = _wfWinByTurn(); win = (m && m.get(e.id)) || 0; }
+  var win = e.maxContext || 0;
+  var m = _wfWinByTurn();
+  var laneWin = (m && m.get(e.id)) || 0;
+  if (laneWin > win) win = laneWin; // turn's own maxContext under-inferred vs the lane's real window
   if (!win) win = 200000;
   return Math.min(100, (e.ctxUsed || 0) / win * 100);
 }

--- a/server/importer.js
+++ b/server/importer.js
@@ -322,21 +322,23 @@ async function scanAndImport() {
   // "id" is the first INDEX_FIELDS key, so the first match is the entry id.
   const existingIds = new Set(store.entries.map(e => e.id));
   try {
-    const indexContent = await config.storage.readIndex();
-    if (indexContent) {
-      const re = /"id":"([^"]+)"/;
-      for (const line of indexContent.split('\n')) {
-        if (!line) continue;
-        const m = re.exec(line);
-        if (m) existingIds.add(m[1]);
-      }
-      // #333: seed dedup state (cost + count) from responseIds already logged by a
-      // proxy, so an imported duplicate of the same turn re-adds neither its cost
-      // (fable round-4 M1) nor its turn count (the count-side twin) — the fix for
-      // the cross-restart double count on the fast-load-sessions.json path. Must
-      // run BEFORE the import loops below so their updateFromEntry is deduped.
-      sessionIdx.seedDedupState(indexContent);
+    // #345: stream — the index can exceed Node's ~512MB single-string limit,
+    // where readIndex() throws ERR_STRING_TOO_LONG and the import dedup breaks
+    // (re-importing everything, unbounded index growth + doubled counts). One
+    // parse per line builds existingIds and the metas for dedup seeding.
+    const metas = [];
+    for await (const line of config.storage.readIndexLines()) {
+      let m;
+      try { m = JSON.parse(line); } catch { continue; }
+      if (m && m.id) existingIds.add(m.id);
+      metas.push(m);
     }
+    // #333: seed dedup state (cost + count) from responseIds already logged by a
+    // proxy, so an imported duplicate of the same turn re-adds neither its cost
+    // (fable round-4 M1) nor its turn count (the count-side twin) — the fix for
+    // the cross-restart double count on the fast-load-sessions.json path. Must
+    // run BEFORE the import loops below so their updateFromEntry is deduped.
+    sessionIdx.seedDedupFromMetas(metas);
   } catch {}
 
   for (const { dir } of homes) {

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,12 @@
 
 // ── "usage" — fast-path, no server deps ──
 if (process.argv[2] === 'usage') {
-  require('./usage').run(process.argv.slice(3));
+  // run() is async (#345: streams the index). Handle rejection so a read error
+  // exits non-zero instead of becoming an unhandled promise rejection.
+  require('./usage').run(process.argv.slice(3)).catch(err => {
+    console.error(err && err.message ? err.message : String(err));
+    process.exit(1);
+  });
   return;
 }
 

--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -226,6 +226,10 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   const explicitTimeline = []; // [{ id, sid, cwd }] — explicit, non-inferred sessions
   const sessionCwd = new Map(); // sid → latest cwd, for backfilling inferred turns
   let enrichedResponseIds = 0;  // #333 legacy backfill count
+  let enrichedIdentity = 0;     // #342 legacy identity backfill count
+  // Reconstruction cache shared by the existing-line identity backfill (#342)
+  // and the orphan reconstruction pass below (delta ancestors are reused).
+  const cache = new Map();
   // #345: stream lines — a recovered index can exceed Node's ~512MB single-string
   // limit, where readIndex() (readFile utf8) throws ERR_STRING_TOO_LONG.
   for await (const line of storage.readIndexLines()) {
@@ -250,6 +254,32 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
       try { rid = getParser('anthropic').extractResponseId(JSON.parse(await storage.read(m.id, '_res.json'))); } catch {}
       if (rid) { m.responseId = rid; outLine = JSON.stringify(m); enrichedResponseIds++; }
     }
+    // #342 add-only identity backfill: a legacy line predating identity-field
+    // extraction lacks convId/coreHash/agentKey/msgCount/isSubagent, so lane
+    // inference (ADR 0005/0009/0010) defaults it into the main lane — the
+    // context% sawtooth. When its _req.json is reconstructable, recompute those
+    // fields from the on-disk request and ADD only the ones currently absent —
+    // never overwrite an existing value (#48 never-degrade). Imported lines and
+    // lines whose _req was pruned have no reconstructable body ⇒ untouched.
+    // `convId === undefined` (the key is absent, not a persisted null) is the
+    // legacy-line marker; a value/null convId is added via computeConvId — the
+    // SAME function the live pipeline uses, so the recovered key matches exactly.
+    if (m.convId === undefined && m.provider !== 'openai') {
+      try {
+        const r = await reconstructReq(m.id, storage, cache);
+        const pb = r && r.parsedBody;
+        if (pb && Array.isArray(pb.messages)) {
+          const identity = promptIdentity(pb.system);
+          m.convId = getParser('anthropic').computeConvId(pb); // may be null
+          if (m.coreHash == null && identity.coreHash) m.coreHash = identity.coreHash;
+          if (m.agentKey == null && identity.agentKey) { m.agentKey = identity.agentKey; m.agentLabel = identity.agentLabel; }
+          if (m.msgCount == null) m.msgCount = pb.messages.length;
+          if (m.isSubagent == null) m.isSubagent = store.isAnthropicSubagent(pb);
+          outLine = JSON.stringify(m);
+          enrichedIdentity++;
+        }
+      } catch { /* unreconstructable (_req pruned / delta broken) → leave verbatim */ }
+    }
     existingLineObjs.push({ id: m.id, line: outLine });
     if (m.sessionId && !m.sessionInferred && m.sessionId !== 'direct-api') {
       explicitTimeline.push({ id: m.id, sid: m.sessionId, cwd: m.cwd || null });
@@ -267,7 +297,6 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
 
   // ── 3. Pass 1: reconstruct every orphan body; extend the explicit timeline. ──
   // (Only Anthropic turns survive reconstructReq; non-Anthropic/WS are skipped.)
-  const cache = new Map();
   const recon = []; // { id, parsedBody, explicitSid, prevId }
   let unrecoverable = 0;
   for (const id of orphanIds) {
@@ -382,30 +411,32 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   log(`recovered ${N} / ${M} turns; ${unrecoverable} unrecoverable (source pruned)`);
   log(`  index: ${existingIds.size} existing lines${N ? ` + ${N} recovered` : ''}`);
   if (enrichedResponseIds) log(`  backfilled responseId onto ${enrichedResponseIds} legacy line(s) (#333)`);
+  if (enrichedIdentity) log(`  backfilled convId/coreHash/agentKey onto ${enrichedIdentity} legacy line(s) (#342)`);
 
   // A run with no orphans to add can still have enriched existing lines — those
-  // rewritten lines must be flushed, so the write is gated on either change.
-  const hasChanges = N > 0 || enrichedResponseIds > 0;
+  // rewritten lines must be flushed, so the write is gated on any change.
+  const hasChanges = N > 0 || enrichedResponseIds > 0 || enrichedIdentity > 0;
   if (!hasChanges) {
     log(apply ? '  nothing to add — index left unchanged.' : '  dry run — nothing to add.');
-    return { refused: false, recovered: 0, enriched: 0, total: M, unrecoverable, applied: false, cacheFinalSize: cache.size };
+    return { refused: false, recovered: 0, enriched: 0, enrichedIdentity: 0, total: M, unrecoverable, applied: false, cacheFinalSize: cache.size };
   }
   if (!apply) {
     log(`  dry run — pass --apply to write ${storage.location || 'index.ndjson'}.`);
-    return { refused: false, recovered: N, enriched: enrichedResponseIds, total: M, unrecoverable, applied: false, cacheFinalSize: cache.size };
+    return { refused: false, recovered: N, enriched: enrichedResponseIds, enrichedIdentity, total: M, unrecoverable, applied: false, cacheFinalSize: cache.size };
   }
 
   // ── 6. Atomic merge-write (local filesystem only). ──
   if (!storage.supportsDelta || !storage.location) {
     log('  --apply needs the local filesystem backend; aborting without writing.');
-    return { refused: false, recovered: N, enriched: enrichedResponseIds, total: M, unrecoverable, applied: false };
+    return { refused: false, recovered: N, enriched: enrichedResponseIds, enrichedIdentity, total: M, unrecoverable, applied: false };
   }
   const indexPath = path.join(storage.location, 'index.ndjson');
   const tmpPath = `${indexPath}.rebuild-${process.pid}.tmp`;
-  // Merge existing (verbatim, or add-only responseId-enriched) + recovered,
-  // ordered by id so recovered turns land in chronological position instead of
-  // all at the end. Existing lines are never dropped and never degraded — at
-  // most the additive responseId key is appended to a legacy line (#333).
+  // Merge existing (verbatim, or add-only enriched with responseId #333 /
+  // identity #342) + recovered, ordered by id so recovered turns land in
+  // chronological position instead of all at the end. Existing lines are never
+  // dropped and never degraded — at most additive keys are appended to a legacy
+  // line (#333 responseId, #342 convId/coreHash/agentKey/msgCount/isSubagent).
   const merged = [...existingLineObjs, ...recovered]
     .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
   // #345: stream lines to the temp file — merged.join('\n') would throw
@@ -414,7 +445,7 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   await writeLinesToFile(tmpPath, merged);
   fs.renameSync(tmpPath, indexPath);
   log(`  wrote ${indexPath} (${existingIds.size + N} lines). Restart the dashboard to see recovered turns.`);
-  return { refused: false, recovered: N, enriched: enrichedResponseIds, total: M, unrecoverable, applied: true, cacheFinalSize: cache.size };
+  return { refused: false, recovered: N, enriched: enrichedResponseIds, enrichedIdentity, total: M, unrecoverable, applied: true, cacheFinalSize: cache.size };
 }
 
 module.exports = { rebuildIndex, reconstructReq, tsFromId, nearestPrecedingSession };

--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -59,6 +59,24 @@ function promptIdentity(system) {
   return { coreHash, agentKey, agentLabel };
 }
 
+// #345: write [{ line }] objects to a file one line at a time (backpressure-
+// aware), never building a single >512MB string via Array.join.
+function writeLinesToFile(filePath, objs) {
+  return new Promise((resolve, reject) => {
+    const ws = fs.createWriteStream(filePath);
+    ws.on('error', reject);
+    let i = 0;
+    (function pump() {
+      while (i < objs.length) {
+        const ok = ws.write(objs[i].line + '\n');
+        i++;
+        if (!ok) { ws.once('drain', pump); return; }
+      }
+      ws.end(resolve);
+    })();
+  });
+}
+
 // "2026-05-01T11-47-17-808" → "11:47:17". The id IS a Taipei-local timestamp, so
 // ts (the live pipeline's wall-clock time-of-day) is exact, not a guess.
 function tsFromId(id) {
@@ -203,13 +221,14 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   // exception: a legacy line that predates the #333 responseId key is enriched
   // with it when its _res.json survives on disk (see below). Unparseable lines
   // are dropped exactly as restoreFromLogs already ignores them.
-  const existingContent = await storage.readIndex();
   const existingIds = new Set();
   const existingLineObjs = []; // [{ id, line }] — preserved verbatim, re-sorted by id on write
   const explicitTimeline = []; // [{ id, sid, cwd }] — explicit, non-inferred sessions
   const sessionCwd = new Map(); // sid → latest cwd, for backfilling inferred turns
   let enrichedResponseIds = 0;  // #333 legacy backfill count
-  for (const line of (existingContent || '').split('\n')) {
+  // #345: stream lines — a recovered index can exceed Node's ~512MB single-string
+  // limit, where readIndex() (readFile utf8) throws ERR_STRING_TOO_LONG.
+  for await (const line of storage.readIndexLines()) {
     if (!line.trim()) continue;
     let m;
     try { m = JSON.parse(line); } catch { continue; } // one bad line must not abort
@@ -388,9 +407,11 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   // all at the end. Existing lines are never dropped and never degraded — at
   // most the additive responseId key is appended to a legacy line (#333).
   const merged = [...existingLineObjs, ...recovered]
-    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
-    .map(o => o.line);
-  fs.writeFileSync(tmpPath, merged.join('\n') + '\n');
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  // #345: stream lines to the temp file — merged.join('\n') would throw
+  // ERR_STRING_TOO_LONG once the combined index passes ~512MB. (The lines are
+  // still held in memory to sort; a manual recovery CLI can afford that.)
+  await writeLinesToFile(tmpPath, merged);
   fs.renameSync(tmpPath, indexPath);
   log(`  wrote ${indexPath} (${existingIds.size + N} lines). Restart the dashboard to see recovered turns.`);
   return { refused: false, recovered: N, enriched: enrichedResponseIds, total: M, unrecoverable, applied: true, cacheFinalSize: cache.size };

--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -63,8 +63,14 @@ function promptIdentity(system) {
 // aware), never building a single >512MB string via Array.join.
 function writeLinesToFile(filePath, objs) {
   return new Promise((resolve, reject) => {
-    const ws = fs.createWriteStream(filePath);
+    // mode 0600: the rebuilt index replaces a 0600 file; default 0666&~umask
+    // would downgrade it to 0644 and expose log metadata (codex m10).
+    const ws = fs.createWriteStream(filePath, { mode: 0o600 });
     ws.on('error', reject);
+    // Resolve only on 'close' — the fd is closed by then, so a close-time error
+    // (which emits 'error' first → reject wins) can't arrive after we settle and
+    // the caller renames (codex B1 + round-2 minor).
+    ws.on('close', resolve);
     let i = 0;
     (function pump() {
       while (i < objs.length) {
@@ -72,7 +78,7 @@ function writeLinesToFile(filePath, objs) {
         i++;
         if (!ok) { ws.once('drain', pump); return; }
       }
-      ws.end(resolve);
+      ws.end();
     })();
   });
 }
@@ -227,9 +233,6 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   const sessionCwd = new Map(); // sid → latest cwd, for backfilling inferred turns
   let enrichedResponseIds = 0;  // #333 legacy backfill count
   let enrichedIdentity = 0;     // #342 legacy identity backfill count
-  // Reconstruction cache shared by the existing-line identity backfill (#342)
-  // and the orphan reconstruction pass below (delta ancestors are reused).
-  const cache = new Map();
   // #345: stream lines — a recovered index can exceed Node's ~512MB single-string
   // limit, where readIndex() (readFile utf8) throws ERR_STRING_TOO_LONG.
   for await (const line of storage.readIndexLines()) {
@@ -266,15 +269,24 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
     // SAME function the live pipeline uses, so the recovered key matches exactly.
     if (m.convId === undefined && m.provider !== 'openai') {
       try {
-        const r = await reconstructReq(m.id, storage, cache);
+        // Fresh cache per line: reconstructReq stores a messages-only entry per
+        // id, so any shared cache can hand THIS leaf a messages-only ancestor
+        // entry (losing system → null coreHash/agentKey) when index lines are
+        // physically out of id order (codex round-3). Per-line isolation keeps
+        // every backfill leaf a full reconstruction; legacy lines are few.
+        const r = await reconstructReq(m.id, storage, new Map());
         const pb = r && r.parsedBody;
         if (pb && Array.isArray(pb.messages)) {
           const identity = promptIdentity(pb.system);
-          m.convId = getParser('anthropic').computeConvId(pb); // may be null
-          if (m.coreHash == null && identity.coreHash) m.coreHash = identity.coreHash;
-          if (m.agentKey == null && identity.agentKey) { m.agentKey = identity.agentKey; m.agentLabel = identity.agentLabel; }
-          if (m.msgCount == null) m.msgCount = pb.messages.length;
-          if (m.isSubagent == null) m.isSubagent = store.isAnthropicSubagent(pb);
+          // Strict add-only: `=== undefined` (key ABSENT) only — never overwrite
+          // a persisted null (a legitimately-computed empty value) with a fresh
+          // computation (#48 never-degrade). Each field gated independently.
+          if (m.convId === undefined) m.convId = getParser('anthropic').computeConvId(pb); // may be null
+          if (m.coreHash === undefined && identity.coreHash) m.coreHash = identity.coreHash;
+          if (m.agentKey === undefined && identity.agentKey) m.agentKey = identity.agentKey;
+          if (m.agentLabel === undefined && identity.agentLabel) m.agentLabel = identity.agentLabel;
+          if (m.msgCount === undefined) m.msgCount = pb.messages.length;
+          if (m.isSubagent === undefined) m.isSubagent = store.isAnthropicSubagent(pb);
           outLine = JSON.stringify(m);
           enrichedIdentity++;
         }
@@ -297,6 +309,9 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
 
   // ── 3. Pass 1: reconstruct every orphan body; extend the explicit timeline. ──
   // (Only Anthropic turns survive reconstructReq; non-Anthropic/WS are skipped.)
+  // Own cache (not the #342 backfillCache) so orphan leaves are always projected
+  // from a full reconstruction, never a messages-only ancestor entry.
+  const cache = new Map();
   const recon = []; // { id, parsedBody, explicitSid, prevId }
   let unrecoverable = 0;
   for (const id of orphanIds) {
@@ -443,6 +458,7 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   // ERR_STRING_TOO_LONG once the combined index passes ~512MB. (The lines are
   // still held in memory to sort; a manual recovery CLI can afford that.)
   await writeLinesToFile(tmpPath, merged);
+  try { fs.chmodSync(tmpPath, 0o600); } catch {} // guarantee 0600 even if a stale tmp pre-existed
   fs.renameSync(tmpPath, indexPath);
   log(`  wrote ${indexPath} (${existingIds.size + N} lines). Restart the dashboard to see recovered turns.`);
   return { refused: false, recovered: N, enriched: enrichedResponseIds, enrichedIdentity, total: M, unrecoverable, applied: true, cacheFinalSize: cache.size };

--- a/server/restore.js
+++ b/server/restore.js
@@ -446,6 +446,71 @@ async function buildVersionIndex(knownHashes) {
   return sysHashToAgentKey;
 }
 
+// ── Prune index.ndjson lines whose _req/_res files are gone (#344) ───
+// Pure decision function: given the raw index content plus which req files
+// still survive on disk and which ids are star/in-memory protected, return the
+// lines to keep and the drop count. No I/O — the caller owns read/write so this
+// is unit-testable in isolation.
+//
+// Rules (see #344):
+//   • Protected (starred cascade / in-memory) line → always kept.
+//   • Proxy (non-imported) line → kept iff its _req.json survives on disk. This
+//     also cleans PRE-EXISTING ghosts left by prunes from before this fix, not
+//     just files deleted in the current pass.
+//   • Imported line (never had _req/_res, by design) → kept, UNLESS it is the
+//     orphaned duplicate of a pruned proxy turn: it carries a responseId that
+//     some proxy line also carried (a read-time merge twin, #333/#329) and NO
+//     surviving proxy copy carries that responseId anymore. Standalone imported
+//     lines (no proxy twin, or no responseId key) are always kept — they are the
+//     importer's durable domain, re-imported from ~/.claude while the source
+//     transcript exists.
+//   • Unparseable / id-less lines → kept verbatim (never lose data we can't
+//     classify; mirrors restore's ignore-and-keep handling).
+//
+// NOTE (delta chains): a delta line whose OWN _req.json survives is kept even
+// when its pruned anchor makes reconstruction partial — the delta is within the
+// retention window and loadEntryReqRes degrades gracefully, so dropping it would
+// delete a within-retention turn (a retention-contract violation). This diverges
+// from the issue's literal "prune the delta line too" for the anchor-gone case.
+function pruneIndexLines(indexContent, { survivingReqIds, protectedIds }) {
+  const parsed = [];
+  for (const line of (indexContent || '').split('\n')) {
+    if (!line) continue;
+    let m = null;
+    try { m = JSON.parse(line); } catch {}
+    parsed.push({ line, m });
+  }
+
+  // Pre-scan: responseIds carried by any proxy line, and the subset that still
+  // has a surviving (loadable) proxy copy.
+  const proxyResponseIds = new Set();
+  const survivingProxyResponseIds = new Set();
+  for (const { m } of parsed) {
+    if (!m || !m.id || m.imported || !m.responseId) continue;
+    proxyResponseIds.add(m.responseId);
+    if (protectedIds.has(m.id) || survivingReqIds.has(m.id)) survivingProxyResponseIds.add(m.responseId);
+  }
+
+  const keptLines = [];
+  let dropped = 0;
+  for (const { line, m } of parsed) {
+    let keep;
+    if (!m || !m.id) {
+      keep = true; // unclassifiable — keep verbatim
+    } else if (protectedIds.has(m.id)) {
+      keep = true;
+    } else if (m.imported) {
+      const rid = m.responseId;
+      const orphanDup = rid && proxyResponseIds.has(rid) && !survivingProxyResponseIds.has(rid);
+      keep = !orphanDup;
+    } else {
+      keep = survivingReqIds.has(m.id); // proxy line: keep iff its _req.json is on disk
+    }
+    if (keep) keptLines.push(line); else dropped++;
+  }
+  return { keptLines, dropped };
+}
+
 // ── Prune log files older than LOG_RETENTION_DAYS ───────────────────
 // Files belonging to entries currently restored in memory are never pruned —
 // otherwise lazy-load (loadEntryReqRes) would return null after restart.
@@ -499,6 +564,7 @@ async function pruneLogs() {
   try { files = await config.storage.list(); } catch { return; }
 
   let deleted = 0, kept = 0;
+  const deletedIds = new Set();
   for (const filename of files) {
     const m = filename.match(/^(\d{4}-\d{2}-\d{2}T.*?)_(req\.received|req|res)\.json$/);
     if (!m) continue;
@@ -507,6 +573,7 @@ async function pruneLogs() {
     try {
       await config.storage.deleteFile(filename);
       deleted++;
+      deletedIds.add(m[1]);
     } catch {}
   }
 
@@ -514,6 +581,35 @@ async function pruneLogs() {
     const keptMsg = kept > 0 ? `, kept ${kept} referenced by restored entries` : '';
     console.log(`\x1b[90m   Pruned ${deleted} log files older than ${config.LOG_RETENTION_DAYS} days${keptMsg}\x1b[0m`);
   }
+
+  // #344: sync index.ndjson + sessions.json with the files that survived. The
+  // scan runs every prune (not just when files were deleted this pass) so that
+  // ghost lines from prunes predating this fix are cleaned up too; the atomic
+  // rewrite only fires when a line is actually dropped.
+  if (typeof config.storage.writeIndex !== 'function') return; // non-local backend
+  try {
+    const survivingReqIds = new Set();
+    for (const filename of files) {
+      if (filename.endsWith('_req.json') && !filename.endsWith('_req.received.json')) {
+        const id = filename.slice(0, -'_req.json'.length);
+        if (!deletedIds.has(id)) survivingReqIds.add(id);
+      }
+    }
+    const indexContent = await config.storage.readIndex();
+    const { keptLines, dropped } = pruneIndexLines(indexContent, { survivingReqIds, protectedIds });
+    if (dropped > 0) {
+      const newContent = keptLines.length ? keptLines.join('\n') + '\n' : '';
+      await config.storage.writeIndex(newContent);
+      // INVARIANT: index.ndjson is the source of truth for sessions.json — after
+      // dropping lines, rebuild the session index so card counts/costs match the
+      // pruned index (dedup-by-responseId preserved) — @docs/decisions/0012-response-id-read-time-merge.md
+      sessionIdx.rebuildFromIndexContent(keptLines.join('\n'));
+      await sessionIdx.flush();
+      console.log(`\x1b[90m   Pruned ${dropped} orphaned index line(s); session index rebuilt (${sessionIdx.size()} sessions)\x1b[0m`);
+    }
+  } catch (err) {
+    console.error('[ccxray] index prune failed:', err.message);
+  }
 }
 
-module.exports = { loadEntryReqRes, restoreFromLogs, pruneLogs };
+module.exports = { loadEntryReqRes, restoreFromLogs, pruneLogs, pruneIndexLines };

--- a/server/restore.js
+++ b/server/restore.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
+const { pipeline } = require('stream/promises');
 const config = require('./config');
 const store = require('./store');
 const { calculateCost } = require('./pricing');
@@ -472,6 +475,34 @@ async function buildVersionIndex(knownHashes) {
 // retention window and loadEntryReqRes degrades gracefully, so dropping it would
 // delete a within-retention turn (a retention-contract violation). This diverges
 // from the issue's literal "prune the delta line too" for the anchor-gone case.
+// Per-line keep decision, shared by the in-memory pruneIndexLines (tests) and
+// the streaming prune passes in pruneLogs. `ctx` carries the survivor/protection
+// sets plus the responseId pre-scan.
+function _shouldKeepIndexLine(m, ctx) {
+  if (!m || !m.id) return true;                     // unclassifiable — keep verbatim
+  if (ctx.protectedIds.has(m.id)) return true;
+  if (m.imported) {
+    const rid = m.responseId;
+    const orphanDup = rid && ctx.proxyResponseIds.has(rid) && !ctx.survivingProxyResponseIds.has(rid);
+    return !orphanDup;
+  }
+  return ctx.survivingReqIds.has(m.id);             // proxy line: keep iff its _req.json is on disk
+}
+
+// Pre-scan a list of parsed metas: responseIds carried by any proxy line, and
+// the subset that still has a surviving (loadable) proxy copy.
+function _buildResponseIdSets(metas, { survivingReqIds, protectedIds }) {
+  const proxyResponseIds = new Set();
+  const survivingProxyResponseIds = new Set();
+  for (const m of metas) {
+    if (!m || !m.id || m.imported || !m.responseId) continue;
+    proxyResponseIds.add(m.responseId);
+    if (protectedIds.has(m.id) || survivingReqIds.has(m.id)) survivingProxyResponseIds.add(m.responseId);
+  }
+  return { proxyResponseIds, survivingProxyResponseIds };
+}
+
+// In-memory variant (tests / small indexes). pruneLogs uses the streaming passes.
 function pruneIndexLines(indexContent, { survivingReqIds, protectedIds }) {
   const parsed = [];
   for (const line of (indexContent || '').split('\n')) {
@@ -480,33 +511,12 @@ function pruneIndexLines(indexContent, { survivingReqIds, protectedIds }) {
     try { m = JSON.parse(line); } catch {}
     parsed.push({ line, m });
   }
-
-  // Pre-scan: responseIds carried by any proxy line, and the subset that still
-  // has a surviving (loadable) proxy copy.
-  const proxyResponseIds = new Set();
-  const survivingProxyResponseIds = new Set();
-  for (const { m } of parsed) {
-    if (!m || !m.id || m.imported || !m.responseId) continue;
-    proxyResponseIds.add(m.responseId);
-    if (protectedIds.has(m.id) || survivingReqIds.has(m.id)) survivingProxyResponseIds.add(m.responseId);
-  }
-
+  const sets = _buildResponseIdSets(parsed.map(p => p.m), { survivingReqIds, protectedIds });
+  const ctx = { survivingReqIds, protectedIds, ...sets };
   const keptLines = [];
   let dropped = 0;
   for (const { line, m } of parsed) {
-    let keep;
-    if (!m || !m.id) {
-      keep = true; // unclassifiable — keep verbatim
-    } else if (protectedIds.has(m.id)) {
-      keep = true;
-    } else if (m.imported) {
-      const rid = m.responseId;
-      const orphanDup = rid && proxyResponseIds.has(rid) && !survivingProxyResponseIds.has(rid);
-      keep = !orphanDup;
-    } else {
-      keep = survivingReqIds.has(m.id); // proxy line: keep iff its _req.json is on disk
-    }
-    if (keep) keptLines.push(line); else dropped++;
+    if (_shouldKeepIndexLine(m, ctx)) keptLines.push(line); else dropped++;
   }
   return { keptLines, dropped };
 }
@@ -521,8 +531,10 @@ async function pruneLogs() {
   // ponytail: if index is empty/missing, star-protection cascade can't map
   // turn→session→project — starred old entries would be silently deleted.
   // Skip prune entirely so files survive for `ccxray rebuild-index`.
-  const idx = await config.storage.readIndex();
-  if (!idx || !idx.trim()) {
+  // #345: stream — the index can exceed Node's 512MB single-string limit.
+  let hasAnyIndexLine = false;
+  for await (const _line of config.storage.readIndexLines()) { hasAnyIndexLine = true; break; }
+  if (!hasAnyIndexLine) {
     console.log('\x1b[33m[ccxray] Skipping prune: index.ndjson empty/missing — star protection cannot be computed.\x1b[0m');
     return;
   }
@@ -540,20 +552,17 @@ async function pruneLogs() {
   try {
     const stars = readStarsSafe();
     if (stars.projects.length || stars.sessions.length || stars.turns.length || stars.steps.length) {
-      const idx = await config.storage.readIndex();
-      if (idx) {
-        const indexEntries = [];
-        for (const line of idx.split('\n')) {
-          if (!line) continue;
-          try {
-            const m = JSON.parse(line);
-            if (m && m.id) indexEntries.push({ id: m.id, sessionId: m.sessionId, cwd: m.cwd });
-          } catch {}
-        }
-        const sets = computeRetentionSets(indexEntries, stars);
-        for (const e of indexEntries) {
-          if (isProtectedByStar(e, sets)) protectedIds.add(e.id);
-        }
+      const indexEntries = [];
+      // #345: stream — the index can exceed Node's 512MB single-string limit.
+      for await (const line of config.storage.readIndexLines()) {
+        try {
+          const m = JSON.parse(line);
+          if (m && m.id) indexEntries.push({ id: m.id, sessionId: m.sessionId, cwd: m.cwd });
+        } catch {}
+      }
+      const sets = computeRetentionSets(indexEntries, stars);
+      for (const e of indexEntries) {
+        if (isProtectedByStar(e, sets)) protectedIds.add(e.id);
       }
     }
   } catch (err) {
@@ -582,11 +591,14 @@ async function pruneLogs() {
     console.log(`\x1b[90m   Pruned ${deleted} log files older than ${config.LOG_RETENTION_DAYS} days${keptMsg}\x1b[0m`);
   }
 
-  // #344: sync index.ndjson + sessions.json with the files that survived. The
-  // scan runs every prune (not just when files were deleted this pass) so that
-  // ghost lines from prunes predating this fix are cleaned up too; the atomic
-  // rewrite only fires when a line is actually dropped.
-  if (typeof config.storage.writeIndex !== 'function') return; // non-local backend
+  // #344 + #345: sync index.ndjson + sessions.json with the files that survived,
+  // by STREAMING (the index can exceed Node's 512MB single-string limit). The
+  // scan runs every prune (not just when files were deleted this pass) so ghost
+  // lines from prunes predating this fix are cleaned up too. Three passes keep
+  // memory O(responseIds + survivor metas): (1) build responseId sets, (2) count
+  // drops — early-exit with NO rewrite (and no index-mtime bump) when nothing is
+  // droppable, (3) stream survivors to a temp file, then rename + rebuild.
+  if (!config.storage.location) return; // non-local backend: no atomic index rewrite
   try {
     const survivingReqIds = new Set();
     for (const filename of files) {
@@ -595,18 +607,49 @@ async function pruneLogs() {
         if (!deletedIds.has(id)) survivingReqIds.add(id);
       }
     }
-    const indexContent = await config.storage.readIndex();
-    const { keptLines, dropped } = pruneIndexLines(indexContent, { survivingReqIds, protectedIds });
-    if (dropped > 0) {
-      const newContent = keptLines.length ? keptLines.join('\n') + '\n' : '';
-      await config.storage.writeIndex(newContent);
-      // INVARIANT: index.ndjson is the source of truth for sessions.json — after
-      // dropping lines, rebuild the session index so card counts/costs match the
-      // pruned index (dedup-by-responseId preserved) — @docs/decisions/0012-response-id-read-time-merge.md
-      sessionIdx.rebuildFromIndexContent(keptLines.join('\n'));
-      await sessionIdx.flush();
-      console.log(`\x1b[90m   Pruned ${dropped} orphaned index line(s); session index rebuilt (${sessionIdx.size()} sessions)\x1b[0m`);
+
+    // Pass 1: responseId sets (for the imported-orphan-dup rule). Built inline
+    // to avoid holding every meta in memory — mirrors _buildResponseIdSets.
+    const proxyResponseIds = new Set();
+    const survivingProxyResponseIds = new Set();
+    for await (const line of config.storage.readIndexLines()) {
+      let m; try { m = JSON.parse(line); } catch { continue; }
+      if (!m || !m.id || m.imported || !m.responseId) continue;
+      proxyResponseIds.add(m.responseId);
+      if (protectedIds.has(m.id) || survivingReqIds.has(m.id)) survivingProxyResponseIds.add(m.responseId);
     }
+    const ctx = { survivingReqIds, protectedIds, proxyResponseIds, survivingProxyResponseIds };
+
+    // Pass 2: count drops; bail without rewriting when nothing is droppable.
+    let dropped = 0;
+    for await (const line of config.storage.readIndexLines()) {
+      let m; try { m = JSON.parse(line); } catch { m = null; }
+      if (!_shouldKeepIndexLine(m, ctx)) dropped++;
+    }
+    if (dropped === 0) return;
+
+    // Pass 3: stream survivors to a temp file (verbatim lines), collecting metas
+    // for the session rebuild. Atomic rename commits.
+    const indexPath = path.join(config.storage.location, 'index.ndjson');
+    const tmpPath = `${indexPath}.prune-${process.pid}.tmp`;
+    const survivorMetas = [];
+    async function* survivorLines() {
+      for await (const line of config.storage.readIndexLines()) {
+        let m; try { m = JSON.parse(line); } catch { m = null; }
+        if (!_shouldKeepIndexLine(m, ctx)) continue;
+        if (m) survivorMetas.push(m);
+        yield line + '\n';
+      }
+    }
+    await pipeline(survivorLines(), fs.createWriteStream(tmpPath));
+    fs.renameSync(tmpPath, indexPath);
+
+    // INVARIANT: index.ndjson is the source of truth for sessions.json — rebuild
+    // from the surviving metas so card counts/costs match the pruned index
+    // (dedup-by-responseId preserved) — @docs/decisions/0012-response-id-read-time-merge.md
+    sessionIdx.rebuildFromMetas(survivorMetas);
+    await sessionIdx.flush();
+    console.log(`\x1b[90m   Pruned ${dropped} orphaned index line(s); session index rebuilt (${sessionIdx.size()} sessions)\x1b[0m`);
   } catch (err) {
     console.error('[ccxray] index prune failed:', err.message);
   }

--- a/server/restore.js
+++ b/server/restore.js
@@ -132,24 +132,30 @@ async function restoreFromLogs() {
     console.log(`\x1b[90m   Session index: ${sessionIdx.size()} sessions\x1b[0m`);
   }
 
-  // 1. Read the lightweight index (one file read for all metadata)
+  // 1. Read the lightweight index by STREAMING lines into parsed metas. #345:
+  // the index can exceed Node's ~512MB single-string limit, so we must not call
+  // readIndex() (readFile utf8) here — it would throw ERR_STRING_TOO_LONG and
+  // fail restore. readIndexLines() streams without materializing the whole file.
   console.time('restore:index');
-  const indexContent = await config.storage.readIndex();
+  const parsed = [];
+  for await (const line of config.storage.readIndexLines()) {
+    try { parsed.push(JSON.parse(line)); } catch {}
+  }
   console.timeEnd('restore:index');
 
-  if (!indexContent) {
+  if (!parsed.length) {
     console.timeEnd('restore:total');
     return;
   }
 
   // 1b. Reconcile sessions.json against index.ndjson if loaded (#309)
-  if (sessionIndexLoaded && indexContent) {
-    if (sessionIdx.reconcile(indexContent)) {
+  if (sessionIndexLoaded) {
+    if (sessionIdx.reconcileMetas(parsed)) {
       console.log(`\x1b[90m   Session index reconciled: ${sessionIdx.size()} sessions\x1b[0m`);
     }
   }
 
-  // 2. Parse index lines and filter by RESTORE_DAYS
+  // 2. Filter by RESTORE_DAYS
   console.time('restore:parse');
   let cutoffStr = null;
   if (config.RESTORE_DAYS > 0) {
@@ -158,12 +164,6 @@ async function restoreFromLogs() {
     cutoffStr = cutoff.toLocaleString('sv-SE', { timeZone: 'Asia/Taipei' }).slice(0, 10);
   }
 
-  // ponytail: parse JSON once instead of three times per line
-  const parsed = [];
-  for (const line of indexContent.split('\n')) {
-    if (!line) continue;
-    try { parsed.push(JSON.parse(line)); } catch {}
-  }
   let restored = 0;
 
   // Star-protection + session pre-count in one pass over pre-parsed data.
@@ -359,9 +359,9 @@ async function restoreFromLogs() {
 
   // 5. Session index: rebuild from index.ndjson if sessions.json was missing,
   //    then replay titles into the session index.
-  if (!sessionIndexLoaded && indexContent) {
+  if (!sessionIndexLoaded && parsed.length) {
     console.time('restore:session-index-rebuild');
-    sessionIdx.rebuildFromIndexContent(indexContent);
+    sessionIdx.rebuildFromMetas(parsed);
     console.timeEnd('restore:session-index-rebuild');
     console.log(`\x1b[90m   Session index rebuilt: ${sessionIdx.size()} sessions\x1b[0m`);
   }

--- a/server/restore.js
+++ b/server/restore.js
@@ -533,7 +533,10 @@ async function pruneLogs() {
   // Skip prune entirely so files survive for `ccxray rebuild-index`.
   // #345: stream — the index can exceed Node's 512MB single-string limit.
   let hasAnyIndexLine = false;
-  for await (const _line of config.storage.readIndexLines()) { hasAnyIndexLine = true; break; }
+  // Require a non-whitespace line (matches the old `idx.trim()` guard):
+  // readIndexLines only skips empty strings, so a whitespace-only index would
+  // otherwise pass here and let prune delete logs with no usable metadata.
+  for await (const line of config.storage.readIndexLines()) { if (line.trim()) { hasAnyIndexLine = true; break; } }
   if (!hasAnyIndexLine) {
     console.log('\x1b[33m[ccxray] Skipping prune: index.ndjson empty/missing — star protection cannot be computed.\x1b[0m');
     return;
@@ -573,7 +576,6 @@ async function pruneLogs() {
   try { files = await config.storage.list(); } catch { return; }
 
   let deleted = 0, kept = 0;
-  const deletedIds = new Set();
   for (const filename of files) {
     const m = filename.match(/^(\d{4}-\d{2}-\d{2}T.*?)_(req\.received|req|res)\.json$/);
     if (!m) continue;
@@ -582,7 +584,6 @@ async function pruneLogs() {
     try {
       await config.storage.deleteFile(filename);
       deleted++;
-      deletedIds.add(m[1]);
     } catch {}
   }
 
@@ -599,12 +600,40 @@ async function pruneLogs() {
   // drops — early-exit with NO rewrite (and no index-mtime bump) when nothing is
   // droppable, (3) stream survivors to a temp file, then rename + rebuild.
   if (!config.storage.location) return; // non-local backend: no atomic index rewrite
+  const indexPath = path.join(config.storage.location, 'index.ndjson');
+
+  // #344 concurrency (codex): pruneLogs runs after the server is listening, so a
+  // live turn can appendIndex() while we read + rewrite; fs.appendFile writes on
+  // the libuv threadpool, so a stat-based CAS alone cannot close the race. Hold
+  // the storage exclusive lock across the whole read+rewrite: beginExclusive()
+  // first (new appends queue on the gate), THEN drain() (flush appends already
+  // dispatched before the gate). After that no append is in flight and none can
+  // start until release() → the intra-process race is closed. (Raw test adapter
+  // has neither method → guarded.)
+  const releaseExclusive = config.storage.beginExclusive ? config.storage.beginExclusive() : null;
   try {
+    if (config.storage.drain) await config.storage.drain();
+
+    // Belt-and-suspenders for a SECOND ccxray writing the same shared index (the
+    // #333 multi-instance case, which the in-process lock can't cover): snapshot
+    // size/mtime before the read and re-check right before the sync rename; abort
+    // if it changed (next startup retries; the line's files survive on disk and
+    // are recoverable via `ccxray rebuild-index`).
+    let statBefore;
+    try { statBefore = fs.statSync(indexPath); } catch { statBefore = null; }
+
+    // Re-list AFTER deletion so survivingReqIds reflects the _req.json files
+    // actually on disk. deletedIds would be keyed on ANY artifact, so a _res
+    // delete that succeeded while its _req delete FAILED must not drop a
+    // still-loadable line — the authoritative signal is the file itself (M6). If
+    // the re-list fails we can't compute survivors safely → skip the rewrite
+    // rather than risk dropping loadable lines or retaining ghosts.
+    let filesNow;
+    try { filesNow = await config.storage.list(); } catch { return; }
     const survivingReqIds = new Set();
-    for (const filename of files) {
+    for (const filename of filesNow) {
       if (filename.endsWith('_req.json') && !filename.endsWith('_req.received.json')) {
-        const id = filename.slice(0, -'_req.json'.length);
-        if (!deletedIds.has(id)) survivingReqIds.add(id);
+        survivingReqIds.add(filename.slice(0, -'_req.json'.length));
       }
     }
 
@@ -629,8 +658,8 @@ async function pruneLogs() {
     if (dropped === 0) return;
 
     // Pass 3: stream survivors to a temp file (verbatim lines), collecting metas
-    // for the session rebuild. Atomic rename commits.
-    const indexPath = path.join(config.storage.location, 'index.ndjson');
+    // for the session rebuild. mode 0600 so the rename doesn't downgrade the
+    // index from 0600 to 0644 (log metadata is sensitive).
     const tmpPath = `${indexPath}.prune-${process.pid}.tmp`;
     const survivorMetas = [];
     async function* survivorLines() {
@@ -641,17 +670,42 @@ async function pruneLogs() {
         yield line + '\n';
       }
     }
-    await pipeline(survivorLines(), fs.createWriteStream(tmpPath));
+    await pipeline(survivorLines(), fs.createWriteStream(tmpPath, { mode: 0o600 }));
+
+    // CAS commit: statSync then renameSync, both synchronous, no await between.
+    let statNow;
+    try { statNow = fs.statSync(indexPath); } catch { statNow = null; }
+    if (!statBefore || !statNow || statNow.size !== statBefore.size || statNow.mtimeMs !== statBefore.mtimeMs) {
+      try { fs.unlinkSync(tmpPath); } catch {}
+      console.log('\x1b[33m[ccxray] index changed during prune — skipping rewrite (will retry next startup)\x1b[0m');
+      return;
+    }
+    try { fs.chmodSync(tmpPath, 0o600); } catch {} // guarantee 0600 even if a stale tmp pre-existed
     fs.renameSync(tmpPath, indexPath);
 
     // INVARIANT: index.ndjson is the source of truth for sessions.json — rebuild
     // from the surviving metas so card counts/costs match the pruned index
     // (dedup-by-responseId preserved) — @docs/decisions/0012-response-id-read-time-merge.md
     sessionIdx.rebuildFromMetas(survivorMetas);
+    // Replay in-memory session titles the same way restoreFromLogs does — the
+    // rebuild only carries titles present on surviving index lines, so a
+    // generated title held only in store.sessionMeta would otherwise be lost (M4).
+    for (const [sid, meta] of Object.entries(store.sessionMeta)) {
+      if (meta.title) sessionIdx.setTitle(sid, meta.title);
+    }
+    if (sessionIdx.size() === 0) {
+      // Everything pruned: the map is empty and flush() no-ops on an empty map,
+      // which would leave a stale sessions.json contradicting the emptied index.
+      // Remove it so the next load rebuilds from the (empty) index (M5).
+      try { fs.unlinkSync(path.join(config.LOGS_DIR, 'sessions.json')); } catch {}
+    }
     await sessionIdx.flush();
     console.log(`\x1b[90m   Pruned ${dropped} orphaned index line(s); session index rebuilt (${sessionIdx.size()} sessions)\x1b[0m`);
   } catch (err) {
     console.error('[ccxray] index prune failed:', err.message);
+  } finally {
+    // Always release — otherwise every subsequent appendIndex() deadlocks on the gate.
+    if (releaseExclusive) releaseExclusive();
   }
 }
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -27,11 +27,11 @@ async function loadColdEntry(id) {
     coldEntryCache.delete(id); coldEntryCache.set(id, e); // touch
     return e;
   }
-  const indexContent = await config.storage.readIndex();
-  if (!indexContent) return null;
   const needle = '"id":"' + id + '"';
-  for (const line of indexContent.split('\n')) {
-    if (!line || !line.includes(needle)) continue;
+  // #345: stream lines — the index can exceed Node's ~512MB single-string limit,
+  // where readIndex() throws ERR_STRING_TOO_LONG and cold-load returns nothing.
+  for await (const line of config.storage.readIndexLines()) {
+    if (!line.includes(needle)) continue;
     let meta;
     try { meta = JSON.parse(line); } catch { continue; }
     if (meta.id !== id) continue;
@@ -96,15 +96,14 @@ function normalizeIndexEntry(meta) {
 // Scan index.ndjson for entries of the given session ids (cold sessions have
 // no store.entries presence — index.ndjson is their durable source).
 async function loadSessionEntriesFromIndex(targetSids, opts) {
-  const indexContent = await config.storage.readIndex();
-  if (!indexContent) return [];
   // String pre-filter before JSON.parse: parsing all ~150K lines costs
   // seconds per cold click; substring containment skips 99.9% of them.
   // The exact targetSids check after parse stays authoritative.
   const needles = [...targetSids].map(s => '"sessionId":"' + s + '"');
   const metas = [];
-  for (const line of indexContent.split('\n')) {
-    if (!line) continue;
+  // #345: stream lines — the index can exceed Node's ~512MB single-string limit,
+  // where readIndex() throws ERR_STRING_TOO_LONG and cold sessions never load.
+  for await (const line of config.storage.readIndexLines()) {
     let hit = false;
     for (const n of needles) { if (line.includes(n)) { hit = true; break; } }
     if (!hit) continue;

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -57,27 +57,43 @@ async function loadSessionIndex() {
   }
 }
 
-// Build session index from raw index.ndjson content string.
-function rebuildFromIndexContent(indexContent) {
+// Parse index.ndjson content into an array of metas. #345: only used by the
+// string-accepting back-compat wrappers below (tests, small indexes). Throws
+// ERR_STRING_TOO_LONG if `indexContent` came from readIndex() on a >512MB file —
+// production callers stream via storage.readIndexLines() and call the *FromMetas
+// variants directly, never building that string.
+function _parseLines(indexContent) {
+  const out = [];
+  if (!indexContent) return out;
+  for (const line of indexContent.split('\n')) {
+    if (!line) continue;
+    try { out.push(JSON.parse(line)); } catch {}
+  }
+  return out;
+}
+
+// Build session index from an array of parsed index metas.
+function rebuildFromMetas(metas) {
   sessionIndex.clear();
   _costByRid.clear();
   _countedRids.clear();
-  if (!indexContent) return;
+  if (!Array.isArray(metas)) return;
   // #333: a shared log holds 2–8 duplicate copies per turn (same responseId).
   // Both COST and COUNT are deduped by responseId here (_upsert via _costByRid /
   // _countedRids), so the session card shows merged turns and cost is counted once.
   // reconcile() dedups its index-side comparison the SAME way — the two must stay
   // paired: deduping count without deduping reconcile's tally would make merged
   // s.count (e.g. 15) never equal the raw line total (45) and thrash rebuilds.
-  for (const line of indexContent.split('\n')) {
-    if (!line) continue;
-    try {
-      const m = JSON.parse(line);
-      if (!m || !m.sessionId) continue;
-      _upsert(m.sessionId, m);
-    } catch {}
+  for (const m of metas) {
+    if (!m || !m.sessionId) continue;
+    _upsert(m.sessionId, m);
   }
   dirty = true;
+}
+
+// Back-compat string entry point (tests / small indexes).
+function rebuildFromIndexContent(indexContent) {
+  rebuildFromMetas(_parseLines(indexContent));
 }
 
 // #333: seed the dedup state (cost + count) from the responseIds already present
@@ -91,12 +107,9 @@ function rebuildFromIndexContent(indexContent) {
 // would re-add both (cost = fable round-4 M1; count = its count-side twin).
 // Idempotent: re-seeding a known responseId only lifts its tracked cost max and is
 // a no-op on the count Set. Never adds to totalCost or s.count.
-function seedDedupState(indexContent) {
-  if (!indexContent) return;
-  for (const line of indexContent.split('\n')) {
-    if (!line) continue;
-    let m;
-    try { m = JSON.parse(line); } catch { continue; }
+function seedDedupFromMetas(metas) {
+  if (!Array.isArray(metas)) return;
+  for (const m of metas) {
     const rid = m && m.responseId;
     if (!rid) continue;
     // COUNT: any responseId already in the log is counted — even a cost-null
@@ -111,6 +124,11 @@ function seedDedupState(indexContent) {
   }
 }
 
+// Back-compat string entry point (tests / small indexes).
+function seedDedupState(indexContent) {
+  seedDedupFromMetas(_parseLines(indexContent));
+}
+
 // Compare loaded sessions.json against index.ndjson content. Returns true if
 // drift detected (and rebuilds). Checks both unique session count and total
 // entry count — the latter catches appendIndex failures for existing sessions
@@ -118,33 +136,33 @@ function seedDedupState(indexContent) {
 // #333: the entry tally is deduped by responseId so it matches the merged s.count
 // _upsert now keeps; a raw-line tally here would always exceed merged s.count on a
 // duplicate-heavy shared log and rebuild on every reconcile.
-function reconcile(indexContent) {
-  if (!indexContent || !sessionIndex.size) return false;
+function reconcileMetas(metas) {
+  if (!Array.isArray(metas) || !metas.length || !sessionIndex.size) return false;
   let indexSessions = 0, indexEntries = 0;
   const seen = new Set();
   const seenRid = new Set();
-  const re = /"sessionId":"([^"]+)"/;
-  const reRid = /"responseId":"([^"]+)"/;
-  for (const line of indexContent.split('\n')) {
-    if (!line) continue;
-    const m = re.exec(line);
-    if (!m) continue;
+  for (const m of metas) {
+    if (!m || !m.sessionId) continue;
     // Count once per responseId (merged turns); a line without responseId
     // (legacy/exempt) has no dedup key ⇒ always counts. Mirrors _upsert.
-    const rm = reRid.exec(line);
-    const rid = rm ? rm[1] : null;
+    const rid = m.responseId || null;
     if (!rid || !seenRid.has(rid)) {
       indexEntries++;
       if (rid) seenRid.add(rid);
     }
-    if (!seen.has(m[1])) { seen.add(m[1]); indexSessions++; }
+    if (!seen.has(m.sessionId)) { seen.add(m.sessionId); indexSessions++; }
   }
   let totalEntries = 0;
   for (const s of sessionIndex.values()) totalEntries += s.count;
   if (indexSessions === sessionIndex.size && indexEntries === totalEntries) return false;
   console.warn(`\x1b[33m[session-index] drift detected: sessions.json has ${sessionIndex.size} sessions / ${totalEntries} entries, index.ndjson has ${indexSessions} sessions / ${indexEntries} entries — rebuilding\x1b[0m`);
-  rebuildFromIndexContent(indexContent);
+  rebuildFromMetas(metas);
   return true;
+}
+
+// Back-compat string entry point (tests / small indexes).
+function reconcile(indexContent) {
+  return reconcileMetas(_parseLines(indexContent));
 }
 
 // Upsert a session summary from an entry's index fields.
@@ -245,4 +263,10 @@ function size() {
   return sessionIndex.size;
 }
 
-module.exports = { loadSessionIndex, rebuildFromIndexContent, seedDedupState, reconcile, updateFromEntry, setTitle, flush, getAll, size };
+module.exports = {
+  loadSessionIndex,
+  rebuildFromIndexContent, rebuildFromMetas,
+  seedDedupState, seedDedupFromMetas,
+  reconcile, reconcileMetas,
+  updateFromEntry, setTitle, flush, getAll, size,
+};

--- a/server/storage/index.js
+++ b/server/storage/index.js
@@ -21,12 +21,44 @@ function withWriteTracking(adapter) {
     promise.then(cleanup, cleanup);
     return promise;
   };
+  // #344: exclusive index lock. While pruneLogs rewrites index.ndjson it holds
+  // exclusivity; appendIndex() awaits it so a concurrent append can never land
+  // between the rewrite's read and its atomic rename (which would drop the line).
+  // Order at the prune site: beginExclusive() (new appends start queuing) →
+  // drain() (flush appends already dispatched to the fs threadpool) → rewrite →
+  // release(). This closes the intra-process race that a stat-based CAS cannot
+  // (fs.appendFile writes on the libuv threadpool, truly concurrent with a
+  // synchronous rename). Cross-process writers to a shared index are out of
+  // scope (the #333 multi-instance case), same as the file-delete pass.
+  let exclusive = null;
+  const awaitExclusive = async () => { while (exclusive) await exclusive; };
   return {
     ...adapter,
     write: (id, suffix, data) => track(adapter.write(id, suffix, data)),
-    appendIndex: (line) => track(adapter.appendIndex(line)),
+    // Fast path (no lock held — the overwhelming common case): dispatch AND
+    // track synchronously, so `appendIndex(); await drain()` sees the write in
+    // `pending` (an unconditional async await would delay track() past a drain).
+    // Locked path (only while pruneLogs rewrites): park until release, THEN
+    // track the write. track() is never on the gate-wait itself — otherwise
+    // prune's own drain() (right after beginExclusive) would await an append
+    // parked on the gate it holds → deadlock. The trade: a parked append isn't
+    // in `pending`, so a shutdown landing inside the brief startup-prune window
+    // won't drain it — rare, and the turn's _req/_res are still on disk
+    // (recoverable via `ccxray rebuild-index`).
+    appendIndex: (line) => {
+      if (!exclusive) return track(adapter.appendIndex(line));
+      return (async () => { await awaitExclusive(); return track(adapter.appendIndex(line)); })();
+    },
     writeSharedIfAbsent: (filename, data) => track(adapter.writeSharedIfAbsent(filename, data)),
     deleteFile: (filename) => track(adapter.deleteFile(filename)),
+    // Acquire exclusive index access; returns a release fn. Caller MUST release
+    // (finally) or appends deadlock. Single-holder by contract (only pruneLogs).
+    beginExclusive: () => {
+      let release;
+      const p = new Promise((res) => { release = res; });
+      exclusive = p;
+      return () => { if (exclusive === p) exclusive = null; release(); };
+    },
     drain: async () => {
       while (pending.size > 0) {
         await Promise.allSettled([...pending]);

--- a/server/storage/index.js
+++ b/server/storage/index.js
@@ -25,6 +25,7 @@ function withWriteTracking(adapter) {
     ...adapter,
     write: (id, suffix, data) => track(adapter.write(id, suffix, data)),
     appendIndex: (line) => track(adapter.appendIndex(line)),
+    writeIndex: (content) => track(adapter.writeIndex(content)),
     writeSharedIfAbsent: (filename, data) => track(adapter.writeSharedIfAbsent(filename, data)),
     deleteFile: (filename) => track(adapter.deleteFile(filename)),
     drain: async () => {

--- a/server/storage/index.js
+++ b/server/storage/index.js
@@ -25,7 +25,6 @@ function withWriteTracking(adapter) {
     ...adapter,
     write: (id, suffix, data) => track(adapter.write(id, suffix, data)),
     appendIndex: (line) => track(adapter.appendIndex(line)),
-    writeIndex: (content) => track(adapter.writeIndex(content)),
     writeSharedIfAbsent: (filename, data) => track(adapter.writeSharedIfAbsent(filename, data)),
     deleteFile: (filename) => track(adapter.deleteFile(filename)),
     drain: async () => {

--- a/server/storage/interface.js
+++ b/server/storage/interface.js
@@ -19,6 +19,11 @@
  * @property {() => Promise<string[]>} list
  *   List all filenames in the log store (e.g. ['2025-03-17T12-00-00-000_req.json', ...]).
  *
+ * @property {() => AsyncIterable<string>} readIndexLines
+ *   Stream index.ndjson line-by-line (blank lines skipped). Unlike readIndex(),
+ *   never materializes the whole file into one string, so it is safe past Node's
+ *   ~512MB single-string limit (#345). Missing index → empty iteration.
+ *
  * @property {(id: string, suffix: string) => Promise<{mtimeMs: number}>} stat
  *   Get metadata (at minimum mtimeMs) for a log artifact. Throws if not found.
  *

--- a/server/storage/interface.js
+++ b/server/storage/interface.js
@@ -31,11 +31,6 @@
  *   Delete a log artifact by full filename (e.g. '2025-03-17T12-00-00-000_req.json').
  *   Must silently succeed if the file does not exist.
  *
- * @property {(content: string) => Promise<void>} writeIndex
- *   Atomically replace the entire index.ndjson with `content`. Used by pruneLogs
- *   (#344) to drop index lines whose _req/_res files were pruned. Must be atomic
- *   (tmp + rename) so a concurrent reader never sees a half-written index.
- *
  * @property {boolean} supportsDelta
  *   When true, the proxy may write _req.json in delta format (prevId + partial messages)
  *   instead of storing the full messages array every turn. Set false for high-latency or

--- a/server/storage/interface.js
+++ b/server/storage/interface.js
@@ -26,6 +26,11 @@
  *   Delete a log artifact by full filename (e.g. '2025-03-17T12-00-00-000_req.json').
  *   Must silently succeed if the file does not exist.
  *
+ * @property {(content: string) => Promise<void>} writeIndex
+ *   Atomically replace the entire index.ndjson with `content`. Used by pruneLogs
+ *   (#344) to drop index lines whose _req/_res files were pruned. Must be atomic
+ *   (tmp + rename) so a concurrent reader never sees a half-written index.
+ *
  * @property {boolean} supportsDelta
  *   When true, the proxy may write _req.json in delta format (prevId + partial messages)
  *   instead of storing the full messages array every turn. Set false for high-latency or

--- a/server/storage/local.js
+++ b/server/storage/local.js
@@ -92,15 +92,6 @@ function createLocalStorage(logsDir, opts = {}) {
       await fsp.appendFile(indexPath, line, { mode: 0o600 });
     },
 
-    // Atomically replace the whole index (tmp + rename). Used by pruneLogs (#344)
-    // to drop ghost lines whose _req/_res files were pruned. Callers pass the
-    // full new content; an empty string writes an empty index.
-    async writeIndex(content) {
-      const tmp = `${indexPath}.prune-${process.pid}.tmp`;
-      await fsp.writeFile(tmp, content, { mode: 0o600 });
-      await fsp.rename(tmp, indexPath);
-    },
-
     async readIndex() {
       try {
         return await fsp.readFile(indexPath, 'utf8');

--- a/server/storage/local.js
+++ b/server/storage/local.js
@@ -108,15 +108,20 @@ function createLocalStorage(logsDir, opts = {}) {
     readIndexLines() {
       const p = indexPath;
       return (async function* () {
-        if (!fs.existsSync(p)) return;
-        const rl = readline.createInterface({
-          input: fs.createReadStream(p, { encoding: 'utf8' }),
-          crlfDelay: Infinity,
-        });
+        // Open directly (no existsSync → no TOCTOU): a missing file surfaces as
+        // an ENOENT 'error' on the stream, which we swallow to honor the
+        // "missing index → empty iteration" contract. Other read errors propagate.
+        const input = fs.createReadStream(p, { encoding: 'utf8' });
+        const rl = readline.createInterface({ input, crlfDelay: Infinity });
         try {
           for await (const line of rl) if (line) yield line;
+        } catch (e) {
+          if (!e || e.code !== 'ENOENT') throw e;
         } finally {
+          // Close BOTH: rl.close() alone leaves the underlying fd open when a
+          // consumer breaks early (cold-load returns mid-iteration) → fd leak.
           rl.close();
+          input.destroy();
         }
       })();
     },

--- a/server/storage/local.js
+++ b/server/storage/local.js
@@ -91,6 +91,15 @@ function createLocalStorage(logsDir, opts = {}) {
       await fsp.appendFile(indexPath, line, { mode: 0o600 });
     },
 
+    // Atomically replace the whole index (tmp + rename). Used by pruneLogs (#344)
+    // to drop ghost lines whose _req/_res files were pruned. Callers pass the
+    // full new content; an empty string writes an empty index.
+    async writeIndex(content) {
+      const tmp = `${indexPath}.prune-${process.pid}.tmp`;
+      await fsp.writeFile(tmp, content, { mode: 0o600 });
+      await fsp.rename(tmp, indexPath);
+    },
+
     async readIndex() {
       try {
         return await fsp.readFile(indexPath, 'utf8');

--- a/server/storage/local.js
+++ b/server/storage/local.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const fsp = fs.promises;
 const path = require('path');
+const readline = require('readline');
 
 /**
  * Local filesystem storage adapter.
@@ -107,6 +108,26 @@ function createLocalStorage(logsDir, opts = {}) {
         if (e.code === 'ENOENT') return '';
         throw e;
       }
+    },
+
+    // Streaming line iterator over index.ndjson. Blank lines are skipped. Safe
+    // for indexes past Node's ~512MB single-string limit (#345) — readIndex()
+    // throws ERR_STRING_TOO_LONG there; this never materializes the whole file.
+    // Missing file → empty iteration.
+    readIndexLines() {
+      const p = indexPath;
+      return (async function* () {
+        if (!fs.existsSync(p)) return;
+        const rl = readline.createInterface({
+          input: fs.createReadStream(p, { encoding: 'utf8' }),
+          crlfDelay: Infinity,
+        });
+        try {
+          for await (const line of rl) if (line) yield line;
+        } finally {
+          rl.close();
+        }
+      })();
     },
 
     // ── Shared content-addressed storage (shared/) ───────────────────

--- a/server/usage.js
+++ b/server/usage.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const readline = require('readline');
 const { resolveCcxrayHome } = require('./paths');
 
 const HELP = `Usage: ccxray usage [options]
@@ -51,7 +52,7 @@ function parseArgs(argv) {
   return args;
 }
 
-function run(argv) {
+async function run(argv) {
   const args = parseArgs(argv);
   const home = resolveCcxrayHome();
   const indexPath = path.join(home, 'logs', 'index.ndjson');
@@ -63,13 +64,16 @@ function run(argv) {
     process.exit(1);
   }
 
-  // ponytail: whole-file read + split holds the full index in memory (~tens of
-  // MB in practice). Fine for this one-shot CLI; if index.ndjson grows into the
-  // hundreds of MB or this ever runs long-lived, switch to a streaming
-  // readline pass (which would make run() async).
-  const raw = fs.readFileSync(indexPath, 'utf8');
+  // #345: stream the index line-by-line. readFileSync(indexPath, 'utf8') throws
+  // "Invalid string length" once index.ndjson passes Node's ~512MB single-string
+  // limit (real indexes already do). readline never materializes the whole file
+  // as one string; entries[] is still built (one-shot CLI), but no giant string.
   let entries = [];
-  for (const line of raw.split('\n')) {
+  const rl = readline.createInterface({
+    input: fs.createReadStream(indexPath, { encoding: 'utf8' }),
+    crlfDelay: Infinity,
+  });
+  for await (const line of rl) {
     if (!line) continue;
     try { entries.push(JSON.parse(line)); } catch {}
   }

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -193,6 +193,7 @@ module.exports = {
   isNoiseRequest,
   extractUsage,
   extractResponseId,
+  computeConvId,
   detectSession,
   buildEntryFields,
   registerPromptVersion,

--- a/test/image-xss.test.js
+++ b/test/image-xss.test.js
@@ -45,6 +45,7 @@ function loadImageHelpers() {
     function clearInterval() {}
     window.ccxraySettings = { visibleProviders: [] };
     function fetch() { return Promise.resolve({ ok: false, json() { return Promise.resolve({}); } }); }
+    function _apiQ(u) { return u; } // settings.js helper; stub so addEntry's async prefetch/pill fetches don't ReferenceError post-test
   `, context);
   for (const f of ['format.js', 'session-label.js', 'miller-columns.js', 'entry-rendering.js']) {
     vm.runInContext(fs.readFileSync(path.join(__dirname, '..', 'public', f), 'utf8'), context);

--- a/test/index-large-streaming.test.js
+++ b/test/index-large-streaming.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+// #345: index.ndjson can exceed Node's ~512MB single-string limit (0x1fffffe8).
+// readIndex() (readFile utf8) then throws ERR_STRING_TOO_LONG, which broke
+// restore / cold-load / import / rebuild-index. readIndexLines() streams and
+// must handle any size. These tests lock both the small-file behavior and the
+// large-file fail-on-old proof.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { createLocalStorage } = require('../server/storage/local');
+
+const STRING_LIMIT = 0x1fffffe8; // ~536.87 MB — Node's max single-string length
+
+async function collect(iter) {
+  const out = [];
+  for await (const line of iter) out.push(line);
+  return out;
+}
+
+describe('readIndexLines: behavior', () => {
+  let dir, storage;
+  before(async () => {
+    dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ccxray-idxlines-'));
+    storage = createLocalStorage(dir);
+    await storage.init();
+  });
+  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('missing index → empty iteration', async () => {
+    assert.deepEqual(await collect(storage.readIndexLines()), []);
+  });
+
+  it('yields non-blank lines in file order, skipping blanks', async () => {
+    fs.writeFileSync(path.join(dir, 'index.ndjson'), 'a\n\nb\n\n\nc\n');
+    assert.deepEqual(await collect(storage.readIndexLines()), ['a', 'b', 'c']);
+  });
+
+  it('handles a final line with no trailing newline', async () => {
+    fs.writeFileSync(path.join(dir, 'index.ndjson'), 'x\ny\nz');
+    assert.deepEqual(await collect(storage.readIndexLines()), ['x', 'y', 'z']);
+  });
+});
+
+describe('readIndexLines: > 512MB (fail-on-old)', () => {
+  let dir, storage, indexPath, wrote = false, totalLines = 0;
+
+  before(async () => {
+    dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ccxray-idxbig-'));
+    storage = createLocalStorage(dir);
+    await storage.init();
+    indexPath = path.join(dir, 'index.ndjson');
+
+    // Build a ~4MB chunk of valid NDJSON, write it enough times to pass the
+    // single-string limit by ~8MB. Padded lines keep the line count modest.
+    let chunk = '', chunkLines = 0;
+    for (let i = 0; i < 4000; i++) {
+      chunk += JSON.stringify({
+        id: `2020-01-01T00-00-00-${String(i).padStart(6, '0')}`,
+        sessionId: 'sBIG', pad: 'x'.repeat(900),
+      }) + '\n';
+      chunkLines++;
+    }
+    const chunkBytes = Buffer.byteLength(chunk);
+    const repeats = Math.ceil((STRING_LIMIT + 8 * 1024 * 1024) / chunkBytes);
+    totalLines = chunkLines * repeats;
+
+    try {
+      const ws = fs.createWriteStream(indexPath);
+      await new Promise((resolve, reject) => {
+        ws.on('error', reject);
+        let r = 0;
+        (function pump() {
+          while (r < repeats) {
+            const ok = ws.write(chunk);
+            r++;
+            if (!ok) { ws.once('drain', pump); return; }
+          }
+          ws.end(resolve);
+        })();
+      });
+      wrote = fs.statSync(indexPath).size > STRING_LIMIT;
+    } catch {
+      wrote = false; // constrained env (ENOSPC / EFBIG) → tests skip
+    }
+  });
+
+  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('readIndex() throws ERR_STRING_TOO_LONG (the pre-fix failure)', async (t) => {
+    if (!wrote) return t.skip('could not create a >512MB index in this environment');
+    // readFileSync throws code ERR_STRING_TOO_LONG ("Cannot create a string
+    // longer than…"); async readFile throws a bare V8 RangeError ("Invalid
+    // string length") with no .code. Either proves the single-string read fails.
+    await assert.rejects(
+      () => storage.readIndex(),
+      (err) => /ERR_STRING_TOO_LONG|string longer than|invalid string length/i.test(`${err.code || ''} ${err.message || ''}`),
+      'reading a >512MB index into one string must throw',
+    );
+  });
+
+  it('readIndexLines() streams every line past the 512MB ceiling', async (t) => {
+    if (!wrote) return t.skip('could not create a >512MB index in this environment');
+    let count = 0;
+    for await (const line of storage.readIndexLines()) {
+      if (line) count++;
+    }
+    assert.equal(count, totalLines, 'streaming reads all lines regardless of total size');
+  });
+});

--- a/test/prune-index-sync.test.js
+++ b/test/prune-index-sync.test.js
@@ -178,10 +178,41 @@ describe('pruneLogs: index + sessions.json sync (#344)', () => {
     writeFiles(recentId);
     writeIndex([{ id: recentId, sessionId: 'sOnly' }]);
     const before = fs.readFileSync(path.join(tmpDir, 'index.ndjson'), 'utf8');
+    const mtimeBefore = fs.statSync(path.join(tmpDir, 'index.ndjson')).mtimeMs;
 
     await pruneLogs();
 
     const afterRaw = fs.readFileSync(path.join(tmpDir, 'index.ndjson'), 'utf8');
     assert.equal(afterRaw, before, 'no ghost → index unchanged');
+    assert.equal(fs.statSync(path.join(tmpDir, 'index.ndjson')).mtimeMs, mtimeBefore,
+      'no rewrite → mtime unchanged (avoids spurious session-index staleness rebuild)');
+  });
+
+  it('streams a many-line index through pipeline: drops ghosts, keeps imported filler', async () => {
+    // Enough lines to exercise write backpressure (default highWaterMark 16KB)
+    // and the 3-pass streaming path, without approaching the 512MB ceiling.
+    const N = 20000;
+    const lines = [];
+    for (let i = 0; i < N; i++) {
+      lines.push({ id: `2020-02-01T00-00-00-${String(i).padStart(6, '0')}`, sessionId: 'sFill', imported: true, pad: 'x'.repeat(80) });
+    }
+    // Interleave a handful of old proxy GHOST lines (no _req.json) that must drop.
+    const ghosts = [];
+    for (let i = 0; i < 5; i++) {
+      const gid = `2020-01-05T00-00-00-${String(i).padStart(6, '0')}`;
+      ghosts.push(gid);
+      lines.splice(i * 3000, 0, { id: gid, sessionId: 'sGhost' });
+    }
+    writeIndex(lines);
+
+    await pruneLogs();
+
+    const kept = new Set(readIndexIds());
+    for (const g of ghosts) assert.ok(!kept.has(g), `ghost ${g} dropped`);
+    // All imported filler survives (standalone imported, no proxy twin).
+    assert.equal(kept.size, N, `all ${N} imported filler lines retained`);
+    // Result is still stream-readable and parseable.
+    const raw = fs.readFileSync(path.join(tmpDir, 'index.ndjson'), 'utf8');
+    for (const line of raw.split('\n').filter(Boolean)) JSON.parse(line);
   });
 });

--- a/test/prune-index-sync.test.js
+++ b/test/prune-index-sync.test.js
@@ -1,0 +1,187 @@
+'use strict';
+
+// #344: pruneLogs must sync index.ndjson + sessions.json with the _req/_res
+// files it prunes, so a session card never survives without loadable turn data.
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const config = require('../server/config');
+const store = require('../server/store');
+const { createLocalStorage } = require('../server/storage/local');
+const { pruneLogs, pruneIndexLines } = require('../server/restore');
+
+// ── Pure decision function ──────────────────────────────────────────
+describe('pruneIndexLines (pure)', () => {
+  const L = (o) => JSON.stringify(o);
+
+  it('drops a proxy line whose _req.json is gone; keeps one whose file survives', () => {
+    const content = [
+      L({ id: 'a', sessionId: 's1' }),          // file gone → drop
+      L({ id: 'b', sessionId: 's1' }),          // file survives → keep
+    ].join('\n');
+    const { keptLines, dropped } = pruneIndexLines(content, {
+      survivingReqIds: new Set(['b']),
+      protectedIds: new Set(),
+    });
+    assert.equal(dropped, 1);
+    assert.deepEqual(keptLines.map(l => JSON.parse(l).id), ['b']);
+  });
+
+  it('keeps a protected (starred / in-memory) proxy line even with no file', () => {
+    const content = L({ id: 'a', sessionId: 's1' });
+    const { keptLines, dropped } = pruneIndexLines(content, {
+      survivingReqIds: new Set(),
+      protectedIds: new Set(['a']),
+    });
+    assert.equal(dropped, 0);
+    assert.equal(keptLines.length, 1);
+  });
+
+  it('keeps a standalone imported line (no files by design)', () => {
+    const content = L({ id: 'i1', sessionId: 's1', imported: true, responseId: 'msg_solo' });
+    const { keptLines, dropped } = pruneIndexLines(content, {
+      survivingReqIds: new Set(),
+      protectedIds: new Set(),
+    });
+    assert.equal(dropped, 0);
+    assert.equal(keptLines.length, 1);
+  });
+
+  it('drops an imported line orphaned by a pruned proxy twin (shared responseId, no survivor)', () => {
+    const content = [
+      L({ id: 'p1', sessionId: 's1', responseId: 'msg_x' }),               // proxy, file gone
+      L({ id: 'i1', sessionId: 's1', imported: true, responseId: 'msg_x' }), // imported dup
+    ].join('\n');
+    const { keptLines, dropped } = pruneIndexLines(content, {
+      survivingReqIds: new Set(),      // p1 file gone
+      protectedIds: new Set(),
+    });
+    assert.equal(dropped, 2, 'both the pruned proxy AND its orphaned imported twin drop');
+    assert.equal(keptLines.length, 0);
+  });
+
+  it('keeps an imported dup when a proxy copy of the same responseId survives', () => {
+    const content = [
+      L({ id: 'p1', sessionId: 's1', responseId: 'msg_y' }),               // proxy, file survives
+      L({ id: 'i1', sessionId: 's1', imported: true, responseId: 'msg_y' }), // imported dup
+    ].join('\n');
+    const { keptLines, dropped } = pruneIndexLines(content, {
+      survivingReqIds: new Set(['p1']),
+      protectedIds: new Set(),
+    });
+    assert.equal(dropped, 0);
+    assert.deepEqual(keptLines.map(l => JSON.parse(l).id).sort(), ['i1', 'p1']);
+  });
+
+  it('keeps unparseable / id-less lines verbatim', () => {
+    const content = ['not json', L({ noId: true })].join('\n');
+    const { keptLines, dropped } = pruneIndexLines(content, {
+      survivingReqIds: new Set(),
+      protectedIds: new Set(),
+    });
+    assert.equal(dropped, 0);
+    assert.equal(keptLines.length, 2);
+  });
+});
+
+// ── Integration: pruneLogs end-to-end ───────────────────────────────
+describe('pruneLogs: index + sessions.json sync (#344)', () => {
+  const tmpDir = path.join(os.tmpdir(), 'ccxray-prune-idx-' + process.pid);
+  let storage, origStorage, origRetention, origLogsDir;
+
+  before(async () => {
+    storage = createLocalStorage(tmpDir);
+    await storage.init();
+    origStorage = config.storage;
+    origRetention = config.LOG_RETENTION_DAYS;
+    origLogsDir = config.LOGS_DIR;
+    config.storage = storage;
+    config.LOG_RETENTION_DAYS = 14;
+    Object.defineProperty(config, 'LOGS_DIR', { value: tmpDir, writable: true, configurable: true });
+  });
+
+  after(() => {
+    config.storage = origStorage;
+    config.LOG_RETENTION_DAYS = origRetention;
+    Object.defineProperty(config, 'LOGS_DIR', { value: origLogsDir, writable: true, configurable: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.mkdirSync(path.join(tmpDir, 'shared'), { recursive: true });
+    store.entries.length = 0;
+  });
+
+  const OLD = '2020-01-01';                                     // < cutoff → prunable
+  const recentId = new Date().toISOString().slice(0, 10) + 'T10-00-00-000';
+
+  function writeFiles(id) {
+    fs.writeFileSync(path.join(tmpDir, `${id}_req.json`), '{"messages":[]}');
+    fs.writeFileSync(path.join(tmpDir, `${id}_res.json`), '[]');
+  }
+  function writeIndex(lines) {
+    fs.writeFileSync(path.join(tmpDir, 'index.ndjson'), lines.map(JSON.stringify).join('\n') + '\n');
+  }
+  function readIndexIds() {
+    const raw = fs.readFileSync(path.join(tmpDir, 'index.ndjson'), 'utf8');
+    return raw.split('\n').filter(Boolean).map(l => JSON.parse(l).id).sort();
+  }
+
+  it('drops ghost proxy lines + orphaned imported twin; keeps loadable + standalone imported', async () => {
+    const ghostNoFile   = `${OLD}T00-00-00-001`;  // proxy, index line only (pre-existing ghost)
+    const oldWithFile   = `${OLD}T00-00-00-002`;  // proxy, old files → pruned this run
+    const importedSolo  = `${OLD}T00-00-00-003`;  // imported standalone → keep
+    const importedOrphan = `${OLD}T00-00-00-004`; // imported dup of a pruned proxy → drop
+    const oldTwinProxy  = `${OLD}T00-00-00-005`;  // proxy twin of importedOrphan → pruned
+    const importedLive  = `${OLD}T00-00-00-006`;  // imported dup of a SURVIVING proxy → keep
+    const recentProxy   = recentId;               // proxy, recent files → keep
+
+    writeFiles(oldWithFile);
+    writeFiles(oldTwinProxy);
+    writeFiles(recentProxy);
+
+    writeIndex([
+      { id: ghostNoFile, sessionId: 'sA' },
+      { id: oldWithFile, sessionId: 'sA' },
+      { id: importedSolo, sessionId: 'sB', imported: true, responseId: 'msg_solo' },
+      { id: importedOrphan, sessionId: 'sB', imported: true, responseId: 'msg_x' },
+      { id: oldTwinProxy, sessionId: 'sA', responseId: 'msg_x' },
+      { id: importedLive, sessionId: 'sC', imported: true, responseId: 'msg_y' },
+      { id: recentProxy, sessionId: 'sC', responseId: 'msg_y', cost: { cost: 1.0 } },
+    ]);
+
+    await pruneLogs();
+
+    const ids = readIndexIds();
+    assert.deepEqual(ids, [importedSolo, importedLive, recentProxy].sort(),
+      'only loadable proxy lines + standalone/live-backed imported lines survive');
+
+    // Files: old with-file proxies deleted, recent kept.
+    const files = fs.readdirSync(tmpDir);
+    assert.ok(!files.includes(`${oldWithFile}_req.json`), 'old proxy _req.json pruned');
+    assert.ok(!files.includes(`${oldTwinProxy}_req.json`), 'old twin proxy _req.json pruned');
+    assert.ok(files.includes(`${recentProxy}_req.json`), 'recent proxy _req.json kept');
+
+    // sessions.json rebuilt from the pruned index — session sA (all lines gone)
+    // must be absent; sC (recentProxy) present.
+    const sraw = fs.readFileSync(path.join(tmpDir, 'sessions.json'), 'utf8');
+    const sids = sraw.split('\n').filter(Boolean).map(l => JSON.parse(l).sid).sort();
+    assert.deepEqual(sids, ['sB', 'sC'], 'sA (fully pruned) removed from sessions.json; sB/sC remain');
+  });
+
+  it('leaves index.ndjson untouched when nothing is dropped', async () => {
+    writeFiles(recentId);
+    writeIndex([{ id: recentId, sessionId: 'sOnly' }]);
+    const before = fs.readFileSync(path.join(tmpDir, 'index.ndjson'), 'utf8');
+
+    await pruneLogs();
+
+    const afterRaw = fs.readFileSync(path.join(tmpDir, 'index.ndjson'), 'utf8');
+    assert.equal(afterRaw, before, 'no ghost → index unchanged');
+  });
+});

--- a/test/rebuild-index.test.js
+++ b/test/rebuild-index.test.js
@@ -93,6 +93,52 @@ describe('rebuild-index', () => {
     assert.ok(!('responseId' in lines.find(l => l.id === idC)), 'openai line exempt');
   });
 
+  it('#342: add-only backfills identity onto legacy lines whose _req is reconstructable', async () => {
+    writeShared();
+    const { getParser } = require('../server/wire-parsers');
+    const computeConvId = getParser('anthropic').computeConvId;
+
+    // Legacy line: no convId/msgCount/isSubagent keys, _req.json survives.
+    const idL = '2026-07-02T10-00-00-000';
+    const reqBody = {
+      model: 'claude-opus-4-7', max_tokens: 100, sysHash: SYS_HASH,
+      messages: [{ role: 'user', content: 'legacy hello' }, { role: 'assistant', content: 'hi' }],
+      metadata: { session_id: 'S1' },
+    };
+    writeReq(idL, reqBody);
+    writeIndexLine({ id: idL, ts: '10:00:00', sessionId: 'S1', sessionInferred: false, provider: 'anthropic', model: 'claude-opus-4-7', isSSE: true, status: 200 });
+
+    // Legacy line whose _req was pruned → unreconstructable → untouched.
+    const idPruned = '2026-07-02T11-00-00-000';
+    writeIndexLine({ id: idPruned, ts: '11:00:00', sessionId: 'S1', provider: 'anthropic', model: 'claude-opus-4-7' });
+
+    // Already-populated line (convId present) → gate skips it, left verbatim.
+    const idHave = '2026-07-02T12-00-00-000';
+    writeReq(idHave, { ...reqBody, messages: [{ role: 'user', content: 'other' }] });
+    writeIndexLine({ id: idHave, ts: '12:00:00', sessionId: 'S1', provider: 'anthropic', model: 'claude-opus-4-7', convId: 'deadbeef', msgCount: 99 });
+
+    // OpenAI legacy line → exempt.
+    const idO = '2026-07-02T13-00-00-000';
+    writeIndexLine({ id: idO, ts: '13:00:00', sessionId: 'S1', provider: 'openai', model: 'gpt-5' });
+
+    const res = await rebuildIndex({ apply: true, storage, log });
+    assert.equal(res.enrichedIdentity, 1, 'exactly the reconstructable legacy line is identity-enriched');
+
+    const lines = readIndexIds();
+    const L = lines.find(l => l.id === idL);
+    assert.equal(L.convId, computeConvId(reqBody), 'convId matches the live computeConvId of the same body');
+    assert.equal(L.msgCount, 2, 'msgCount backfilled from reconstructed messages');
+    assert.equal(typeof L.isSubagent, 'boolean', 'isSubagent backfilled');
+
+    const P = lines.find(l => l.id === idPruned);
+    assert.ok(!('convId' in P), 'pruned-_req line untouched');
+    const H = lines.find(l => l.id === idHave);
+    assert.equal(H.convId, 'deadbeef', 'already-populated convId not overwritten');
+    assert.equal(H.msgCount, 99, 'already-populated msgCount not overwritten');
+    const O = lines.find(l => l.id === idO);
+    assert.ok(!('convId' in O), 'openai line exempt');
+  });
+
   it('tsFromId / nearestPrecedingSession pure helpers', () => {
     assert.equal(tsFromId('2026-05-01T11-47-17-808'), '11:47:17');
     const tl = [{ id: 'a', sid: 'S1' }, { id: 'm', sid: 'S2' }];

--- a/test/seq-interleave-rendering.test.js
+++ b/test/seq-interleave-rendering.test.js
@@ -49,6 +49,7 @@ function loadDashboardContext() {
     function clearInterval() {}
     window.ccxraySettings = { visibleProviders: [] };
     function fetch() { return Promise.resolve({ ok: false, json() { return Promise.resolve({}); } }); }
+    function _apiQ(u) { return u; } // settings.js helper; stub so addEntry's async prefetch/pill fetches don't ReferenceError post-test
   `, context);
   for (const f of ['format.js', 'session-label.js', 'workflow-timeline.js', 'miller-columns.js', 'entry-rendering.js']) {
     vm.runInContext(fs.readFileSync(path.join(publicDir, f), 'utf8'), context);

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -6,6 +6,49 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { createLocalStorage } = require('../server/storage/local');
+const { createStorage } = require('../server/storage');
+
+// #344: the write-tracking wrapper serializes appendIndex against an exclusive
+// index rewrite (pruneLogs), so a concurrent append can't be dropped by the
+// rewrite's rename.
+describe('storage exclusive index lock (#344)', () => {
+  const tmpDir = path.join(os.tmpdir(), 'ccxray-lock-' + process.pid);
+  let storage, origHome;
+
+  before(async () => {
+    origHome = process.env.CCXRAY_HOME;
+    process.env.CCXRAY_HOME = tmpDir;
+    storage = createStorage();
+    await storage.init();
+  });
+  after(() => {
+    if (origHome === undefined) delete process.env.CCXRAY_HOME; else process.env.CCXRAY_HOME = origHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('appendIndex dispatched while exclusive is held completes only after release', async () => {
+    const order = [];
+    const release = storage.beginExclusive();
+    const appendDone = storage.appendIndex('LOCKED\n').then(() => order.push('append'));
+    await new Promise(r => setTimeout(r, 30));
+    order.push('still-held'); // the append must not have run yet
+    release();
+    await appendDone;
+    assert.deepEqual(order, ['still-held', 'append'], 'append is parked until release');
+  });
+
+  it('drain() does not wait on appends parked behind the exclusive gate (no deadlock)', async () => {
+    const release = storage.beginExclusive();
+    let done = false;
+    const parked = storage.appendIndex('PARKED\n').then(() => { done = true; });
+    // drain must resolve even though a parked append is outstanding.
+    await storage.drain();
+    assert.equal(done, false, 'parked append has not run; drain returned anyway');
+    release();
+    await parked;
+    assert.equal(done, true);
+  });
+});
 
 describe('storage/local', () => {
   const tmpDir = path.join(os.tmpdir(), 'ccxray-test-' + Date.now());

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -150,6 +150,29 @@ describe('workflow-timeline data layer', () => {
     assert.equal(ctx.wfState.lanes[1].name, 'agent-explore');
   });
 
+  it('#342: wfCtxPctRender uses the lane window for imported turns lacking maxContext', () => {
+    const ctx = loadWfModule();
+    // Main lane: a 1M proxy turn + an imported turn with NO maxContext (importer
+    // never sets one). Both used 500K tokens.
+    const proxy = { id: 'p1', maxContext: 1000000, ctxUsed: 500000 };
+    const imported = { id: 'i1', ctxUsed: 500000 }; // imported: maxContext absent
+    ctx.wfState = { lanes: [{ key: 'main', name: 'main', turns: [proxy, imported] }] };
+
+    // Proxy turn: divided by its own 1M window → 50%.
+    assert.equal(Math.round(ctx.wfCtxPctRender(proxy)), 50);
+    // Imported turn: inherits the lane's 1M window → 50% (NOT 100% capped from
+    // the 200K default). This is the sawtooth fix.
+    assert.equal(Math.round(ctx.wfCtxPctRender(imported)), 50);
+
+    // Classification stays on the plain wfCtxPct 200K default (unchanged), so
+    // lane-inference decisions never shift with the render fallback.
+    assert.equal(Math.round(ctx.wfCtxPct(imported)), 100); // 500K/200K → capped 100
+
+    // A purely-imported lane (no proxy window signal) falls back to 200K.
+    ctx.wfState = { lanes: [{ key: 'main', name: 'main', turns: [{ id: 'x1', ctxUsed: 100000 }] }] };
+    assert.equal(Math.round(ctx.wfCtxPctRender({ id: 'x1', ctxUsed: 100000 })), 50); // 100K/200K
+  });
+
   it('convId splits parallel same-agent instances into separate lanes (#117)', () => {
     const ctx = loadWfModule();
     var entries = [

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -150,27 +150,37 @@ describe('workflow-timeline data layer', () => {
     assert.equal(ctx.wfState.lanes[1].name, 'agent-explore');
   });
 
-  it('#342: wfCtxPctRender uses the lane window for imported turns lacking maxContext', () => {
+  it('#342: wfCtxPctRender rescopes a turn to the lane window when the lane window exceeds its own maxContext', () => {
     const ctx = loadWfModule();
-    // Main lane: a 1M proxy turn + an imported turn with NO maxContext (importer
-    // never sets one). Both used 500K tokens.
-    const proxy = { id: 'p1', maxContext: 1000000, ctxUsed: 500000 };
-    const imported = { id: 'i1', ctxUsed: 500000 }; // imported: maxContext absent
-    ctx.wfState = { lanes: [{ key: 'main', name: 'main', turns: [proxy, imported] }] };
 
-    // Proxy turn: divided by its own 1M window → 50%.
-    assert.equal(Math.round(ctx.wfCtxPctRender(proxy)), 50);
-    // Imported turn: inherits the lane's 1M window → 50% (NOT 100% capped from
-    // the 200K default). This is the sawtooth fix.
-    assert.equal(Math.round(ctx.wfCtxPctRender(imported)), 50);
+    // REAL PATH (the case the shipped fix missed): since #303 cold-load,
+    // server normalizeIndexEntry/inferMaxContext gives a turn whose usage stayed
+    // ≤200K the 200K base window — NOT an absent maxContext. A high-usage proxy
+    // turn in the same session carries the stored 1M. Both used ~199K tokens.
+    // OLD code (rescope only when `!maxContext`) left the 200K turn at 199K/200K
+    // ≈ 100% next to the proxy's 199K/1M ≈ 20% — the sawtooth. The 200K turn must
+    // rescope to the lane's 1M window because 1M > its own inferred 200K.
+    const proxy = { id: 'p1', maxContext: 1000000, ctxUsed: 199000 };
+    const inferred200k = { id: 'i1', maxContext: 200000, ctxUsed: 199000 };
+    ctx.wfState = { lanes: [{ key: 'main', name: 'main', turns: [proxy, inferred200k] }] };
 
-    // Classification stays on the plain wfCtxPct 200K default (unchanged), so
-    // lane-inference decisions never shift with the render fallback.
-    assert.equal(Math.round(ctx.wfCtxPct(imported)), 100); // 500K/200K → capped 100
+    assert.equal(Math.round(ctx.wfCtxPctRender(proxy)), 20);       // 199K/1M
+    // FAIL-ON-OLD: old `!win` gate → 199K/200K ≈ 100%; new `laneWin>win` → 199K/1M ≈ 20%.
+    assert.equal(Math.round(ctx.wfCtxPctRender(inferred200k)), 20);
 
-    // A purely-imported lane (no proxy window signal) falls back to 200K.
-    ctx.wfState = { lanes: [{ key: 'main', name: 'main', turns: [{ id: 'x1', ctxUsed: 100000 }] }] };
-    assert.equal(Math.round(ctx.wfCtxPctRender({ id: 'x1', ctxUsed: 100000 })), 50); // 100K/200K
+    // Classification stays on the plain wfCtxPct raw per-turn value (unchanged),
+    // so lane-inference decisions never shift with the render rescope.
+    assert.equal(Math.round(ctx.wfCtxPct(inferred200k)), 100);     // 199K/200K → capped 100
+
+    // Legacy path still covered: a turn with maxContext ABSENT also inherits the
+    // lane's 1M window (laneWin > 0).
+    const importedAbsent = { id: 'i2', ctxUsed: 500000 };
+    ctx.wfState = { lanes: [{ key: 'main', name: 'main', turns: [{ id: 'p2', maxContext: 1000000, ctxUsed: 500000 }, importedAbsent] }] };
+    assert.equal(Math.round(ctx.wfCtxPctRender(importedAbsent)), 50); // 500K/1M
+
+    // A lane whose turns are all ≤200K keeps 200K (no wider signal to rescope to).
+    ctx.wfState = { lanes: [{ key: 'main', name: 'main', turns: [{ id: 'x1', maxContext: 200000, ctxUsed: 100000 }] }] };
+    assert.equal(Math.round(ctx.wfCtxPctRender({ id: 'x1', maxContext: 200000, ctxUsed: 100000 })), 50); // 100K/200K
   });
 
   it('convId splits parallel same-agent instances into separate lanes (#117)', () => {


### PR DESCRIPTION
## 摘要（繁中）

真實 `~/.ccxray/logs/index.ndjson` 已達 **544 MB（> Node 單字串上限 512 MiB）**，這條分支修好三個環環相扣的 index 生命週期問題，並全部以 **browser-harness + 真實資料 e2e** 驗證：

- **#347（產品當機根因）**：所有 `readIndex()` 一次讀成單字串的消費者在 > 512 MiB 會丟 `Invalid string length` → restore / cold-load / import / rebuild / `usage` 全掛。改為串流讀取。
- **#344（ghost 卡片）**：`pruneLogs` 只刪 `_req/_res` 檔卻留下 index line → sidebar 有卡片但「turn data could not be loaded」。改為同步清 index line + 重建 sessions.json。
- **#342（context% 鋸齒）**：swimlane / turn-list 的 context% 相鄰 turn 在 20%↔100% 亂跳。**e2e 過程推翻了已提交的修法**——原本的 `wfCtxPctRender`（僅在 maxContext falsy 時 rescope）在真實 cold-load 路徑完全無效，因為 `inferMaxContext` 早已為每筆 entry 補上 maxContext（短 turn 200K、長 turn 1M）。真因是「同 session 相鄰 turn 分母 200K vs 1M」，已改為「lane 視窗 > 該 turn 視窗時 rescope」並在真實資料驗證 sawtooth 92→4。

> 每個修復都用真實資料 e2e 驗過（不是只有 unit test）——這正是抓到 #342 舊修法無效的原因。

Closes #347
Closes #344
Addresses #342 (swimlane ctx% only — see update below)

> ⚠️ Scope note: issue **#345** (a separate CI proxy e2e timeout) is unrelated and intentionally left open by this PR.

> **Update (post-codex二審):** the #342 fix in this PR is **swimlane-only** (`workflow-timeline.js wfCtxPctRender`, codex-cleared). The turn-list/session-card session-window consensus (originally in `entry-rendering.js`) was **reverted** — codex found 3 blockers from a stale stored `sess.maxWindow` (retro-flip doesn't retract; severity not recomputed on consensus grow; `entry_update` doesn't refresh it). Correct fix = render-time consensus (not a stored field) → tracked in **#350 Phase B**. So #342 is **Addressed, not Closed** (turn-list/card sawtooth remains, #342 stays open). Also includes one unrelated pre-existing CI-red test-harness fix (`_apiQ` stub in the vm harness) — see the `test:` commit.

---

## What & why (English detail)

### #347 — streaming index reads (the product-breaking root cause)
The real index is **544,962,993 bytes ≈ 519.7 MiB**, past Node's `String::kMaxLength` (536,870,888 B). Every `readFile(index, 'utf8')` consumer throws `Invalid string length`, breaking restore, cold-load, importer, `rebuild-index`, and `ccxray usage`. Replaced whole-string reads with a `storage.readIndexLines()` async iterator across restore, cold-load (`routes/api.js`), importer, `rebuild-index`, and `usage`.

### #344 — ghost prune (index/file lifecycle sync)
`pruneLogs` deleted `_req/_res` files but left their index lines, so the sidebar showed cards whose turns "could not be loaded". Now a streaming 3-pass prune drops index lines whose `_req.json` is gone (imported lines and protected/in-memory ids are kept), rebuilds `sessions.json` from survivors, under a storage-level exclusive lock so a concurrent `appendIndex` can't interleave with the rewrite.

### #342 — context% sawtooth (root cause corrected during e2e)
Issue #342's literal ask (backfill `convId`/`coreHash`/`agentKey` onto legacy lines from `_req/_res`) is delivered by the `rebuild-index` Phase-6b backfill (add-only, never degrades). But the **user-visible symptom** — the sawtooth — has a different root cause than the issue hypothesized, uncovered by real-data e2e:

- Since #303 (cold-load), `normalizeIndexEntry` fills `maxContext` for **every** served entry via `config.inferMaxContext`, which returns **200000** for a turn whose usage stayed ≤200K and the stored **1000000** for one that exceeded it.
- So two adjacent main turns with the *same* ~199K `ctxUsed` render **100% (÷200K) next to 20% (÷1M)** — the sawtooth. It is **not** (only) lane misplacement.
- The previously-committed fix rescoped a turn only when `!maxContext` (falsy). On the real path maxContext is `200000` (truthy), so it **never fired** — verified inert: running the shipped client code on 4b15c248's 291 real main-lane turns, `wfCtxPctRender` == `wfCtxPct` for every turn (0 changed).

**Fix:** rescope to the lane's context window whenever it **exceeds** the turn's own (`laneWin > win`), covering both the truthy-200K and legacy-absent cases; same treatment for the turn-list/session-card via a per-session window consensus. **Classification is untouched** — lane placement (`wfInferLanes`→`wfCtxPct`) and `isCompacted` still read the raw per-turn `maxContext`, per the ADR 0005/0008/0009 invariant. (Design input from Fable 5: render-only fix, not a `maxContext` mutation that would overload one field for both render and classification.)

---

## Real-data e2e verification (browser-harness, real index)

| Issue | Result | Evidence |
|---|---|---|
| #347 | ✅ | Server restored **40,492 entries + stream-pruned the 544 MB index in 3.5s, zero `Invalid string length`**. Old `readFile utf8` throws at `restore:index`. |
| #344 | ✅ | Startup prune removed **133,873** orphaned index lines + rebuilt `sessions.json` in sync (at scale). Controlled subset: delete a session's bodies → restart → **"Pruned 13 orphaned index line(s); session index rebuilt (0 sessions)"**, card gone, cold-load returns 0 — no ghost. |
| #342 | ✅ | Real 4b15c248, 291 main turns, real cold-load + shipped client code: effective windows `{200000:44, 1000000:283}` → `{1000000:291}`; adjacent >15pt sawtooth jumps **92 → 4** (residual 4 = legit compaction/rewind); max jump 79.9 → 44.8. Test rewritten to the **real path** (maxContext=200000 truthy) — **fail-on-old confirmed**. |

Full suite: **1451 pass / 2 fail**; the 2 (`image-xss`, `seq-interleave-rendering`) fail identically on the base commit — pre-existing, browser/env-dependent, not introduced here.

---

## Codex review (4 rounds) — outcomes

Addressed: `writeLinesToFile` resolve-on-close; **storage exclusive index lock** (`beginExclusive → drain → rewrite → release`, closing the `pruneLogs` vs live `appendIndex` race that a pure CAS can't because `appendFile` runs in the libuv threadpool); `readIndexLines` fd-leak + ENOENT; prune replay-titles / empty-session unlink / `survivingReqIds` re-list-with-abort; #342a strict `=== undefined` add-only + fresh per-line cache; temp-file mode 0600; whitespace-index guard; `appendIndex` fast-path kept for the no-lock case.

**Two residuals — owner-accepted (not fixed), with reasons:**
1. **Cross-process prune/append race** — the in-process lock serialises one hub process only; two ccxray sharing one `~/.ccxray` (the #333 chained-proxy case) are out of scope by ADR 0012, share the same race profile as the existing file-delete pass, and any dropped line's `_req/_res` remain on disk → recoverable via `ccxray rebuild-index`.
2. **#342a per-line fresh reconstruction cache is O(N²) only for delta chains** — but identity-missing lines predate delta storage (all full-format anchors), so `reconstructReq` returns without recursion → effectively O(N) on a bounded, one-time offline command.

---

## Follow-ups (not in scope here)
- `entry-rendering.js` compaction heuristic keeps raw `prev.maxContext` by design (classification input) — intentionally not rescoped.
- Layer-B write-amplification (relay header / `skipEntry`) for chained proxies — ADR 0012 optional optimization, still deferred.
- If a genuine **non-render** consumer ever needs a coherent session window, add it as an **additive** server field (e.g. `sessionWindow`) rather than mutating `maxContext` (Fable 5's B-as-additive path); until then the client lane/session consensus is sufficient.
- `scripts/*.js` (migrate-to-delta / cleanup-count-tokens / extract-fixture / perf-measure) still use single-string index readers — dev-only, not the product path.
- #348 (`parsed[]` resident-memory) remains a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
