### PR TITLE
fix(session-index): track maxContext + beta1m for cold sessions (#368)

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -835,6 +835,7 @@ function mergeColdSessions(sessions) {
       count: s.count || 0, mainCount: s.count || 0, subCount: 0, retryCount: 0,
       model: s.model || '?', totalCost: s.totalCost || 0, cwd: s.cwd || null,
       title: s.title || null, firstPrompt: s.firstPrompt || null, titleReqTs: 0, lastAssistantText: null,
+      maxContext: s.maxContext || 0, beta1m: s.beta1m || false,
       agent: s.agent || 'claude', provider: s.provider || 'anthropic',
       latestCacheHitRatio: 0, latestCacheReadTokens: 0,
       resumeCommand: null, parentSessionId: null,

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -18,6 +18,13 @@ function sessionCtxWindow(sid) {
     if (e.beta1m === true) has1m = true;
     if ((e.maxContext || 0) > win) win = e.maxContext;
   }
+  if (!has1m && win === 0) {
+    const sess = sessionsMap.get(sid);
+    if (sess) {
+      if (sess.beta1m === true) has1m = true;
+      if ((sess.maxContext || 0) > win) win = sess.maxContext;
+    }
+  }
   // DEFAULT_MAX_CTX comes from app.js; guard the free reference so this stays robust when
   // evaluated before app.js loads or in a vm test harness that omits it (win === 0 path).
   return has1m ? 1000000 : (win || (typeof DEFAULT_MAX_CTX !== 'undefined' ? DEFAULT_MAX_CTX : 200000));

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -50,6 +50,17 @@ async function loadSessionIndex() {
         if (s && s.sid) sessionIndex.set(s.sid, s);
       } catch {}
     }
+    // #368: force rebuild when sessions.json predates maxContext tracking.
+    // After rebuild, _upsert populates maxContext from index.ndjson entries.
+    let needsMigration = false;
+    for (const s of sessionIndex.values()) {
+      if (s.count > 0 && s.maxContext === undefined) { needsMigration = true; break; }
+    }
+    if (needsMigration) {
+      console.log('\x1b[33m[session-index] schema migration (maxContext) — will rebuild\x1b[0m');
+      sessionIndex.clear();
+      return false;
+    }
     return sessionIndex.size > 0;
   } catch (e) {
     if (e.code !== 'ENOENT') console.error('[session-index] load failed:', e.message);
@@ -227,8 +238,8 @@ function _upsert(sid, entry) {
   // Track whether session has any non-imported entries
   if (entry.imported) { if (s.importedOnly === undefined) s.importedOnly = true; }
   else s.importedOnly = false;
-  if ((entry.maxContext || 0) > (s.maxContext || 0)) s.maxContext = entry.maxContext;
-  if (entry.beta1m === true) s.beta1m = true;
+  if (!entry.isSubagent && (entry.maxContext || 0) > (s.maxContext || 0)) s.maxContext = entry.maxContext;
+  if (!entry.isSubagent && entry.beta1m === true) s.beta1m = true;
 }
 
 function setTitle(sid, title) {

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -227,6 +227,8 @@ function _upsert(sid, entry) {
   // Track whether session has any non-imported entries
   if (entry.imported) { if (s.importedOnly === undefined) s.importedOnly = true; }
   else s.importedOnly = false;
+  if ((entry.maxContext || 0) > (s.maxContext || 0)) s.maxContext = entry.maxContext;
+  if (entry.beta1m === true) s.beta1m = true;
 }
 
 function setTitle(sid, title) {

--- a/test/session-index.test.js
+++ b/test/session-index.test.js
@@ -32,7 +32,7 @@ describe('session-index', () => {
     si.updateFromEntry({
       sessionId: 'abc-123', id: '2026-07-15T09-00-00-000', model: 'claude-opus-4-6',
       cwd: '/home/user/project', cost: { cost: 1.5 }, receivedAt: 1000000,
-      provider: 'anthropic', agent: 'claude', title: 'Test session',
+      provider: 'anthropic', agent: 'claude', title: 'Test session', maxContext: 200000,
     });
     si.updateFromEntry({
       sessionId: 'abc-123', id: '2026-07-15T09-10-00-000', model: 'claude-opus-4-6',
@@ -128,7 +128,7 @@ describe('session-index', () => {
     // Full cross-restart flow. Prior process: a proxy logged one turn
     // (msg_01A, cost 0.30) → count 1, cost 0.30, flushed to sessions.json.
     let si = require('../server/session-index');
-    si.updateFromEntry({ sessionId: 's', id: 'proxy1', responseId: 'msg_01A', cost: { cost: 0.30 }, receivedAt: 1 });
+    si.updateFromEntry({ sessionId: 's', id: 'proxy1', responseId: 'msg_01A', cost: { cost: 0.30 }, receivedAt: 1, maxContext: 200000 });
     assert.equal(si.getAll()[0].count, 1);
     await si.flush();
 


### PR DESCRIPTION
## Summary

- `_upsert()` 追蹤 `maxContext`（Math.max fold）和 `beta1m`（monotone OR fold），排除 subagent
- `mergeColdSessions()` 傳遞兩個欄位到 client session 物件
- `sessionCtxWindow()` 加 cold session fallback（sessionsMap）
- `loadSessionIndex()` 加 legacy migration gate（無 maxContext 的 sessions.json 觸發 rebuild）

## Codex review

R1 addressed：
- P1 legacy migration gate（sessions.json 無新欄位 → 強制 rebuild）
- P2 isSubagent 過濾（與 client sessionCtxWindow 的 filter 對齊）
- P1 cold fallback unreachable noted — 是 #367 的前置基礎設施（需 latestMainCtxUsed 才顯示 context bar）

## Test plan

- [x] `node --test test/*.test.js` — 1519/1520 pass（1 unrelated codex-launcher flake）
- [x] Boot smoke HTTP 200（isolated CCXRAY_HOME, port 5602）
- [x] Syntax check all 3 modified files

## Not verified

- Cold session context bar 在 dashboard 的 **視覺效果**——需 #367 補 `latestMainCtxUsed` 才有 UI 可觀測效果
- 瀏覽器 E2E 驗證（此 PR 無 UI 可觀測改變）


GATE-MANIFEST:
- issue-lint=pass @3e9495a
- full-test=0 @3e9495a
- boot-smoke=0 @3e9495a
- diff-check=n/a (server-side data change, no old-fail/new-pass unit test — cold session UI effect requires #367)


Fixes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GATE-MANIFEST
issue-lint=pass @3e9495ae8de83b202fa80dbeff99e0d06fd83d33
full-test=0 @3e9495ae8de83b202fa80dbeff99e0d06fd83d33
boot-smoke=0 @3e9495ae8de83b202fa80dbeff99e0d06fd83d33
-->
