### PR TITLE
fix(session-index): feed canonical to updateFromEntry after merge (#388)

### DIFF
--- a/docs/decisions/0013-beta1m-persist-session-window-derive.md
+++ b/docs/decisions/0013-beta1m-persist-session-window-derive.md
@@ -218,6 +218,11 @@ The seam's direction is safe: the window can only be under-reported, producing
 over-warning rather than hiding pressure. It is bounded and recoverable, but
 recovery is manual — this ADR does not claim it heals on its own.
 
+**Resolved by #388 (2026-07-31).** `forward.js` and `restore.js` now call
+`updateFromEntry(canonical)` unconditionally after merge. The `!merged` guard
+is removed; enrichment fields propagate on every path. The "not self-healing"
+analysis above is no longer applicable — the seam is closed.
+
 Classification remains separate and unchanged. `isCompacted`, per-turn
 `severity`, and lane placement still read raw per-turn `maxContext`; this
 amendment changes only weather's display/health denominator and preserves the

--- a/server/forward.js
+++ b/server/forward.js
@@ -789,9 +789,10 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
     const indexLine = buildIndexLine(entry);
     // Log-first: only update session index after index.ndjson write succeeds (#309)
     config.storage.appendIndex(indexLine + '\n').then(() => {
-      // Skip the session-index update on a merge — the canonical was already
-      // counted; counting the duplicate would inflate the session card cost (#333).
-      if (!merged) sessionIdx.updateFromEntry(entry);
+      // #388: always feed the canonical (post-merge) entry to session-index.
+      // count/cost are rid-deduped (_countedRids/_costByRid) so re-feeding is safe;
+      // window fields (maxContext, beta1m) are monotone max/OR — idempotent on re-feed.
+      sessionIdx.updateFromEntry(canonical);
     }).catch(e => console.error('Write index failed:', e.message));
 
     // Release req/res from memory — data is on disk (or being written), lazy-load on demand
@@ -1043,9 +1044,10 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
     // Log-first: only update session index after index.ndjson write succeeds (#309).
     // Raw line written even on a merge — restore/cold-load re-merge from disk (#333).
     config.storage.appendIndex(indexLine + '\n').then(() => {
-      // Skip the session-index update on a merge — the canonical was already
-      // counted; counting the duplicate would inflate the session card cost (#333).
-      if (!merged) sessionIdx.updateFromEntry(entry);
+      // #388: always feed the canonical (post-merge) entry to session-index.
+      // count/cost are rid-deduped (_countedRids/_costByRid) so re-feeding is safe;
+      // window fields (maxContext, beta1m) are monotone max/OR — idempotent on re-feed.
+      sessionIdx.updateFromEntry(canonical);
     }).catch(e => console.error('Write index failed:', e.message));
 
     // Release req/res from memory — data is on disk (or being written), lazy-load on demand

--- a/server/restore.js
+++ b/server/restore.js
@@ -314,6 +314,10 @@ async function restoreFromLogs() {
       // the enriched canonical to any connected client (codex round-2 M6). Harmless
       // no-op when no client is connected yet (the common startup case).
       broadcastEntryUpdate(canonical);
+      // #388: feed canonical to session-index so enrichment fields (beta1m, maxContext)
+      // from the restored copy propagate to the window fold. Safe: count/cost are
+      // rid-deduped; window fields are monotone max/OR.
+      sessionIdx.updateFromEntry(canonical);
       continue;
     }
     store.entries.push(entry);

--- a/test/merge-enrichment-window.test.js
+++ b/test/merge-enrichment-window.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+// #388: when store.registerOrMerge returns merged=true, the canonical (post-merge)
+// entry must still be fed to sessionIdx.updateFromEntry so that enrichment fields
+// (beta1m, maxContext) from the merged-away copy reach the session-index window fold.
+// Without this fix, the session window stays at 200K instead of 1M.
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const os = require('os');
+
+describe('#388 merge enrichment reaches session-index window fold', () => {
+  let tmpDir, origLogsDir;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'ccxray-388-'));
+    await fsp.mkdir(path.join(tmpDir, 'logs'), { recursive: true });
+    const config = require('../server/config');
+    origLogsDir = config.LOGS_DIR;
+    Object.defineProperty(config, 'LOGS_DIR', { value: path.join(tmpDir, 'logs'), writable: true, configurable: true });
+  });
+
+  afterEach(async () => {
+    // #388 codex R1: flush/cancel the pending timer BEFORE restoring LOGS_DIR,
+    // otherwise the delayed flush can write test data to the real sessions.json.
+    const si = require('../server/session-index');
+    await si.flush();
+    const config = require('../server/config');
+    Object.defineProperty(config, 'LOGS_DIR', { value: origLogsDir, writable: true, configurable: true });
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+    delete require.cache[require.resolve('../server/session-index')];
+    delete require.cache[require.resolve('../server/store')];
+  });
+
+  // ── Structural contract: forward.js must not gate updateFromEntry on !merged ──
+  // This is the fail-on-old test. Old code has `if (!merged) sessionIdx.updateFromEntry(entry)`;
+  // new code calls `sessionIdx.updateFromEntry(canonical)` unconditionally.
+  it('#388 fail-on-old: forward.js must not gate updateFromEntry on !merged', () => {
+    const src = fs.readFileSync(path.join(__dirname, '../server/forward.js'), 'utf8');
+    const gatedPattern = /if\s*\(\s*!merged\s*\)\s*sessionIdx\.updateFromEntry/;
+    assert.equal(gatedPattern.test(src), false,
+      'forward.js must call updateFromEntry unconditionally after merge — the !merged guard hides enrichment (#388)');
+  });
+
+  // ── Behavioral: merged enrichment propagates when caller does the right thing ──
+  it('merged-away copy carrying beta1m propagates to session window via canonical', () => {
+    const si = require('../server/session-index');
+    const store = require('../server/store');
+    const sid = 'test-session-388';
+    const rid = 'msg_01_merge_test';
+
+    // First copy — no beta1m, maxContext=200000
+    const entryA = {
+      id: '2026-07-31T10-00-00-000', ts: '10:00:00', responseId: rid,
+      sessionId: sid, receivedAt: 1000, elapsed: '2.0',
+      maxContext: 200000, beta1m: undefined,
+      usage: { input_tokens: 100, output_tokens: 50 },
+      cost: { cost: 0.01 },
+    };
+    const resultA = store.registerOrMerge(entryA);
+    assert.equal(resultA.merged, false, 'first copy registers as canonical');
+    si.updateFromEntry(entryA);
+    assert.equal(si.sessionWindow(sid), 200000, 'window starts at 200K');
+
+    // Second copy — same responseId, carries beta1m=true + maxContext=1000000
+    const entryB = {
+      id: '2026-07-31T10-00-01-000', ts: '10:00:01', responseId: rid,
+      sessionId: sid, receivedAt: 2000, elapsed: '1.0',
+      maxContext: 1000000, beta1m: true,
+      usage: { input_tokens: 100, output_tokens: 50 },
+      cost: { cost: 0.01 },
+    };
+    const resultB = store.registerOrMerge(entryB);
+    assert.equal(resultB.merged, true, 'second copy merges into canonical');
+
+    // Simulate NEW forward.js: always feed canonical to session-index
+    si.updateFromEntry(resultB.canonical);
+
+    assert.equal(si.sessionWindow(sid), 1000000, 'window folds to 1M after merge enrichment');
+    assert.equal(si.get(sid).beta1m, true, 'beta1m propagated to session');
+    assert.equal(si.get(sid).count, 1, 'count stays 1 — rid dedup prevents double-count');
+  });
+});


### PR DESCRIPTION
## Summary
`forward.js`/`restore.js` 的 `if (!merged)` guard 跳過 `updateFromEntry`，merged-away copy 攜帶的 `beta1m`/`maxContext` enrichment 不進 session-index window fold。改為 unconditional `updateFromEntry(canonical)`——count/cost 已由 rid dedup 保護，window fields 是 monotone max/OR（冪等）。

ADR 0013 §F5 "known seam" 標記 resolved。

## Verification
- fail-on-old: 1 FAIL (結構斷言 — forward.js 不得 gate updateFromEntry on `!merged`)
- pass-on-new: 2/2 PASS

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)