### PR TITLE
fix: exit cost-worker on parent disconnect (#395)

### DIFF
--- a/server/cost-worker.js
+++ b/server/cost-worker.js
@@ -2,6 +2,9 @@
 
 // Worker process for JSONL cost parsing — runs in a child process
 // to avoid blocking the main event loop during heavy I/O + JSON.parse.
+// #395: exit when parent dies (SIGKILL/OOM-kill) — the IPC channel closes
+// and 'disconnect' fires; without this, the worker becomes an orphan (PPID=1).
+process.on('disconnect', () => process.exit(0));
 
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION
## Summary

`cost-worker.js` 沒有 parent-death detection。Server 被 SIGKILL 時 worker 變孤兒（PPID=1）並累積——實測 72 個孤兒吃 4.5GB RAM。加一行 `process.on('disconnect')` 在 IPC channel 關閉時自動退出。

Closes #395

## Verification

- Fable 分析確認：無資料損壞風險（worker 純讀）、無重生風暴（costsInflight 序列化 + 60s backoff）、IPC channel 可靠（無 unref）、gracefulExit 交互無害
- usage.test.js 53/53 pass

## Test plan

- [ ] 起 server → 觸發 cost scan → `kill -9` → 確認無 PPID=1 孤兒
- [ ] 正常 Ctrl-C exit 仍正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)