### PR TITLE
fix(pricing): restore LiteLLM-wins precedence, lazy route access, xai-only mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Launchers are registered in `server/providers.js` (same hub + dashboard for all)
 
 OpenAI-wire clients that are not Codex (today: Grok) are listed in `OPENAI_WIRE_CLIENTS` — shared parser, distinct host/agent/raw-session bucket. Multi-agent hubs mix them without swapping `OPENAI_BASE_URL`. Acceptance notes: [`docs/grok-testing.md`](docs/grok-testing.md).
 
+**Grok billing disclosure:** When proxying Grok CLI traffic, ccxray calls `cli-chat-proxy.grok.com/v1/billing` (using the same auth token the CLI already sends through the proxy) to populate the Usage tab's account card. This call is throttled to at most once per alias+credential per 60 seconds. Set `XAI_BASE_URL` to point the call at a different host, or `CCXRAY_GROK_BILLING_TTL_MS=0` to disable throttle-gating (the call still runs only on proxied traffic).
+
 ## Codex support (Beta)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Launchers are registered in `server/providers.js` (same hub + dashboard for all)
 
 OpenAI-wire clients that are not Codex (today: Grok) are listed in `OPENAI_WIRE_CLIENTS` — shared parser, distinct host/agent/raw-session bucket. Multi-agent hubs mix them without swapping `OPENAI_BASE_URL`. Acceptance notes: [`docs/grok-testing.md`](docs/grok-testing.md).
 
-**Grok billing disclosure:** When proxying Grok CLI traffic, ccxray calls `cli-chat-proxy.grok.com/v1/billing` (using the same auth token the CLI already sends through the proxy) to populate the Usage tab's account card. This call is throttled to at most once per alias+credential per 60 seconds. Set `XAI_BASE_URL` to point the call at a different host, or `CCXRAY_GROK_BILLING_TTL_MS=0` to disable throttle-gating (the call still runs only on proxied traffic).
+**Grok billing disclosure:** When proxying Grok CLI traffic, ccxray calls `cli-chat-proxy.grok.com/v1/billing` (using the same auth token the CLI already sends through the proxy) to populate the Usage tab's account card. Repeat calls are suppressed for 60 seconds after a successful response (per alias+credential). Set `XAI_BASE_URL` to point the call at a different host.
 
 ## Codex support (Beta)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -84,6 +84,8 @@ Launcher 註冊在 `server/providers.js`（共用同一 hub + dashboard）：
 
 非 Codex 的 OpenAI-wire 客戶端列在 `OPENAI_WIRE_CLIENTS`：共用 parser、各自 host/agent/raw-session。多 agent hub 可並存，不必改 `OPENAI_BASE_URL`。驗收備註：[`docs/grok-testing.md`](docs/grok-testing.md)。
 
+**Grok 帳單揭露：** 代理 Grok CLI 流量時，ccxray 會呼叫 `cli-chat-proxy.grok.com/v1/billing`（使用 CLI 已經透過 proxy 傳送的同一組 auth token）來填充 Usage 分頁的帳戶卡片。此呼叫限制為每個 alias+credential 每 60 秒最多一次。設定 `XAI_BASE_URL` 可將呼叫導向其他主機，或設定 `CCXRAY_GROK_BILLING_TTL_MS=0` 停用節流門控（呼叫仍僅在代理流量時執行）。
+
 ## 功能
 
 ### 工作流程時間軸

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -84,7 +84,7 @@ Launcher 註冊在 `server/providers.js`（共用同一 hub + dashboard）：
 
 非 Codex 的 OpenAI-wire 客戶端列在 `OPENAI_WIRE_CLIENTS`：共用 parser、各自 host/agent/raw-session。多 agent hub 可並存，不必改 `OPENAI_BASE_URL`。驗收備註：[`docs/grok-testing.md`](docs/grok-testing.md)。
 
-**Grok 帳單揭露：** 代理 Grok CLI 流量時，ccxray 會呼叫 `cli-chat-proxy.grok.com/v1/billing`（使用 CLI 已經透過 proxy 傳送的同一組 auth token）來填充 Usage 分頁的帳戶卡片。此呼叫限制為每個 alias+credential 每 60 秒最多一次。設定 `XAI_BASE_URL` 可將呼叫導向其他主機，或設定 `CCXRAY_GROK_BILLING_TTL_MS=0` 停用節流門控（呼叫仍僅在代理流量時執行）。
+**Grok 帳單揭露：** 代理 Grok CLI 流量時，ccxray 會呼叫 `cli-chat-proxy.grok.com/v1/billing`（使用 CLI 已經透過 proxy 傳送的同一組 auth token）來填充 Usage 分頁的帳戶卡片。成功回應後的 60 秒內會抑制重複呼叫（per alias+credential）。設定 `XAI_BASE_URL` 可將呼叫導向其他主機。
 
 ## 功能
 

--- a/server/pricing.js
+++ b/server/pricing.js
@@ -36,9 +36,6 @@ const DEFAULT_PRICING = {
   // Prefix match covers grok-4.5-build / grok-4.5-latest variants.
   'grok-4.5':          { input: 2.00, output: 6.00, cache_create: 0, cache_read: 0.50 },
   'grok-4.5-latest':   { input: 2.00, output: 6.00, cache_create: 0, cache_read: 0.50 },
-  // Permanently shadows LiteLLM (buildPricingTable spreads DEFAULT after
-  // mirrored live data). Remove once LiteLLM lists xai/grok-4.5-build
-  // (same lifecycle as #202 lag overrides — not a temporary lag row).
   'grok-4.5-build':    { input: 2.00, output: 6.00, cache_create: 0, cache_read: 0.50 },
   'grok-4.3':          { input: 1.25, output: 2.50, cache_create: 0, cache_read: 0.20 },
   'grok-4.3-latest':   { input: 1.25, output: 2.50, cache_create: 0, cache_read: 0.20 },
@@ -87,12 +84,17 @@ function ratesFromLiteLLMEntry(val) {
   };
 }
 
-/** Mirror `provider/model` → bare `model` so wire IDs match LiteLLM rows. */
-function mirrorProviderPrefixedKeys(table) {
+/**
+ * Mirror `provider/model` → bare `model` so wire IDs match LiteLLM rows.
+ * @param {string[]} [onlyProviders] — restrict to these prefixes (e.g. ['xai']).
+ *   Omit to mirror all providers (safe for context windows, not for pricing).
+ */
+function mirrorProviderPrefixedKeys(table, onlyProviders) {
   const out = { ...table };
   for (const [key, val] of Object.entries(table)) {
     const slash = key.indexOf('/');
     if (slash === -1) continue;
+    if (onlyProviders && !onlyProviders.includes(key.slice(0, slash))) continue;
     const bare = key.slice(slash + 1);
     if (bare && out[bare] == null) out[bare] = val;
   }
@@ -153,11 +155,13 @@ function logLagOverrideStatus(status) {
 }
 
 function buildPricingTable(litellmPricing) {
-  // Order: LiteLLM (+ bare mirrors) → stable DEFAULT → lag overrides only if missing.
-  // Lag overrides intentionally run AFTER DEFAULT so temporary rates apply only
-  // when LiteLLM lacks the model; when LiteLLM catches up they no-op.
-  const mirrored = mirrorProviderPrefixedKeys(litellmPricing || {});
-  const withDefaults = { ...mirrored, ...DEFAULT_PRICING };
+  // INVARIANT(#397 defect 1): LiteLLM wins over DEFAULT_PRICING.
+  // DEFAULT is the offline floor — safety nets when LiteLLM lacks a key.
+  // Lag overrides run last, only when LiteLLM still lacks the model.
+  // INVARIANT(#397 defect 4): only xai/ keys are mirrored for pricing.
+  // Other providers (azure_ai/, oci/) can have different rates for the same model.
+  const mirrored = mirrorProviderPrefixedKeys(litellmPricing || {}, ['xai']);
+  const withDefaults = { ...DEFAULT_PRICING, ...mirrored };
   return applyLagOverrides(withDefaults);
 }
 

--- a/server/routes/costs.js
+++ b/server/routes/costs.js
@@ -5,7 +5,7 @@ const path = require('node:path');
 const os = require('node:os');
 const store = require('../store');
 const { getCostsCacheOrNull, calculateBurnRate, getEffectiveTokenLimit } = require('../cost-budget');
-const { pricingTable } = require('../pricing');
+const pricing = require('../pricing');
 const { readAllAccounts } = require('../local-usage-reader');
 const { refreshCodex, refreshCodexAsync } = require('../adapters/codex-adapter');
 const { resolveCcxrayHome } = require('../paths');
@@ -213,7 +213,7 @@ function handleCostRoutes(clientReq, clientRes) {
 
   if (pathname === '/_api/pricing') {
     const result = {};
-    for (const [model, rates] of Object.entries(pricingTable)) {
+    for (const [model, rates] of Object.entries(pricing.pricingTable)) {
       result[model] = {
         input_cost_per_mtok: rates.input,
         output_cost_per_mtok: rates.output,

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -116,6 +116,36 @@ describe('pricing', () => {
     });
   });
 
+  describe('buildPricingTable precedence (#397)', () => {
+    it('LiteLLM wins over DEFAULT_PRICING for models present in both', () => {
+      // DEFAULT_PRICING has gpt-5.5 as 2/10/0/1.
+      // LiteLLM has it as 5/30/5/0.5. LiteLLM must win.
+      const table = buildPricingTable({
+        'gpt-5.5': { input: 5, output: 30, cache_create: 5, cache_read: 0.5 },
+      });
+      assert.equal(table['gpt-5.5'].input, 5, 'LiteLLM input rate must win');
+      assert.equal(table['gpt-5.5'].output, 30, 'LiteLLM output rate must win');
+      assert.equal(table['gpt-5.5'].cache_create, 5, 'LiteLLM cache_create rate must win');
+      assert.equal(table['gpt-5.5'].cache_read, 0.5, 'LiteLLM cache_read rate must win');
+    });
+
+    it('DEFAULT_PRICING applies when LiteLLM lacks the model', () => {
+      const table = buildPricingTable({});
+      assert.ok(table['gpt-5.5'], 'DEFAULT_PRICING floor must still provide gpt-5.5');
+      assert.equal(table['gpt-5.5'].input, 2);
+    });
+
+    it('only xai/ keys are mirrored to bare names, not azure_ai/ (#397 defect 4)', () => {
+      const table = buildPricingTable({
+        'azure_ai/grok-code-fast-1': { input: 0.2, output: 1.5, cache_create: 0, cache_read: 0.2 },
+        'xai/grok-code-fast-1':     { input: 0.2, output: 1.5, cache_create: 0, cache_read: 0.02 },
+      });
+      assert.ok(table['grok-code-fast-1'], 'bare key must exist from xai/ mirror');
+      assert.equal(table['grok-code-fast-1'].cache_read, 0.02,
+        'bare key must have xai/ rate, not azure_ai/ rate');
+    });
+  });
+
   describe('calculateCost', () => {
     it('returns null for null usage', () => {
       assert.equal(calculateCost(null, 'claude-sonnet-4'), null);


### PR DESCRIPTION
## 摘要

修復 #397 的缺陷 1、3、4（缺陷 2 不在範圍，留在 issue 上）。

三個獨立的 pricing 缺陷，全是 maintainer-side——#313 只是載體。#313 的外部貢獻者
@lolxl 在源碼處記錄了缺陷 1 並主動提出修復，被要求不要處理以免他的 PR 被我方的
技術債拖住。Credit: @lolxl 的文檔讓問題可見。

## Detail

**Defect 1 — `DEFAULT_PRICING` outranks LiteLLM (`996498b`, PR #205)**

`buildPricingTable` spread order was `{ ...mirrored, ...DEFAULT_PRICING }` (hardcoded wins).
Flipped to `{ ...DEFAULT_PRICING, ...mirrored }` (LiteLLM wins, defaults are the offline floor).

Measured: only `gpt-5.5` differs among the 17 real wire model IDs in the live index —
`2/10/0/1` → `5/30/5/0.5`. All other models resolve identically.

Regression test: asserts LiteLLM wins for a model present in both. Verified fail-on-old
(`0274cf7`) / pass-on-new.

**Defect 3 — `/_api/pricing` served a require-time snapshot**

`routes/costs.js:8` destructured `pricingTable` from the getter at require time, freezing
the value. Now accesses `pricing.pricingTable` lazily at request time.

**Defect 4 — mirror was provider-agnostic and first-writer-wins**

`mirrorProviderPrefixedKeys` mirrored all `provider/model` keys to bare names. Result:
`azure_ai/grok-code-fast-1` (cache_read 0.20) could shadow `xai/grok-code-fast-1`
(cache_read 0.02) — a 10× error. The same mechanism could falsely retire a lag override.

Now restricted to an explicit allow-list (`['xai']`). Context window mirroring still mirrors
all providers (context windows are model-inherent, not provider-specific).

**README disclosure**: documents the `cli-chat-proxy.grok.com/v1/billing` call (user's own
auth token, throttled to 1/60s per alias+credential, `XAI_BASE_URL` overridable).

## Test plan

- [x] Regression test fails on `0274cf7`, passes with the fix
- [x] Full suite green: `CCXRAY_HOME=$(mktemp -d) node --test test/*.test.js` (1657/1657)
- [x] Real-data sanity: only `gpt-5.5` differs between old and new among 17 real wire IDs
- [x] No `CCXRAY_IMPORT_DISABLE` set (importer tests self-isolate via `CCXRAY_IMPORT_HOMES`)

Closes defects 1, 3, 4 of #397. Leaves #397 open for defect 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)