### PR TITLE
fix(weather): set maxContext for imported OpenAI sessions (#384)

### DIFF
--- a/server/importer.js
+++ b/server/importer.js
@@ -281,6 +281,9 @@ async function parseCodexSessionFile(filePath) {
       tokens,
       cost: { cost },
       model: lastModel,
+      // #384: the transcript's model_context_window is authoritative — write it
+      // so weather/session-fold/cold-load all see the real denominator.
+      maxContext: contextWindow,
       sessionId,
       title: '(imported)',
       stopReason: null,

--- a/server/restore.js
+++ b/server/restore.js
@@ -228,6 +228,12 @@ async function restoreFromLogs() {
     // this, the dashboard would show "600K / 200K (clamped to 100%)" for
     // entries that predate the inferMaxContext fix. Math.max keeps previously
     // correct 1M values when current usage happens to fit inside 200K.
+    // #384: heal legacy openai lines that were imported without maxContext.
+    // Fill-only (never overwrite), recognized models only (unknown stays silent).
+    if (!meta.maxContext && meta.provider === 'openai' && meta.model) {
+      const ctx = config.getMaxContext(meta.model, null);
+      if (ctx !== config.DEFAULT_CONTEXT) meta.maxContext = ctx;
+    }
     // EXCEPTION(#158): data-layer — anthropic-specific maxContext inference from persisted usage
     if (meta.provider === 'anthropic') {
       const inferred = config.inferMaxContext(meta.model, null, meta.usage);

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -83,6 +83,12 @@ function normalizeIndexEntry(meta) {
   if (meta.provider === 'anthropic') {
     meta.maxContext = Math.max(meta.maxContext || 0, config.inferMaxContext(meta.model, null, meta.usage));
   }
+  // #384: heal legacy openai lines that were imported without maxContext.
+  // Fill-only (never overwrite), recognized models only (unknown stays silent).
+  if (!meta.maxContext && meta.provider === 'openai' && meta.model) {
+    const ctx = config.getMaxContext(meta.model, null);
+    if (ctx !== config.DEFAULT_CONTEXT) meta.maxContext = ctx;
+  }
   if (meta.usage) {
     const before = meta.usage;
     meta.usage = normalizeUsageForProvider(meta.provider, meta.usage);
@@ -475,4 +481,4 @@ function handleApiRoutes(clientReq, clientRes) {
   return false;
 }
 
-module.exports = { handleApiRoutes, computeSettings };
+module.exports = { handleApiRoutes, computeSettings, normalizeIndexEntry };

--- a/test/importer.test.js
+++ b/test/importer.test.js
@@ -339,6 +339,54 @@ describe('codex importer', () => {
       assert.strictEqual(entries[0].tokens.cacheRead, 4992);
       assert.strictEqual(entries[0].tokens.output, 35 + 28);
       assert.strictEqual(entries[0].tokens.contextWindow, 258400);
+      // #384: maxContext must be written to the entry (was missing before fix)
+      assert.strictEqual(entries[0].maxContext, 258400);
+    });
+
+    it('#384: writes maxContext from model_context_window', async () => {
+      const sessDir = path.join(codexDir, '2026', '07', '15');
+      fs.mkdirSync(sessDir, { recursive: true });
+      const file = path.join(sessDir, 'rollout-ctx.jsonl');
+      fs.writeFileSync(file, [
+        makeCodexSessionMeta({ sessionId: 'codex-ctx-test' }),
+        makeCodexTurnContext({ model: 'gpt-5-codex' }),
+        makeCodexTokenCount({ timestamp: '2026-07-15T10:30:05.000Z', contextWindow: 400000 }),
+      ].join('\n'));
+
+      const entries = await parseCodexSessionFile(file);
+      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries[0].maxContext, 400000, 'maxContext should come from model_context_window');
+    });
+
+    it('#384: uses CODEX_CONTEXT_WINDOW fallback when model_context_window absent', async () => {
+      const sessDir = path.join(codexDir, '2026', '07', '15');
+      fs.mkdirSync(sessDir, { recursive: true });
+      const file = path.join(sessDir, 'rollout-no-ctx.jsonl');
+      // Build a token_count line without model_context_window
+      const line = JSON.stringify({
+        timestamp: '2026-07-15T10:30:05.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            last_token_usage: {
+              input_tokens: 5000,
+              cached_input_tokens: 1000,
+              output_tokens: 100,
+              reasoning_output_tokens: 0,
+              total_tokens: 5100,
+            },
+          },
+        },
+      });
+      fs.writeFileSync(file, [
+        makeCodexSessionMeta({ sessionId: 'codex-no-ctx' }),
+        line,
+      ].join('\n'));
+
+      const entries = await parseCodexSessionFile(file);
+      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries[0].maxContext, 400000, 'should fall back to CODEX_CONTEXT_WINDOW');
     });
 
     it('skips token_count events with zero usage', async () => {

--- a/test/restore.test.js
+++ b/test/restore.test.js
@@ -286,7 +286,7 @@ describe('restoreFromLogs — maxContext re-inference for legacy entries', () =>
     assert.equal(entry.maxContext, 1_000_000);
   });
 
-  it('leaves OpenAI entries untouched (no Claude bump)', async () => {
+  it('heals legacy OpenAI entries with fill-only maxContext (#384)', async () => {
     store.entries.length = 0;
     const id = '2026-05-14T15-00-00-000';
     await config.storage.appendIndex(JSON.stringify({
@@ -301,7 +301,8 @@ describe('restoreFromLogs — maxContext re-inference for legacy entries', () =>
     await restoreFromLogs();
     const entry = store.entries.find(e => e.id === id);
     assert.ok(entry);
-    assert.equal(entry.maxContext, null);
+    // #384: recognized openai model gets fill-only healing (null → 400K)
+    assert.equal(entry.maxContext, 400000);
   });
 });
 


### PR DESCRIPTION
## Summary
Importer 已解析 transcript 的 `model_context_window` 但沒寫進 entry，97% OpenAI session 的 ctx 信號永久靜默。三層修復：
- (a) importer 加 `maxContext: contextWindow`
- (b) restore + cold-load 加 fill-only healing（recognized openai models only）
- (c) unknown model 保持靜默（honest absence）

## Verification
- fail-on-old: 3 FAIL (maxContext 未設 + fallback 未生效)
- pass-on-new: 17/17 PASS

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)