### PR TITLE
fix: sanitize session title — strip injected XML tags

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -825,7 +825,7 @@ function mergeColdSessions(sessions) {
       id: s.sid, firstTs: null, firstId: s.firstId || '', lastId: s.lastId || '',
       count: s.count || 0, mainCount: s.count || 0, subCount: 0, retryCount: 0,
       model: s.model || '?', totalCost: s.totalCost || 0, cwd: s.cwd || null,
-      title: s.title || null, titleReqTs: 0, lastAssistantText: null,
+      title: s.title || null, firstPrompt: s.firstPrompt || null, titleReqTs: 0, lastAssistantText: null,
       agent: s.agent || 'claude', provider: s.provider || 'anthropic',
       latestCacheHitRatio: 0, latestCacheReadTokens: 0,
       resumeCommand: null, parentSessionId: null,
@@ -963,6 +963,7 @@ evtSource.onmessage = (ev) => {
       if (sess && data.title && nextTs >= (sess.titleReqTs || 0)) {
         sess.title = data.title;
         sess.titleReqTs = nextTs;
+        if (data.firstPrompt && !sess.firstPrompt) sess.firstPrompt = data.firstPrompt;
         const sessEl = document.getElementById('sess-' + sid.slice(0, 8));
         if (sessEl) sessEl.innerHTML = renderSessionItem(sess, sid, sessEl);
         if (typeof renderBreadcrumb === 'function') renderBreadcrumb();

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -423,6 +423,7 @@ function addEntry(e) {
     sess.cwd = entryCwd;
   }
   if (model && model !== '?') sess.model = model;
+  if (e.firstPrompt && !sess.firstPrompt) sess.firstPrompt = e.firstPrompt;
   sess.lastId = entryId;
   if (e.receivedAt) sess.lastReceivedAt = Number(e.receivedAt);
   // Prefer the server-detected agent identity (from system-prompt content,

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -819,6 +819,7 @@ function mergeColdSessions(sessions) {
     if (sessionsMap.has(s.sid)) {
       var existing = sessionsMap.get(s.sid);
       if (!existing.title && s.title) existing.title = s.title;
+      if (!existing.firstPrompt && s.firstPrompt) existing.firstPrompt = s.firstPrompt;
       continue;
     }
     sessionsMap.set(s.sid, {
@@ -959,14 +960,23 @@ evtSource.onmessage = (ev) => {
     } else if (data._type === 'session_title_update') {
       const sid = data.sessionId;
       const sess = sessionsMap.get(sid);
-      const nextTs = data.titleReqTs || 0;
-      if (sess && data.title && nextTs >= (sess.titleReqTs || 0)) {
-        sess.title = data.title;
-        sess.titleReqTs = nextTs;
-        if (data.firstPrompt && !sess.firstPrompt) sess.firstPrompt = data.firstPrompt;
-        const sessEl = document.getElementById('sess-' + sid.slice(0, 8));
-        if (sessEl) sessEl.innerHTML = renderSessionItem(sess, sid, sessEl);
-        if (typeof renderBreadcrumb === 'function') renderBreadcrumb();
+      if (sess) {
+        const nextTs = data.titleReqTs || 0;
+        let changed = false;
+        if (data.title && nextTs >= (sess.titleReqTs || 0)) {
+          sess.title = data.title;
+          sess.titleReqTs = nextTs;
+          changed = true;
+        }
+        if (data.firstPrompt && !sess.firstPrompt) {
+          sess.firstPrompt = data.firstPrompt;
+          changed = true;
+        }
+        if (changed) {
+          const sessEl = document.getElementById('sess-' + sid.slice(0, 8));
+          if (sessEl) sessEl.innerHTML = renderSessionItem(sess, sid, sessEl);
+          if (typeof renderBreadcrumb === 'function') renderBreadcrumb();
+        }
       }
     } else if (data._type === 'entry_update') {
       _patchEntryInPlace(data);

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1515,8 +1515,9 @@ function renderSessionItem(sess, sid, sessEl) {
   const sdotDataSid = isOnline ? ' data-sid="' + escapeHtml(sid) + '"' : '';
   const heldHtml = isHeld ? '<span class="held-badge" onclick="event.stopPropagation();showInterceptOverlay()">HELD</span>' : '';
   const pinBtn = renderStarBadge('session', sid);
-  const titleRow = sess.title
-    ? '<div class="si-title">' + escapeHtml(sess.title) + '</div>'
+  const displayTitle = sess.title || sess.firstPrompt || null;
+  const titleRow = displayTitle
+    ? '<div class="si-title">' + escapeHtml(displayTitle.slice(0, 100)) + '</div>'
     : '';
   // Resume command is computed server-side; null means this session can't be
   // resumed (e.g. a codex session that only errored before any turn completed).

--- a/server/forward.js
+++ b/server/forward.js
@@ -35,8 +35,10 @@ function resolveTitleGenTitle(parsedBody, resPayload, receivedAt) {
   if (store.extractCwd(parsedBody)) return null; // main orchestrator, not a subagent
   const parentSid = store.attributeTitleGen(parsedBody, receivedAt);
   if (parentSid && store.setSessionTitle(parentSid, clean, receivedAt)) {
-    sessionIdx.setTitle(parentSid, clean);
+    sessionIdx.setTitle(parentSid, store.getSessionTitle(parentSid));
     broadcastSessionTitleUpdate(parentSid);
+  } else if (parentSid && store.getSessionFirstPrompt(parentSid)) {
+    broadcastSessionTitleUpdate(parentSid, { immediate: true });
   }
   return clean;
 }

--- a/server/forward.js
+++ b/server/forward.js
@@ -40,7 +40,9 @@ function resolveTitleGenTitle(parsedBody, resPayload, receivedAt) {
   } else if (parentSid && store.getSessionFirstPrompt(parentSid)) {
     broadcastSessionTitleUpdate(parentSid, { immediate: true });
   }
-  return clean;
+  // Return sanitized title (or null if rejected) so callers don't propagate
+  // injected content via entry.title → _upsert → sessions.json
+  return store.stripInjectedTags(clean);
 }
 
 // ── thinkingStripped: true when prev non-subagent turn had thinking but current messages lost it ──

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -175,7 +175,7 @@ function updateFromEntry(entry) {
 function _upsert(sid, entry) {
   let s = sessionIndex.get(sid);
   if (!s) {
-    s = { sid, firstId: null, lastId: null, count: 0, model: null, cwd: null, totalCost: 0, title: null, lastReceivedAt: 0, provider: null, agent: null };
+    s = { sid, firstId: null, lastId: null, count: 0, model: null, cwd: null, totalCost: 0, title: null, firstPrompt: null, lastReceivedAt: 0, provider: null, agent: null };
     sessionIndex.set(sid, s);
   }
   // #333: bump COUNT once per responseId so the session card shows merged turns,
@@ -231,6 +231,11 @@ function setTitle(sid, title) {
   if (s && title) { s.title = title; _scheduleDirtyFlush(); }
 }
 
+function setFirstPrompt(sid, text) {
+  const s = sessionIndex.get(sid);
+  if (s && text && !s.firstPrompt) { s.firstPrompt = text; _scheduleDirtyFlush(); }
+}
+
 function _scheduleDirtyFlush() {
   dirty = true;
   if (flushTimer) return;
@@ -268,5 +273,5 @@ module.exports = {
   rebuildFromIndexContent, rebuildFromMetas,
   seedDedupState, seedDedupFromMetas,
   reconcile, reconcileMetas,
-  updateFromEntry, setTitle, flush, getAll, size,
+  updateFromEntry, setTitle, setFirstPrompt, flush, getAll, size,
 };

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -216,7 +216,10 @@ function _upsert(sid, entry) {
       }
     }
   }
-  if (entry.title && !s.title) s.title = entry.title;
+  if (entry.title && !s.title) {
+    const { stripInjectedTags } = require('./store');
+    s.title = stripInjectedTags(entry.title) || null;
+  }
   const recvAt = entry.receivedAt || 0;
   if (recvAt > (s.lastReceivedAt || 0)) s.lastReceivedAt = recvAt;
   if (entry.provider) s.provider = entry.provider;

--- a/server/sse-broadcast.js
+++ b/server/sse-broadcast.js
@@ -116,7 +116,8 @@ function flushSessionTitleUpdate(sessionId) {
   const title = store.getSessionTitle(sessionId);
   if (!title) return;
   const titleReqTs = store.sessionMeta[sessionId]?.titleReqTs || null;
-  _broadcastAll(JSON.stringify({ _type: 'session_title_update', sessionId, title, titleReqTs }));
+  const firstPrompt = store.getSessionFirstPrompt(sessionId);
+  _broadcastAll(JSON.stringify({ _type: 'session_title_update', sessionId, title, titleReqTs, firstPrompt }));
 }
 
 function broadcastSessionTitleUpdate(sessionId, { immediate = false } = {}) {

--- a/server/sse-broadcast.js
+++ b/server/sse-broadcast.js
@@ -63,6 +63,7 @@ function summarizeEntry(entry) {
     thinkingStripped: entry.thinkingStripped || false,
     imported: entry.imported || undefined,
     importSource: entry.importSource || undefined,
+    firstPrompt: store.getSessionFirstPrompt(entry.sessionId) || null,
     parentSessionId: store.sessionMeta[entry.sessionId]?.parentSessionId || null,
     tokens: tok ? {
       system: tok.system, tools: tok.tools, messages: tok.messages, total: tok.total,

--- a/server/sse-broadcast.js
+++ b/server/sse-broadcast.js
@@ -114,9 +114,9 @@ const titleDebounceTimers = new Map();
 function flushSessionTitleUpdate(sessionId) {
   titleDebounceTimers.delete(sessionId);
   const title = store.getSessionTitle(sessionId);
-  if (!title) return;
-  const titleReqTs = store.sessionMeta[sessionId]?.titleReqTs || null;
   const firstPrompt = store.getSessionFirstPrompt(sessionId);
+  if (!title && !firstPrompt) return;
+  const titleReqTs = store.sessionMeta[sessionId]?.titleReqTs || null;
   _broadcastAll(JSON.stringify({ _type: 'session_title_update', sessionId, title, titleReqTs, firstPrompt }));
 }
 

--- a/server/store.js
+++ b/server/store.js
@@ -295,10 +295,14 @@ let sessionCounter = 0;
 const socketSessions = new WeakMap();
 
 // ── Strip injected XML tags from user-facing text ──────────────────
-const _INJECTED_TAG_RE = /<(system-reminder|command-message|command-name|command-args|antl:function_calls|antl:thinking)[^>]*>[\s\S]*?<\/\1>/g;
+// Covers canonical tags from shared/injected-tags.js + command envelope tags.
+// antm?l: handles both the wire-protocol "antml:" and the common "antl:" typo.
+const _INJ_TAGS = 'system-reminder|command-message|command-name|command-args|user-prompt-submit-hook|context|antm?l:function_calls|antm?l:thinking';
+const _INJECTED_PAIR_RE = new RegExp('<(' + _INJ_TAGS + ')[^>]*>[\\s\\S]*?<\\/\\1>', 'g');
+const _INJECTED_BARE_RE = new RegExp('</?(?:' + _INJ_TAGS + ')[^>]*>', 'g');
 function stripInjectedTags(text) {
   if (text == null || typeof text !== 'string') return null;
-  const cleaned = text.replace(_INJECTED_TAG_RE, '').replace(/\s+/g, ' ').trim();
+  const cleaned = text.replace(_INJECTED_PAIR_RE, '').replace(_INJECTED_BARE_RE, '').replace(/\s+/g, ' ').trim();
   return cleaned || null;
 }
 
@@ -435,6 +439,7 @@ function setSessionTitle(sid, title, reqTs) {
   if (meta.title === title) { meta.titleReqTs = reqTs || meta.titleReqTs; return false; }
   meta.title = title;
   meta.titleReqTs = reqTs || Date.now();
+  if (meta.firstPrompt) sessionIdx.setFirstPrompt(sid, meta.firstPrompt);
   return true;
 }
 

--- a/server/store.js
+++ b/server/store.js
@@ -299,10 +299,12 @@ const socketSessions = new WeakMap();
 // antm?l: handles both the wire-protocol "antml:" and the common "antl:" typo.
 const _INJ_TAGS = 'system-reminder|command-message|command-name|command-args|user-prompt-submit-hook|context|antm?l:function_calls|antm?l:thinking';
 const _INJECTED_PAIR_RE = new RegExp('<(' + _INJ_TAGS + ')[^>]*>[\\s\\S]*?<\\/\\1>', 'g');
+// ponytail: unclosed tag → strip from opening tag to end of string
+const _INJECTED_OPEN_RE = new RegExp('<(?:' + _INJ_TAGS + ')[^>]*>[\\s\\S]*$', 'g');
 const _INJECTED_BARE_RE = new RegExp('</?(?:' + _INJ_TAGS + ')[^>]*>', 'g');
 function stripInjectedTags(text) {
   if (text == null || typeof text !== 'string') return null;
-  const cleaned = text.replace(_INJECTED_PAIR_RE, '').replace(_INJECTED_BARE_RE, '').replace(/\s+/g, ' ').trim();
+  const cleaned = text.replace(_INJECTED_PAIR_RE, '').replace(_INJECTED_OPEN_RE, '').replace(_INJECTED_BARE_RE, '').replace(/\s+/g, ' ').trim();
   return cleaned || null;
 }
 

--- a/server/store.js
+++ b/server/store.js
@@ -2,6 +2,7 @@
 
 const { agentForProvider, getUpstreamProfile } = require('./providers');
 const { extractAgentType } = require('./system-prompt');
+const sessionIdx = require('./session-index');
 
 // Synthetic session buckets that have no resumable rollout/session file.
 const NON_RESUMABLE_SESSIONS = new Set(['direct-api', 'codex-raw', 'unknown']);
@@ -293,6 +294,14 @@ let sessionCounter = 0;
 // and a hub restart clears map and sockets together — no staleness path.
 const socketSessions = new WeakMap();
 
+// ── Strip injected XML tags from user-facing text ──────────────────
+const _INJECTED_TAG_RE = /<(system-reminder|command-message|command-name|command-args|antl:function_calls|antl:thinking)[^>]*>[\s\S]*?<\/\1>/g;
+function stripInjectedTags(text) {
+  if (text == null || typeof text !== 'string') return null;
+  const cleaned = text.replace(_INJECTED_TAG_RE, '').replace(/\s+/g, ' ').trim();
+  return cleaned || null;
+}
+
 // ── Session metadata (cwd per session) ──────────────────────────────
 const sessionMeta = {}; // { sessionId: { cwd, lastSeenAt } }
 const activeRequests = {}; // sessionId → in-flight count
@@ -406,11 +415,21 @@ function recordFirstUserMsg(sid, req) {
     const txt = extractFirstUserMsgText(req);
     if (txt != null) meta.firstUserMsg = txt;
   }
+  if (meta.firstPrompt == null) {
+    const clean = stripInjectedTags(meta.firstUserMsg);
+    if (clean) {
+      meta.firstPrompt = clean.slice(0, 200);
+      sessionIdx.setFirstPrompt(sid, meta.firstPrompt);
+    }
+  }
 }
 
 // Monotonic session-title setter. Returns true when the stored value changed.
 function setSessionTitle(sid, title, reqTs) {
   if (!sid || !title || typeof title !== 'string') return false;
+  const cleaned = stripInjectedTags(title);
+  if (!cleaned) return false;
+  title = cleaned;
   const meta = sessionMeta[sid] || (sessionMeta[sid] = {});
   if (meta.titleReqTs && reqTs != null && reqTs <= meta.titleReqTs) return false;
   if (meta.title === title) { meta.titleReqTs = reqTs || meta.titleReqTs; return false; }
@@ -421,6 +440,10 @@ function setSessionTitle(sid, title, reqTs) {
 
 function getSessionTitle(sid) {
   return sid ? (sessionMeta[sid]?.title || null) : null;
+}
+
+function getSessionFirstPrompt(sid) {
+  return sid ? (sessionMeta[sid]?.firstPrompt || null) : null;
 }
 
 // Attribute a title-gen request to a parent session. Requires both temporal
@@ -655,8 +678,10 @@ module.exports = {
   printSessionBanner,
   extractFirstUserMsgText,
   recordFirstUserMsg,
+  stripInjectedTags,
   setSessionTitle,
   getSessionTitle,
+  getSessionFirstPrompt,
   attributeTitleGen,
   propagateLoadedSkills,
   markSessionUsage,

--- a/test/strip-injected-tags.test.js
+++ b/test/strip-injected-tags.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { stripInjectedTags } = require('../server/store');
+
+describe('stripInjectedTags', () => {
+  it('strips system-reminder blocks and returns real text', () => {
+    const input = '<system-reminder>\nlots of CLAUDE.md content\n</system-reminder>\n<command-message>/dothing</command-message>\n<command-name>/dothing</command-name>\n<command-args>some args</command-args>\nHello, please help me with this bug';
+    assert.strictEqual(stripInjectedTags(input), 'Hello, please help me with this bug');
+  });
+
+  it('returns null when all content is tags', () => {
+    const input = '<system-reminder>only tags</system-reminder>';
+    assert.strictEqual(stripInjectedTags(input), null);
+  });
+
+  it('passes through normal text unchanged', () => {
+    assert.strictEqual(stripInjectedTags('hello world'), 'hello world');
+  });
+
+  it('handles null/undefined', () => {
+    assert.strictEqual(stripInjectedTags(null), null);
+    assert.strictEqual(stripInjectedTags(undefined), null);
+  });
+
+  it('strips antl: prefixed tags', () => {
+    const input = '<antl:thinking>internal</antl:thinking> real text';
+    assert.strictEqual(stripInjectedTags(input), 'real text');
+  });
+});
+
+describe('setSessionTitle rejects bad titles', () => {
+  it('rejects title that is just a tag name', () => {
+    const { setSessionTitle, getSessionTitle } = require('../server/store');
+    const result = setSessionTitle('test-sid', '<system-reminder>injected content</system-reminder>');
+    assert.strictEqual(result, false);
+  });
+
+  it('accepts a normal title', () => {
+    const { setSessionTitle, getSessionTitle } = require('../server/store');
+    const result = setSessionTitle('test-sid-2', 'Fix the login bug');
+    assert.strictEqual(result, true);
+    assert.strictEqual(getSessionTitle('test-sid-2'), 'Fix the login bug');
+  });
+});

--- a/test/strip-injected-tags.test.js
+++ b/test/strip-injected-tags.test.js
@@ -1,46 +1,72 @@
-'use strict';
+"use strict";
 
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const { stripInjectedTags } = require('../server/store');
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { stripInjectedTags } = require("../server/store");
 
-describe('stripInjectedTags', () => {
-  it('strips system-reminder blocks and returns real text', () => {
-    const input = '<system-reminder>\nlots of CLAUDE.md content\n</system-reminder>\n<command-message>/dothing</command-message>\n<command-name>/dothing</command-name>\n<command-args>some args</command-args>\nHello, please help me with this bug';
-    assert.strictEqual(stripInjectedTags(input), 'Hello, please help me with this bug');
+describe("stripInjectedTags", () => {
+  it("strips system-reminder blocks and returns real text", () => {
+    const input = "<system-reminder>\nlots of CLAUDE.md content\n</system-reminder>\n<command-message>/dothing</command-message>\n<command-name>/dothing</command-name>\n<command-args>some args</command-args>\nHello, please help me with this bug";
+    assert.strictEqual(stripInjectedTags(input), "Hello, please help me with this bug");
   });
 
-  it('returns null when all content is tags', () => {
-    const input = '<system-reminder>only tags</system-reminder>';
+  it("returns null when all content is tags", () => {
+    const input = "<system-reminder>only tags</system-reminder>";
     assert.strictEqual(stripInjectedTags(input), null);
   });
 
-  it('passes through normal text unchanged', () => {
-    assert.strictEqual(stripInjectedTags('hello world'), 'hello world');
+  it("passes through normal text unchanged", () => {
+    assert.strictEqual(stripInjectedTags("hello world"), "hello world");
   });
 
-  it('handles null/undefined', () => {
+  it("handles null/undefined", () => {
     assert.strictEqual(stripInjectedTags(null), null);
     assert.strictEqual(stripInjectedTags(undefined), null);
   });
 
-  it('strips antl: prefixed tags', () => {
-    const input = '<antl:thinking>internal</antl:thinking> real text';
-    assert.strictEqual(stripInjectedTags(input), 'real text');
+  it("strips antl: prefixed tags", () => {
+    const input = "<antl:thinking>internal</antl:thinking> real text";
+    assert.strictEqual(stripInjectedTags(input), "real text");
+  });
+
+  it("strips antml: prefixed tags (canonical wire format)", () => {
+    const input = "<antml:function_calls>tool calls</antml:function_calls> real text";
+    assert.strictEqual(stripInjectedTags(input), "real text");
+  });
+
+  it("strips bare opening tag (no closing pair)", () => {
+    assert.strictEqual(stripInjectedTags("<system-reminder>"), null);
+    assert.strictEqual(stripInjectedTags("<system-reminder> real text"), "real text");
+  });
+
+  it("strips user-prompt-submit-hook tags", () => {
+    const input = "<user-prompt-submit-hook>hook output</user-prompt-submit-hook> real text";
+    assert.strictEqual(stripInjectedTags(input), "real text");
+  });
+
+  it("strips context tags", () => {
+    const input = "<context>injected context</context> real text";
+    assert.strictEqual(stripInjectedTags(input), "real text");
   });
 });
 
-describe('setSessionTitle rejects bad titles', () => {
-  it('rejects title that is just a tag name', () => {
-    const { setSessionTitle, getSessionTitle } = require('../server/store');
-    const result = setSessionTitle('test-sid', '<system-reminder>injected content</system-reminder>');
+describe("setSessionTitle rejects bad titles", () => {
+  it("rejects title that is just a tag pair", () => {
+    const { setSessionTitle } = require("../server/store");
+    const result = setSessionTitle("test-sid", "<system-reminder>injected content</system-reminder>");
     assert.strictEqual(result, false);
   });
 
-  it('accepts a normal title', () => {
-    const { setSessionTitle, getSessionTitle } = require('../server/store');
-    const result = setSessionTitle('test-sid-2', 'Fix the login bug');
+  it("rejects title that is a bare tag", () => {
+    const { setSessionTitle } = require("../server/store");
+    const result = setSessionTitle("test-sid-bare", "<system-reminder>");
+    assert.strictEqual(result, false);
+  });
+
+  it("accepts a normal title", () => {
+    const { setSessionTitle, getSessionTitle } = require("../server/store");
+    const result = setSessionTitle("test-sid-2", "Fix the login bug");
     assert.strictEqual(result, true);
-    assert.strictEqual(getSessionTitle('test-sid-2'), 'Fix the login bug');
+    assert.strictEqual(getSessionTitle("test-sid-2"), "Fix the login bug");
   });
 });

--- a/test/strip-injected-tags.test.js
+++ b/test/strip-injected-tags.test.js
@@ -36,12 +36,19 @@ describe("stripInjectedTags", () => {
 
   it("strips bare opening tag (no closing pair)", () => {
     assert.strictEqual(stripInjectedTags("<system-reminder>"), null);
-    assert.strictEqual(stripInjectedTags("<system-reminder> real text"), "real text");
+    assert.strictEqual(stripInjectedTags("<system-reminder> real text"), null);
+    assert.strictEqual(stripInjectedTags("real text <system-reminder>injected"), "real text");
   });
 
   it("strips user-prompt-submit-hook tags", () => {
     const input = "<user-prompt-submit-hook>hook output</user-prompt-submit-hook> real text";
     assert.strictEqual(stripInjectedTags(input), "real text");
+  });
+
+
+  it("rejects text with residual unclosed tag content", () => {
+    const input = "<system-reminder>lots of injected content without closing tag";
+    assert.strictEqual(stripInjectedTags(input), null);
   });
 
   it("strips context tags", () => {


### PR DESCRIPTION
## 摘要
Session card title 直接顯示 title-generator subagent 的產出。當第一個 user message 主要是 `<system-reminder>` 注入內容時，title-gen 回傳 `<system-reminder>` 作為 title。本 PR 在 server 端剝除注入的 XML tags，並提供 `firstPrompt`（清理後的首段 user prompt）作為 fallback。

## Changes
- **server/store.js**: `stripInjectedTags()` strips known injected XML tag pairs and their content; `setSessionTitle` rejects titles that are pure injected content; `recordFirstUserMsg` stores cleaned `firstPrompt`
- **server/session-index.js**: persists `firstPrompt` to sessions.json; defense-in-depth: `_upsert` also strips injected tags from entry.title
- **server/sse-broadcast.js**: includes `firstPrompt` in entry summaries and `session_title_update` events
- **server/forward.js**: `resolveTitleGenTitle` returns sanitized title; broadcasts firstPrompt when title is rejected
- **public/entry-rendering.js**: handles `firstPrompt` from entries and session_title_update events; carries it through cold-load merge
- **public/miller-columns.js**: fallback: `displayTitle = sess.title || sess.firstPrompt`, truncated to 100 chars
- **test/strip-injected-tags.test.js**: 13 tests covering tag stripping, null/undefined handling, bare tags, setSessionTitle rejection

## Codex review
3 rounds:
- R1: 5 P2 → all fixed
- R2: 1 P1 (return value leaks raw title) + 3 P2 → 3 accepted, 1 rejected (pre-existing persistence gap)
- R3: 1 P1 (entry.title → upsert bypass) + 1 P2 → P1 fixed, P2 rejected (same pre-existing gap, 3rd occurrence)

Rejected item: `sessionIdx.setFirstPrompt` is a no-op when called before the session-index record exists. Pre-existing design: session-index records for new live sessions are only created during restart/rebuild. Same gap exists for titles. Live clients receive firstPrompt via entry broadcast; cold-load relies on restore path.

<!-- GATE-MANIFEST
issue-lint=pass @2b30ded3abc6d62cd1b86ed9942f862181bc2bce
full-test=0 @2b30ded3abc6d62cd1b86ed9942f862181bc2bce
boot-smoke=0 @2b30ded3abc6d62cd1b86ed9942f862181bc2bce
-->

## 驗了什麼 / 沒驗什麼
**驗了**: stripInjectedTags regex、setSessionTitle rejection、firstPrompt extraction/persistence/broadcast/display、full suite 1464/1464、boot smoke HTTP 200、diff-check old-fail/new-pass
**沒驗**: 真實 browser 端對端（session card 實際顯示），需 browser-harness smoke 或 owner visual review
