### PR TITLE
chore: fix stale MIT in lockfile + add CONTRIBUTING with relicensing grant

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What changes and why. One paragraph is fine. -->
+
+## Verification
+
+<!-- What you ran and what it showed. Say what you did NOT verify — that is
+     more useful than a claim that everything works. -->
+
+- [ ] `CCXRAY_HOME=$(mktemp -d) npm test` passes
+- [ ] Evidence the change does what it claims (for a bug fix: a test that fails
+      when the fix is reverted)
+
+Not verified:
+
+## License
+
+- [ ] I agree to license this contribution under **PolyForm Noncommercial 1.0.0**
+      and grant the maintainer the right to relicense it under different terms in
+      the future, including commercial licenses
+      (see [CONTRIBUTING.md](https://github.com/lis186/ccxray/blob/main/CONTRIBUTING.md))
+- [ ] My commits are signed off (`git commit -s`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to ccxray
+
+Thanks for the interest. Bug reports and wire-protocol findings are especially
+welcome — this project lives or dies on whether it reads the wire correctly.
+
+## License of contributions (read this first)
+
+ccxray is licensed under **PolyForm Noncommercial 1.0.0** (see [LICENSE](LICENSE)).
+It was MIT-licensed until 2026-07-21; versions `1.9.3` and earlier on npm remain
+MIT and always will be.
+
+By opening a pull request you agree that:
+
+1. Your contribution is licensed under **PolyForm Noncommercial 1.0.0**, and
+2. You grant the maintainer the right to **relicense your contribution under
+   different terms in the future, including commercial licenses**.
+
+Point 2 exists so the project can offer commercial licenses without having to
+track down every past contributor. If you are not willing to grant it, please
+say so in the PR — a patch is still welcome, it just needs a different
+conversation first.
+
+### Sign your commits (DCO)
+
+Every commit must carry a `Signed-off-by` line certifying you wrote the code or
+have the right to submit it under the terms above — the
+[Developer Certificate of Origin](https://developercertificate.org/):
+
+```bash
+git commit -s -m "your message"
+```
+
+To add it to commits you already made:
+
+```bash
+git rebase --signoff origin/main
+```
+
+## Before you open a PR
+
+```bash
+npm ci
+CCXRAY_HOME=$(mktemp -d) npm test
+```
+
+Always run tests against an isolated `CCXRAY_HOME`. A test that reads your real
+`~/.ccxray` will pass on your machine and fail in CI — see
+[docs/testing.md](docs/testing.md) for the isolation rules.
+
+## What makes a PR easy to accept
+
+Show your work. A PR body that states what you verified — and what you did
+*not* — gets reviewed faster than one that claims everything works.
+
+- **Bug fix**: evidence the fix actually fixes it. The strongest form is
+  fail-on-old / pass-on-new: your new test fails when the fix is reverted.
+- **Refactor**: the existing suite stays green, plus whatever structural
+  measure motivated the change.
+- **Wire-protocol change**: a fixture captured from real traffic
+  (`test/fixtures/wire-parsers/`), with secrets scrubbed.
+- **New provider or upstream**: routing test + one end-to-end test against a
+  mock upstream. Live verification against the real service is welcome but not
+  required — say which you did.
+
+[docs/verification-principles.md](docs/verification-principles.md) describes the
+ladder of evidence this project uses (written in Traditional Chinese). You do not
+need to read it to contribute — the four bullets above are the short version.
+
+### Scope
+
+Keep a PR to one concern. Unrelated cleanups in the same diff make it hard to
+tell which change caused a regression — if you spot something adjacent that
+needs fixing, mention it rather than folding it in.
+
+## CI on fork pull requests
+
+GitHub does not run workflows on pull requests from forks until a maintainer
+approves them, so your PR may sit with no checks for a while. That is a
+permission gate, not a judgment about your patch. Feel free to ping if it stalls.
+
+## Reporting bugs
+
+Include the raw output — proxy log lines, console errors, the wire request or
+response if the bug is protocol-related. Scrub API keys and any prompt content
+you would not want public. A report with real data gets diagnosed; a report
+without it gets a round of questions first.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "ccxray",
       "version": "2.2.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "ws": "^8.19.0"
       },


### PR DESCRIPTION
## 摘要

授權衛生兩件事，皆為 metadata / docs，無程式碼變更。

## ① `package-lock.json` 的 root entry 還寫著 MIT

2026-07-21 換授權的 commit（`98bc85d`）只改了 `LICENSE` 與 `package.json`，**漏了 lockfile**：

```diff
     "": {
       "name": "ccxray",
       "version": "2.2.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
```

授權掃描器、SBOM 產生器、企業法務清查讀的正是 lockfile —— 所以所有自動化檢查看到的 ccxray 都是 MIT，而實際授權是 PolyForm Noncommercial。對一個靠 noncommercial 限制走商業化的專案，這是在合規檢查那一關自己開的後門。

只動一個欄位，相依套件的 entry 完全未觸碰（它們的 MIT 是它們自己的授權，本來就該留）。

## ② 新增 `CONTRIBUTING.md` + PR template

專案原本**沒有** CONTRIBUTING、沒有 CLA、沒有 DCO —— 貢獻進來時除了 GitHub 服務條款的 inbound=outbound 慣例之外沒有任何依據，而那個慣例把貢獻綁在**當時生效的授權**上。

PR #313 的 fork 建立於 `2026-07-20 06:19:14Z`，換授權是 `2026-07-21 07:06:58Z` —— **早 25 小時**，所以那份貢獻是以 MIT 進來的。

貢獻者現在同意兩件事：

1. 貢獻以 PolyForm Noncommercial 1.0.0 授權
2. **授予維護者日後以不同條款重新授權的權利，包含商業授權**

第二條比第一條重要。沒有它，要提供商業授權就得回頭找每一個過去的貢獻者，而這件事拖越久越難辦。

另外記錄了 MIT 邊界（npm `1.9.3` 及之前永久是 MIT）、DCO sign-off 要求、以及 fork PR 為何一直沒有 CI 檢查（權限閘門，不是對 patch 的評價）。

**PR template 不影響 pipeline 產生的 PR** —— `gh pr create --body` 會覆蓋 template。

## 驗證

- `package-lock.json` 仍為合法 JSON（`JSON.parse` 通過）
- root `license` 與 `version` 皆與 `package.json` 一致
- `npm ls --package-lock-only --all` exit **0**
- `npm ci --dry-run` 解析 **171 個套件無錯誤** → CI 的 `npm ci` step 不受影響
- `CONTRIBUTING.md` 三個相對連結（`LICENSE`、`docs/testing.md`、`docs/verification-principles.md`）逐一確認檔案存在
- 引用內容核對過：`docs/testing.md` 第 1 節確實是 "Isolate `CCXRAY_HOME`"；`docs/verification-principles.md` 確實有可信度階梯（且已標註該檔為正體中文，避免英文讀者點進去撞牆）

**未驗證**：沒跑測試套件 —— 本 PR 零程式碼變更，`npm ci --dry-run` 是與 CI 相關的實際風險面。

## 尚未做（需 owner 決定）

- 在 #313 請 @lolxl 留授權確認留言
- 關閉 #205 與 #202
- DCO 的**機械強制**（GitHub Action）刻意未加：它會讓 owner 自己 pipeline 產生的每一個 PR 都 CI 失敗（那些 commit 不帶 `-s`）。要做的話得先決定是否豁免 owner 的 PR