### PR TITLE
feat(weather): clickable turn links in overlay zoom to swimlane (#369)

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -733,6 +733,8 @@
 .weather-overlay .wo-header { font-size: 16px; font-weight: 600; margin-bottom: 8px; color: #fff; }
 .weather-overlay .wo-factors { color: #aaa; font-size: 13px; margin-bottom: 8px; }
 .weather-overlay .wo-action { color: #e0e0e0; font-size: 13px; }
+.wo-turn-link { color: var(--accent); cursor: pointer; text-decoration: underline; }
+.wo-turn-link:hover { color: #58a6ff; }
 .wf-tooltip { position: fixed; display: none; background: var(--surface); border: 1px solid var(--border); border-radius: 4px; padding: 6px 10px; font-size: 11px; color: var(--text); z-index: 100; pointer-events: none; max-width: 300px; box-shadow: 0 2px 8px rgba(0,0,0,0.3); line-height: 1.6; }
 .wf-tooltip .r { display: flex; justify-content: space-between; gap: 16px; }
 .wf-tooltip .l { color: var(--dim); }

--- a/public/style.css
+++ b/public/style.css
@@ -733,8 +733,8 @@
 .weather-overlay .wo-header { font-size: 16px; font-weight: 600; margin-bottom: 8px; color: #fff; }
 .weather-overlay .wo-factors { color: #aaa; font-size: 13px; margin-bottom: 8px; }
 .weather-overlay .wo-action { color: #e0e0e0; font-size: 13px; }
-.wo-turn-link { color: var(--accent); cursor: pointer; text-decoration: underline; }
-.wo-turn-link:hover { color: #58a6ff; }
+.wo-turn-link { color: #7eb8da; cursor: pointer; text-decoration: underline; }
+.wo-turn-link:hover { color: #a8d4f0; }
 .wf-tooltip { position: fixed; display: none; background: var(--surface); border: 1px solid var(--border); border-radius: 4px; padding: 6px 10px; font-size: 11px; color: var(--text); z-index: 100; pointer-events: none; max-width: 300px; box-shadow: 0 2px 8px rgba(0,0,0,0.3); line-height: 1.6; }
 .wf-tooltip .r { display: flex; justify-content: space-between; gap: 16px; }
 .wf-tooltip .l { color: var(--dim); }

--- a/public/style.css
+++ b/public/style.css
@@ -729,12 +729,12 @@
 #wf-detail-area { flex: 1; display: flex; min-height: 180px; overflow: hidden; }
 #wf-agent-card-panel { width: 240px; flex-shrink: 0; overflow-y: auto; border-right: 1px solid var(--border); background: var(--surface); }
 #wf-steps-panel { flex: 1; overflow-y: auto; min-width: 0; }
-.weather-overlay { position: fixed; display: none; background: #1a1f2b; border: 1px solid #333; border-radius: 6px; padding: 12px 16px; font-size: 13px; color: #e0e0e0; z-index: 200; pointer-events: none; max-width: 380px; box-shadow: 0 4px 20px rgba(0,0,0,0.6); line-height: 1.8; }
-.weather-overlay .wo-header { font-size: 16px; font-weight: 600; margin-bottom: 8px; color: #fff; }
-.weather-overlay .wo-factors { color: #aaa; font-size: 13px; margin-bottom: 8px; }
-.weather-overlay .wo-action { color: #e0e0e0; font-size: 13px; }
-.wo-turn-link { color: #7eb8da; cursor: pointer; text-decoration: underline; }
-.wo-turn-link:hover { color: #a8d4f0; }
+.weather-overlay { position: fixed; display: none; background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 12px 16px; font-size: 13px; color: var(--text); z-index: 200; pointer-events: none; max-width: 380px; box-shadow: 0 4px 20px rgba(0,0,0,0.6); line-height: 1.8; }
+.weather-overlay .wo-header { font-size: 16px; font-weight: 600; margin-bottom: 8px; color: var(--text); }
+.weather-overlay .wo-factors { color: var(--dim); font-size: 13px; margin-bottom: 8px; }
+.weather-overlay .wo-action { color: var(--text); font-size: 13px; }
+.wo-turn-link { color: var(--link, #58a6ff); cursor: pointer; text-decoration: underline; }
+.wo-turn-link:hover { color: var(--link-hover, #79c0ff); }
 .wf-tooltip { position: fixed; display: none; background: var(--surface); border: 1px solid var(--border); border-radius: 4px; padding: 6px 10px; font-size: 11px; color: var(--text); z-index: 100; pointer-events: none; max-width: 300px; box-shadow: 0 2px 8px rgba(0,0,0,0.3); line-height: 1.6; }
 .wf-tooltip .r { display: flex; justify-content: space-between; gap: 16px; }
 .wf-tooltip .l { color: var(--dim); }

--- a/public/weather.js
+++ b/public/weather.js
@@ -119,18 +119,18 @@ function sigErrorCluster(turns) {
 
 // ponytail: catches chronic tool errors spread across long sessions that error_cluster misses (exp9: ~30 false negatives).
 function sigErrorCumulative(turns) {
-  var toolTurns = 0, errTurns = 0;
+  var toolTurns = 0, errTurns = 0, firstErrId = null;
   for (var i = 0; i < turns.length; i++) {
     if (turns[i].stopReason === 'tool_use') {
       toolTurns++;
-      if (turns[i].toolFail) errTurns++;
+      if (turns[i].toolFail) { errTurns++; if (!firstErrId) firstErrId = turns[i].id || null; }
     }
   }
   if (toolTurns < 10) return { severity: 0, detail: {} };
   var rate = errTurns / toolTurns;
   // ponytail: 20% cumulative error rate = severity 0.5, 40% = 1.0. Requires ≥10 tool turns to avoid noise.
   var sev = clamp01(rate / 0.4);
-  return { severity: sev, detail: { errTurns: errTurns, toolTurns: toolTurns, rate: Math.round(rate * 100) / 100 } };
+  return { severity: sev, detail: { errTurns: errTurns, toolTurns: toolTurns, rate: Math.round(rate * 100) / 100, firstErrId: firstErrId } };
 }
 
 function assessWeather(turns) {
@@ -198,7 +198,7 @@ var _FACTOR_FMT = {
   stuck: function(d) { return 'stuck ' + (d.maxStreak || 0) + ' failures (' + _rangeLink(d.turnStart || 0, d.turnEnd || 0, d.entryIdStart, d.entryIdEnd) + ')'; },
   latency_drift: function(d) { return 'latency ' + (d.ratio || '?') + 'x baseline'; },
   error_cluster: function(d) { return 'error burst ' + Math.round((d.errorRate || 0) * 100) + '% (' + _rangeLink(d.windowStart || 0, d.windowEnd || 0, d.entryIdStart, d.entryIdEnd) + ')'; },
-  error_cumulative: function(d) { return d.errTurns + '/' + d.toolTurns + ' tool errors (' + Math.round((d.rate || 0) * 100) + '%)'; },
+  error_cumulative: function(d) { var label = d.errTurns + '/' + d.toolTurns + ' tool errors (' + Math.round((d.rate || 0) * 100) + '%)'; return d.firstErrId ? _turnLink(label, d.firstErrId) : label; },
 };
 
 var _LEVEL_SUMMARY = {
@@ -220,7 +220,7 @@ var _ACTION_TABLE = {
   stuck: function(d) { return 'Check ' + _rangeLink(d.turnStart || 0, d.turnEnd || 0, d.entryIdStart, d.entryIdEnd) + ' — usually permissions or paths'; },
   latency_drift: function() { return 'Use subagent to reduce context load'; },
   error_cluster: function(d) { return 'Check ' + _rangeLink(d.windowStart || 0, d.windowEnd || 0, d.entryIdStart, d.entryIdEnd); },
-  error_cumulative: function() { return 'Check tool errors — common: permissions, paths, settings'; },
+  error_cumulative: function(d) { return d.firstErrId ? 'Check ' + _turnLink('first error', d.firstErrId) + ' — common: permissions, paths, settings' : 'Check tool errors — common: permissions, paths, settings'; },
 };
 
 function _buildTooltip(level, factors, stats) {

--- a/public/weather.js
+++ b/public/weather.js
@@ -44,11 +44,11 @@ function sigCtxPressure(turns) {
   var last = turns[turns.length - 1];
   var u = last.usage || {};
   var mx = last.maxContext;
-  if (!mx || mx < 1000) return { severity: 0, detail: { ctxPct: 0, turnIndex: turns.length - 1 } };
+  if (!mx || mx < 1000) return { severity: 0, detail: { ctxPct: 0, turnIndex: turns.length - 1, entryId: last && last.id || null } };
   var used = (u.input_tokens || 0) + (u.cache_read_input_tokens || 0) + (u.cache_creation_input_tokens || 0);
   var pct = used / mx;
   var sev = clamp01((pct - CTX_FLOOR) / (1 - CTX_FLOOR));
-  return { severity: sev, detail: { ctxPct: Math.round(pct * 1000) / 10, turnIndex: turns.length - 1 } };
+  return { severity: sev, detail: { ctxPct: Math.round(pct * 1000) / 10, turnIndex: turns.length - 1, entryId: last && last.id || null } };
 }
 
 function sigCompaction(turns) {
@@ -62,7 +62,7 @@ function sigTruncation(turns) {
   for (var i = 0; i < turns.length; i++) {
     var u = turns[i].usage || {};
     if (turns[i].stopReason === 'max_tokens' && (u.output_tokens || 0) >= 16000) {
-      return { severity: 0.5, detail: { turnIndex: i } };
+      return { severity: 0.5, detail: { turnIndex: i, entryId: turns[i] && turns[i].id || null } };
     }
   }
   return { severity: 0, detail: {} };
@@ -79,7 +79,7 @@ function sigStuck(turns) {
     }
   }
   var startIdx = maxStreak > 0 ? maxStreakEnd - maxStreak + 1 : 0;
-  return { severity: maxStreak >= 10 ? 0.9 : 0, detail: { maxStreak: maxStreak, turnStart: startIdx, turnEnd: maxStreakEnd } };
+  return { severity: maxStreak >= 10 ? 0.9 : 0, detail: { maxStreak: maxStreak, turnStart: startIdx, turnEnd: maxStreakEnd, entryIdStart: turns[startIdx] && turns[startIdx].id || null, entryIdEnd: turns[maxStreakEnd] && turns[maxStreakEnd].id || null } };
 }
 
 function sigLatencyDrift(turns) {
@@ -114,7 +114,7 @@ function sigErrorCluster(turns) {
   }
   // ponytail: denom=2.0 — window needs 100% error rate to reach severity 0.5. Exp2: 0.6 flagged 247/346 sessions.
   var sev = clamp01(maxRate / 2.0);
-  return { severity: sev, detail: { windowStart: bestStart, windowEnd: bestEnd, errorRate: Math.round(maxRate * 100) / 100 } };
+  return { severity: sev, detail: { windowStart: bestStart, windowEnd: bestEnd, errorRate: Math.round(maxRate * 100) / 100, entryIdStart: turns[bestStart] && turns[bestStart].id || null, entryIdEnd: turns[bestEnd] && turns[bestEnd].id || null } };
 }
 
 // ponytail: catches chronic tool errors spread across long sessions that error_cluster misses (exp9: ~30 false negatives).
@@ -179,13 +179,24 @@ function assessWeather(turns) {
   return { level: pick.level, emoji: pick.emoji, score: Math.round(score * 1000) / 1000, factors: factors, stats: stats, tooltip: tooltip };
 }
 
+function _turnLink(label, entryId) {
+  if (!entryId || typeof document === 'undefined') return label;
+  return '<span class="wo-turn-link" onclick="event.stopPropagation();wfLockTurn(\'' + entryId + '\')">' + label + '</span>';
+}
+
+function _rangeLink(start, end, startId, endId) {
+  var label = 'turn ' + start + '-' + end;
+  if ((!startId && !endId) || typeof document === 'undefined') return label;
+  return '<span class="wo-turn-link" onclick="event.stopPropagation();wfLockTurn(\'' + (startId || endId) + '\')">' + label + '</span>';
+}
+
 var _FACTOR_FMT = {
   ctx_pressure: function(d) { return 'context ' + (d.ctxPct || 0) + '%'; },
   compaction_scar: function(d) { return 'compaction ×' + (d.compactionCount || 1) + ' (info lost)'; },
-  truncation: function(d) { return 'output truncated (turn ' + (d.turnIndex || '?') + ')'; },
-  stuck: function(d) { return 'stuck ' + (d.maxStreak || 0) + ' failures (turn ' + (d.turnStart || 0) + '-' + (d.turnEnd || 0) + ')'; },
+  truncation: function(d) { return 'output truncated (' + _turnLink('turn ' + (d.turnIndex || '?'), d.entryId) + ')'; },
+  stuck: function(d) { return 'stuck ' + (d.maxStreak || 0) + ' failures (' + _rangeLink(d.turnStart || 0, d.turnEnd || 0, d.entryIdStart, d.entryIdEnd) + ')'; },
   latency_drift: function(d) { return 'latency ' + (d.ratio || '?') + 'x baseline'; },
-  error_cluster: function(d) { return 'error burst ' + Math.round((d.errorRate || 0) * 100) + '% (turn ' + (d.windowStart || 0) + '-' + (d.windowEnd || 0) + ')'; },
+  error_cluster: function(d) { return 'error burst ' + Math.round((d.errorRate || 0) * 100) + '% (' + _rangeLink(d.windowStart || 0, d.windowEnd || 0, d.entryIdStart, d.entryIdEnd) + ')'; },
   error_cumulative: function(d) { return d.errTurns + '/' + d.toolTurns + ' tool errors (' + Math.round((d.rate || 0) * 100) + '%)'; },
 };
 
@@ -205,9 +216,9 @@ var _ACTION_TABLE = {
   },
   compaction_scar: function() { return 'Save decisions to CLAUDE.md, or start fresh with --resume'; },
   truncation: function() { return 'Break into smaller steps'; },
-  stuck: function(d) { return 'Check turn ' + (d.turnStart || 0) + '-' + (d.turnEnd || 0) + ' — usually permissions or paths'; },
+  stuck: function(d) { return 'Check ' + _rangeLink(d.turnStart || 0, d.turnEnd || 0, d.entryIdStart, d.entryIdEnd) + ' — usually permissions or paths'; },
   latency_drift: function() { return 'Use subagent to reduce context load'; },
-  error_cluster: function(d) { return 'Check turn ' + (d.windowStart || 0) + '-' + (d.windowEnd || 0); },
+  error_cluster: function(d) { return 'Check ' + _rangeLink(d.windowStart || 0, d.windowEnd || 0, d.entryIdStart, d.entryIdEnd); },
   error_cumulative: function() { return 'Check tool errors — common: permissions, paths, settings'; },
 };
 

--- a/public/weather.js
+++ b/public/weather.js
@@ -181,13 +181,14 @@ function assessWeather(turns) {
 
 function _turnLink(label, entryId) {
   if (!entryId || typeof document === 'undefined') return label;
-  return '<span class="wo-turn-link" onclick="event.stopPropagation();wfLockTurn(\'' + entryId + '\');if(typeof wfState!==\'undefined\'&&wfState&&!wfState.laneFocusMode)wfToggleLaneFocus()">' + label + '</span>';
+  return '<span class="wo-turn-link" onclick="event.stopPropagation();if(typeof wfZoomToTurnRange===\'function\')wfZoomToTurnRange(\'' + entryId + '\')">' + label + '</span>';
 }
 
 function _rangeLink(start, end, startId, endId) {
   var label = 'turn ' + start + '-' + end;
   if ((!startId && !endId) || typeof document === 'undefined') return label;
-  return '<span class="wo-turn-link" onclick="event.stopPropagation();wfLockTurn(\'' + (startId || endId) + '\');if(typeof wfState!==\'undefined\'&&wfState&&!wfState.laneFocusMode)wfToggleLaneFocus()">' + label + '</span>';
+  var sid = startId || endId, eid = endId || startId;
+  return '<span class="wo-turn-link" onclick="event.stopPropagation();if(typeof wfZoomToTurnRange===\'function\')wfZoomToTurnRange(\'' + sid + '\',\'' + eid + '\')">' + label + '</span>';
 }
 
 var _FACTOR_FMT = {

--- a/public/weather.js
+++ b/public/weather.js
@@ -181,13 +181,13 @@ function assessWeather(turns) {
 
 function _turnLink(label, entryId) {
   if (!entryId || typeof document === 'undefined') return label;
-  return '<span class="wo-turn-link" onclick="event.stopPropagation();wfLockTurn(\'' + entryId + '\')">' + label + '</span>';
+  return '<span class="wo-turn-link" onclick="event.stopPropagation();wfLockTurn(\'' + entryId + '\');if(typeof wfState!==\'undefined\'&&wfState&&!wfState.laneFocusMode)wfToggleLaneFocus()">' + label + '</span>';
 }
 
 function _rangeLink(start, end, startId, endId) {
   var label = 'turn ' + start + '-' + end;
   if ((!startId && !endId) || typeof document === 'undefined') return label;
-  return '<span class="wo-turn-link" onclick="event.stopPropagation();wfLockTurn(\'' + (startId || endId) + '\')">' + label + '</span>';
+  return '<span class="wo-turn-link" onclick="event.stopPropagation();wfLockTurn(\'' + (startId || endId) + '\');if(typeof wfState!==\'undefined\'&&wfState&&!wfState.laneFocusMode)wfToggleLaneFocus()">' + label + '</span>';
 }
 
 var _FACTOR_FMT = {

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -3099,6 +3099,21 @@ function wfLockTurn(turnId) {
   }
 }
 
+function wfZoomToTurnRange(startId, endId) {
+  if (!wfState) return;
+  var s = wfState.turnIndex && wfState.turnIndex.get(startId);
+  var e = endId ? wfState.turnIndex && wfState.turnIndex.get(endId) : s;
+  if (!s) return;
+  var t0 = Number(s.turn.receivedAt) || 0;
+  var t1 = e ? (Number(e.turn.receivedAt) || 0) + (parseFloat(e.turn.elapsed) || 0) * 1000 : t0 + 60000;
+  if (t1 <= t0) t1 = t0 + 60000;
+  var pad = (t1 - t0) * 0.15;
+  wfState.viewT0 = Math.max(wfState.tMin, t0 - pad);
+  wfState.viewT1 = Math.min(wfState.tMax, t1 + pad);
+  wfLockTurn(startId);
+  wfDeferRender();
+}
+
 // ── Section Navigation ───────────────────────────────────────────────────
 function wfSelectSection(name) {
   if (!wfState) return;

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -3112,6 +3112,16 @@ function wfZoomToTurnRange(startId, endId) {
   wfState.viewT1 = Math.min(wfState.tMax, t1 + pad);
   wfLockTurn(startId);
   wfDeferRender();
+  // Scroll the turn list to the selected turn after render
+  setTimeout(function() {
+    for (var i = 0; i < allEntries.length; i++) {
+      if (allEntries[i].id === startId) {
+        var el = colTurns && colTurns.querySelector('.turn-item[data-entry-idx="' + i + '"]');
+        if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        break;
+      }
+    }
+  }, 100);
 }
 
 // ── Section Navigation ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Signal functions 加 `entryId` / `entryIdStart` / `entryIdEnd` 到 detail
- `_turnLink` / `_rangeLink` helper 產生 clickable spans（呼叫 `wfZoomToTurnRange`）
- `wfZoomToTurnRange(startId, endId)` — zoom overview + lock turn + scroll turn list
- `sigErrorCumulative` 追蹤 `firstErrId`，format/action 可點擊 zoom 到第一個 error
- Overlay 改用 CSS variables（`--surface`, `--text`, `--dim`, `--link`）匹配 theme

## Known limitations

- Turn list scroll 對 cold-load session 的 timeline 不一定到達精確位置（accepted）

## Test plan

- [x] `node --test test/weather.test.js` — 28/28 pass
- [x] Boot smoke HTTP 200
- [x] Syntax check weather.js + workflow-timeline.js
- [x] Browser visual review（overlay colors, turn link click → zoom, scroll）

## Not verified

- Cold session overlay turn links（server-side weather 沒有 entryId，退化成純文字——by design）

<!-- GATE-MANIFEST
issue-lint=pass @3997ca6684f54deb61fcfbb637e501183aa14b05
full-test=0 @3997ca6684f54deb61fcfbb637e501183aa14b05
boot-smoke=0 @3997ca6684f54deb61fcfbb637e501183aa14b05
-->

Fixes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)