### PR TITLE
fix(ui): auto-expand collapsed sidebar when boot ends with no session selected

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -132,6 +132,18 @@ function toggleSidebar() {
   if (typeof renderCmdBar === 'function') renderCmdBar();
 }
 window.isSidebarCollapsed = () => sidebarCollapsed;
+
+// #358: boot ended with no session selected while the sidebar is collapsed —
+// all visible columns are empty and the |▷ expand button only renders in the
+// timeline header (needs a selected session), so the page is a dead-end blank.
+// Called once at the end of the boot chain (entry-rendering.js).
+function maybeAutoExpandSidebar() {
+  if (!sidebarCollapsed) return false;
+  if (typeof selectedSessionId !== 'undefined' && selectedSessionId) return false;
+  toggleSidebar();
+  return true;
+}
+
 applySidebarState();
 
 // ── Unified Escape + tab switching handler ──────────────────────────

--- a/public/app.js
+++ b/public/app.js
@@ -148,7 +148,8 @@ function maybeAutoExpandSidebar() {
   // codex r3: while boot is still restoring (entry-rendering.js sets this
   // false right before auto-select/deep-link settle), a tab-return sees a
   // transiently-null selection — don't rewrite the preference until settled.
-  if (window._entriesLoading) return false;
+  // ponytail: undefined = entry-rendering.js hasn't loaded yet → still booting
+  if (window._entriesLoading !== false) return false;
   if (typeof selectedSessionId !== 'undefined' && selectedSessionId) return false;
   toggleSidebar();
   return true;

--- a/public/app.js
+++ b/public/app.js
@@ -126,6 +126,9 @@ function applySidebarState() {
 }
 
 function toggleSidebar() {
+  // #358 prevention: collapsing with no session selected → dead-end blank page.
+  // Expand direction always allowed (boot rescue / manual expand).
+  if (!sidebarCollapsed && !(typeof selectedSessionId !== 'undefined' && selectedSessionId)) return;
   sidebarCollapsed = !sidebarCollapsed;
   localStorage.setItem(SIDEBAR_COLLAPSE_KEY, sidebarCollapsed ? '1' : '0');
   applySidebarState();

--- a/public/app.js
+++ b/public/app.js
@@ -145,6 +145,10 @@ function maybeAutoExpandSidebar() {
   // codex r1: only the dashboard view shows the sidebar — a ?view=usage/
   // sysprompt boot must not silently rewrite the collapse preference.
   if (activeTab !== 'dashboard') return false;
+  // codex r3: while boot is still restoring (entry-rendering.js sets this
+  // false right before auto-select/deep-link settle), a tab-return sees a
+  // transiently-null selection — don't rewrite the preference until settled.
+  if (window._entriesLoading) return false;
   if (typeof selectedSessionId !== 'undefined' && selectedSessionId) return false;
   toggleSidebar();
   return true;

--- a/public/app.js
+++ b/public/app.js
@@ -23,6 +23,9 @@ function switchTab(tab, forceDiff) {
   if (tab === 'dashboard' && typeof exitFocusedMode === 'function' && typeof isFocusedMode !== 'undefined' && isFocusedMode) {
     exitFocusedMode();
   }
+  // #358 codex r1: returning to dashboard with nothing selected + collapsed
+  // sidebar is the same blank dead-end — expand now (idempotent no-op otherwise).
+  if (tab === 'dashboard') maybeAutoExpandSidebar();
   const costPage = document.getElementById('cost-page');
   const diffOverlay = document.getElementById('diff-overlay');
   if (tab === 'usage') {
@@ -139,6 +142,9 @@ window.isSidebarCollapsed = () => sidebarCollapsed;
 // Called once at the end of the boot chain (entry-rendering.js).
 function maybeAutoExpandSidebar() {
   if (!sidebarCollapsed) return false;
+  // codex r1: only the dashboard view shows the sidebar — a ?view=usage/
+  // sysprompt boot must not silently rewrite the collapse preference.
+  if (activeTab !== 'dashboard') return false;
   if (typeof selectedSessionId !== 'undefined' && selectedSessionId) return false;
   toggleSidebar();
   return true;

--- a/public/app.js
+++ b/public/app.js
@@ -152,6 +152,7 @@ function maybeAutoExpandSidebar() {
   if (window._entriesLoading !== false) return false;
   if (typeof selectedSessionId !== 'undefined' && selectedSessionId) return false;
   toggleSidebar();
+  setFocus(selectedProjectName ? 'sessions' : 'projects');
   return true;
 }
 

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -1337,9 +1337,6 @@ Promise.all([_entriesReady, _starsReady, _sessionsReady]).then(async ([data, , s
   } else if (sessionsMap.size) {
     initAutoSelect();
   }
-  // #358: nothing ended up selected → auto-expand a collapsed sidebar so the
-  // dashboard isn't a blank page with no expand affordance.
-  if (typeof maybeAutoExpandSidebar === 'function') maybeAutoExpandSidebar();
   // #308: re-render selected session card after recompute (deep link may have
   // selected a session whose stats were recomputed but card not yet refreshed)
   if (selectedSessionId) {
@@ -1350,6 +1347,11 @@ Promise.all([_entriesReady, _starsReady, _sessionsReady]).then(async ([data, , s
   applySessionFilter();
   setFocus(focusedCol);
   if (typeof restoreTabFromUrl === 'function') restoreTabFromUrl();
+  // #358: nothing ended up selected → auto-expand a collapsed sidebar so the
+  // dashboard isn't a blank page with no expand affordance. Runs after
+  // restoreTabFromUrl so a ?view=usage/sysprompt boot is gated off (codex r1);
+  // switchTab back to dashboard re-runs the check.
+  if (typeof maybeAutoExpandSidebar === 'function') maybeAutoExpandSidebar();
   _flushLoadTimings();
 });
 

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -1337,6 +1337,9 @@ Promise.all([_entriesReady, _starsReady, _sessionsReady]).then(async ([data, , s
   } else if (sessionsMap.size) {
     initAutoSelect();
   }
+  // #358: nothing ended up selected → auto-expand a collapsed sidebar so the
+  // dashboard isn't a blank page with no expand affordance.
+  if (typeof maybeAutoExpandSidebar === 'function') maybeAutoExpandSidebar();
   // #308: re-render selected session card after recompute (deep link may have
   // selected a session whose stats were recomputed but card not yet refreshed)
   if (selectedSessionId) {

--- a/public/keyboard-nav.js
+++ b/public/keyboard-nav.js
@@ -310,6 +310,7 @@ function isEnabled(keyId) {
     case 'enter-sections': return selectedSection != null;
     case 'f-star':         return getStarTargetFromSelection() !== null;
     case 'p-popover':      return _hasBadgeDescendants() && !window._openPopover;
+    case 'sidebar-toggle': return isSidebarCollapsed() || !!(typeof selectedSessionId !== 'undefined' && selectedSessionId);
     case 'tab-switch':     return !window._openPopover;
     case 'star-nav':       return !window._openPopover && _hasStarNavTargets();
     case 'timeline-star-nav': return !window._openPopover && _hasTimelineStarNavTargets();
@@ -375,7 +376,7 @@ function getCmdBarState() {
         { key: 'f', label: _fStarLabel(), id: 'f-star', clickKey: 'f' },
         pPopoverItem,
         ..._starNavItems(),
-        { key: '\\', label: 'sidebar', clickKey: '\\' },
+        { key: '\\', label: 'sidebar', id: 'sidebar-toggle', clickKey: '\\' },
         ...tabKeys,
       ],
       row2: null, row2Visible: false,
@@ -390,7 +391,7 @@ function getCmdBarState() {
         { key: 'f', label: _fStarLabel(), id: 'f-star', clickKey: 'f' },
         pPopoverItem,
         ..._starNavItems(),
-        { key: '\\', label: 'sidebar', clickKey: '\\' },
+        { key: '\\', label: 'sidebar', id: 'sidebar-toggle', clickKey: '\\' },
         ...tabKeys,
       ],
       row2: null, row2Visible: false,
@@ -406,7 +407,7 @@ function getCmdBarState() {
         { key: 'f', label: _fStarLabel(), id: 'f-star', clickKey: 'f' },
         pPopoverItem,
         ..._starNavItems(),
-        { key: '\\', label: 'sidebar', clickKey: '\\' },
+        { key: '\\', label: 'sidebar', id: 'sidebar-toggle', clickKey: '\\' },
         ...tabKeys,
       ],
       row2: null, row2Visible: false,
@@ -420,7 +421,7 @@ function getCmdBarState() {
         { key: 'Enter', label: 'focus detail', id: 'enter-sections', clickKey: 'Enter' },
         { key: 'f', label: _fStarLabel(), id: 'f-star', clickKey: 'f' },
         pPopoverItem,
-        { key: '\\', label: 'sidebar', clickKey: '\\' },
+        { key: '\\', label: 'sidebar', id: 'sidebar-toggle', clickKey: '\\' },
         ...tabKeys,
       ],
       row2: null, row2Visible: false,

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1773,13 +1773,16 @@ function selectProject(name) {
   clearSelectedStepSelection();
   colSections.innerHTML = '';
   colDetail.innerHTML = '';
-  // Clear workflow timeline
+  // Clear workflow timeline + split-view state
   if (typeof wfState !== 'undefined') wfState = null;
-  document.getElementById('columns').classList.remove('wf-active');
+  isFocusedMode = false;
+  document.getElementById('columns').classList.remove('wf-active', 'focused');
   var wfEl = document.getElementById('wf-timeline');
   if (wfEl) wfEl.remove();
   renderBreadcrumb();
   setFocus('projects');
+  // #358 r7: clearing the session while collapsed → dead-end blank; expand.
+  if (typeof maybeAutoExpandSidebar === 'function') maybeAutoExpandSidebar();
 }
 
 function fmt(n) { return n != null ? n.toLocaleString() : '—'; }

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1781,8 +1781,10 @@ function selectProject(name) {
   if (wfEl) wfEl.remove();
   renderBreadcrumb();
   setFocus('projects');
-  // #358 r7: clearing the session while collapsed → dead-end blank; expand.
-  if (typeof maybeAutoExpandSidebar === 'function') maybeAutoExpandSidebar();
+  // #358 r7/r8: breadcrumb root (name===null) clears session while collapsed →
+  // dead-end blank; expand. Gated on null so initAutoSelect / deep-link
+  // (which pass a real name, then selectSession) don't mis-expand mid-nav.
+  if (name === null && typeof maybeAutoExpandSidebar === 'function') maybeAutoExpandSidebar();
 }
 
 function fmt(n) { return n != null ? n.toLocaleString() : '—'; }

--- a/test/sidebar-auto-expand.test.js
+++ b/test/sidebar-auto-expand.test.js
@@ -112,12 +112,16 @@ describe('#358 maybeAutoExpandSidebar', () => {
     assert.equal(focusCalls.at(-1), 'sessions');
   });
 
-  it('selectProject wiring: maybeAutoExpandSidebar called after clearing session (r7)', () => {
+  it('selectProject wiring: maybeAutoExpandSidebar gated on name===null (r7/r8)', () => {
     const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'miller-columns.js'), 'utf8');
-    const clearIdx = src.indexOf('selectedSessionId = null', src.indexOf('function selectProject'));
+    const fnStart = src.indexOf('function selectProject');
+    const clearIdx = src.indexOf('selectedSessionId = null', fnStart);
     const expandIdx = src.indexOf('maybeAutoExpandSidebar()', clearIdx);
     assert.ok(clearIdx > 0, 'selectProject clears selectedSessionId');
     assert.ok(expandIdx > clearIdx, 'maybeAutoExpandSidebar called after clearing session');
+    // r8: gated on name===null so initAutoSelect/deep-link don't mis-expand
+    const gateIdx = src.lastIndexOf('name === null', expandIdx);
+    assert.ok(gateIdx > fnStart && gateIdx < expandIdx, 'gated on name===null');
   });
 
   it('boot chain wiring: entry-rendering.js calls it after restoreTabFromUrl (view gate, codex r1)', () => {

--- a/test/sidebar-auto-expand.test.js
+++ b/test/sidebar-auto-expand.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+// #358 — auto-expand collapsed sidebar when boot ends with no session selected.
+// Loads the real public/app.js in a vm with minimal DOM stubs (same pattern as
+// test/sysprompt-ui-logic.test.js) and exercises maybeAutoExpandSidebar().
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function makeElement() {
+  const classes = new Set();
+  return {
+    textContent: '',
+    title: '',
+    inert: false,
+    style: {},
+    classList: {
+      toggle(name, force) {
+        const on = force === undefined ? !classes.has(name) : !!force;
+        if (on) classes.add(name); else classes.delete(name);
+      },
+      contains: (n) => classes.has(n),
+    },
+  };
+}
+
+function loadAppJs({ collapsed }) {
+  const store = { 'ccxray-sidebar-collapsed': collapsed ? '1' : '0' };
+  const elements = new Map();
+  const context = {
+    console,
+    localStorage: {
+      getItem: (k) => (k in store ? store[k] : null),
+      setItem: (k, v) => { store[k] = String(v); },
+    },
+    document: {
+      getElementById(id) {
+        if (id === 'proxy-config') return { textContent: '{}' };
+        if (!elements.has(id)) elements.set(id, makeElement());
+        return elements.get(id);
+      },
+      documentElement: { getAttribute: () => null, setAttribute() {} },
+      querySelectorAll: () => [],
+      addEventListener() {},
+    },
+    history: { pushState() {}, replaceState() {} },
+    location: { search: '', pathname: '/' },
+    addEventListener() {},
+    URLSearchParams,
+  };
+  context.window = context;
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(path.join(__dirname, '..', 'public', 'app.js'), 'utf8'), context);
+  return { ctx: context, store };
+}
+
+describe('#358 maybeAutoExpandSidebar', () => {
+  it('exists in app.js (fail-on-old)', () => {
+    const { ctx } = loadAppJs({ collapsed: true });
+    assert.equal(typeof ctx.maybeAutoExpandSidebar, 'function');
+  });
+
+  it('collapsed + no session selected → expands and persists to localStorage', () => {
+    const { ctx, store } = loadAppJs({ collapsed: true });
+    assert.equal(ctx.isSidebarCollapsed(), true);
+    assert.equal(ctx.maybeAutoExpandSidebar(), true);
+    assert.equal(ctx.isSidebarCollapsed(), false);
+    assert.equal(store['ccxray-sidebar-collapsed'], '0');
+  });
+
+  it('collapsed + session selected (?s= deep link, #206) → stays collapsed', () => {
+    const { ctx, store } = loadAppJs({ collapsed: true });
+    ctx.selectedSessionId = 'abc123';
+    assert.equal(ctx.maybeAutoExpandSidebar(), false);
+    assert.equal(ctx.isSidebarCollapsed(), true);
+    assert.equal(store['ccxray-sidebar-collapsed'], '1');
+  });
+
+  it('already expanded → no-op (never toggles toward collapsed)', () => {
+    const { ctx, store } = loadAppJs({ collapsed: false });
+    assert.equal(ctx.maybeAutoExpandSidebar(), false);
+    assert.equal(ctx.isSidebarCollapsed(), false);
+    assert.equal(store['ccxray-sidebar-collapsed'], '0');
+  });
+
+  it('boot chain wiring: entry-rendering.js calls it after deep-link/auto-select', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'entry-rendering.js'), 'utf8');
+    const autoSelectIdx = src.indexOf('initAutoSelect()');
+    const callIdx = src.indexOf('maybeAutoExpandSidebar()');
+    assert.ok(autoSelectIdx > 0, 'initAutoSelect call present');
+    assert.ok(callIdx > autoSelectIdx, 'maybeAutoExpandSidebar called after the auto-select block');
+  });
+});

--- a/test/sidebar-auto-expand.test.js
+++ b/test/sidebar-auto-expand.test.js
@@ -83,6 +83,7 @@ describe('#358 maybeAutoExpandSidebar', () => {
 
   it('collapsed + session selected (?s= deep link, #206) → stays collapsed', () => {
     const { ctx, store } = loadAppJs({ collapsed: true });
+    ctx._entriesLoading = false;
     ctx.selectedSessionId = 'abc123';
     assert.equal(ctx.maybeAutoExpandSidebar(), false);
     assert.equal(ctx.isSidebarCollapsed(), true);
@@ -109,6 +110,14 @@ describe('#358 maybeAutoExpandSidebar', () => {
     ctx.selectedProjectName = 'my-project';
     ctx.maybeAutoExpandSidebar();
     assert.equal(focusCalls.at(-1), 'sessions');
+  });
+
+  it('selectProject wiring: maybeAutoExpandSidebar called after clearing session (r7)', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'miller-columns.js'), 'utf8');
+    const clearIdx = src.indexOf('selectedSessionId = null', src.indexOf('function selectProject'));
+    const expandIdx = src.indexOf('maybeAutoExpandSidebar()', clearIdx);
+    assert.ok(clearIdx > 0, 'selectProject clears selectedSessionId');
+    assert.ok(expandIdx > clearIdx, 'maybeAutoExpandSidebar called after clearing session');
   });
 
   it('boot chain wiring: entry-rendering.js calls it after restoreTabFromUrl (view gate, codex r1)', () => {
@@ -142,6 +151,7 @@ describe('#358 maybeAutoExpandSidebar', () => {
 
   it('switch back to dashboard with a session selected → stays collapsed', () => {
     const { ctx, store } = loadAppJs({ collapsed: true, search: '?view=usage' });
+    ctx._entriesLoading = false;
     ctx.restoreTabFromUrl();
     ctx.selectedSessionId = 'abc123';
     ctx.switchTab('dashboard');

--- a/test/sidebar-auto-expand.test.js
+++ b/test/sidebar-auto-expand.test.js
@@ -56,7 +56,9 @@ function loadAppJs({ collapsed, search = '' }) {
     loadCostPage() {},
     openSystemPromptPanel() {},
     selectedProjectName: null,
+    focusedCol: 'projects',
     setFocus(col) { focusCalls.push(col); },
+    renderCmdBar() {},
   };
   context.window = context;
   vm.createContext(context);
@@ -166,6 +168,30 @@ describe('#358 maybeAutoExpandSidebar', () => {
     ctx._entriesLoading = false; // boot settled, still nothing selected
     ctx.switchTab('usage');
     ctx.switchTab('dashboard'); // same path now expands
+    assert.equal(ctx.isSidebarCollapsed(), false);
+    assert.equal(store['ccxray-sidebar-collapsed'], '0');
+  });
+
+  // ── R6: source prevention — toggleSidebar gate ──
+
+  it('expanded + no session → toggleSidebar refuses to collapse (r6 prevention)', () => {
+    const { ctx, store } = loadAppJs({ collapsed: false });
+    ctx.toggleSidebar(); // attempt collapse with no selectedSessionId
+    assert.equal(ctx.isSidebarCollapsed(), false, 'must stay expanded');
+    assert.equal(store['ccxray-sidebar-collapsed'], '0', 'localStorage must not flip');
+  });
+
+  it('expanded + session selected → toggleSidebar collapses normally (#206 compat)', () => {
+    const { ctx, store } = loadAppJs({ collapsed: false });
+    ctx.selectedSessionId = 'abc123';
+    ctx.toggleSidebar();
+    assert.equal(ctx.isSidebarCollapsed(), true);
+    assert.equal(store['ccxray-sidebar-collapsed'], '1');
+  });
+
+  it('collapsed + no session → toggleSidebar still expands (rescue direction always allowed)', () => {
+    const { ctx, store } = loadAppJs({ collapsed: true });
+    ctx.toggleSidebar(); // expand direction — always permitted
     assert.equal(ctx.isSidebarCollapsed(), false);
     assert.equal(store['ccxray-sidebar-collapsed'], '0');
   });

--- a/test/sidebar-auto-expand.test.js
+++ b/test/sidebar-auto-expand.test.js
@@ -69,6 +69,7 @@ describe('#358 maybeAutoExpandSidebar', () => {
 
   it('collapsed + no session selected → expands and persists to localStorage', () => {
     const { ctx, store } = loadAppJs({ collapsed: true });
+    ctx._entriesLoading = false; // boot settled
     assert.equal(ctx.isSidebarCollapsed(), true);
     assert.equal(ctx.maybeAutoExpandSidebar(), true);
     assert.equal(ctx.isSidebarCollapsed(), false);
@@ -110,6 +111,7 @@ describe('#358 maybeAutoExpandSidebar', () => {
 
   it('switch back to dashboard, still nothing selected → expands at that moment', () => {
     const { ctx, store } = loadAppJs({ collapsed: true, search: '?view=usage' });
+    ctx._entriesLoading = false; // boot settled
     ctx.restoreTabFromUrl();
     ctx.maybeAutoExpandSidebar(); // boot-end check: no-op off-dashboard
     assert.equal(ctx.isSidebarCollapsed(), true);
@@ -123,6 +125,15 @@ describe('#358 maybeAutoExpandSidebar', () => {
     ctx.restoreTabFromUrl();
     ctx.selectedSessionId = 'abc123';
     ctx.switchTab('dashboard');
+    assert.equal(ctx.isSidebarCollapsed(), true);
+    assert.equal(store['ccxray-sidebar-collapsed'], '1');
+  });
+
+  it('_entriesLoading undefined (entry-rendering.js not yet loaded) → no expand, localStorage stays 1 (codex r4)', () => {
+    const { ctx, store } = loadAppJs({ collapsed: true });
+    // window._entriesLoading is undefined — app.js loaded, entry-rendering.js hasn't
+    assert.equal(ctx._entriesLoading, undefined);
+    assert.equal(ctx.maybeAutoExpandSidebar(), false);
     assert.equal(ctx.isSidebarCollapsed(), true);
     assert.equal(store['ccxray-sidebar-collapsed'], '1');
   });

--- a/test/sidebar-auto-expand.test.js
+++ b/test/sidebar-auto-expand.test.js
@@ -22,12 +22,14 @@ function makeElement() {
         const on = force === undefined ? !classes.has(name) : !!force;
         if (on) classes.add(name); else classes.delete(name);
       },
+      add: (n) => classes.add(n),
+      remove: (n) => classes.delete(n),
       contains: (n) => classes.has(n),
     },
   };
 }
 
-function loadAppJs({ collapsed }) {
+function loadAppJs({ collapsed, search = '' }) {
   const store = { 'ccxray-sidebar-collapsed': collapsed ? '1' : '0' };
   const elements = new Map();
   const context = {
@@ -47,9 +49,11 @@ function loadAppJs({ collapsed }) {
       addEventListener() {},
     },
     history: { pushState() {}, replaceState() {} },
-    location: { search: '', pathname: '/' },
+    location: { search, pathname: '/' },
     addEventListener() {},
     URLSearchParams,
+    loadCostPage() {},
+    openSystemPromptPanel() {},
   };
   context.window = context;
   vm.createContext(context);
@@ -86,11 +90,40 @@ describe('#358 maybeAutoExpandSidebar', () => {
     assert.equal(store['ccxray-sidebar-collapsed'], '0');
   });
 
-  it('boot chain wiring: entry-rendering.js calls it after deep-link/auto-select', () => {
+  it('boot chain wiring: entry-rendering.js calls it after restoreTabFromUrl (view gate, codex r1)', () => {
     const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'entry-rendering.js'), 'utf8');
     const autoSelectIdx = src.indexOf('initAutoSelect()');
+    const restoreTabIdx = src.indexOf('restoreTabFromUrl()');
     const callIdx = src.indexOf('maybeAutoExpandSidebar()');
     assert.ok(autoSelectIdx > 0, 'initAutoSelect call present');
-    assert.ok(callIdx > autoSelectIdx, 'maybeAutoExpandSidebar called after the auto-select block');
+    assert.ok(restoreTabIdx > autoSelectIdx, 'restoreTabFromUrl after auto-select block');
+    assert.ok(callIdx > restoreTabIdx, 'maybeAutoExpandSidebar called after restoreTabFromUrl');
+  });
+
+  it('?view=usage boot → gated off, localStorage stays 1 (codex r1)', () => {
+    const { ctx, store } = loadAppJs({ collapsed: true, search: '?view=usage' });
+    ctx.restoreTabFromUrl(); // boot chain switches tab before the expand check
+    assert.equal(ctx.maybeAutoExpandSidebar(), false);
+    assert.equal(ctx.isSidebarCollapsed(), true);
+    assert.equal(store['ccxray-sidebar-collapsed'], '1');
+  });
+
+  it('switch back to dashboard, still nothing selected → expands at that moment', () => {
+    const { ctx, store } = loadAppJs({ collapsed: true, search: '?view=usage' });
+    ctx.restoreTabFromUrl();
+    ctx.maybeAutoExpandSidebar(); // boot-end check: no-op off-dashboard
+    assert.equal(ctx.isSidebarCollapsed(), true);
+    ctx.switchTab('dashboard'); // dashboard branch calls maybeAutoExpandSidebar
+    assert.equal(ctx.isSidebarCollapsed(), false);
+    assert.equal(store['ccxray-sidebar-collapsed'], '0');
+  });
+
+  it('switch back to dashboard with a session selected → stays collapsed', () => {
+    const { ctx, store } = loadAppJs({ collapsed: true, search: '?view=usage' });
+    ctx.restoreTabFromUrl();
+    ctx.selectedSessionId = 'abc123';
+    ctx.switchTab('dashboard');
+    assert.equal(ctx.isSidebarCollapsed(), true);
+    assert.equal(store['ccxray-sidebar-collapsed'], '1');
   });
 });

--- a/test/sidebar-auto-expand.test.js
+++ b/test/sidebar-auto-expand.test.js
@@ -32,6 +32,7 @@ function makeElement() {
 function loadAppJs({ collapsed, search = '' }) {
   const store = { 'ccxray-sidebar-collapsed': collapsed ? '1' : '0' };
   const elements = new Map();
+  const focusCalls = [];
   const context = {
     console,
     localStorage: {
@@ -54,11 +55,13 @@ function loadAppJs({ collapsed, search = '' }) {
     URLSearchParams,
     loadCostPage() {},
     openSystemPromptPanel() {},
+    selectedProjectName: null,
+    setFocus(col) { focusCalls.push(col); },
   };
   context.window = context;
   vm.createContext(context);
   vm.runInContext(fs.readFileSync(path.join(__dirname, '..', 'public', 'app.js'), 'utf8'), context);
-  return { ctx: context, store };
+  return { ctx: context, store, focusCalls };
 }
 
 describe('#358 maybeAutoExpandSidebar', () => {
@@ -89,6 +92,21 @@ describe('#358 maybeAutoExpandSidebar', () => {
     assert.equal(ctx.maybeAutoExpandSidebar(), false);
     assert.equal(ctx.isSidebarCollapsed(), false);
     assert.equal(store['ccxray-sidebar-collapsed'], '0');
+  });
+
+  it('auto-expand refocuses to projects when no project selected (codex r5)', () => {
+    const { ctx, focusCalls } = loadAppJs({ collapsed: true });
+    ctx._entriesLoading = false;
+    ctx.maybeAutoExpandSidebar();
+    assert.equal(focusCalls.at(-1), 'projects');
+  });
+
+  it('auto-expand refocuses to sessions when a project is selected (codex r5)', () => {
+    const { ctx, focusCalls } = loadAppJs({ collapsed: true });
+    ctx._entriesLoading = false;
+    ctx.selectedProjectName = 'my-project';
+    ctx.maybeAutoExpandSidebar();
+    assert.equal(focusCalls.at(-1), 'sessions');
   });
 
   it('boot chain wiring: entry-rendering.js calls it after restoreTabFromUrl (view gate, codex r1)', () => {

--- a/test/sidebar-auto-expand.test.js
+++ b/test/sidebar-auto-expand.test.js
@@ -126,4 +126,18 @@ describe('#358 maybeAutoExpandSidebar', () => {
     assert.equal(ctx.isSidebarCollapsed(), true);
     assert.equal(store['ccxray-sidebar-collapsed'], '1');
   });
+
+  it('tab-return during boot (_entriesLoading) → deferred; after boot settles → expands (codex r3)', () => {
+    const { ctx, store } = loadAppJs({ collapsed: true, search: '?view=usage' });
+    ctx.restoreTabFromUrl();
+    ctx._entriesLoading = true; // window === context: boot restore in flight
+    ctx.switchTab('dashboard'); // selection transiently null — must NOT rewrite
+    assert.equal(ctx.isSidebarCollapsed(), true);
+    assert.equal(store['ccxray-sidebar-collapsed'], '1');
+    ctx._entriesLoading = false; // boot settled, still nothing selected
+    ctx.switchTab('usage');
+    ctx.switchTab('dashboard'); // same path now expands
+    assert.equal(ctx.isSidebarCollapsed(), false);
+    assert.equal(store['ccxray-sidebar-collapsed'], '0');
+  });
 });


### PR DESCRIPTION
Closes #358

## 摘要

Sidebar 收合狀態（localStorage 持久）+ boot 結束無選中 session（根 URL、`?p=` project deep link、多 session 專案）時，dashboard 整頁空白且無任何可見的展開控制（`|▷` 只在 timeline header 渲染）。本 PR 在 boot 鏈尾端與 switchTab 返回 dashboard 兩個時點呼叫冪等的 `maybeAutoExpandSidebar()`：收合 ∧ dashboard view ∧ boot 已 settle ∧ 無選中 session → 自動展開並將鍵盤焦點落回可見欄。#206 的收合偏好在有 timeline 可看（session 已選中）時完整保留。

**Scope upgrade（owner 裁決，2026-07-26 新舊並排比較後）**：從「boot 補救」升級為「源頭預防」——無選中 session 時收合方向直接被拒（`\` no-op、cmd-bar 灰化）；breadcrumb root 清選中時退出 split-view 並展開。補救鏈保留（歷史壞 localStorage 仍需 boot 救回）。

## Root cause

- `sidebar-toggle-btn` (`|▷`) only renders inside the workflow-timeline overview header (`_wfOverviewLabelHtml()`, `public/workflow-timeline.js:1817`) — no selected session → no expand affordance at all.
- `applySidebarState()` silently no-ops when the button is absent (`public/app.js`).
- Collapse state persists across sessions, so one `\` keypress turned every later boot into a blank page.

## Fix (4 commits, each gated by a codex round)

| commit | what |
|---|---|
| 703528d | `maybeAutoExpandSidebar()` (expand-only, idempotent) + boot-chain call |
| 7ba1931 | gate `activeTab === 'dashboard'`; move boot call after `restoreTabFromUrl()`; `switchTab('dashboard')` re-check (codex r1) |
| 5fb0901 | treat unset `_entriesLoading` as still booting — `!== false` (codex r4) |
| 6f1636a | refocus visible column after auto-expand (codex r5) |
| 2a82493 | **owner scope upgrade**: refuse collapse while no session selected + cmd-bar grey-out (r6) |
| 6a1265f | breadcrumb root: exit split-view + expand (codex r6-round P2; also fixed test false-verification P3) (r7) |
| 5297fc9 | gate selectProject auto-expand on name===null — fixes r7's `?s=` deep-link guard regression (r8) |

## codex-loop record（6 rounds, final CLEAN）

| round | runner | finding | disposition |
|---|---|---|---|
| r1 | orchestrator | P2 `?view=` boot rewrites pref | fixed 7ba1931 |
| r2 | dev self-run | "clean" | not trusted as gate |
| r3 | orchestrator | P2 mid-boot tab-return race | fixed f2cd6fb |
| r4 | orchestrator | P2 undefined `_entriesLoading` bypasses gate | fixed 5fb0901 (owner-approved past stop-loss) |
| r5 | orchestrator | P2 keyboard focus stuck on empty turns col | fixed 6f1636a (owner-approved, hard cap set) |
| r6 | orchestrator | **CLEAN — zero findings** | — |
| r7 (scope upgrade) | orchestrator | P2 breadcrumb-root dead-end (dev's boundary claim refuted) + P3 test false-verification | fixed 6a1265f |
| r8 | orchestrator | P2 selectProject call site broke `?s=` guard (orchestrator-verified real regression) | fixed 5297fc9 |
| r9 | orchestrator | **CLEAN — no actionable regression** | — |

Rejected list: empty. Dev-self-run rounds were twice contradicted by orchestrator reruns — only orchestrator-run rounds counted.

## Verification (all orchestrator-rerun, not relayed)

- **diff-check (fail-on-old / pass-on-new), cumulative per round**: 703528d tests on origin/main code = 0 pass / 5 fail → HEAD 12 pass / 0 fail (`test/sidebar-auto-expand.test.js`, vm-loads the real `public/app.js`)
- **Full suite (bounded 300s, empty CCXRAY_HOME)**: 1504 pass / 0 fail @6f1636a
- **boot-smoke.sh**: exit 0 @6f1636a
- **Browser (isolated CCXRAY_HOME + mock upstream, real hot sessions)**:
  - root boot, collapsed=1, multi-session → auto-expands, `localStorage` → '0', focus lands on sessions col
  - `?view=usage` boot → pref stays '1' (sidebar invisible there); `switchTab('dashboard')` → expands + focus sessions
  - `?s=<sid>` warm-session deep link → **stays collapsed** (#206 semantics; timeline `|▷` present)
  - single-session project → auto-select picks it, no expand (correct: timeline visible)

### Evidence (branch `evidence/358`)

| scenario | frame |
|---|---|
| tab-return interaction (before→after) | ![tab-return](https://raw.githubusercontent.com/lis186/ccxray/evidence/358/tab-return-expand.gif) |
| root boot auto-expanded | ![root](https://raw.githubusercontent.com/lis186/ccxray/evidence/358/358-f3-root-autoexpand.png) |
| `?s=` deep link stays collapsed | ![deeplink](https://raw.githubusercontent.com/lis186/ccxray/evidence/358/f4-deeplink-stays-collapsed.png) |

## Not verified

- Live SSE mid-boot arrival interplay (out of scope — the check is a one-shot boot/tab-switch decision).
- `hub.test.js` "hub fork and readiness" flaked once during one full-suite run (3× isolated reruns green; this diff touches zero server files).

## GATE-MANIFEST

<!-- GATE-MANIFEST
issue-lint=pass @5297fc958a4476025bc4244e3255d8469d065400
full-test=0 @5297fc958a4476025bc4244e3255d8469d065400
boot-smoke=0 @5297fc958a4476025bc4244e3255d8469d065400
diff-check=0 @5297fc958a4476025bc4244e3255d8469d065400
-->
issue-lint=pass · full-test=0 · boot-smoke=0 · diff-check=0 （@5297fc9）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

