### PR TITLE
fix(dashboard): hide Turns column when no session selected

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -162,7 +162,8 @@
   .project-item .pi-meta { font-size: 11px; color: var(--dim); margin-top: 2px; }
   .project-item .pi-cost { color: var(--yellow); }
   .project-item .pi-range { font-size: 10px; color: var(--dim); margin-top: 1px; }
-  #col-turns { width: 220px; position: relative; }
+  /* #324: hidden by default; shown by .wf-active or .cold-loading on #columns */
+  #col-turns { width: 220px; position: relative; display: none; }
   #col-sections { width: 220px; }
 
   .col-empty { color: var(--dim); text-align: center; padding: 40px 12px; font-size: 12px; }
@@ -681,7 +682,7 @@
 /* Cold-loading: hide empty sections/detail, let turns fill the space (#316) */
 #columns.cold-loading #col-sections,
 #columns.cold-loading #col-detail { display: none; }
-#columns.cold-loading #col-turns { flex: 1; overflow: hidden; }
+#columns.cold-loading #col-turns { display: block; flex: 1; overflow: hidden; }
 
 /* ── Workflow Swimlane Timeline (#91) ── */
 /* When workflow is active, col-turns becomes the full-width right area;


### PR DESCRIPTION
## 摘要
- `#col-turns` 在無 session 選取時仍顯示為 220px 空白欄位，切換 session 時也會短暫閃現
- 預設 `display: none`，由 `.wf-active`（workflow timeline）和 `.cold-loading`（載入中）的 CSS 規則覆寫顯示

## Detail

`#col-turns` was always visible (220px wide) even without a selected session, showing an empty column. After #332 removed the old turn-item DOM, the column only hosts content when `wf-active` (workflow timeline) or `cold-loading` (spinner) is active on `#columns`.

The fix adds `display: none` to the base `#col-turns` rule and adds `display: block` to the `cold-loading` override (the `wf-active` rule already had `display: flex`). This also eliminates the flash-on-switch: the column stays hidden during the synchronous gap between session selection and `wf-active` class application.

### Acceptance
1. Switch to a project with 0 sessions → no Turns column ✓
2. Switch project without selecting a session → no Turns column ✓
3. Select a session → Turns column (workflow timeline) appears normally ✓
4. Switch between sessions → no flash ✓

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)