### PR TITLE
fix(session): fail-closed heuristic prevents cross-session agent leak

### DIFF
--- a/server/store.js
+++ b/server/store.js
@@ -332,10 +332,29 @@ function isQuotaCheck(req) {
 
 function extractCwd(req) {
   if (isQuotaCheck(req)) return '(quota-check)';
-  if (!req?.system) return null;
-  const txt = Array.isArray(req.system) ? req.system.map(b => b.text || '').join('\n') : String(req.system);
-  const m = txt.match(/Primary working directory: (.+)/);
-  return m ? m[1].trim() : null;
+  if (req?.system) {
+    const txt = Array.isArray(req.system) ? req.system.map(b => b.text || '').join('\n') : String(req.system);
+    const m = txt.match(/Primary working directory: (.+)/);
+    if (m) return m[1].trim();
+    return null;
+  }
+  // context_management format: system content in messages[0].content[] blocks.
+  // Defense-in-depth for project attribution (sessionMeta.cwd).
+  if (req?.context_management && Array.isArray(req?.messages?.[0]?.content)) {
+    for (const block of req.messages[0].content) {
+      if (block?.type === 'text' && typeof block.text === 'string') {
+        const m = block.text.match(/Primary working directory: (.+)/);
+        if (m) return m[1].trim();
+      }
+    }
+    for (const block of req.messages[0].content) {
+      if (block?.type === 'text' && typeof block.text === 'string') {
+        const cm = block.text.match(/Contents of (\/[^\n]+)\/CLAUDE\.md/);
+        if (cm) return cm[1].trim();
+      }
+    }
+  }
+  return null;
 }
 
 function extractSessionId(req) {
@@ -356,6 +375,7 @@ function extractSessionId(req) {
 // is absent but session_id is present, fall back to agentKey — a known
 // non-main key (e.g. 'general-purpose') still means subagent.
 function isAnthropicSubagent(parsedBody) {
+  if (parsedBody?.context_management) return false;
   const noCwd = !extractCwd(parsedBody);
   const noSid = !extractSessionId(parsedBody);
   if (noCwd && noSid) return true;
@@ -371,6 +391,7 @@ function isAnthropicSubagent(parsedBody) {
 // These are Claude Code's Agent tool kickoff calls that lack any identifying metadata.
 function isLikelySubagent(req) {
   if (extractSessionId(req)) return false;      // has explicit session → not orphan
+  if (req?.context_management) return false;     // context_management = main session
   if (extractCwd(req)) return false;             // has system prompt with cwd → not bare
   if (req?.tools?.length) return false;           // has tool definitions → not bare
   if ((req?.messages?.length || 0) > 2) return false;
@@ -492,10 +513,13 @@ function linkParentSession(sessionId, parsedBody, isSubagentHint) {
   // wire-level hint (Codex subagent header) still overrides — those child
   // sessions never carry a cwd of their own.
   if (!isSubagentHint && meta.cwd) return null;
-  // Unlike isLikelySubagent (which screens orphan requests without session_id),
-  // this handles sessions WITH their own session_id. Tools and metadata guards
-  // are intentionally absent because Codex subagents may carry both.
-  const looksSubagent = isSubagentHint || (!extractCwd(parsedBody) && (parsedBody?.messages?.length || 0) <= 2);
+  // Fail-closed: require POSITIVE subagent evidence, not absence of main evidence.
+  // isSubagentHint (Codex header) is authoritative. For Anthropic: any main signal
+  // (system blocks, tools, context_management) → independent session. Only a truly
+  // bare request (no system, no tools, no context_management, ≤2 msgs) can be a
+  // subagent. This prevents new request formats from tripping the heuristic.
+  const hasMainSignal = extractCwd(parsedBody) || parsedBody?.system || parsedBody?.tools?.length || parsedBody?.context_management;
+  const looksSubagent = isSubagentHint || (!hasMainSignal && (parsedBody?.messages?.length || 0) <= 2);
   if (!looksSubagent) return null;
   const parent = inferParentSession();
   if (parent && parent !== sessionId) {
@@ -683,6 +707,7 @@ module.exports = {
   extractCwd,
   extractSessionId,
   isAnthropicSubagent,
+  isLikelySubagent,
   inferParentSession,
   linkParentSession,
   detectSession,

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -618,4 +618,171 @@ describe('store', () => {
       assert.equal(result, null);
     });
   });
+
+  // ── context_management + fail-closed heuristic ───────────────────────
+  // P0 bug: context_management format (no req.system) caused extractCwd to
+  // return null → looksSubagent true → cross-project false link.
+
+  describe('extractCwd – context_management format', () => {
+    it('extracts cwd from "Primary working directory" in messages[0].content', () => {
+      const store = require('../server/store');
+      const req = {
+        context_management: { edits: [] },
+        messages: [{ role: 'user', content: [
+          { type: 'text', text: 'Primary working directory: /home/user/project\nOther info' },
+        ] }],
+      };
+      assert.equal(store.extractCwd(req), '/home/user/project');
+    });
+
+    it('falls back to CLAUDE.md path', () => {
+      const store = require('../server/store');
+      const req = {
+        context_management: { edits: [] },
+        messages: [{ role: 'user', content: [
+          { type: 'text', text: 'Contents of /home/user/project/CLAUDE.md (project instructions):\n# Docs' },
+        ] }],
+      };
+      assert.equal(store.extractCwd(req), '/home/user/project');
+    });
+
+    it('returns null when neither pattern matches', () => {
+      const store = require('../server/store');
+      const req = {
+        context_management: { edits: [] },
+        messages: [{ role: 'user', content: [
+          { type: 'text', text: 'Just some text with no path info.' },
+        ] }],
+      };
+      assert.equal(store.extractCwd(req), null);
+    });
+
+    it('still works for traditional system blocks', () => {
+      const store = require('../server/store');
+      const req = {
+        system: [{ text: 'Primary working directory: /trad/project' }],
+        messages: [{ role: 'user', content: 'hi' }],
+      };
+      assert.equal(store.extractCwd(req), '/trad/project');
+    });
+
+    it('prefers traditional system block over messages content', () => {
+      const store = require('../server/store');
+      const req = {
+        system: [{ text: 'Primary working directory: /from/system' }],
+        messages: [{ role: 'user', content: [
+          { type: 'text', text: 'Primary working directory: /from/messages' },
+        ] }],
+      };
+      assert.equal(store.extractCwd(req), '/from/system');
+    });
+  });
+
+  describe('isAnthropicSubagent – context_management guard', () => {
+    it('returns false for context_management requests', () => {
+      const store = require('../server/store');
+      const req = { context_management: { edits: [] }, messages: [{ role: 'user', content: 'hi' }] };
+      assert.equal(store.isAnthropicSubagent(req), false);
+    });
+  });
+
+  describe('isLikelySubagent – context_management guard', () => {
+    it('returns false for context_management requests', () => {
+      const store = require('../server/store');
+      const req = { context_management: { edits: [] }, messages: [{ role: 'user', content: 'hi' }] };
+      assert.equal(store.isLikelySubagent(req), false);
+    });
+  });
+
+  describe('linkParentSession – fail-closed heuristic', () => {
+    it('does NOT link context_management session (hasMainSignal)', () => {
+      const store = require('../server/store');
+      resetSessionState(store);
+      store.detectSession(mainReq('parent-fc1', 3));
+      store.activeRequests['parent-fc1'] = 1;
+      store.sessionMeta['parent-fc1'] = { cwd: '/proj-a', lastSeenAt: Date.now(), bannerPrinted: true };
+
+      const ctxBody = {
+        context_management: { edits: [] },
+        metadata: { session_id: 'child-fc1' },
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+      };
+      store.detectSession(ctxBody);
+      store.sessionMeta['child-fc1'] = store.sessionMeta['child-fc1'] || {};
+      store.sessionMeta['child-fc1'].lastSeenAt = Date.now();
+
+      assert.equal(store.linkParentSession('child-fc1', ctxBody, false), null);
+    });
+
+    it('does NOT link session with system blocks (hasMainSignal)', () => {
+      const store = require('../server/store');
+      resetSessionState(store);
+      store.detectSession(mainReq('parent-fc2', 3));
+      store.activeRequests['parent-fc2'] = 1;
+      store.sessionMeta['parent-fc2'] = { cwd: '/proj-a', lastSeenAt: Date.now(), bannerPrinted: true };
+
+      const sysBody = {
+        system: [{ text: 'You are helpful.' }],
+        metadata: { session_id: 'child-fc2' },
+        messages: [{ role: 'user', content: 'hi' }],
+      };
+      store.detectSession(sysBody);
+      store.sessionMeta['child-fc2'] = store.sessionMeta['child-fc2'] || {};
+      store.sessionMeta['child-fc2'].lastSeenAt = Date.now();
+
+      assert.equal(store.linkParentSession('child-fc2', sysBody, false), null);
+    });
+
+    it('does NOT link session with tools (hasMainSignal)', () => {
+      const store = require('../server/store');
+      resetSessionState(store);
+      store.detectSession(mainReq('parent-fc3', 3));
+      store.activeRequests['parent-fc3'] = 1;
+      store.sessionMeta['parent-fc3'] = { cwd: '/proj-a', lastSeenAt: Date.now(), bannerPrinted: true };
+
+      const toolBody = {
+        metadata: { session_id: 'child-fc3' },
+        messages: [{ role: 'user', content: 'hi' }],
+        tools: [{ name: 'Read' }, { name: 'Write' }],
+      };
+      store.detectSession(toolBody);
+      store.sessionMeta['child-fc3'] = store.sessionMeta['child-fc3'] || {};
+      store.sessionMeta['child-fc3'].lastSeenAt = Date.now();
+
+      assert.equal(store.linkParentSession('child-fc3', toolBody, false), null);
+    });
+
+    it('still links bare request (no main signal, ≤2 msgs)', () => {
+      const store = require('../server/store');
+      resetSessionState(store);
+      store.detectSession(mainReq('parent-fc4', 3));
+      store.activeRequests['parent-fc4'] = 1;
+      store.sessionMeta['parent-fc4'] = { cwd: '/proj-a', lastSeenAt: Date.now(), bannerPrinted: true };
+
+      const bareBody = {
+        metadata: { session_id: 'child-fc4' },
+        messages: [{ role: 'user', content: 'research this' }],
+      };
+      store.detectSession(bareBody);
+      store.sessionMeta['child-fc4'] = store.sessionMeta['child-fc4'] || {};
+      store.sessionMeta['child-fc4'].lastSeenAt = Date.now();
+
+      assert.equal(store.linkParentSession('child-fc4', bareBody, false), 'parent-fc4');
+    });
+
+    it('still links when isSubagentHint is true (Codex header)', () => {
+      const store = require('../server/store');
+      resetSessionState(store);
+      store.detectSession(mainReq('parent-fc5', 3));
+      store.activeRequests['parent-fc5'] = 1;
+      store.sessionMeta['parent-fc5'] = { cwd: '/proj-a', lastSeenAt: Date.now(), bannerPrinted: true };
+
+      const codexBody = mainReq('child-fc5', 2);
+      store.detectSession(codexBody);
+      store.sessionMeta['child-fc5'] = store.sessionMeta['child-fc5'] || {};
+      store.sessionMeta['child-fc5'].lastSeenAt = Date.now();
+
+      assert.equal(store.linkParentSession('child-fc5', codexBody, true), 'parent-fc5');
+    });
+  });
 });


### PR DESCRIPTION
## 摘要

P0 bug 修復：`context_management` 格式（Opus 4.6 1M context）的請求沒有 `req.system`，導致 `extractCwd` 回傳 null → `looksSubagent` 誤判為 true → `inferParentSession` 把不同 project 的 session 連在一起。

修正方式：將 `linkParentSession` 的 heuristic 從 fail-open（缺少 main 證據 = subagent）翻轉為 fail-closed（要求正面 subagent 證據）。任何有 `system`、`tools`、或 `context_management` 的請求都被視為獨立 session，未來新格式也自動安全。

## Detail

### Root cause

`linkParentSession` (store.js:498) used a fail-open heuristic:
```js
const looksSubagent = isSubagentHint || (!extractCwd(parsedBody) && msgs <= 2);
```

`extractCwd` only searches `req.system` (traditional system blocks). The `context_management` format puts system content in `messages[0].content[]` instead — `extractCwd` returns null, `looksSubagent` fires, and `inferParentSession` picks whatever inflight session is most recent with **no project/cwd check**.

### Fix

Flip to fail-closed — require positive main-signal absence:
```js
const hasMainSignal = extractCwd(parsedBody) || parsedBody?.system
  || parsedBody?.tools?.length || parsedBody?.context_management;
const looksSubagent = isSubagentHint || (!hasMainSignal && msgs <= 2);
```

Defense-in-depth:
- `isAnthropicSubagent`: `context_management` early guard
- `isLikelySubagent`: `context_management` early guard
- `extractCwd`: extended to search `messages[0].content[]` for `context_management` format

### Verification

Fail-on-old / pass-on-new differential:

| Test | Old (main) | New (fix) |
|---|---|---|
| context_management not linked | FAIL | PASS |
| system blocks not linked | FAIL | PASS |
| tools not linked | FAIL | PASS |

Real-data replay (session edf9f0ed actual request shape):
- Main request (54 tools + context_management): `hasMainSignal=true` → NOT linked ✓
- Title-gen (context_management, no tools): `hasMainSignal=true` → NOT linked ✓
- Bare subagent (no system/tools/ctx_mgmt): `hasMainSignal=false` → linked ✓ (no regression)

Past data: `parentSessionId` is in-memory only → deploy = restart = healed.

## Test plan

- [x] 12 new unit tests (extractCwd, isAnthropicSubagent, isLikelySubagent, linkParentSession fail-closed)
- [x] 324/324 unit tests pass
- [x] Fail-on-old / pass-on-new differential verified
- [x] Real request shape from the bug session verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)