### PR TITLE
fix(cold-session): compute weather in rebuildFromMetas + preview fallback (#367)

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1497,8 +1497,9 @@ function renderSessionItem(sess, sid, sessEl) {
   // keep taking precedence per normal HTML tooltip nesting.
   if (sessEl) sessEl.title = sessionCardTooltip;
 
-  const previewText = sess.lastAssistantText
-    ? sess.lastAssistantText.slice(0, 60) + (sess.lastAssistantText.length > 60 ? '…' : '')
+  const rawPreview = sess.lastAssistantText || sess.firstPrompt || null;
+  const previewText = rawPreview
+    ? rawPreview.slice(0, 60) + (rawPreview.length > 60 ? '…' : '')
     : null;
   const previewRow = previewText ? '<div class="si-preview">' + escapeHtml(previewText) + '</div>' : '';
   const truncatedRow = sess.truncated

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -99,6 +99,22 @@ function rebuildFromMetas(metas) {
     if (!m || !m.sessionId) continue;
     _upsert(m.sessionId, m);
   }
+  // #367: compute weather for all sessions from index metas.
+  // Index metas have all fields assessWeather needs (usage, maxContext, elapsed,
+  // model, toolFail, stopReason). isCompacted is unavailable (client-derived) —
+  // conservative (no false compaction signal).
+  const { assessWeather } = require('../public/weather');
+  const bySid = new Map();
+  for (const m of metas) {
+    if (!m || !m.sessionId || m.isSubagent) continue;
+    let arr = bySid.get(m.sessionId);
+    if (!arr) { arr = []; bySid.set(m.sessionId, arr); }
+    arr.push(m);
+  }
+  for (const [sid, turns] of bySid) {
+    const s = sessionIndex.get(sid);
+    if (s) s.weather = assessWeather(turns);
+  }
   dirty = true;
 }
 


### PR DESCRIPTION
## Summary

- `rebuildFromMetas` 加 weather post-pass：用 index metas（有 usage/maxContext/elapsed/model/toolFail/stopReason）對所有 session 算 `assessWeather`，結果存進 sessions.json
- `renderSessionItem` preview text fallback：`lastAssistantText || firstPrompt`，cold session 至少顯示 firstPrompt

## 已有（#370 + #371 已解決）

ctxPct / cacheHitRatio / cacheBreaks / latestCacheReadTokens / maxContext / beta1m 全部已在 _upsert 追蹤

## 已知限制

- isCompacted 不在 index fields——cold session weather 少算 compaction 信號（保守安全）
- lastAssistantText 需從 response body 提取，index meta 無此欄位——fallback 到 firstPrompt

## Test plan

- [x] `node --test test/*.test.js` — 1548/1548 pass
- [x] Boot smoke HTTP 200
- [x] Syntax check both modified files

## Not verified

- cold session card **視覺效果**——需瀏覽器驗收（動 public/）

<!-- GATE-MANIFEST
issue-lint=pass @161461705ca7415d2b3dc3feaa43a43754ee5431
full-test=0 @161461705ca7415d2b3dc3feaa43a43754ee5431
boot-smoke=0 @161461705ca7415d2b3dc3feaa43a43754ee5431
-->

Fixes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)