### PR TITLE
docs(adr): 0014 — providers declare capability, attribution layer infers

### DIFF
--- a/docs/decisions/0014-provider-declares-capability-attribution-infers.md
+++ b/docs/decisions/0014-provider-declares-capability-attribution-infers.md
@@ -1,0 +1,257 @@
+# 0014 — Providers declare capability; a provider-agnostic layer infers parentage
+
+- Status: **Accepted** (expert-panel design 2026-07-29; owner ruling same day) — **decision only, not yet implemented**
+- Date: 2026-07-29
+- Related: ADR 0005 (agentKey unreliable — this ADR raises its conclusion to the
+  protocol layer) / ADR 0008 (temporal overlap overrides declaration) / ADR 0010
+  (coreHash-authoritative identity)
+- **Depends on #313** (Grok as an OpenAI-wire module — open at time of writing).
+  The registry this ADR extends (`OPENAI_WIRE_CLIENTS`) and the contract document
+  it amends (`docs/provider-modules.md`) both arrive with that PR; neither exists
+  on `main` yet, where `server/providers.js` carries only `AGENT_PROVIDERS`
+  (:19), `PROVIDER_AGENT` (:80) and `UPSTREAM_PROFILES` (:85). This ADR is
+  therefore unimplementable until #313 lands, and is recorded now because the
+  design question it settles is what #313 exposed.
+
+## Context
+
+#313 introduces a four-layer provider contract (`docs/provider-modules.md`):
+launcher, wire family, OpenAI-wire client, upstream host. Every field in it
+describes **how to get bytes to the right place** — `upstreamKey`,
+`rawSessionId`, `modelPattern`, `sessionHeaderNames`, `matchHeaders`. No field
+describes how a CLI expresses the relationship *between* its agents. Subagent
+identification — which drives the swimlane, the product's differentiator — was
+never part of the contract.
+
+### The mechanism of the failure
+
+Subagent detection dispatches on **wire family, not client**:
+
+```
+server/index.js:407   provider === 'openai' ? parser.isSubagent(parsedBody, clientReq.headers) : undefined
+server/wire-parsers/openai.js:113   isOpenAISubagent → x-openai-subagent | metadata.is_subagent
+```
+
+`OPENAI_WIRE_CLIENTS` lets a new CLI share the Responses parser for body/SSE
+shape — and thereby inherit Codex's subagent rule for free. Grok emits neither
+signal, so `isSubagent` is permanently `false` for it. The hint feeds both
+`store.linkParentSession` (`server/index.js:408`) and the entry field
+(`server/index.js:468`), so one wrong verdict propagates to both.
+
+### Observed evidence (live capture through the merged #313 tree, 2026-07-29)
+
+One Grok run with an inline subagent (`grok --agents '{...}'`), four entries:
+
+```
+17:23:30  session A  cwd=/Users/…/dev/ccxray  coreHash=f6e1100a  msgs=6   parent
+17:23:37  session B  cwd=(absent)             coreHash=e818f306  msgs=4   subagent
+17:23:42  session B  cwd=(absent)             coreHash=e818f306  msgs=7   subagent
+17:23:43  session A  cwd=/Users/…/dev/ccxray  coreHash=f6e1100a  msgs=10  parent
+```
+
+`isSubagent=false` on all four; `agentKey=default` / `agentLabel=Grok` for both
+roles; `parentSessionId=none`. The subagent surfaces as a **sibling session**,
+not a lane inside its parent. Note the two session ids share the prefix
+`019fad2f` — that is UUIDv7 timestamp encoding, **not** a parent link; do not
+read identity into it.
+
+The three CLIs express subagents three incompatible ways:
+
+| | Claude Code | Codex | Grok |
+|---|---|---|---|
+| subagent's session id | reuses the **parent's** | same session | **its own, new** |
+| role signal | system-prompt content → `agentKey` | header `x-openai-subagent` | **none** |
+| usable observable | `agentKey` + content hash | header | content hash, absent `cwd`, temporal nesting |
+
+### Why inference is not a shortcut
+
+OpenTelemetry's GenAI semantic conventions cover multi-agent tracing, but
+express parent attribution **structurally, through span parentage carried by
+propagated trace context** — there is no parent-agent attribute, and the
+conventions name propagation failure as the primary way attribution breaks
+(conventions still in Development; `gen_ai.*` moved to a dedicated repo
+2026-06-12). ccxray is a passive wire observer: it cannot inject or propagate
+context. **The industry answer is structurally unavailable here**, so inference
+is the only available mechanism, not a cheaper substitute for a better one.
+
+### Why not simply declare more
+
+The obvious fix — add optional fields (`detectSubagent`, `sessionTopology`,
+`titleExtractor`, `quotaAdapter`) to the client entry — was rejected. It adds
+*self-reported* fields at precisely the point where ADR 0005, 0008, and 0010
+each independently concluded that self-reported identity is untrustworthy and
+content-derived identity is authoritative. The protocol was one generation
+behind its own ADRs.
+
+## Decision
+
+**Two axes only** — session topology and role signal. Title extraction and
+quota introspection stay declarative: they have no observable basis to infer
+from, and inverting them would relocate the coupling rather than remove it.
+The other provider-specific branches outside the registry (≈55 across 12 files
+at time of writing) are **not** in scope.
+
+### 1. The client declares one capability, not a mechanism
+
+```js
+// OPENAI_WIRE_CLIENTS entry (registry introduced by #313) — routing fields unchanged
+{
+  id: 'grok',
+  upstreamKey: 'xai', rawSessionId: 'grok-raw', /* … */
+  roleSignal: null,   // Codex: (headers, body) => isOpenAISubagent(headers, body)
+}
+```
+
+**`sessionTopology` is deliberately NOT declarable.** Once a provider declares
+"my subagents get their own session id", that inference is promoted from a
+recomputable view to a pseudo source of truth, and a later CLI release cannot be
+overruled by observation. Topology is derived from what is on the wire, always.
+
+### 2. Inference lives in one provider-agnostic module
+
+```js
+// server/attribution.js (new)
+inferParentage({ sessionId, cwd, coreHash, receivedAt, msgCount,
+                 roleSignal, openSessions })
+  → { parentSessionId, authority, basis }
+```
+
+**The signature contains no `provider` argument. This is the load-bearing
+constraint of this ADR, not a stylistic preference.** The predicted failure mode
+is that the inference layer accumulates provider conditionals and becomes the
+old coupling relocated. Adding one requires changing the signature, which a
+reviewer sees.
+
+`basis` records which observables fired (e.g.
+`['no-cwd','core-hash-differs','temporally-enclosed']`). It exists so fixtures
+have something to assert on. It is deliberately **not** a vote tally and drives
+**no** alerting — at three CLIs that machinery is unjustified.
+
+### 3. `parentAuthority` is tri-state; only the weakest tier is marked
+
+| value | source | lane rendering |
+|---|---|---|
+| `declared` | Codex header — the CLI states it | solid |
+| `derived` | Claude Code — read from system-prompt **content the agent actually sent** | solid |
+| `inferred` | Grok — **circumstantial only** (temporal nesting + absent `cwd` + differing hash) | **dashed + `inferred` badge** |
+
+A two-tier split (only `declared` is trusted) was considered and rejected by the
+owner: it would mark every Claude Code lane, and a marker present everywhere
+warns about nothing. The `derived`/`inferred` line is drawn at a real
+distinction — content the agent emitted versus circumstances around it — not at
+convenience.
+
+**Unlabelled inference must not reach the UI.** This is an admission condition
+for the inference layer, not a follow-up: a passive observer that renders a
+guess identically to a fact spends the trust the tool exists to earn.
+
+### 4. Reuse the existing precedent; invent nothing
+
+`sessionInferred` is already the same shape — a flag recording that identity was
+inferred rather than read. `server/store.js:160,181,262` adopt
+`(sessionId + sessionInferred + isSubagent)` as **one identity unit,
+atomically**; `parentSessionId` + `parentAuthority` join that unit.
+`public/miller-columns.js:2532` already renders a dashed-yellow `inferred` badge
+(`title="Session attributed by inference"`) — lanes reuse that component. The
+swimlane is SVG and already draws `stroke-dasharray="3 2"` for the model-switch
+marker beside the subagent-spawn marker (`public/workflow-timeline.js:1604`), so
+dashed lane rendering is available, not new.
+
+### 5. Granularity: field on the entry, verdict at conversation level
+
+Parentage is properly a *relation*, not a per-turn boolean. Changing granularity
+now is scope creep against the atomic identity unit above, so the field rides on
+the entry while the **lane-level verdict is a conversation majority** — exactly
+what ADR 0010 already does for `coreHash`. `AGENT_KEY_UNRELIABLE`
+(`public/workflow-timeline.js:279`) and its gates are untouched; this ADR
+upholds ADR 0005, it does not amend it.
+
+## Preconditions (blocking, not advisory)
+
+0. **#313 must land**, or `OPENAI_WIRE_CLIENTS` must be introduced by other
+   means. There is no registry to add `roleSignal` to until then.
+1. **`linkParentSession` (`server/store.js:503`) currently has five unmerged
+   worktree variants**, each carrying a different ~80-line change to the same
+   function. Five variants means there is no specification. They must be
+   collapsed to one before the inference layer is written. All four panellists
+   raised this independently and unprompted.
+2. **Golden fixtures before the layer.** The four-entry capture above becomes
+   `test/fixtures/attribution/grok-subagent.json`, asserting `parentSessionId`,
+   `authority='inferred'`, and `basis`. A **second fixture with `cwd`
+   populated** — simulating a future Grok release that fills the field — must
+   assert that `basis` changes. Absent `cwd` is not an interface; it is Grok not
+   filling a field. Without that fixture, a signal flip degrades silently while
+   the majority still passes and the swimlane keeps drawing confidently.
+
+## Consequences
+
+**Good**: a fourth CLI costs nothing on these two axes. The decision aligns the
+protocol with ADR 0005/0008/0010 instead of contradicting them. Because the raw
+request/response bodies and `rebuild-index` already exist, an improved inference
+rule needs no migration — re-run it. That turns "the inference will sometimes be
+wrong" from a risk into an iterable cost.
+
+**Accepted limits**: (1) Grok parentage is circumstantial and will sometimes be
+wrong; the dashed marker is the mitigation, not a fix. (2) Two genuinely
+independent concurrent sessions in the same repo and time window can be merged
+into a false parent-child, and that error direction is not observable from the
+wire. (3) Live rendering may show a provisional verdict before enough of the
+enclosing session is seen; it heals on re-render, and recomputability does not
+repair the experience of having seen it wrong. (4) The ≈55 provider branches
+remain.
+
+**New consistency contract**: any site needing parentage reads
+`parentSessionId` + `parentAuthority`; any renderer of a lane must consult
+`parentAuthority` and must not draw `inferred` as solid. Adding a provider
+conditional inside `server/attribution.js` is a contract violation, visible as a
+signature change.
+
+## Panel record (independent assessments, 2026-07-29)
+
+Four lenses, briefed identically and answering without knowledge of each other,
+then a final ruling. **Verdicts: three for a scoped inversion, one for full
+inversion with a blocking precondition.**
+
+- **Sigelman lens** (Dapper/OpenTracing): Dapper's parentage was reliable only
+  because Google owned the RPC libraries — "not an engineering gap, a topology
+  fact". Declaring topology writes a guess into a field that reads like an
+  assertion. Demanded UI confidence tiers as a condition, golden fixtures, and
+  the worktree collapse first.
+- **Nottingham lens** (RFC 9170): "you are not writing a protocol, you are
+  writing an observation model" — the peers are third-party CLIs that will never
+  negotiate. An optional field with one implementer is the SNI extension-point
+  lesson; Grok inheriting Codex's rule is the TLS version-intolerance pattern
+  (an implementer believing it negotiated while copying a default). Argued for
+  inverting **only** these two axes, leaving title and quota declarative — the
+  scope this ADR adopts.
+- **Kleppmann lens** (DDIA 2nd ed., 2026-03): the only system of record is the
+  raw bytes plus arrival order; `agentKey`, `isSubagent`, `coreHash`, parentage
+  and the swimlane are all derived. A per-turn `isSubagent` boolean is "a
+  conclusion stored at the wrong granularity". Predicted the decisive failure
+  mode: the inference layer becoming a new hidden provider branch — which
+  §Decision 2 exists to prevent.
+- **Metz lens** (*The Wrong Abstraction*): dissented. Judged the wire-family
+  abstraction already expired ("Grok inheriting Codex's rule is not a bug, it is
+  the interest on a wrong abstraction") and argued for un-sharing the OpenAI
+  parser per client and waiting for a fourth CLI before abstracting anything.
+- **Ruling**: scoped inversion, over Metz's objection. Temporal nesting, content
+  hash and `cwd` presence are physical properties of the bytes, not an
+  abstraction induced from three samples, so sample count does not bear on them;
+  and one maintainer carrying three parsers is the headcount blind spot Metz
+  named herself. Vote tallying with consensus alerting was ruled out as
+  over-engineering at three CLIs.
+- **Owner ruling**: tri-state `parentAuthority`, marking only `inferred`.
+
+All four panellists independently disclaimed the same blind spot — none could
+judge whether a wrongly drawn lane costs more trust than an absent swimlane.
+That question was ruled on directly: for an observability tool it does, because
+such a tool sells credibility rather than coverage, and one silent error
+discredits the whole surface. §Decision 3's admission condition follows from
+that ruling.
+
+## Implementation sequence (not yet started)
+
+Land #313 → collapse the five `linkParentSession` variants → land both fixtures
+(including the `cwd`-flip) → `server/attribution.js` + `roleSignal` declaration →
+lane rendering reads `parentAuthority`. No verification section: nothing is built
+yet. This ADR records the decision only.


### PR DESCRIPTION
## 摘要

記錄 2026-07-29 由**四位專家獨立評估 ＋ Fable 裁決 ＋ owner 拍板**定案的 provider 身分協議設計。**只是決定,零實作**,docs-only 257 行。

## 為什麼需要這張 ADR

#313 暴露出:subagent 偵測是**按 wire family 分派,不是按 client 分派**（`server/index.js:407`),所以 Grok 共用 OpenAI parser 時「免費繼承」了 Codex 的 `x-openai-subagent` 規則 —— 而那規則對它永遠為假。

live 實測（經合併樹的 :5610）四筆記錄證實:

```
17:23:30  session A  cwd=/Users/…/dev/ccxray  coreHash=f6e1100a  msgs=6   父
17:23:37  session B  cwd=(空)                 coreHash=e818f306  msgs=4   subagent
17:23:42  session B  cwd=(空)                 coreHash=e818f306  msgs=7   subagent
17:23:43  session A  cwd=/Users/…/dev/ccxray  coreHash=f6e1100a  msgs=10  父
```

`isSubagent` 四筆全 false、`parentSessionId` none → **swimlane（產品差異化核心）對 Grok 靜默失效**。

## 為什麼不是「多加幾個宣告欄位」

顯而易見的修法（加 `detectSubagent` / `sessionTopology` / `titleExtractor` / `quotaAdapter` 選填欄位）被否決:它**恰好在 ADR 0005、0008、0010 三次獨立得出「自報身分不可信、內容推導權威」結論的地方,增加自報欄位**。

protocol 落後自家 ADR 一個世代。

## 決定

| | |
|---|---|
| 範圍 | **只反轉兩軸**:session 拓樸 ＋ 角色訊號。標題抽取、額度自省維持宣告式（無可觀測推論基礎） |
| 宣告 | client 只宣告 `roleSignal`（能力）。**`sessionTopology` 刻意不可宣告** —— 一宣告就把推論升格成偽 source of truth,CLI 改版時觀察無法否決 |
| 推論層 | `server/attribution.js`,**簽名刻意不含 `provider` 參數** —— 這是「推論層變成舊耦合換位置」唯一的機械防線,想加 provider 條件得先改簽名,而改簽名 review 看得到 |
| 標記 | `parentAuthority` 三值:`declared`（Codex header）／`derived`（Claude 讀系統提示內容）／`inferred`（Grok 純旁證）。**只有 `inferred` 畫虛線** |

**兩級方案被 owner 否決**:那會讓每一條 Claude Code lane 都掛標記,標記變壁紙。三級的分界線畫在真實差異上 —— agent **實際送出的內容** vs 它周遭的**旁證**。

**未標示的推論不准上 UI** —— 這是推論層的准入條件而非後續事項:被動觀測器把猜測畫得跟事實一樣,花掉的正是這個工具存在的理由。

## 什麼都沒發明

- `sessionInferred` 已是同型欄位
- `server/store.js:160/181/262` 已把身分當**一個原子單元**採用
- `public/miller-columns.js:2532` 已有虛線黃框 `inferred` badge
- `public/workflow-timeline.js:1604` 已在畫 `stroke-dasharray`

## 阻塞前提（已寫進 ADR,非建議）

0. **#313 必須先落地** —— `OPENAI_WIRE_CLIENTS` 與 `docs/provider-modules.md` 都隨它進來,**main 上都不存在**（main 的 `server/providers.js` 只有 `AGENT_PROVIDERS`:19、`PROVIDER_AGENT`:80、`UPSTREAM_PROFILES`:85）
1. **`linkParentSession`（`server/store.js:503`）目前有五個未合併 worktree 分身**,各帶不同的 ~80 行改動。五個分身即無規格。四位專家都在不知情的情況下獨立提出這一點
2. **golden fixture 先於推論層**,而且關鍵是**第二筆**:把 `cwd` 填上（模擬 Grok 未來改版）並斷言 `basis` 必須改變。`cwd` 為空不是介面,是 Grok 沒填欄位 —— 沒有這筆 fixture,訊號翻轉會靜默退化而多數決仍過關

## 專家會審記錄（照 ADR 0013 的慣例）

四個視角、相同簡報、互不知情作答,最後裁決。**票數:三票範圍反轉、一票完整反轉附阻塞前提。**

- **Sigelman 視角**:Dapper 的 parentage 可靠只因 Google 擁有 RPC 庫 ——「這不是工程缺口,是拓樸事實」。要求 UI 信心分級為准入條件
- **Nottingham 視角**（RFC 9170）:「你不是在寫協議,你在寫觀測模型」。選填欄位只有一個實作者 = SNI 擴充點腐爛的教訓;Grok 繼承 Codex 規則 = TLS 版本容忍度崩壞的同型病。**本 ADR 採用他的範圍限制**
- **Kleppmann 視角**（DDIA 2nd ed.）:唯一 system of record 是原始 bytes ＋ 抵達順序;per-turn `isSubagent` boolean 是「結論存在錯的粒度」。預言了決定性失敗模式:推論層變成新的隱形 provider 分支 —— §Decision 2 就是為此存在
- **Metz 視角**（*The Wrong Abstraction*）:**異議**。判 wire family 抽象已過期,主張拆散 parser、等第四家 CLI 再抽象
- **裁決**:採範圍反轉,駁 Metz —— 時序嵌套、內容雜湊、`cwd` 有無是**位元組的物理性質,不是從三個樣本歸納的抽象**,樣本數與之無關;且一人維護三份 parser 正是她自承的 headcount 盲點

四位專家**都獨立聲明同一個盲點**:無法判斷「畫錯一條 lane」是否比「沒有 swimlane」更傷信任。該問題被直接裁決:對觀測工具而言**是** —— 它賣的是可信而非覆蓋率,一次靜默錯誤會讓整個介面失去信用。

## 驗證

- **docs-only**:1 檔 257 行新增,零程式碼
- **10 個 `file:line` 引用逐行對過 `origin/main`** —— 注意 `server/*` 的行號與合併樹不同（`index.js` 是 407/408/468 而非 412/413/475、`store.js:503` 而非 581),已全部修正為 main 的值
- ADR 0005／0008／0010 三個引用確認檔案存在;0014 編號未被占用
- 文件中三個無法解析的路徑（`docs/provider-modules.md`、`server/attribution.js`、fixture）**已在文件內標明**為新增或隨 #313 到來

**未跑測試套件**:零程式碼變更。

## 沒有 Verification 段

刻意的 —— 什麼都還沒建。本 ADR 只記錄決定。