### PR TITLE
docs(test): correct the mutation-coverage claim in cost-worker-exit header

### DIFF
--- a/test/cost-worker-exit.test.js
+++ b/test/cost-worker-exit.test.js
@@ -10,8 +10,10 @@ const path = require('node:path');
 // Regression guards for server/cost-worker.js's process lifecycle.
 //
 // server/cost-budget.js resolves ONLY inside worker.on('exit'), else rejects
-// after 120s. Three regressions are guarded; mutation testing (2026-08-01)
-// showed each test is the ONLY one that catches its mutation:
+// after 120s. Three regressions are guarded. Mutation testing (2026-08-01)
+// showed all three mutations turn this file red, and that X is the only guard
+// against deleting the disconnect handler. The other two mutations trip more
+// than one test, so do not read the list below as one-test-per-mutation:
 //   Y  — the worker exits on its own after writing output. Restoring #396's
 //        worker (disconnect listener without channel unref) fails this,
 //        bounded at ~15s.


### PR DESCRIPTION
## 摘要（繁中）

#402 出貨的 `test/cost-worker-exit.test.js` header 註解寫「each test is the ONLY one that catches its mutation」，但這句話**和它自己下面三行的細節互相矛盾**：X 那行明說「刪掉 disconnect handler 時 Y 和 Y2 保持綠」，可是總結句把「一對一」推廣到三個測試。實測矩陣只支持其中一列。

註解-only，無行為變更。

## Detail

The three per-test lines were already accurate. Only the summary sentence overstated them.

Measured mutation matrix (2026-08-01, re-run by hand before this change):

| mutation | Y | Y2 | X |
|---|---|---|---|
| restore `67d6da5`'s worker (the #396 regression) | FAIL | FAIL | pass |
| delete only the `process.on('disconnect', …)` line | pass | pass | **FAIL** |
| append a bare `process.exit(0)` after the final write | pass | **FAIL** | FAIL |

So exactly one row is one-test-per-mutation: X is the sole guard against deleting the disconnect handler — which is the load-bearing claim, since that mutation would silently revert #395. The other two mutations trip two tests each.

The corrected wording states what was measured and explicitly warns against reading the list as a one-to-one mapping.

Found while closing #304, when the mutation matrix was re-examined against the shipped comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)