### PR TITLE
fix(weather): give the session context window a single derivation (#377)

### DIFF
--- a/docs/decisions/0013-beta1m-persist-session-window-derive.md
+++ b/docs/decisions/0013-beta1m-persist-session-window-derive.md
@@ -132,3 +132,52 @@ stay 200K".
   no-backfill decision.
 - Classification zero-change by construction (no severity/isCompacted/lane code
   touched) + 296 affected tests green (incl. #44/#222/#332/#230 classifiers).
+
+## Amended by #377 (2026-07-30)
+
+Weather is an isomorphic pure function: the same `public/weather.js` is loaded
+by a browser script tag and by Node via `require`. It therefore cannot call the
+client-only `sessionCtxWindow`. Callers with a partial view must inject the
+per-session or per-lane window, while callers whose turns contain the complete
+evidence may let weather fold those turns itself. The context-window contract
+above is unchanged: weather was violating the contract; the contract was not
+wrong.
+
+On the server, deriving the injected window from `session-index`'s `s.beta1m`
+and `s.maxContext` does not violate this ADR's stateless-at-render decision and
+does not repeat `8b6789f`. That revert removed a client-side `sess.maxWindow`
+attached to incremental `addEntry`; its commit touched only
+`entry-rendering.js`, and all three blockers were incremental-render state
+failures (failure to retract after reclassification, stale stored severity,
+and live-merge enrichment not updating the latch). In contrast,
+`session-index` is a rebuildable derived view whose monotone
+`OR(beta1m)`/`max(maxContext)` aggregation is checked for mtime staleness,
+rebuilt when reconcile detects drift, and forcibly rebuilt on schema
+migration. There is already a precedent: `463bf61` (2026-07-28, four days
+after this ADR) added these two aggregate fields specifically to feed
+`sessionCtxWindow`'s cold-session fallback.
+
+One known seam remains in the live merge path. In `server/forward.js`,
+`if (!merged) sessionIdx.updateFromEntry(entry)` means `beta1m` enrichment
+carried only by a merged duplicate copy does not enter the session-index fold.
+
+**It is not self-healing.** `reconcileMetas` (`server/session-index.js:184`)
+compares only session count and responseId-deduped entry count; an enrichment
+on an already-counted responseId changes neither, so no drift is detected and
+no rebuild fires. The mtime staleness check in `loadSessionIndex` (`:37-41`)
+does not cover it either: the live path still appends the raw line to
+`index.ndjson`, but `sessions.json` is flushed afterwards by subsequent
+entries, so at the next startup `sessions.json` is typically the newer file
+and the check passes. Only an explicit rebuild (`ccxray rebuild-index`, a
+schema migration, or a startup that happens to find `index.ndjson` newer)
+re-derives the fold from the raw lines — where the evidence has been all
+along, since the merge path never stops persisting it.
+
+The seam's direction is safe: the window can only be under-reported, producing
+over-warning rather than hiding pressure. It is bounded and recoverable, but
+recovery is manual — this ADR does not claim it heals on its own.
+
+Classification remains separate and unchanged. `isCompacted`, per-turn
+`severity`, and lane placement still read raw per-turn `maxContext`; this
+amendment changes only weather's display/health denominator and preserves the
+ADR's display/classification boundary.

--- a/docs/decisions/0013-beta1m-persist-session-window-derive.md
+++ b/docs/decisions/0013-beta1m-persist-session-window-derive.md
@@ -143,6 +143,16 @@ evidence may let weather fold those turns itself. The context-window contract
 above is unchanged: weather was violating the contract; the contract was not
 wrong.
 
+`sessionCtxWindow` originally used the server-provided per-session fold only
+when the client had no entry for that session. When `allEntries` is truncated
+by `RESTORE_DAYS` or `SESSION_ENTRY_CAP`, a surviving turn can carry a smaller
+`maxContext` while the discarded history contained the true 1M evidence; the
+old gate then skipped the complete server fold. The client now unconditionally
+merges that fold with its surviving turns using monotone `max(maxContext)` /
+`OR(beta1m)`. This remains safe in the same direction: the window can only grow,
+so context percentages and warnings can only decrease, never create a false
+warning.
+
 On the server, deriving the injected window from `session-index`'s `s.beta1m`
 and `s.maxContext` does not violate this ADR's stateless-at-render decision and
 does not repeat `8b6789f`. That revert removed a client-side `sess.maxWindow`

--- a/docs/decisions/0013-beta1m-persist-session-window-derive.md
+++ b/docs/decisions/0013-beta1m-persist-session-window-derive.md
@@ -149,9 +149,26 @@ by `RESTORE_DAYS` or `SESSION_ENTRY_CAP`, a surviving turn can carry a smaller
 `maxContext` while the discarded history contained the true 1M evidence; the
 old gate then skipped the complete server fold. The client now unconditionally
 merges that fold with its surviving turns using monotone `max(maxContext)` /
-`OR(beta1m)`. This remains safe in the same direction: the window can only grow,
-so context percentages and warnings can only decrease, never create a false
-warning.
+`OR(beta1m)`. The operator can only grow the window, so it cannot create a false
+warning. That is only half of the safety argument, however: a wrongly enlarged
+window can hide a true warning.
+
+**F5 known limitation — server/client classification disagreement can hide a
+true warning.** The server fold is gated by the server-side `entry.isSubagent`,
+while the client uses the ADR 0005 / 0008 / 0009 / 0010 classification
+pipeline. If the server classifies a turn as main but the client classifies it
+as subagent, and that turn is the session's only 1M evidence, the server fold
+can enlarge an actually-200K main session to 1M and suppress real context
+pressure. On 2026-07-30 we replayed L1 (the `agentKey` rule) and L2 (#350's
+per-conversation `coreHash` plurality) over 84 sessions carrying 1M evidence:
+all 44 `beta1m` sessions plus the 40 most recent `maxContext`-fossil sessions.
+F5 hit **0/84**, with **0 observed harmful signal suppressions**. This
+measurement is bounded: 631 other fossil candidates were not tested, and the
+turn-level flips from ADR 0008 overlap and ADR 0009 sequencing were not run
+through a complete `wfInferLanes` replay. The empirical shape explains the zero:
+the main conversation almost always enables its own 1M window; “a subagent
+exclusively owns the 1M evidence while main is truly 200K” did not occur in the
+measured corpus.
 
 On the server, deriving the injected window from `session-index`'s `s.beta1m`
 and `s.maxContext` does not violate this ADR's stateless-at-render decision and
@@ -166,6 +183,20 @@ rebuilt when reconcile detects drift, and forcibly rebuilt on schema
 migration. There is already a precedent: `463bf61` (2026-07-28, four days
 after this ADR) added these two aggregate fields specifically to feed
 `sessionCtxWindow`'s cold-session fallback.
+
+Although the computed `sessionWindow` remains stateless-at-render,
+`sessionsMap.beta1m` and `sessionsMap.maxContext` are stored client state. This
+client latch is admissible only while all three premises hold: (i) it is a
+monotone merge of facts (`OR` / `max`), not a classification conclusion; (ii)
+it mirrors a server-derived view that reload can reconstruct; and (iii) it
+never feeds classification — `isCompacted`, per-turn `severity`, and lane
+placement do not read it. If any premise stops holding, the latch must be
+re-evaluated.
+
+**New consistency contract:** any monotone merge into a hot session's window
+fields (`mergeColdSessions`) must trigger weather/stats recomputation for every
+affected session; otherwise it repeats `8b6789f` blocker 2's stale stored
+severity failure.
 
 One known seam remains in the live merge path. In `server/forward.js`,
 `if (!merged) sessionIdx.updateFromEntry(entry)` means `beta1m` enrichment

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -844,6 +844,7 @@ window.recomputeProjectCost = recomputeProjectCost;
 
 // ── Merge cold sessions from session index into sessionsMap + DOM + projectsMap ──
 function mergeColdSessions(sessions) {
+  const widenedSessionIds = new Set();
   for (const s of sessions) {
     if (!s || !s.sid) continue;
     if (s.importedOnly && window.ccxraySettings?.hideImported) continue;
@@ -859,8 +860,16 @@ function mergeColdSessions(sessions) {
       // only widen the window, never narrow it, so it cannot degrade a hot value. A hot
       // session truncated by RESTORE_DAYS / SESSION_ENTRY_CAP has strictly less evidence
       // than the server fold. See ADR 0013 + #377.
-      if (s.beta1m === true) existing.beta1m = true;
-      if ((s.maxContext || 0) > (existing.maxContext || 0)) existing.maxContext = s.maxContext;
+      var windowWidened = false;
+      if (s.beta1m === true && existing.beta1m !== true) {
+        existing.beta1m = true;
+        windowWidened = true;
+      }
+      if ((s.maxContext || 0) > (existing.maxContext || 0)) {
+        existing.maxContext = s.maxContext;
+        windowWidened = true;
+      }
+      if (windowWidened) widenedSessionIds.add(s.sid);
       // #367: merge cold derived fields ONLY when the hot session truly lacks them.
       // Hot sessions compute these from entries — never overwrite with cold fallbacks.
       if (!existing._cold) continue;
@@ -900,6 +909,14 @@ function mergeColdSessions(sessions) {
     proj.sessionIds.add(s.sid);
     if (s.lastId && s.lastId > (proj.lastId || '')) proj.lastId = s.lastId;
     if (s.lastReceivedAt && s.lastReceivedAt > (proj.lastSeenAt || 0)) proj.lastSeenAt = s.lastReceivedAt;
+  }
+  // #377 / ADR 0013: widening a stored hot-session window changes weather's
+  // denominator, so rebuild dependent stats in the same merge. Cold sessions
+  // have no entries in allEntries; recomputing them would erase server stats.
+  for (const sid of widenedSessionIds) {
+    const s = sessionsMap.get(sid);
+    if (!s || s._cold) continue;
+    recomputeSessionStats(sid);
   }
   // #308: derive project costs from session costs (idempotent)
   for (const [name] of projectsMap) recomputeProjectCost(name);

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -852,6 +852,15 @@ function mergeColdSessions(sessions) {
       if (!existing.title && s.title) existing.title = s.title;
       if (!existing.firstPrompt && s.firstPrompt) existing.firstPrompt = s.firstPrompt;
       if (s.weather && !existing.weather) existing.weather = s.weather;
+      // #377: beta1m/maxContext are exempt from the #367 rule below. That rule guards
+      // against cold *approximations* (e.g. latestCtxPct-derived values) overwriting
+      // accurate hot computations. These two are facts folded server-side across the
+      // whole session (gated on !isSubagent), and the merge is monotone max/OR — it can
+      // only widen the window, never narrow it, so it cannot degrade a hot value. A hot
+      // session truncated by RESTORE_DAYS / SESSION_ENTRY_CAP has strictly less evidence
+      // than the server fold. See ADR 0013 + #377.
+      if (s.beta1m === true) existing.beta1m = true;
+      if ((s.maxContext || 0) > (existing.maxContext || 0)) existing.maxContext = s.maxContext;
       // #367: merge cold derived fields ONLY when the hot session truly lacks them.
       // Hot sessions compute these from entries — never overwrite with cold fallbacks.
       if (!existing._cold) continue;

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -826,7 +826,7 @@ function recomputeSessionStats(sid) {
     for (var wi = 0; wi < allEntries.length; wi++) {
       if (allEntries[wi].sessionId === sid && !allEntries[wi].isSubagent && !allEntries[wi].isRetry) weatherTurns.push(allEntries[wi]);
     }
-    sess.weather = assessWeather(weatherTurns);
+    sess.weather = assessWeather(weatherTurns, { sessionWindow: sessionCtxWindow(sid) });
   }
 }
 

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -18,12 +18,14 @@ function sessionCtxWindow(sid) {
     if (e.beta1m === true) has1m = true;
     if ((e.maxContext || 0) > win) win = e.maxContext;
   }
-  if (!has1m && win === 0) {
-    const sess = sessionsMap.get(sid);
-    if (sess) {
-      if (sess.beta1m === true) has1m = true;
-      if ((sess.maxContext || 0) > win) win = sess.maxContext;
-    }
+  // #377: allEntries may be truncated by restore age/cap limits, so always merge the
+  // server session-index fold. This max/OR merge is monotone (the denominator can only
+  // grow, reducing false alarms), and the server fold is gated on !isSubagent, preserving
+  // the #211 over-latch guard against borrowing a subagent's window. See ADR 0013.
+  const sess = sessionsMap.get(sid);
+  if (sess) {
+    if (sess.beta1m === true) has1m = true;
+    if ((sess.maxContext || 0) > win) win = sess.maxContext;
   }
   // DEFAULT_MAX_CTX comes from app.js; guard the free reference so this stays robust when
   // evaluated before app.js loads or in a vm test harness that omits it (win === 0 path).

--- a/public/weather.js
+++ b/public/weather.js
@@ -39,11 +39,23 @@ function _wDurMs(entry) {
 // ponytail: ctxFloor=0.4 — below 40% no signal, ramps to 1.0 at 100%. Lost in the Middle (Liu 2023): quality degrades well before max context.
 var CTX_FLOOR = 0.4;
 
-function sigCtxPressure(turns) {
+// #377: derive the window from the turns we were given — mirrors _wfLaneWindow
+// (workflow-timeline.js:196) and sessionCtxWindow (miller-columns.js:13) so the
+// weather denominator matches what the rest of the dashboard shows.
+function _foldWindow(turns) {
+  var win = 0, has1m = false;
+  for (var i = 0; i < turns.length; i++) {
+    if (turns[i].beta1m === true) has1m = true;
+    if ((turns[i].maxContext || 0) > win) win = turns[i].maxContext;
+  }
+  return has1m ? 1000000 : win;
+}
+
+function sigCtxPressure(turns, opts) {
   if (!turns.length) return { severity: 0, detail: {} };
   var last = turns[turns.length - 1];
   var u = last.usage || {};
-  var mx = last.maxContext;
+  var mx = (opts && opts.sessionWindow) || _foldWindow(turns);
   if (!mx || mx < 1000) return { severity: 0, detail: { ctxPct: 0, turnIndex: turns.length - 1, entryId: last && last.id || null } };
   var used = (u.input_tokens || 0) + (u.cache_read_input_tokens || 0) + (u.cache_creation_input_tokens || 0);
   var pct = used / mx;
@@ -133,13 +145,13 @@ function sigErrorCumulative(turns) {
   return { severity: sev, detail: { errTurns: errTurns, toolTurns: toolTurns, rate: Math.round(rate * 100) / 100, firstErrId: firstErrId } };
 }
 
-function assessWeather(turns) {
+function assessWeather(turns, opts) {
   if (!turns || !turns.length) {
     return { level: 'sunny', emoji: LEVELS[0].emoji, score: 0, factors: [], stats: { ctxPct: 0, errRate: 0, errTurns: 0, latencyRatio: null, compactions: 0 }, tooltip: 'Operating normally' };
   }
 
   var signals = [
-    { type: 'ctx_pressure', result: sigCtxPressure(turns) },
+    { type: 'ctx_pressure', result: sigCtxPressure(turns, opts) },
     { type: 'compaction_scar', result: sigCompaction(turns) },
     { type: 'truncation', result: sigTruncation(turns) },
     { type: 'stuck', result: sigStuck(turns) },

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -215,11 +215,18 @@ function _wfWinByTurn() {
   wfState._winByTurn = map;
   return map;
 }
-function wfCtxPctRender(e) {
+// #377 slice 2: the window a single turn should be measured against —
+// its own maxContext, widened by the lane fold. Returns 0 when nothing is
+// known, so callers decide their own fallback.
+function _wfTurnWindow(e) {
   var win = e.maxContext || 0;
   var m = _wfWinByTurn();
   var laneWin = (m && m.get(e.id)) || 0;
-  if (laneWin > win) win = laneWin; // turn's own maxContext under-inferred vs the lane's real window
+  if (laneWin > win) win = laneWin;
+  return win;
+}
+function wfCtxPctRender(e) {
+  var win = _wfTurnWindow(e);
   if (!win) win = 200000;
   return Math.min(100, (e.ctxUsed || 0) / win * 100);
 }
@@ -2578,7 +2585,7 @@ function _wfShowTooltip(e, t, lane) {
   var lockLbl = (lock && lane && lock.lane === lane && lock.lane.turns[lock.tidx] !== t)
     ? ' <span class="wf-tt-lock">🔒#' + wfEsc(String(lock.lane.turns[lock.tidx].displayNum || lock.tidx + 1)) + '</span>' : '';
   var row = function(l, v) { return '<div class="r"><span class="l">' + l + '</span><span class="v">' + v + '</span></div>'; };
-  var ttWeather = typeof assessWeather === 'function' ? assessWeather([t]) : null;
+  var ttWeather = typeof assessWeather === 'function' ? assessWeather([t], { sessionWindow: _wfTurnWindow(t) }) : null;
   _wfTooltipEl.innerHTML =
     row('#' + wfEsc(String(t.displayNum || '?')), wfEsc(wfShortModel(t.model)) + (t._wfSeqStitched ? ' · seq-stitched' : '') + lockLbl)
     + (ttWeather ? row('Health', ttWeather.emoji + ' ' + (ttWeather.tooltip || ttWeather.level).replace(/\n/g, ' · ')) : '')
@@ -2914,7 +2921,7 @@ function wfRenderTurnCard(turnEntry) {
 
   var html = '<div class="wf-agent-card wf-turn-card" style="border-left:2px solid ' + color + '">';
   html += '<div class="wf-tc-back" onclick="wfBackToLane()">&#8592; back</div>';
-  var turnW = typeof assessWeather === 'function' ? assessWeather([turnEntry]) : null;
+  var turnW = typeof assessWeather === 'function' ? assessWeather([turnEntry], { sessionWindow: _wfTurnWindow(turnEntry) }) : null;
   html += '<div class="wf-tc-title">' + (turnW && turnW.level !== 'sunny' ? '<span style="cursor:default" data-weather=\'' + wfEsc(JSON.stringify(turnW)) + '\' onmouseenter="showWeatherOverlay(event,JSON.parse(this.dataset.weather))" onmouseleave="hideWeatherOverlay()">' + turnW.emoji + '</span> ' : '') + '#' + displayNum + '  ' + wfEsc(wfShortModel(turnEntry.model)) + ' · ' + wfFmtDur(dur * 1000) + '</div>';
 
   // Breadcrumb

--- a/server/restore.js
+++ b/server/restore.js
@@ -383,7 +383,7 @@ async function restoreFromLogs() {
     arr.push(e);
   }
   for (const [sid, turns] of bySid) {
-    sessionIdx.setWeather(sid, assessWeather(turns));
+    sessionIdx.setWeather(sid, assessWeather(turns, { sessionWindow: sessionIdx.sessionWindow(sid) }));
   }
   console.timeEnd('restore:weather');
 

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -208,7 +208,7 @@ function _recomputeWeather(sid) {
     if (e.sessionId === sid && !e.isSubagent) turns.push(e);
   }
   const s = sessionIndex.get(sid);
-  if (s) s.weather = assessWeather(turns);
+  if (s) s.weather = assessWeather(turns, { sessionWindow: sessionWindow(sid) });
 }
 
 function _upsert(sid, entry) {
@@ -333,6 +333,12 @@ function get(sid) {
   return sessionIndex.get(sid) || null;
 }
 
+function sessionWindow(sid) {
+  const s = sessionIndex.get(sid);
+  if (!s) return 0;
+  return s.beta1m === true ? 1000000 : (s.maxContext || 0);
+}
+
 function getAll() {
   return [...sessionIndex.values()];
 }
@@ -351,5 +357,5 @@ module.exports = {
   rebuildFromIndexContent, rebuildFromMetas,
   seedDedupState, seedDedupFromMetas,
   reconcile, reconcileMetas,
-  updateFromEntry, setTitle, setFirstPrompt, flush, getAll, get, size, setWeather,
+  updateFromEntry, setTitle, setFirstPrompt, flush, getAll, get, size, setWeather, sessionWindow,
 };

--- a/test/session-ctx-window.test.js
+++ b/test/session-ctx-window.test.js
@@ -13,7 +13,7 @@ const vm = require('vm');
 
 const publicDir = path.join(__dirname, '..', 'public');
 
-function loadCtx() {
+function loadCtx(includeEntryRendering) {
   function el() {
     return {
       style: {}, dataset: {}, innerHTML: '', textContent: '',
@@ -43,15 +43,25 @@ function loadCtx() {
     function updateSysPromptBadge() {}
     function startQuotaTicker() {}
     function EventSource() { this.onmessage = null; }
+    function setInterval() { return 0; }
+    function clearInterval() {}
     window.ccxraySettings = { visibleProviders: [] };
     function _apiQ(url) { return url; }
     function fetch() { return Promise.resolve({ ok: false, json() { return Promise.resolve({}); } }); }
   `, context);
-  for (const f of ['format.js', 'session-label.js', 'miller-columns.js']) {
+  const scripts = ['session-label.js', 'format.js', 'weather.js', 'miller-columns.js'];
+  if (includeEntryRendering) scripts.push('entry-rendering.js');
+  for (const f of scripts) {
     vm.runInContext(fs.readFileSync(path.join(publicDir, f), 'utf8'), context);
   }
   // Bridge the const/let declarations (they don't attach to the context global) for test access.
-  vm.runInContext('this.allEntries = allEntries; this.sessionCtxWindow = sessionCtxWindow; this.turnCtxWindow = turnCtxWindow;', context);
+  vm.runInContext(`
+    this.allEntries = allEntries;
+    this.sessionsMap = sessionsMap;
+    this.sessionCtxWindow = sessionCtxWindow;
+    this.turnCtxWindow = turnCtxWindow;
+    ${includeEntryRendering ? 'this.recomputeSessionStats = recomputeSessionStats;' : ''}
+  `, context);
   return context;
 }
 
@@ -89,6 +99,15 @@ describe('#339 sessionCtxWindow — per-session context% denominator fold', () =
       { sessionId: 's2', isSubagent: false, maxContext: 200000 },
     ]);
     assert.equal(ctx.sessionCtxWindow('s2'), 1000000);
+  });
+
+  it('#377 truncated entries: server session fold promotes a surviving 200K turn to 1M', () => {
+    seed(ctx, [
+      { sessionId: 'trimmed', isSubagent: false, maxContext: 200000 },
+    ]);
+    ctx.sessionsMap.set('trimmed', { beta1m: true, maxContext: 1000000 });
+
+    assert.equal(ctx.sessionCtxWindow('trimmed'), 1000000);
   });
 
   it('#211 over-latch guard: a true 200K session with no 1M signal stays 200K', () => {
@@ -159,5 +178,35 @@ describe('#339 turnCtxWindow — per-turn minimap denominator (main=session, sub
       { sessionId: 'sY', isSubagent: true, convId: 'dup8', maxContext: 200000 },
     ]);
     assert.equal(ctx.turnCtxWindow(ctx.allEntries[1]), 200000, "session Y's subagent stays 200K, not promoted by session X");
+  });
+});
+
+describe('#377 recomputeSessionStats — truncated client weather uses the server session fold', () => {
+  it('keeps a 180K surviving turn sunny when the complete session ran with a 1M window', () => {
+    const ctx = loadCtx(true);
+    const sid = 'trimmed-weather';
+    seed(ctx, [{
+      id: 'survivor',
+      sessionId: sid,
+      isSubagent: false,
+      isRetry: false,
+      model: 'claude-opus-4-6',
+      elapsed: '?',
+      stopReason: 'end_turn',
+      maxContext: 200000,
+      usage: {
+        input_tokens: 180000,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      toolCalls: {},
+    }]);
+    const sess = { beta1m: true, maxContext: 1000000 };
+    ctx.sessionsMap.set(sid, sess);
+
+    ctx.recomputeSessionStats(sid);
+
+    assert.equal(sess.weather.level, 'sunny');
   });
 });

--- a/test/session-ctx-window.test.js
+++ b/test/session-ctx-window.test.js
@@ -202,36 +202,40 @@ describe('#377 recomputeSessionStats — truncated client weather uses the serve
     seed(ctx, [weatherTurn(sid)]);
 
     assert.equal(ctx.sessionsMap.has(sid), false, 'exercise the cold-session creation branch');
-    ctx.mergeColdSessions([{ sid, beta1m: true, maxContext: 1000000 }]);
+    ctx.mergeColdSessions([{ sid, beta1m: true, maxContext: 1000000, weather: { level: 'rainy' } }]);
 
     assert.equal(ctx.sessionCtxWindow(sid), 1000000);
+    assert.equal(ctx.sessionsMap.get(sid).weather.level, 'rainy', 'cold sessions keep server stats');
     ctx.recomputeSessionStats(sid);
 
     assert.equal(ctx.sessionsMap.get(sid).weather.level, 'sunny');
   });
 
-  it('hot truncated session: mergeColdSessions widens the local 200K fold and keeps a 180K turn sunny', () => {
+  it('hot truncated session: widening the server fold immediately recomputes rainy weather', () => {
     const ctx = loadCtx(true);
     const sid = 'hot-weather';
     seed(ctx, [weatherTurn(sid)]);
     ctx.sessionsMap.set(sid, { _cold: false, beta1m: false, maxContext: 200000 });
+    ctx.recomputeSessionStats(sid);
 
+    assert.equal(ctx.sessionsMap.get(sid).weather.level, 'rainy');
     ctx.mergeColdSessions([{ sid, beta1m: true, maxContext: 1000000 }]);
 
     assert.equal(ctx.sessionCtxWindow(sid), 1000000);
-    ctx.recomputeSessionStats(sid);
     assert.equal(ctx.sessionsMap.get(sid).weather.level, 'sunny');
   });
 
   it('hot session merge is monotone: a smaller server fold cannot narrow an existing 1M window', () => {
     const ctx = loadCtx(true);
     const sid = 'hot-monotone';
-    const sess = { _cold: false, beta1m: true, maxContext: 1000000 };
+    const weather = { level: 'rainy' };
+    const sess = { _cold: false, beta1m: true, maxContext: 1000000, weather };
     ctx.sessionsMap.set(sid, sess);
 
     ctx.mergeColdSessions([{ sid, beta1m: false, maxContext: 200000 }]);
 
     assert.equal(sess.beta1m, true);
     assert.equal(sess.maxContext, 1000000);
+    assert.equal(sess.weather, weather, 'an unchanged window does not trigger recomputation');
   });
 });

--- a/test/session-ctx-window.test.js
+++ b/test/session-ctx-window.test.js
@@ -60,7 +60,10 @@ function loadCtx(includeEntryRendering) {
     this.sessionsMap = sessionsMap;
     this.sessionCtxWindow = sessionCtxWindow;
     this.turnCtxWindow = turnCtxWindow;
-    ${includeEntryRendering ? 'this.recomputeSessionStats = recomputeSessionStats;' : ''}
+    ${includeEntryRendering ? `
+      this.mergeColdSessions = mergeColdSessions;
+      this.recomputeSessionStats = recomputeSessionStats;
+    ` : ''}
   `, context);
   return context;
 }
@@ -68,6 +71,26 @@ function loadCtx(includeEntryRendering) {
 function seed(ctx, turns) {
   ctx.allEntries.length = 0;
   for (const t of turns) ctx.allEntries.push(t);
+}
+
+function weatherTurn(sid) {
+  return {
+    id: 'survivor',
+    sessionId: sid,
+    isSubagent: false,
+    isRetry: false,
+    model: 'claude-opus-4-6',
+    elapsed: '?',
+    stopReason: 'end_turn',
+    maxContext: 200000,
+    usage: {
+      input_tokens: 180000,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    },
+    toolCalls: {},
+  };
 }
 
 describe('#339 sessionCtxWindow — per-session context% denominator fold', () => {
@@ -99,15 +122,6 @@ describe('#339 sessionCtxWindow — per-session context% denominator fold', () =
       { sessionId: 's2', isSubagent: false, maxContext: 200000 },
     ]);
     assert.equal(ctx.sessionCtxWindow('s2'), 1000000);
-  });
-
-  it('#377 truncated entries: server session fold promotes a surviving 200K turn to 1M', () => {
-    seed(ctx, [
-      { sessionId: 'trimmed', isSubagent: false, maxContext: 200000 },
-    ]);
-    ctx.sessionsMap.set('trimmed', { beta1m: true, maxContext: 1000000 });
-
-    assert.equal(ctx.sessionCtxWindow('trimmed'), 1000000);
   });
 
   it('#211 over-latch guard: a true 200K session with no 1M signal stays 200K', () => {
@@ -182,31 +196,42 @@ describe('#339 turnCtxWindow — per-turn minimap denominator (main=session, sub
 });
 
 describe('#377 recomputeSessionStats — truncated client weather uses the server session fold', () => {
-  it('keeps a 180K surviving turn sunny when the complete session ran with a 1M window', () => {
+  it('cold session: mergeColdSessions creates the 1M server fold and keeps a 180K turn sunny', () => {
     const ctx = loadCtx(true);
-    const sid = 'trimmed-weather';
-    seed(ctx, [{
-      id: 'survivor',
-      sessionId: sid,
-      isSubagent: false,
-      isRetry: false,
-      model: 'claude-opus-4-6',
-      elapsed: '?',
-      stopReason: 'end_turn',
-      maxContext: 200000,
-      usage: {
-        input_tokens: 180000,
-        output_tokens: 0,
-        cache_read_input_tokens: 0,
-        cache_creation_input_tokens: 0,
-      },
-      toolCalls: {},
-    }]);
-    const sess = { beta1m: true, maxContext: 1000000 };
-    ctx.sessionsMap.set(sid, sess);
+    const sid = 'cold-weather';
+    seed(ctx, [weatherTurn(sid)]);
 
+    assert.equal(ctx.sessionsMap.has(sid), false, 'exercise the cold-session creation branch');
+    ctx.mergeColdSessions([{ sid, beta1m: true, maxContext: 1000000 }]);
+
+    assert.equal(ctx.sessionCtxWindow(sid), 1000000);
     ctx.recomputeSessionStats(sid);
 
-    assert.equal(sess.weather.level, 'sunny');
+    assert.equal(ctx.sessionsMap.get(sid).weather.level, 'sunny');
+  });
+
+  it('hot truncated session: mergeColdSessions widens the local 200K fold and keeps a 180K turn sunny', () => {
+    const ctx = loadCtx(true);
+    const sid = 'hot-weather';
+    seed(ctx, [weatherTurn(sid)]);
+    ctx.sessionsMap.set(sid, { _cold: false, beta1m: false, maxContext: 200000 });
+
+    ctx.mergeColdSessions([{ sid, beta1m: true, maxContext: 1000000 }]);
+
+    assert.equal(ctx.sessionCtxWindow(sid), 1000000);
+    ctx.recomputeSessionStats(sid);
+    assert.equal(ctx.sessionsMap.get(sid).weather.level, 'sunny');
+  });
+
+  it('hot session merge is monotone: a smaller server fold cannot narrow an existing 1M window', () => {
+    const ctx = loadCtx(true);
+    const sid = 'hot-monotone';
+    const sess = { _cold: false, beta1m: true, maxContext: 1000000 };
+    ctx.sessionsMap.set(sid, sess);
+
+    ctx.mergeColdSessions([{ sid, beta1m: false, maxContext: 200000 }]);
+
+    assert.equal(sess.beta1m, true);
+    assert.equal(sess.maxContext, 1000000);
   });
 });

--- a/test/session-index.test.js
+++ b/test/session-index.test.js
@@ -27,6 +27,64 @@ describe('session-index', () => {
     delete require.cache[require.resolve('../server/session-index')];
   });
 
+  it('#377 slice 2: unknown session window stays zero and creates no weather signal', () => {
+    const si = require('../server/session-index');
+    const { assessWeather } = require('../public/weather');
+    const turnWithoutFacts = {
+      id: 'no-facts',
+      maxContext: 0,
+      usage: {
+        input_tokens: 176000,
+        output_tokens: 1000,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    };
+
+    const win = si.sessionWindow('missing-session');
+    assert.equal(win, 0);
+    const weather = assessWeather([turnWithoutFacts], { sessionWindow: win });
+    assert.equal(weather.level, 'sunny');
+    assert.equal(weather.stats.ctxPct, 0);
+    assert.equal(weather.score, 0);
+  });
+
+  it('#377 slice 2: partial store weather uses the session-index 1M fold', async () => {
+    const si = require('../server/session-index');
+    const store = require('../server/store');
+    const savedEntries = store.entries.splice(0);
+    const sid = 'partial-1m';
+    store.entries.push({
+      id: 'surviving-200k-copy',
+      sessionId: sid,
+      maxContext: 200000,
+      usage: {
+        input_tokens: 176000,
+        output_tokens: 1000,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    });
+
+    try {
+      si.updateFromEntry({
+        id: 'trimmed-1m-evidence',
+        sessionId: sid,
+        maxContext: 200000,
+        beta1m: true,
+      });
+
+      assert.equal(si.sessionWindow(sid), 1000000);
+      const weather = si.get(sid).weather;
+      assert.equal(weather.level, 'sunny');
+      assert.equal(weather.stats.ctxPct, 17.6);
+      assert.equal(weather.score, 0);
+    } finally {
+      store.entries.splice(0, store.entries.length, ...savedEntries);
+      await si.flush();
+    }
+  });
+
   it('updateFromEntry + flush + load round-trip', async () => {
     const si = require('../server/session-index');
     si.updateFromEntry({

--- a/test/weather.test.js
+++ b/test/weather.test.js
@@ -98,8 +98,9 @@ describe('assessWeather', function() {
       usage: { input_tokens: 1000, cache_read_input_tokens: 175000, cache_creation_input_tokens: 0 },
       maxContext: 200000,
     }));
-    var r = assessWeather(turns, { sessionWindow: 200000 });
-    assert.equal(r.level, 'rainy');
+    var r = assessWeather(turns, { sessionWindow: 400000 });
+    assert.ok(Math.abs(r.stats.ctxPct - 44) <= 0.2, 'ctxPct ' + r.stats.ctxPct + ' should be ≈ 44');
+    assert.equal(r.level, 'sunny');
   });
 
   it('ctx_unknown_window — no observed maxContext produces no signal', function() {

--- a/test/weather.test.js
+++ b/test/weather.test.js
@@ -73,6 +73,46 @@ describe('assessWeather', function() {
     assert.ok(r.level === 'rainy' || r.level === 'stormy', 'level=' + r.level);
   });
 
+  it('ctx_mixed_window — session fold prevents a false context alarm', function() {
+    var turns = repeat(19, {
+      usage: { input_tokens: 500, cache_read_input_tokens: 20000 },
+      maxContext: 1000000,
+      beta1m: true,
+    });
+    turns.push(makeTurn({
+      usage: { input_tokens: 1000, cache_read_input_tokens: 175000, cache_creation_input_tokens: 0 },
+      maxContext: 200000,
+    }));
+    var r = assessWeather(turns);
+    assert.equal(r.level, 'sunny');
+    assert.ok(r.stats.ctxPct < 20, 'ctxPct ' + r.stats.ctxPct + ' should be < 20');
+  });
+
+  it('ctx_session_window_override — explicit window takes priority over the fold', function() {
+    var turns = repeat(19, {
+      usage: { input_tokens: 500, cache_read_input_tokens: 20000 },
+      maxContext: 1000000,
+      beta1m: true,
+    });
+    turns.push(makeTurn({
+      usage: { input_tokens: 1000, cache_read_input_tokens: 175000, cache_creation_input_tokens: 0 },
+      maxContext: 200000,
+    }));
+    var r = assessWeather(turns, { sessionWindow: 200000 });
+    assert.equal(r.level, 'rainy');
+  });
+
+  it('ctx_unknown_window — no observed maxContext produces no signal', function() {
+    var turns = repeat(20, {
+      usage: { input_tokens: 1000, cache_read_input_tokens: 175000, cache_creation_input_tokens: 0 },
+      maxContext: undefined,
+    });
+    var r = assessWeather(turns);
+    assert.equal(r.level, 'sunny');
+    assert.equal(r.stats.ctxPct, 0);
+    assert.ok(!hasFactor(r, 'ctx_pressure'));
+  });
+
   it('compaction_single — one compaction, otherwise healthy', function() {
     var turns = repeat(20);
     turns[10] = makeTurn({ isCompacted: true });

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -6,8 +6,9 @@ const vm = require('node:vm');
 const fs = require('node:fs');
 
 // Load workflow-timeline.js in a browser-like global context
-function loadWfModule() {
+function loadWfModule(opts) {
   const formatSrc = fs.readFileSync(require('path').join(__dirname, '../public/format.js'), 'utf8');
+  const weatherSrc = fs.readFileSync(require('path').join(__dirname, '../public/weather.js'), 'utf8');
   const src = fs.readFileSync(require('path').join(__dirname, '../public/workflow-timeline.js'), 'utf8');
   const ctx = {
     document: { createElement: () => ({ appendChild() {}, style: {}, id: '' }), createElementNS: () => ({ setAttribute() {}, innerHTML: '' }), getElementById: () => null, body: { appendChild() {} }, documentElement: {} },
@@ -31,6 +32,7 @@ function loadWfModule() {
   };
   vm.createContext(ctx);
   vm.runInContext(formatSrc, ctx);
+  if (opts && opts.weather) vm.runInContext(weatherSrc, ctx);
   vm.runInContext(src, ctx);
   return ctx;
 }
@@ -181,6 +183,41 @@ describe('workflow-timeline data layer', () => {
     // A lane whose turns are all ≤200K keeps 200K (no wider signal to rescope to).
     ctx.wfState = { lanes: [{ key: 'main', name: 'main', turns: [{ id: 'x1', maxContext: 200000, ctxUsed: 100000 }] }] };
     assert.equal(Math.round(ctx.wfCtxPctRender({ id: 'x1', maxContext: 200000, ctxUsed: 100000 })), 50); // 100K/200K
+  });
+
+  it('#377 slice 2: single-turn weather matches the lane-fold context window in tooltip and turn card', () => {
+    const ctx = loadWfModule({ weather: true });
+    const turn = mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, {
+      maxContext: 200000,
+      ctxUsed: 176000,
+      usage: {
+        input_tokens: 176000,
+        output_tokens: 1000,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      toolCalls: {},
+    });
+    const laneEvidence = mkEntry('t2', 's1', 'claude-opus-4-6', 7000, 5, {
+      maxContext: 1000000,
+      ctxUsed: 10000,
+    });
+    const lane = { key: 'main', name: 'main', turns: [turn, laneEvidence] };
+    ctx.wfState = { lanes: [lane], selectedLane: lane, selectedSection: 'timeline' };
+
+    const localOnly = ctx.assessWeather([turn]);
+    assert.equal(localOnly.level, 'rainy');
+    assert.equal(localOnly.stats.ctxPct, 88);
+
+    ctx._wfShowTooltip({ clientX: 0, clientY: 0 }, turn, lane);
+    assert.match(ctx._wfTooltipEl.innerHTML, /Operating normally/);
+    assert.match(ctx._wfTooltipEl.innerHTML, /17\.6%/);
+
+    const panel = { innerHTML: '' };
+    ctx.document.getElementById = (id) => id === 'wf-agent-card-panel' ? panel : null;
+    ctx.wfRenderTurnCard(turn);
+    assert.match(panel.innerHTML, /17\.6%/);
+    assert.doesNotMatch(panel.innerHTML, /🌧️/);
   });
 
   it('convId splits parallel same-agent instances into separate lanes (#117)', () => {


### PR DESCRIPTION
## 繁中摘要

`sigCtxPressure` 用**最後一個 turn 的 raw `maxContext`** 當 context% 的分母。但 `sessionCtxWindow`（`public/miller-columns.js:13`）與 `_wfLaneWindow`（`public/workflow-timeline.js:196`）都取 turns 的 **max**，所以 raw 分母恆 ≤ fold —— weather **只可能高估 context 壓力，數學上不可能低估**。

最刺眼的後果在 turn tooltip：相鄰兩行同時顯示 `Health 🌧️ context 88% → Save key decisions to CLAUDE.md` 與 `Context 17.7% (safe)`，而且基於錯的數字發出行動建議。

> **issue body 把因果方向寫反了**（宣稱「1M session 被低估」），修法也從純注入改為混合式 —— 見該 issue 的更正 comment，owner 已於 2026-07-30 裁定。

## What this changes

### 1. Fold what you were handed (`31a1696`, `da31837`)

`assessWeather(turns, opts)` / `sigCtxPressure(turns, opts)` gain an optional second argument. The denominator becomes `(opts && opts.sessionWindow) || _foldWindow(turns)`, where `_foldWindow` mirrors `_wfLaneWindow`: `max(maxContext)` over the turns it was handed, `OR(beta1m) → 1_000_000`. A fold of `0` (no observed fact) keeps the existing `severity: 0` guard — an unknown window must never manufacture a signal from a guessed denominator.

Four callers hold the complete fold domain and are fixed with **no caller change**: `entry-rendering.js` session-card weather, `session-index.js:116` (cold session, full metas), `workflow-timeline.js:1558` (lane label), `:2800` (agent card).

### 2. Inject at the partial-scope sites (`9f08d10`)

| site | why local fold is not enough | injected |
|---|---|---|
| `workflow-timeline.js:2581` tooltip | a single turn | `_wfTurnWindow(t)` |
| `workflow-timeline.js:2917` turn card | a single turn | `_wfTurnWindow(turnEntry)` |
| `session-index.js:211` | scans `store.entries`, capped for oversized sessions | `sessionWindow(sid)` |
| `restore.js:386` | `RESTORE_DAYS` filter + `SESSION_ENTRY_CAP` truncation | `sessionIdx.sessionWindow(sid)` |

`_wfTurnWindow(e)` is extracted from `wfCtxPctRender` so the turn's window is derived in **one** place — the `Health` and `Context` rows of the same tooltip can no longer drift apart, which is the defect that produced this issue. It returns `0` when nothing is known and `wfCtxPctRender` keeps its own `|| 200000` display fallback: a percentage may use a default denominator, a health verdict may not.

### 3. Let the client see the server's whole-session fold (`d417cd6`, `b02cb08`, `605dbe8`)

`sessionCtxWindow` consulted the server's per-session fold only when the client held **no** entries at all (`!has1m && win === 0`). With `allEntries` truncated by `RESTORE_DAYS` / `SESSION_ENTRY_CAP` and the surviving turns saying 200K, `win` is 200K, the gate never fires, and the authoritative fold is ignored. Merge it unconditionally (monotone max/OR — the denominator can only grow). `mergeColdSessions` now carries `beta1m`/`maxContext` onto already-hot sessions too, and recomputes stats for any session whose window actually widened.

### Why mixed rather than the pure injection the issue proposed

`workflow-timeline.js:1558`/`:2800` are called **per lane, including subagent lanes**. Passing `sessionCtxWindow(sid)` there would divide a 200K subagent by a 1M session window — manufacturing the very under-estimate the issue mistakenly believed already existed. Folding internally removes that failure mode structurally instead of relying on eight call sites each picking correctly.

## codex 二審：四輪，每輪往上游推一層

| 輪 | 發現 | 處置 |
|---|---|---|
| R1 | partial-scope 四站仍用錯分母 | `9f08d10` 四處注入 |
| R2 | client `recomputeSessionStats` fold 被裁切的 `allEntries`，覆寫 server 算對的結果 | `d417cd6` — 追下去發現真因在 `sessionCtxWindow` 自己的 gate |
| R3 | `mergeColdSessions` 對已 hot 的 session 從不複製 `beta1m`/`maxContext`，所以 R2 對 hot session 是死信；且 R2 的測試直接寫欄位、繞過真實路徑而假綠 | `b02cb08` — 在 #367 guard 之前單調併入，並重寫測試改走 `mergeColdSessions` |
| R4 | (a) server/client 分類分歧可能撐大 main 窗口 → 隱藏真警示；(b) `sessions_updated` 與 SSE `stale` 兩條路徑 merge 後沒有 recompute，舊 rainy 徽章殘留 | (b) 修於 `605dbe8`；(a) 量測後記為 known limitation，另開 #381 |

**R4(b) 不是 optional** —— 它是 `8b6789f` blocker 2 的翻版（stored 輸入變大、衍生顯示不重算）。三個 `mergeColdSessions` 呼叫點中只有初次載入後面有 recompute。

**R4(a) 經獨立量測後接受**：對所有帶 1M 證據的 session（全部 44 個 `beta1m` + 最近 40 個 fossil）重現 L1（agentKey 規則）與 L2（#350 per-conversation coreHash plurality）兩層分類 —— **命中 0/84、訊號抑制實害 0**。相對地它換掉的風險（裁切造成的假 rainy）在真實資料上是 **123/715** 個 session 結構暴露。取捨與量測侷限全寫進 ADR amendment。

## Evidence

**Diff check** — `scripts/diff-check.sh origin/main <4 test files> -- node --test --test-name-pattern="ctx_mixed_window|ctx_session_window_override|#377" …` → **exit 0**, `✅ old FAIL / new PASS`.

八條新斷言，每條都有鑑別力（每條都用「停用修正 → 必須變紅」的負向對照驗過）：

| test | pre-fix | post-fix |
|---|---|---|
| `ctx_mixed_window` | `rainy`, ctxPct 88 | `sunny`, ctxPct 17.6 |
| `ctx_session_window_override`（注入 400K） | ctxPct 88 | ctxPct 44 |
| slice 2: single-turn tooltip + turn card | `Health rainy 88%` vs `Context 17.6%` | 兩者皆 17.6% |
| slice 2: partial store 用 session-index 1M fold | `sessionWindow is not a function` | 1M 分母 |
| slice 2: unknown window 不製造訊號 | — | severity 0 |
| `sessionCtxWindow` cold / hot 兩分支（走真實 `mergeColdSessions`） | 200000 | 1000000 |
| 單調性回歸：較小的 server 值不得縮窗 | — | 維持 1M |
| widening 後立即重算 weather | 停在 `rainy` | 變 `sunny` |

`ctx_session_window_override` 原本注入 `200000`，與最後一個 turn 自己的 `maxContext` 撞值 —— 舊碼一樣會綠、證明不了任何事。`da31837` 改注入既不等於 fold（1M）也不等於 last（200K）的值。R2 那兩條測試原本直接在 session 物件上寫欄位、繞過 `mergeColdSessions`，`b02cb08` 重寫為驅動真實路徑。

**Real-data corpus replay**（150 個最近 session，走 cold-load 路徑）：

```
sessions replayed: 150   (mixed-window: 111)
level changed:      12
  toward sunny (false alarm removed):  12
  toward storm (REGRESSION):            0
  changed but NOT mixed-window:         0
```

**Full suite**: 1561/1561 pass, 0 fail（isolated `CCXRAY_HOME`，`node --test test/*.test.js`）。既有 28 個 weather fixture 全用單一 `maxContext: 200000`，fold == last，一條都沒動。

**Boot smoke**: `scripts/boot-smoke.sh` → exit 0，`BOOT OK: dashboard HTTP 200`。

**Orphan scan**: 無 top-level symbol 被刪；`wfCtxPctRender` 仍定義且 10 個呼叫點完好。

### Visual

合成的 mixed-window session（19 turns @1M `beta1m` + 最後一筆 fossil 說 200K），isolated `CCXRAY_HOME`、`CCXRAY_IMPORT_DISABLE=1`。無真實專案資料。

**Turn tooltip — 缺陷本體。** 同一張 tooltip 相鄰兩行互相矛盾，錯的數字還驅動了行動建議：

![tooltip before](https://raw.githubusercontent.com/lis186/ccxray/evidence/pr-377/before-tooltip-contradiction.png)

**修後** — `Health context 17.6%` 與 `Context 17.7% (safe)`；0.1pp 差距是已記載的分子殘差（weather 為 input-only，`ctxUsed` 含 `output_tokens`）：

![tooltip after](https://raw.githubusercontent.com/lis186/ccxray/evidence/pr-377/after-tooltip-consistent.png)

**Session card — 修前** 🌧️ 就在「18% of 1M」旁邊，**修後** ☀️ 出現在三個介面，其餘數字逐字相同：

![card before](https://raw.githubusercontent.com/lis186/ccxray/evidence/pr-377/before-old-code.png)
![card after](https://raw.githubusercontent.com/lis186/ccxray/evidence/pr-377/after-new-code.png)

`/_api/sessions` 也同意：舊碼 `🌧️ rainy ctxPct=88`、新碼 `☀️ sunny ctxPct=17.6`。

## ADR 0013 amendment（依 issue 要求，與程式同一個 PR）

- 為何 server 端注入**不是** `8b6789f` 的重蹈覆轍：那次 revert 拿掉的是**client 端**掛在增量 `addEntry` 上的 `sess.maxWindow`（commit 只動 `entry-rendering.js`，三個 blocker 全是增量 render 狀態問題），而 `session-index` 是可重建的 derived view，其單調聚合有 mtime staleness、drift、schema migration 三條重建路徑。先例：`463bf61` 在本 ADR 之後四天加入這兩個欄位，目的正是餵 `sessionCtxWindow` 的冷 session fallback。
- **F5 known limitation**（R4(a)）：機制、方向（可能隱藏真警示，與本 ADR 對 safe failure 的定義相反）、0/84 量測與其侷限（另有 631 個 fossil 候選未測；ADR 0008 overlap 與 ADR 0009 seq 的 turn 級 flip 未跑完整 `wfInferLanes` replay）。
- **新一致性契約**：任何對 hot session 窗口欄位的單調併入，必須對受影響 session 觸發 weather/stats 重算。
- **client latch 的三個成立前提**：單調（事實合併非分類結論）、鏡像自可重建的 derived view、永不餵分類。任一前提被破壞即須重新評估。
- **兩處對初稿的更正**：live-merge seam **不會**自癒（`reconcileMetas` 只比計數、`loadSessionIndex` 的 mtime 檢查也不覆蓋，只有顯式 rebuild 會重算）；「只會減少警示、不會製造假警報」補上「若 server 誤分類可能隱藏真警示」。

## 沒驗什麼

- **分子未動**：weather 為 input-only、`computeCtxUsed` 含 `output_tokens`（#253 的刻意設計）。修好分母後仍有 last-turn 殘差：典型 0.1–1pp，最壞（截斷 turn）在 200K 窗口上 8–16pp。issue T2 的 ±0.1pp 結構性不可達，改寫提案在更正 comment。
- **無操作錄影**：tooltip 為 hover 觸發，兩張 tooltip 截圖是以真實 `Input.dispatchMouseEvent` 觸發後拍的，同一個 turn 的舊/新對照。本次不改任何互動時序，只改一個被渲染的計算值，故未錄影；審查若要求可補。
- **合成 fixture 只有 index 沒有 body 檔**，故 TIMELINE 顯示 "turn data could not be loaded"。預期結果、與本 PR 無關；weather 不依賴 body 檔。
- **F5 未修**（另開 #381）；**server 單一寫入者**為長期方向（另開 #382，Blocked-by #350）。
- **live-merge seam 未修**，僅誠實記載其非自癒性。

## 附帶

`docs/solutions/` 另記一條規則衝突（#379）：`GATE-MANIFEST` 要求完整 40 字元 `headRefOid`，而 `scrub-output.sh` 的 R3 必然攔截它，兩個強制閘無相容形式。

兩個獨立缺陷待開 issue：cold-load 只在 `provider === 'anthropic'` 分支補 `maxContext`，OpenAI/codex 線的 ctx 訊號永遠靜音；`restore.js:386` 會用部分 `store.entries` 覆寫 `session-index.js:116` 剛以全量 metas 算好的 weather。

Closes #377
