### PR TITLE
fix(cost-worker): unref the IPC channel so the worker can exit again

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -125,6 +125,18 @@ These are different layers of isolation — don't conflate them:
   Scrubbing `$HOME` for the whole suite breaks them with "Could not find
   Chrome" — that's a missing toolchain cache, not a hygiene violation.
 
+One test injects a throwaway `$HOME` into its child processes by design:
+`test/cost-worker-exit.test.js`. `server/cost-worker.js` reads `os.homedir()`
+directly (it scans `$HOME/.claude*`, `$HOME/.codex*`, `$HOME/.config/claude` —
+not `CCXRAY_HOME`), so the override goes into the forked worker's env only; the
+test process itself keeps the real `$HOME`, leaving the puppeteer cache intact.
+Its fixture shape is a synthetic `.claude/projects/<p>/*.jsonl` of usage lines
+with unique `message.id`s (the worker dedupes by messageId). Its orphan test
+also writes two tiny child-process entrypoints (a surrogate parent and a
+`--require` hold-open pin) into the same temp dir at runtime — executable
+fixtures, not tests; generating them outside `test/` keeps them invisible to
+`node --test` auto-discovery.
+
 So: scrub `CCXRAY_HOME` for the whole suite; only set a throwaway `$HOME` for a
 specific non-browser test that needs to assert `~` expansion.
 

--- a/server/cost-worker.js
+++ b/server/cost-worker.js
@@ -2,9 +2,25 @@
 
 // Worker process for JSONL cost parsing — runs in a child process
 // to avoid blocking the main event loop during heavy I/O + JSON.parse.
-// #395: exit when parent dies (SIGKILL/OOM-kill) — the IPC channel closes
+
+// #395: exit when the parent dies (SIGKILL/OOM-kill) — the IPC channel closes
 // and 'disconnect' fires; without this, the worker becomes an orphan (PPID=1).
 process.on('disconnect', () => process.exit(0));
+// The 'disconnect' listener refs the child-side IPC channel handle, which keeps
+// the event loop alive forever (the #396 regression: every cost scan burned
+// cost-budget.js's 120s timeout). This worker intentionally has NO exit call on
+// the success path — it ends by letting the event loop drain after the final
+// stdout write. unref() drops the channel as a reason to stay alive without
+// removing the listener, so parent death still fires 'disconnect' (#395 intact).
+// Ordering vs. the listener above is NOT load-bearing: Node latches an explicit
+// channel unref, so unref-before-listener behaves identically (measured on
+// v22.22.3). Do not rely on or "fix" the order.
+// NEVER replace the drain-exit with a bare process.exit(0) after run(): with
+// silent:true stdout is a pipe, and an explicit exit truncates the payload at
+// exactly 65,536 bytes (one pipe buffer; measured on an 11MB output — 0
+// parseable entries). That converts a loud hang into silent cost-data
+// corruption. Regression guards: test/cost-worker-exit.test.js (Y / Y2 / X).
+process.channel?.unref();
 
 const fs = require('fs');
 const path = require('path');

--- a/server/cost-worker.js
+++ b/server/cost-worker.js
@@ -16,10 +16,11 @@ process.on('disconnect', () => process.exit(0));
 // channel unref, so unref-before-listener behaves identically (measured on
 // v22.22.3). Do not rely on or "fix" the order.
 // NEVER replace the drain-exit with a bare process.exit(0) after run(): with
-// silent:true stdout is a pipe, and an explicit exit truncates the payload at
-// exactly 65,536 bytes (one pipe buffer; measured on an 11MB output — 0
-// parseable entries). That converts a loud hang into silent cost-data
-// corruption. Regression guards: test/cost-worker-exit.test.js (Y / Y2 / X).
+// silent:true stdout is a pipe, and an explicit exit abandons whatever has not
+// been flushed, so the payload is cut off at one pipe buffer (65,536 bytes as
+// measured here on macOS + Node 22 — the capacity is platform-specific, the
+// truncation is not) and parses as nothing. That converts a loud hang into
+// silent cost-data corruption. Guards: test/cost-worker-exit.test.js (Y/Y2/X).
 process.channel?.unref();
 
 const fs = require('fs');

--- a/test/cost-worker-exit.test.js
+++ b/test/cost-worker-exit.test.js
@@ -1,0 +1,222 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { fork, spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Regression guards for server/cost-worker.js's process lifecycle.
+//
+// server/cost-budget.js resolves ONLY inside worker.on('exit'), else rejects
+// after 120s. Three regressions are guarded; mutation testing (2026-08-01)
+// showed each test is the ONLY one that catches its mutation:
+//   Y  — the worker exits on its own after writing output. Restoring #396's
+//        worker (disconnect listener without channel unref) fails this,
+//        bounded at ~15s.
+//   Y2 — a payload larger than one 64KB pipe buffer arrives complete. A bare
+//        process.exit(0) after the final stdout write truncates at exactly
+//        65,536 bytes with 0 parseable entries; Y alone stays green.
+//   X  — parent death still terminates the worker (#395). Deleting the
+//        'disconnect' handler leaves Y and Y2 green; only X fails.
+
+const WORKER = path.join(__dirname, '..', 'server', 'cost-worker.js');
+
+// Generous vs. reality (~35ms on an empty HOME, ~64ms on the Y2 fixture):
+// asserts "terminates", not "is fast" — it only needs to sit far below
+// cost-budget.js's 120s timeout while tolerating a loaded CI box.
+const SELF_EXIT_BUDGET_MS = 15_000;
+const ORPHAN_EXIT_BUDGET_MS = 5_000;
+
+// os.homedir() reads $HOME on POSIX; the worker scans $HOME/.claude*,
+// $HOME/.codex* and $HOME/.config/claude — not CCXRAY_HOME. A throwaway HOME
+// keeps the test off the developer's real history and makes runtime
+// machine-independent.
+function makeHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-worker-test-'));
+}
+
+// Forked exactly as server/cost-budget.js does — silent:true makes stdout a
+// pipe, which is what the drain-before-exit behaviour under test depends on.
+function startWorker(home) {
+  const worker = fork(WORKER, [], {
+    silent: true,
+    windowsHide: true,
+    env: { ...process.env, HOME: home },
+  });
+  const chunks = [];
+  const errChunks = [];
+  worker.stdout.on('data', c => chunks.push(c));
+  worker.stderr.on('data', c => errChunks.push(c));
+  const verdict = new Promise(resolve => {
+    // Resolve a verdict instead of hanging: a regression reports "never
+    // exited", bounded at SELF_EXIT_BUDGET_MS, not an opaque runner stall.
+    const timer = setTimeout(() => resolve({ exited: false, code: null }), SELF_EXIT_BUDGET_MS);
+    // 'close', not 'exit': it fires once the stdio pipes have drained, so
+    // `chunks` is complete when the verdict resolves.
+    worker.once('close', code => { clearTimeout(timer); resolve({ exited: true, code }); });
+  });
+  return {
+    worker,
+    verdict,
+    stdout: () => Buffer.concat(chunks),
+    stderr: () => Buffer.concat(errChunks).toString(),
+  };
+}
+
+function killIfAlive(proc) {
+  if (proc && proc.exitCode === null && proc.signalCode === null) {
+    try { proc.kill('SIGKILL'); } catch {}
+  }
+}
+
+function pidExists(pid) {
+  try { process.kill(pid, 0); return true; }
+  catch (err) { if (err.code === 'ESRCH') return false; throw err; }
+}
+
+function readPid(child, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let out = '';
+    const timer = setTimeout(() => reject(new Error('surrogate did not print worker pid')), timeoutMs);
+    child.stdout.on('data', chunk => {
+      out += chunk;
+      const m = out.match(/^(\d+)\n/);
+      if (!m) return;
+      clearTimeout(timer);
+      resolve(Number(m[1]));
+    });
+    child.once('error', err => { clearTimeout(timer); reject(err); });
+    child.once('exit', (code, signal) => {
+      if (/^\d+\n/.test(out)) return;
+      clearTimeout(timer);
+      reject(new Error(`surrogate exited before printing worker pid: code=${code} signal=${signal}`));
+    });
+  });
+}
+
+async function waitForPidExit(pid, timeoutMs) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (!pidExists(pid)) return true;
+    await new Promise(r => setTimeout(r, 50));
+  }
+  return !pidExists(pid);
+}
+
+describe('cost-worker: process lifecycle', () => {
+  it('Y — exits on its own after writing output', async () => {
+    const home = makeHome();
+    let w;
+    try {
+      w = startWorker(home);
+      const result = await w.verdict;
+      assert.equal(result.exited, true,
+        `worker did not exit within ${SELF_EXIT_BUDGET_MS}ms; ` +
+        'cost-budget.js would burn its 120s timeout and reject (Usage tab dark)');
+      assert.equal(result.code, 0, w.stderr());
+      assert.ok(Array.isArray(JSON.parse(w.stdout().toString())),
+        'worker stdout should parse as a JSON array');
+    } finally {
+      killIfAlive(w && w.worker);
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('Y2 — payload larger than one pipe buffer arrives complete', async () => {
+    const home = makeHome();
+    // 5,000 lines with a UNIQUE message.id per line — scanHomes dedupes by
+    // messageId, so duplicate ids would silently shrink the expected count.
+    const projectDir = path.join(home, '.claude', 'projects', 'p');
+    fs.mkdirSync(projectDir, { recursive: true });
+    const LINES = 5000;
+    const lines = Array.from({ length: LINES }, (_, i) => JSON.stringify({
+      timestamp: new Date(1_700_000_000_000 + i).toISOString(),
+      message: {
+        id: `message-${i}`,
+        model: 'claude-sonnet-4-5-20250514',
+        usage: {
+          input_tokens: 100,
+          output_tokens: 20,
+          cache_creation_input_tokens: 30,
+          cache_read_input_tokens: 400,
+        },
+      },
+    }));
+    fs.writeFileSync(path.join(projectDir, 's.jsonl'), lines.join('\n') + '\n');
+
+    let w;
+    try {
+      w = startWorker(home);
+      const result = await w.verdict;
+      assert.equal(result.exited, true,
+        `worker did not exit within ${SELF_EXIT_BUDGET_MS}ms`);
+      assert.equal(result.code, 0, w.stderr());
+
+      const raw = w.stdout();
+      // Vacuity guard: the fixture must actually exceed the 64KB pipe buffer,
+      // otherwise this test cannot detect truncation at all.
+      assert.ok(raw.length > 65_536,
+        `fixture produced only ${raw.length} bytes; must exceed the 65,536-byte pipe buffer`);
+      let entries;
+      try {
+        entries = JSON.parse(raw.toString());
+      } catch (err) {
+        assert.fail(`worker stdout truncated at ${raw.length} bytes ` +
+          `(a bare process.exit() after the final write truncates at exactly 65,536): ${err.message}`);
+      }
+      assert.equal(entries.length, LINES);
+    } finally {
+      killIfAlive(w && w.worker);
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('X — parent SIGKILL still terminates a held-open worker (#395)', async () => {
+    // The worker exits naturally in ~30ms on an empty HOME, which would make
+    // this test vacuous — the pin must keep it alive until the parent dies.
+    // Pin = execArgv --require of a setInterval, NEVER a FIFO .jsonl: a
+    // blocked libuv threadpool read prevents process.exit(0) from terminating
+    // at all, which makes the test fail on CORRECT code (measured dead end).
+    const home = makeHome();
+    const holdOpenPath = path.join(home, 'hold-open.js');
+    const surrogatePath = path.join(home, 'surrogate.js');
+    fs.writeFileSync(holdOpenPath, 'setInterval(() => {}, 1 << 30);\n');
+    fs.writeFileSync(surrogatePath, [
+      "'use strict';",
+      "const { fork } = require('child_process');",
+      'const worker = fork(process.argv[2], [], {',
+      '  env: { ...process.env, HOME: process.argv[3] },',
+      '  silent: true,',
+      '  windowsHide: true,',
+      "  execArgv: ['--require', process.argv[4]],",
+      '});',
+      "process.stdout.write(worker.pid + '\\n');",
+      'setInterval(() => {}, 1 << 30);',
+      '',
+    ].join('\n'));
+
+    let surrogate;
+    let workerPid;
+    try {
+      surrogate = spawn(process.execPath, [surrogatePath, WORKER, home, holdOpenPath],
+        { stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
+      workerPid = await readPid(surrogate, 5000);
+      // Let the pinned worker pass its natural ~30ms exit point, proving the
+      // pin holds — a naturally-dead worker here would pass the kill vacuously.
+      await new Promise(r => setTimeout(r, 250));
+      assert.equal(pidExists(workerPid), true,
+        'held-open worker must still be alive before parent death');
+
+      surrogate.kill('SIGKILL');
+      const gone = await waitForPidExit(workerPid, ORPHAN_EXIT_BUDGET_MS);
+      assert.equal(gone, true,
+        `worker ${workerPid} survived parent SIGKILL for ${ORPHAN_EXIT_BUDGET_MS}ms — #395 orphan regression`);
+    } finally {
+      killIfAlive(surrogate);
+      if (workerPid) { try { process.kill(workerPid, 'SIGKILL'); } catch {} }
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/cost-worker-exit.test.js
+++ b/test/cost-worker-exit.test.js
@@ -15,9 +15,10 @@ const path = require('node:path');
 //   Y  — the worker exits on its own after writing output. Restoring #396's
 //        worker (disconnect listener without channel unref) fails this,
 //        bounded at ~15s.
-//   Y2 — a payload larger than one 64KB pipe buffer arrives complete. A bare
-//        process.exit(0) after the final stdout write truncates at exactly
-//        65,536 bytes with 0 parseable entries; Y alone stays green.
+//   Y2 — a payload larger than one pipe buffer arrives complete. A bare
+//        process.exit(0) after the final stdout write cuts it off at one
+//        buffer (65,536 bytes on this platform) with 0 parseable entries;
+//        Y alone stays green.
 //   X  — parent death still terminates the worker (#395). Deleting the
 //        'disconnect' handler leaves Y and Y2 green; only X fails.
 
@@ -72,8 +73,23 @@ function killIfAlive(proc) {
 }
 
 function pidExists(pid) {
-  try { process.kill(pid, 0); return true; }
+  try { process.kill(pid, 0); }
   catch (err) { if (err.code === 'ESRCH') return false; throw err; }
+  // A terminated process that nobody has reaped yet is a zombie, and a zombie
+  // still answers kill(pid, 0). Once the surrogate is killed the worker is
+  // reparented to PID 1, which reaps promptly on a normal VM but not
+  // necessarily inside a container whose PID 1 is an ordinary app — there the
+  // worker would look alive forever and fail this test for the wrong reason.
+  // Linux exposes the state directly, so read it and treat Z as gone.
+  if (process.platform === 'linux') {
+    try {
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8');
+      // Field 3 is the state char; skip past the comm field, which may itself
+      // contain spaces or parentheses, by scanning from the last ')'.
+      return stat.slice(stat.lastIndexOf(')') + 2).split(' ')[0] !== 'Z';
+    } catch { return false; }
+  }
+  return true;
 }
 
 function readPid(child, timeoutMs) {
@@ -164,7 +180,7 @@ describe('cost-worker: process lifecycle', () => {
         entries = JSON.parse(raw.toString());
       } catch (err) {
         assert.fail(`worker stdout truncated at ${raw.length} bytes ` +
-          `(a bare process.exit() after the final write truncates at exactly 65,536): ${err.message}`);
+          `(a bare process.exit() after the final write cuts the payload off at one pipe buffer): ${err.message}`);
       }
       assert.equal(entries.length, LINES);
     } finally {


### PR DESCRIPTION
## 摘要（繁中）

main 目前是壞的。#396（修 #395 孤兒 worker）在 `server/cost-worker.js` 加的 `process.on('disconnect', …)` 會把 child 端 IPC channel 重新 ref 住，event loop 永遠不會清空——worker 正確寫完輸出後不退出，而 `cost-budget.js` 只在 `worker.on('exit')` resolve，於是每次成本掃描都燒滿 120 秒才 reject，Usage 分頁全黑。

修法是 child 端一行 `process.channel?.unref()`：channel 不再算「存活理由」，但 listener 保留，parent 死亡時仍會觸發 disconnect，#395 的孤兒防護不變。同時補上 #396 當時完全沒有的回歸測試——三個測試互鎖，任一單獨存在都會漏掉另一種回歸。

`server/cost-budget.js` 一行未動；parent 端合約另開 #401 追蹤。

## Root cause

In Node's `lib/child_process.js` `_forkChild()`, the child-side IPC channel starts unref'd — which is why the pre-#396 worker drained and exited in ~30ms. Attaching a `'message'` or `'disconnect'` listener re-refs it through the `newListener` hook (`control.refCounted()`). `cost-worker.js` has no explicit exit on the success path: `run()` ends with `process.stdout.write(...)` and relies on the loop draining. With the channel ref'd, it never does.

## Evidence

Observed live during triage: a `ccxray-stable` server on main had a cost-worker alive for 101s and climbing, heading for the timeout.

| | broken main | with this fix |
|---|---|---|
| worker exit | never (>30s observed) | 30–41ms |
| `getOrComputeCosts()` | hangs, rejects at 120s | 228ms |
| stdout payload | complete (11,160,632 bytes / 40,000 entries) | byte-identical |
| parent SIGKILL → worker dies | yes | yes, ~51ms |

Listener/unref ordering is **not** an invariant — Node latches an explicit channel unref, and both orders measure identically on v22.22.3. The comment says so, to stop someone "fixing" it later.

## Why three tests

Each is the only guard for its own regression. Measured mutation matrix:

| mutation | Y self-exit | Y2 large payload | X orphan |
|---|---|---|---|
| restore #396's worker (`67d6da5`) | **FAIL** ~15s | **FAIL** ~15s | pass |
| delete only the `'disconnect'` line | pass | pass | **FAIL** ~5s |
| add a bare `process.exit(0)` after the write | pass | **FAIL** | FAIL |

Two things this buys:

- **Row 2** is why X exists. Y and Y2 both stay green when #395's orphan protection is deleted, so a suite without X would let a future change silently revert it — the same shape of failure that produced this incident.
- **Row 3** is why Y2 exists. The obvious "helpful" fix for a hang is `process.exit(0)` after the write; with `silent:true` stdout is a pipe, so that abandons the unflushed remainder and cuts the payload off at one pipe buffer (65,536 bytes on this platform), parsing as nothing. That trades a loud 120s hang for silently corrupted cost data. Y alone does not catch it — the empty-HOME payload flushes synchronously.

X is non-vacuous by construction: the worker exits naturally in ~30ms on an empty HOME, so it is pinned open with an `execArgv --require setInterval`, then a surrogate parent is SIGKILLed and the worker's pid polled for ESRCH. Pinning with a `mkfifo` .jsonl is a measured dead end and is called out in a comment — a blocked libuv threadpool syscall prevents even `process.exit(0)` from terminating, so that variant fails on *correct* code.

## Verification

- New tests: **3 pass / 0 fail**, ~0.5s.
- Mutation matrix above: re-run by hand, all three rows reproduce.
- Full suite: **1576 pass / 0 fail** (pristine main baseline 1573, plus 3 new). Note for anyone re-running: do **not** set `CCXRAY_IMPORT_DISABLE` — it makes the importer tests fail spuriously.
- Browser smoke on an isolated `CCXRAY_HOME` + port 5602: Usage tab renders accounts, monthly and daily cost with real values; `document.querySelectorAll('.skeleton').length === 0`, no error text. Cost API settles in under a second.
- No stray or PPID-1 `cost-worker` left after the suite or the smoke run.
- codex review: 3 findings, all addressed in the second commit — zombie-aware pid polling for container CI (a zombie still answers `kill(pid, 0)`), and the "exactly 65,536 bytes" claim reworded since pipe capacity is platform-specific.

## Scope

`server/cost-budget.js` is untouched. A parent-side completion contract (settle on a drained payload, kill on timeout) was prototyped during triage and went green, but it cannot replace the child-side fix — a hung worker keeps its stdout fd open so the stream never ends, and when the parent itself is SIGKILLed only the child can protect itself. Deferred to #401.

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)
