### PR TITLE
fix(weather): include output_tokens in ctx numerator (#387)

### DIFF
--- a/public/weather.js
+++ b/public/weather.js
@@ -57,7 +57,8 @@ function sigCtxPressure(turns, opts) {
   var u = last.usage || {};
   var mx = (opts && opts.sessionWindow) || _foldWindow(turns);
   if (!mx || mx < 1000) return { severity: 0, detail: { ctxPct: 0, turnIndex: turns.length - 1, entryId: last && last.id || null } };
-  var used = (u.input_tokens || 0) + (u.cache_read_input_tokens || 0) + (u.cache_creation_input_tokens || 0);
+  // #387: match computeCtxUsed semantics (format.js:15-21) — four-term sum
+  var used = (u.input_tokens || 0) + (u.cache_read_input_tokens || 0) + (u.cache_creation_input_tokens || 0) + (u.output_tokens || 0);
   var pct = used / mx;
   var sev = clamp01((pct - CTX_FLOOR) / (1 - CTX_FLOOR));
   return { severity: sev, detail: { ctxPct: Math.round(pct * 1000) / 10, turnIndex: turns.length - 1, entryId: last && last.id || null } };

--- a/test/session-index.test.js
+++ b/test/session-index.test.js
@@ -77,7 +77,8 @@ describe('session-index', () => {
       assert.equal(si.sessionWindow(sid), 1000000);
       const weather = si.get(sid).weather;
       assert.equal(weather.level, 'sunny');
-      assert.equal(weather.stats.ctxPct, 17.6);
+      // #387: +output_tokens(1000) shifts 17.6 → 17.7
+      assert.equal(weather.stats.ctxPct, 17.7);
       assert.equal(weather.score, 0);
     } finally {
       store.entries.splice(0, store.entries.length, ...savedEntries);

--- a/test/weather.test.js
+++ b/test/weather.test.js
@@ -99,7 +99,8 @@ describe('assessWeather', function() {
       maxContext: 200000,
     }));
     var r = assessWeather(turns, { sessionWindow: 400000 });
-    assert.ok(Math.abs(r.stats.ctxPct - 44) <= 0.2, 'ctxPct ' + r.stats.ctxPct + ' should be ≈ 44');
+    // #387: shift = output_tokens(800) / window(400000) = 0.2pp → 44.0 → 44.2
+    assert.ok(Math.abs(r.stats.ctxPct - 44.2) <= 0.2, 'ctxPct ' + r.stats.ctxPct + ' should be ≈ 44.2');
     assert.equal(r.level, 'sunny');
   });
 
@@ -347,5 +348,45 @@ describe('assessWeather', function() {
     for (var i = 0; i < 15; i++) turns.push(makeTurn({ stopReason: 'tool_use', toolFail: true }));
     var r = assessWeather(turns);
     assert.ok(r.tooltip.includes('permissions'), 'stuck action should mention permissions');
+  });
+
+  // ── #387: ctx numerator includes output_tokens (match computeCtxUsed) ──
+
+  it('#387 — ctx numerator includes output_tokens (fail-on-old)', function() {
+    var turns = repeat(19);
+    turns.push(makeTurn({
+      usage: { input_tokens: 60000, cache_read_input_tokens: 40000, cache_creation_input_tokens: 0, output_tokens: 20000 },
+      maxContext: 200000,
+    }));
+    var r = assessWeather(turns);
+    // Old code: used = 60000+40000+0 = 100000, pct = 50.0
+    // New code: used = 60000+40000+0+20000 = 120000, pct = 60.0
+    assert.equal(r.stats.ctxPct, 60.0, 'ctxPct should include output_tokens');
+  });
+
+  it('#387 — output_tokens=0 produces same result as before (no drift)', function() {
+    var turns = repeat(19);
+    turns.push(makeTurn({
+      usage: { input_tokens: 60000, cache_read_input_tokens: 40000, cache_creation_input_tokens: 0, output_tokens: 0 },
+      maxContext: 200000,
+    }));
+    var r = assessWeather(turns);
+    assert.equal(r.stats.ctxPct, 50.0, 'ctxPct unchanged when output_tokens=0');
+  });
+
+  it('#387 — output_tokens crosses CTX_FLOOR threshold (fail-on-old)', function() {
+    var turns = repeat(19);
+    // input-only pct = 79000/200000 = 39.5% (below CTX_FLOOR=0.4)
+    // with output: (79000+8000)/200000 = 43.5% (above CTX_FLOOR)
+    turns.push(makeTurn({
+      usage: { input_tokens: 79000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, output_tokens: 8000 },
+      maxContext: 200000,
+    }));
+    var r = assessWeather(turns);
+    assert.ok(hasFactor(r, 'ctx_pressure'), 'should detect ctx_pressure when output pushes past floor');
+    assert.equal(r.stats.ctxPct, 43.5, 'ctxPct should be 43.5 with output_tokens');
+    // Verify other factors are not affected by the ctx numerator change
+    var otherFactors = r.factors.filter(function(f) { return f.type !== 'ctx_pressure'; });
+    assert.equal(otherFactors.length, 0, 'no other factors should fire on this fixture');
   });
 });

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -207,15 +207,17 @@ describe('workflow-timeline data layer', () => {
 
     const localOnly = ctx.assessWeather([turn]);
     assert.equal(localOnly.level, 'rainy');
-    assert.equal(localOnly.stats.ctxPct, 88);
+    // #387: +output_tokens(1000) shifts 88 → 88.5
+    assert.equal(localOnly.stats.ctxPct, 88.5);
 
     ctx._wfShowTooltip({ clientX: 0, clientY: 0 }, turn, lane);
     assert.match(ctx._wfTooltipEl.innerHTML, /Operating normally/);
-    assert.match(ctx._wfTooltipEl.innerHTML, /17\.6%/);
+    assert.match(ctx._wfTooltipEl.innerHTML, /17\.7%/);
 
     const panel = { innerHTML: '' };
     ctx.document.getElementById = (id) => id === 'wf-agent-card-panel' ? panel : null;
     ctx.wfRenderTurnCard(turn);
+    // turn card uses entry.ctxUsed (input-only), not weather's four-term sum
     assert.match(panel.innerHTML, /17\.6%/);
     assert.doesNotMatch(panel.innerHTML, /🌧️/);
   });


### PR DESCRIPTION
## Summary
weather.js `sigCtxPressure()` 的 ctx 分子缺 `output_tokens`，與 `computeCtxUsed`（format.js）不一致。加入 `output_tokens` 對齊四元和。

## Verification
- fail-on-old: 3 FAIL (output_tokens 缺失 → ctxPct 偏低、不過 CTX_FLOOR)
- pass-on-new: 34/34 PASS

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)