### PR TITLE
fix(test): isolate CCXRAY_HOME/LOGS_DIR in cost-worker lifecycle tests

### DIFF
--- a/test/cost-worker-exit.test.js
+++ b/test/cost-worker-exit.test.js
@@ -32,12 +32,25 @@ const WORKER = path.join(__dirname, '..', 'server', 'cost-worker.js');
 const SELF_EXIT_BUDGET_MS = 15_000;
 const ORPHAN_EXIT_BUDGET_MS = 5_000;
 
-// os.homedir() reads $HOME on POSIX; the worker scans $HOME/.claude*,
-// $HOME/.codex* and $HOME/.config/claude — not CCXRAY_HOME. A throwaway HOME
-// keeps the test off the developer's real history and makes runtime
-// machine-independent.
+// The worker reads two independent roots, and BOTH have to be redirected:
+//   • $HOME — os.homedir() on POSIX; it scans $HOME/.claude*, $HOME/.codex*
+//     and $HOME/.config/claude.
+//   • CCXRAY_HOME / LOGS_DIR — since #313 the grok scan reads the ccxray index
+//     (scanGrokFromCcxrayIndex, cost-worker.js), falling back to
+//     os.homedir()/.ccxray only when those are unset.
+// Injecting HOME alone left an ambient CCXRAY_HOME leaking through, so the
+// worker read the developer's real ~587MB index on every run. It happened to
+// stay green only because that index contains zero grok rows — i.e. it passed
+// because of local data, which is the PR #94 failure class docs/testing.md
+// exists to prevent. Redirect both.
 function makeHome() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-worker-test-'));
+}
+
+function isolatedEnv(home) {
+  const env = { ...process.env, HOME: home, CCXRAY_HOME: home };
+  delete env.LOGS_DIR; // would override CCXRAY_HOME and point back at real logs
+  return env;
 }
 
 // Forked exactly as server/cost-budget.js does — silent:true makes stdout a
@@ -46,7 +59,7 @@ function startWorker(home) {
   const worker = fork(WORKER, [], {
     silent: true,
     windowsHide: true,
-    env: { ...process.env, HOME: home },
+    env: isolatedEnv(home),
   });
   const chunks = [];
   const errChunks = [];
@@ -205,7 +218,7 @@ describe('cost-worker: process lifecycle', () => {
       "'use strict';",
       "const { fork } = require('child_process');",
       'const worker = fork(process.argv[2], [], {',
-      '  env: { ...process.env, HOME: process.argv[3] },',
+      '  env: { ...process.env, HOME: process.argv[3], CCXRAY_HOME: process.argv[3], LOGS_DIR: undefined },',
       '  silent: true,',
       '  windowsHide: true,',
       "  execArgv: ['--require', process.argv[4]],",


### PR DESCRIPTION
## 摘要（繁中）

`test/cost-worker-exit.test.js`（#402 出貨）只注入 `HOME`，其餘 env 用 `...process.env` 繼承。#313 之後 cost-worker 多了第二個根——`scanGrokFromCcxrayIndex` 依 `CCXRAY_HOME` / `LOGS_DIR` 去掃 ccxray index——所以環境裡若已有 `CCXRAY_HOME`，worker 會去掃使用者真實的 ~587MB index。

它至今綠燈純粹因為那個 index 剛好 **0 筆 grok 條目**。「因為本機資料而通過」正是 `docs/testing.md` 要防的 PR #94 失敗類別。

## Differential evidence

`CCXRAY_HOME` 指向一個含 **7 筆有效 grok 條目**的 index（也就是任何人真的開始用 grok 之後的世界）：

| | Y2 結果 |
|---|---|
| 舊測試 | **FAIL** — `expected: 5000, actual: 5007` |
| 新測試 | **PASS**（3 pass / 0 fail） |

## What changed

- `isolatedEnv(home)` 同時重導 `HOME` 與 `CCXRAY_HOME`，並刪掉 `LOGS_DIR`（它會覆蓋 `CCXRAY_HOME` 指回真 logs）。
- 測試 X 的 surrogate parent 繼承同一套隔離。
- Header 註解改成點名兩個根，而不是斷言「worker 不讀 CCXRAY_HOME」——那句話在 #313 之後就不成立了。

行為未變，只補隔離。Full suite: **1657 pass / 0 fail**。

Found by codex review while auditing whether #401 should be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)