### PR TITLE
perf(restore): stream index restore, drop full parsed[] residency

### DIFF
--- a/scripts/bench/bench-348-restore.js
+++ b/scripts/bench/bench-348-restore.js
@@ -7,7 +7,7 @@ if (!process.env.CCXRAY_HOME) {
   console.error('Set CCXRAY_HOME to the fixture dir (e.g. /tmp/ccxray-bench-348)');
   process.exit(1);
 }
-process.env.RESTORE_DAYS = '0';
+if (!('RESTORE_DAYS' in process.env)) process.env.RESTORE_DAYS = '0';
 process.env.CCXRAY_DISABLE_TITLES = '1';
 
 const config = require('../../server/config');

--- a/scripts/bench/bench-348-restore.js
+++ b/scripts/bench/bench-348-restore.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Bench driver for #348: run restoreFromLogs against a synthetic fixture and
+// exit. Measure with: /usr/bin/time -l node scripts/bench/bench-348-restore.js
+// Env: CCXRAY_HOME must point at the fixture dir (with logs/index.ndjson).
+'use strict';
+if (!process.env.CCXRAY_HOME) {
+  console.error('Set CCXRAY_HOME to the fixture dir (e.g. /tmp/ccxray-bench-348)');
+  process.exit(1);
+}
+process.env.RESTORE_DAYS = '0';
+process.env.CCXRAY_DISABLE_TITLES = '1';
+
+const config = require('../../server/config');
+config.storage.list = async () => [];
+config.storage.readShared = async () => { throw new Error('no shared'); };
+config.storage.statShared = null;
+
+const { restoreFromLogs } = require('../../server/restore');
+restoreFromLogs().then(() => {
+  const store = require('../../server/store');
+  console.log(`entries: ${store.entries.length}`);
+}).catch(e => { console.error(e); process.exit(1); });

--- a/scripts/bench/gen-348-fixture.js
+++ b/scripts/bench/gen-348-fixture.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Generate a ~300k-line / ~500MB synthetic index.ndjson for #348 benchmarking.
+// Usage: node scripts/bench/gen-348-fixture.js /tmp/ccxray-bench-348
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const dir = process.argv[2] || '/tmp/ccxray-bench-348';
+fs.mkdirSync(path.join(dir, 'logs', 'shared'), { recursive: true });
+const out = fs.createWriteStream(path.join(dir, 'logs', 'index.ndjson'));
+
+const TARGET = parseInt(process.argv[3] || '300000', 10);
+const sessions = 200;
+
+function pad(n, w) { return String(n).padStart(w, '0'); }
+
+for (let i = 0; i < TARGET; i++) {
+  const sid = `sess-${pad(i % sessions, 4)}`;
+  const daysAgo = Math.floor(i / TARGET * 28);
+  const d = new Date(Date.now() - daysAgo * 86400000 + (i % 86400) * 1000);
+  const ts = d.toISOString().replace(/[:.]/g, '-').slice(0, -1);
+  const meta = {
+    id: ts,
+    ts: d.toISOString(),
+    sessionId: sid,
+    provider: 'anthropic',
+    model: 'claude-fable-5[1m]',
+    msgCount: 10 + (i % 50),
+    toolCount: i % 8,
+    toolCalls: { Read: 2 + (i % 5), Edit: 1 + (i % 3), Bash: 3 + (i % 4), Write: i % 2, Grep: i % 6, Glob: i % 4 },
+    skillCalls: i % 10 === 0 ? { 'code-review': 1, tdd: 1, research: 1 } : null,
+    isSubagent: i % 7 === 0,
+    sessionInferred: false,
+    cwd: `/Users/dev/project-${i % 20}`,
+    isSSE: true,
+    usage: {
+      input_tokens: 50000 + (i % 200000),
+      output_tokens: 2000 + (i % 10000),
+      cache_read_input_tokens: 30000 + (i % 100000),
+      cache_creation_input_tokens: 5000 + (i % 50000),
+    },
+    cost: { cost: 0.05 + (i % 100) * 0.001 },
+    maxContext: i % 3 === 0 ? 1000000 : 200000,
+    stopReason: 'end_turn',
+    title: i % 15 === 0 ? `Turn ${i} title string for realistic sizing — a longer title to pad the line toward realistic JSON byte counts per entry` : null,
+    toolSources: i % 5 === 0 ? ['mcp__claude-in-chrome__computer', 'mcp__claude-in-chrome__read_page', 'mcp__argent__gesture-tap'] : null,
+    editSummary: i % 20 === 0 ? ['Changed model parameter', 'Added system instruction'] : null,
+    responseMetadata: i % 4 === 0 ? { id: `resp_${pad(i, 8)}`, model: 'claude-fable-5[1m]' } : null,
+    thinkingDuration: `${(1.5 + i % 10).toFixed(1)}`,
+    toolFail: i % 50 === 0,
+    elapsed: `${(2.0 + i % 30).toFixed(1)}`,
+    status: 200,
+    receivedAt: d.getTime(),
+    sysHash: `sh${pad(i % 40, 3)}`,
+    toolsHash: `th${pad(i % 20, 3)}`,
+    coreHash: `ch${pad(i % 30, 3)}`,
+    agentKey: i % 7 === 0 ? 'agent' : 'orchestrator',
+    agentLabel: i % 7 === 0 ? 'Agent' : 'Claude Code',
+    convId: `conv-${pad(i % 150, 4)}`,
+    responseId: `msg_${pad(i, 8)}`,
+    beta1m: i % 3 === 0 ? true : undefined,
+  };
+  out.write(JSON.stringify(meta) + '\n');
+}
+out.end(() => {
+  const stat = fs.statSync(path.join(dir, 'logs', 'index.ndjson'));
+  console.log(`Generated ${TARGET} lines, ${(stat.size / 1e6).toFixed(1)} MB → ${path.join(dir, 'logs', 'index.ndjson')}`);
+});

--- a/server/restore.js
+++ b/server/restore.js
@@ -192,12 +192,10 @@ async function restoreFromLogs() {
     return;
   }
 
-  // 1b. Reconcile sessions.json against index.ndjson if loaded (#309). Drift
-  // is rare — only then re-stream the full metas the rebuild needs (#348).
-  if (tally && tally.drift()) {
-    await sessionIdx.rebuildFromMetasAsync(streamAllMetas());
-    console.log(`\x1b[90m   Session index reconciled: ${sessionIdx.size()} sessions\x1b[0m`);
-  }
+  // 1b. Detect drift but DON'T rebuild yet — the rebuild is deferred to after
+  // the restore loop so working[] can be released first (codex R1c: rebuilding
+  // here while working[] is live doubles residency → OOM at 400MB).
+  const driftDetected = !!(tally && tally.drift());
 
   // 2. Build the working set (RESTORE_DAYS window + star-protected lines)
   console.time('restore:parse');
@@ -399,14 +397,18 @@ async function restoreFromLogs() {
   }
   console.timeEnd('restore:titles');
 
-  // 5. Session index: rebuild from index.ndjson if sessions.json was missing,
-  //    then replay titles into the session index. #348: re-stream on demand
-  //    rather than keeping 314k parsed metas resident for a rare fallback path.
-  if (!sessionIndexLoaded && parsedCount) {
+  // 5. Session index: rebuild if sessions.json was missing OR drift was detected.
+  // Deferred to here (after the restore loop) so working[] is released first —
+  // streaming rebuild + bySid weather grouping then peaks at ~1× index, not ~2×.
+  // Safe: rebuild re-derives from the full index (superset); updateFromEntry calls
+  // during the loop are overwritten; titles replay stays after this site.
+  if ((!sessionIndexLoaded && parsedCount) || driftDetected) {
+    working.length = 0; // release window-set objects before streaming the full index
     console.time('restore:session-index-rebuild');
     await sessionIdx.rebuildFromMetasAsync(streamAllMetas());
     console.timeEnd('restore:session-index-rebuild');
-    console.log(`\x1b[90m   Session index rebuilt: ${sessionIdx.size()} sessions\x1b[0m`);
+    const reason = driftDetected ? 'reconciled' : 'rebuilt';
+    console.log(`\x1b[90m   Session index ${reason}: ${sessionIdx.size()} sessions\x1b[0m`);
   }
   for (const [sid, meta] of Object.entries(store.sessionMeta)) {
     if (meta.title) sessionIdx.setTitle(sid, meta.title);

--- a/server/restore.js
+++ b/server/restore.js
@@ -124,11 +124,26 @@ function loadEntryReqRes(entry) {
   return entry._loadingPromise;
 }
 
+// #348 codex R2: snapshot byte bound — mid-restore appends must not leak into
+// any streaming pass. Pass A accumulates `snapshotBytes`; all subsequent passes
+// (star pass B, streamAllMetas) stop at that byte offset. Direction of error is
+// benign: we may skip one partial line at the boundary, never include a new one.
+async function* boundedIndexLines(limitBytes) {
+  let n = 0;
+  for await (const line of config.storage.readIndexLines()) {
+    n += Buffer.byteLength(line, 'utf8') + 1; // +1 for the \n separator
+    if (n > limitBytes) return;
+    yield line;
+  }
+}
+
 // #348: on-demand streaming re-read of index.ndjson as an async generator.
 // Used by the rare session-index rebuild/drift fallback paths — never
 // materializes the full array (codex R1: readAllMetas doubled residency).
-async function* streamAllMetas() {
-  for await (const line of config.storage.readIndexLines()) {
+// Bounded by snapshotBytes so mid-restore appends are excluded (codex R2).
+async function* streamAllMetas(snapshotBytes) {
+  const lines = snapshotBytes != null ? boundedIndexLines(snapshotBytes) : config.storage.readIndexLines();
+  for await (const line of lines) {
     try { yield JSON.parse(line); } catch {}
   }
 }
@@ -174,7 +189,9 @@ async function restoreFromLogs() {
   const starLight = [];
   const working = [];
   let parsedCount = 0;
+  let snapshotBytes = 0; // codex R2: byte bound for subsequent passes
   for await (const line of config.storage.readIndexLines()) {
+    snapshotBytes += Buffer.byteLength(line, 'utf8') + 1;
     let m; try { m = JSON.parse(line); } catch { continue; }
     if (!m) continue;
     parsedCount++;
@@ -206,7 +223,8 @@ async function restoreFromLogs() {
     starLight.length = 0;
     // #348 pass B: re-stream in FILE ORDER now that protection is known —
     // star-protected out-of-window lines re-enter the working set here.
-    for await (const line of config.storage.readIndexLines()) {
+    // Bounded by snapshotBytes so mid-restore appends are excluded (codex R2).
+    for await (const line of boundedIndexLines(snapshotBytes)) {
       let m; try { m = JSON.parse(line); } catch { continue; }
       if (!m) continue;
       if (inWindow(m) || isProtectedByStar(m, retentionSets)) working.push(m);
@@ -229,6 +247,11 @@ async function restoreFromLogs() {
   // The cutoff/star filter already ran during the streaming read — `working`
   // is the pre-filtered set, in file order (#348).
   for (let meta of working) {
+
+    // INVARIANT (codex R2 / ADR 0003+0012): a live turn that completed during
+    // post-listen restore may already own this id in entryIndex. Skip to avoid
+    // duplicate push — no-responseId entries can't be folded by mergeByResponseId.
+    if (store.entryIndex.has(meta.id)) continue;
 
     // Per-session cap: oversized sessions load only the first entry
     if (meta.sessionId && oversizedSessions.has(meta.sessionId)) {
@@ -405,7 +428,7 @@ async function restoreFromLogs() {
   if ((!sessionIndexLoaded && parsedCount) || driftDetected) {
     working.length = 0; // release window-set objects before streaming the full index
     console.time('restore:session-index-rebuild');
-    await sessionIdx.rebuildFromMetasAsync(streamAllMetas());
+    await sessionIdx.rebuildFromMetasAsync(streamAllMetas(snapshotBytes));
     console.timeEnd('restore:session-index-rebuild');
     const reason = driftDetected ? 'reconciled' : 'rebuilt';
     console.log(`\x1b[90m   Session index ${reason}: ${sessionIdx.size()} sessions\x1b[0m`);
@@ -766,4 +789,4 @@ async function pruneLogs() {
   }
 }
 
-module.exports = { loadEntryReqRes, restoreFromLogs, pruneLogs, pruneIndexLines };
+module.exports = { loadEntryReqRes, restoreFromLogs, pruneLogs, pruneIndexLines, boundedIndexLines };

--- a/server/restore.js
+++ b/server/restore.js
@@ -251,6 +251,17 @@ async function restoreFromLogs() {
   const rebuildPending = (!sessionIndexLoaded && parsedCount) || driftDetected;
   // codex R3: buffer live updateFromEntry calls during the restore+rebuild window
   // so they survive the rebuild's clear. Replay into rebuilt state afterwards.
+  //
+  // Known limitation (codex R4-P2, owner decision 2026-08-02): a live turn that
+  // completes and appends during pass A (before this point) lands OUTSIDE the
+  // snapshot byte bound AND before the buffer starts. If this startup triggers a
+  // rebuild, that turn's updateFromEntry is cleared and absent from both the
+  // bounded re-read and the replay buffer — its session count/cost are lost from
+  // sessions.json until the next restart. Self-healing: the missing update makes
+  // sessions.json entry count diverge from the index → next startup's tally
+  // detects drift → rebuild re-derives from the full index and restores the turn.
+  // The buffer is deliberately NOT moved before pass A: that would widen the
+  // no-responseId (OpenAI/WS) duplicate-count window from sub-ms to seconds.
   if (rebuildPending) sessionIdx.beginRestoreBuffer();
   let rebuildRan = false;
   // 2. Build the working set (RESTORE_DAYS window + star-protected lines)

--- a/server/restore.js
+++ b/server/restore.js
@@ -124,6 +124,39 @@ function loadEntryReqRes(entry) {
   return entry._loadingPromise;
 }
 
+// INVARIANT (codex R3): restore loop AND streamAllMetas MUST share this function.
+// Any new pure-computation healing rule goes HERE — otherwise the rebuild's
+// persisted session-index values diverge from the restore presentation values.
+// Async: the #211 trustStored sysModelMarker lookup reads a shared file.
+// Boundary: openai _res.json re-parse is I/O-heavy and stays in the loop only.
+async function healMetaInPlace(meta) {
+  // #384: heal legacy openai lines imported without maxContext.
+  if (!meta.maxContext && meta.provider === 'openai' && meta.model) {
+    const ctx = config.getMaxContext(meta.model, null);
+    if (ctx !== config.DEFAULT_CONTEXT) meta.maxContext = ctx;
+  }
+  // anthropic: re-apply usage-aware context inference (#211 trustStored logic)
+  if (meta.provider === 'anthropic') {
+    const inferred = config.inferMaxContext(meta.model, null, meta.usage);
+    const stripped = (meta.model || '').replace(/\[.*\]/, '');
+    let trustStored = !stripped.startsWith('claude-') || config.SUPPORTS_1M.test(stripped);
+    if (trustStored && (meta.maxContext || 0) > inferred && meta.sysHash) {
+      const marker = await sysModelMarker(meta.sysHash);
+      const markerMatches = !!marker && marker.replace(/\[.*\]/, '') === stripped;
+      if (markerMatches && !/\[1m\]/i.test(marker)) trustStored = false;
+    }
+    meta.maxContext = trustStored ? Math.max(meta.maxContext || 0, inferred) : inferred;
+  }
+  // usage normalization + cost recalc
+  if (meta.usage) {
+    const before = meta.usage;
+    meta.usage = normalizeUsageForProvider(meta.provider, meta.usage);
+    if (meta.usage !== before && meta.usage._ccxrayUsageNormalized && meta.model) {
+      meta.cost = calculateCost(meta.usage, meta.model);
+    }
+  }
+}
+
 // #348 codex R2: snapshot byte bound — mid-restore appends must not leak into
 // any streaming pass. Pass A accumulates `snapshotBytes`; all subsequent passes
 // (star pass B, streamAllMetas) stop at that byte offset. Direction of error is
@@ -141,10 +174,12 @@ async function* boundedIndexLines(limitBytes) {
 // Used by the rare session-index rebuild/drift fallback paths — never
 // materializes the full array (codex R1: readAllMetas doubled residency).
 // Bounded by snapshotBytes so mid-restore appends are excluded (codex R2).
+// Each meta is healed in-stream (codex R3) so rebuild persists corrected values.
 async function* streamAllMetas(snapshotBytes) {
   const lines = snapshotBytes != null ? boundedIndexLines(snapshotBytes) : config.storage.readIndexLines();
   for await (const line of lines) {
-    try { yield JSON.parse(line); } catch {}
+    let m; try { m = JSON.parse(line); } catch { continue; }
+    if (m) { await healMetaInPlace(m); yield m; }
   }
 }
 
@@ -213,6 +248,10 @@ async function restoreFromLogs() {
   // the restore loop so working[] can be released first (codex R1c: rebuilding
   // here while working[] is live doubles residency → OOM at 400MB).
   const driftDetected = !!(tally && tally.drift());
+  const rebuildPending = (!sessionIndexLoaded && parsedCount) || driftDetected;
+  // codex R3: buffer live updateFromEntry calls during the restore+rebuild window
+  // so they survive the rebuild's clear. Replay into rebuilt state afterwards.
+  if (rebuildPending) sessionIdx.beginRestoreBuffer();
 
   // 2. Build the working set (RESTORE_DAYS window + star-protected lines)
   console.time('restore:parse');
@@ -271,51 +310,9 @@ async function restoreFromLogs() {
       } catch {}
     }
 
-    // Re-apply usage-aware context inference. Historical index lines may
-    // carry maxContext=200000 for Claude 1M-plan turns whose original request
-    // had no system prompt (e.g. title-gen, some subagent paths) — without
-    // this, the dashboard would show "600K / 200K (clamped to 100%)" for
-    // entries that predate the inferMaxContext fix. Math.max keeps previously
-    // correct 1M values when current usage happens to fit inside 200K.
-    // #384: heal legacy openai lines that were imported without maxContext.
-    // Fill-only (never overwrite), recognized models only (unknown stays silent).
-    if (!meta.maxContext && meta.provider === 'openai' && meta.model) {
-      const ctx = config.getMaxContext(meta.model, null);
-      if (ctx !== config.DEFAULT_CONTEXT) meta.maxContext = ctx;
-    }
-    // EXCEPTION(#158): data-layer — anthropic-specific maxContext inference from persisted usage
-    if (meta.provider === 'anthropic') {
-      const inferred = config.inferMaxContext(meta.model, null, meta.usage);
-      // #211: a stored value is only trusted over the re-inference for
-      // SUPPORTS_1M models, where it can encode a beta-header signal that is
-      // not re-derivable here (headers are not persisted). For non-capable
-      // models a stored 1M can only be pre-clamp LiteLLM pollution (or the
-      // usage hatch, which re-inference reproduces) — re-derive instead.
-      const stripped = (meta.model || '').replace(/\[.*\]/, '');
-      let trustStored = !stripped.startsWith('claude-') || config.SUPPORTS_1M.test(stripped);
-      // Even for SUPPORTS_1M models, a stored value above the re-inference can
-      // be pre-clamp LiteLLM pollution (the #211 fable-5 lines). The persisted
-      // system prompt carries the ground-truth [1m] marker — when it names
-      // THIS entry's model and provably lacks [1m], the stored value is bogus.
-      // A marker naming another model (post-switch lag window) is not evidence
-      // about this entry. Unverifiable cases (no sysHash: title-gen/subagent
-      // legs; pruned shared file; foreign marker) keep the stored value, so
-      // genuine 1M turns never downgrade.
-      if (trustStored && (meta.maxContext || 0) > inferred && meta.sysHash) {
-        const marker = await sysModelMarker(meta.sysHash);
-        const markerMatches = !!marker && marker.replace(/\[.*\]/, '') === stripped;
-        if (markerMatches && !/\[1m\]/i.test(marker)) trustStored = false;
-      }
-      meta.maxContext = trustStored ? Math.max(meta.maxContext || 0, inferred) : inferred;
-    }
-
-    if (meta.usage) {
-      const before = meta.usage;
-      meta.usage = normalizeUsageForProvider(meta.provider, meta.usage);
-      if (meta.usage !== before && meta.usage._ccxrayUsageNormalized && meta.model) {
-        meta.cost = calculateCost(meta.usage, meta.model);
-      }
-    }
+    // INVARIANT (codex R3): shared healMetaInPlace — loop and streamAllMetas
+    // must apply identical healing so rebuild persists the same values.
+    await healMetaInPlace(meta);
 
     const restoredEntry = { ...meta, req: null, res: null, _loaded: false };
     // Deferred: pushed after the loop, once duplicate copies are merged (#333).
@@ -423,13 +420,16 @@ async function restoreFromLogs() {
   // 5. Session index: rebuild if sessions.json was missing OR drift was detected.
   // Deferred to here (after the restore loop) so working[] is released first —
   // streaming rebuild + bySid weather grouping then peaks at ~1× index, not ~2×.
-  // Safe: rebuild re-derives from the full index (superset); updateFromEntry calls
-  // during the loop are overwritten; titles replay stays after this site.
-  if ((!sessionIndexLoaded && parsedCount) || driftDetected) {
+  // Safe: rebuild re-derives from the full index via healMetaInPlace (codex R3);
+  // live updates buffered since beginRestoreBuffer are replayed after rebuild so
+  // they survive the clear (codex R3 P1-B). responseId dedup makes replay
+  // idempotent for entries whose line was inside the snapshot byte bound.
+  if (rebuildPending) {
     working.length = 0; // release window-set objects before streaming the full index
     console.time('restore:session-index-rebuild');
     await sessionIdx.rebuildFromMetasAsync(streamAllMetas(snapshotBytes));
     console.timeEnd('restore:session-index-rebuild');
+    sessionIdx.endRestoreBuffer(true);
     const reason = driftDetected ? 'reconciled' : 'rebuilt';
     console.log(`\x1b[90m   Session index ${reason}: ${sessionIdx.size()} sessions\x1b[0m`);
   }

--- a/server/restore.js
+++ b/server/restore.js
@@ -124,15 +124,13 @@ function loadEntryReqRes(entry) {
   return entry._loadingPromise;
 }
 
-// #348: on-demand full re-stream of index.ndjson into an array of parsed metas.
-// Used only by the rare session-index rebuild/reconcile fallback paths — the
-// normal restore path never materializes the full array.
-async function readAllMetas() {
-  const metas = [];
+// #348: on-demand streaming re-read of index.ndjson as an async generator.
+// Used by the rare session-index rebuild/drift fallback paths — never
+// materializes the full array (codex R1: readAllMetas doubled residency).
+async function* streamAllMetas() {
   for await (const line of config.storage.readIndexLines()) {
-    try { metas.push(JSON.parse(line)); } catch {}
+    try { yield JSON.parse(line); } catch {}
   }
-  return metas;
 }
 
 // ── Restore entries from index.ndjson on startup ─────────────────────
@@ -156,7 +154,7 @@ async function restoreFromLogs() {
   // never enter the working set: the reconcile tally is fed incrementally and
   // the star pre-pass keeps only a lightweight {id, sessionId, cwd} per line.
   // The rare full-meta consumers (session-index rebuild on drift / missing
-  // sessions.json) re-stream via readAllMetas() instead.
+  // sessions.json) re-stream via streamAllMetas() generator instead.
   let cutoffStr = null;
   if (config.RESTORE_DAYS > 0) {
     const cutoff = new Date();
@@ -197,7 +195,7 @@ async function restoreFromLogs() {
   // 1b. Reconcile sessions.json against index.ndjson if loaded (#309). Drift
   // is rare — only then re-stream the full metas the rebuild needs (#348).
   if (tally && tally.drift()) {
-    sessionIdx.rebuildFromMetas(await readAllMetas());
+    await sessionIdx.rebuildFromMetasAsync(streamAllMetas());
     console.log(`\x1b[90m   Session index reconciled: ${sessionIdx.size()} sessions\x1b[0m`);
   }
 
@@ -406,7 +404,7 @@ async function restoreFromLogs() {
   //    rather than keeping 314k parsed metas resident for a rare fallback path.
   if (!sessionIndexLoaded && parsedCount) {
     console.time('restore:session-index-rebuild');
-    sessionIdx.rebuildFromMetas(await readAllMetas());
+    await sessionIdx.rebuildFromMetasAsync(streamAllMetas());
     console.timeEnd('restore:session-index-rebuild');
     console.log(`\x1b[90m   Session index rebuilt: ${sessionIdx.size()} sessions\x1b[0m`);
   }

--- a/server/restore.js
+++ b/server/restore.js
@@ -124,6 +124,17 @@ function loadEntryReqRes(entry) {
   return entry._loadingPromise;
 }
 
+// #348: on-demand full re-stream of index.ndjson into an array of parsed metas.
+// Used only by the rare session-index rebuild/reconcile fallback paths — the
+// normal restore path never materializes the full array.
+async function readAllMetas() {
+  const metas = [];
+  for await (const line of config.storage.readIndexLines()) {
+    try { metas.push(JSON.parse(line)); } catch {}
+  }
+  return metas;
+}
+
 // ── Restore entries from index.ndjson on startup ─────────────────────
 
 async function restoreFromLogs() {
@@ -137,57 +148,77 @@ async function restoreFromLogs() {
     console.log(`\x1b[90m   Session index: ${sessionIdx.size()} sessions\x1b[0m`);
   }
 
-  // 1. Read the lightweight index by STREAMING lines into parsed metas. #345:
-  // the index can exceed Node's ~512MB single-string limit, so we must not call
-  // readIndex() (readFile utf8) here — it would throw ERR_STRING_TOO_LONG and
-  // fail restore. readIndexLines() streams without materializing the whole file.
-  console.time('restore:index');
-  const parsed = [];
-  for await (const line of config.storage.readIndexLines()) {
-    try { parsed.push(JSON.parse(line)); } catch {}
-  }
-  console.timeEnd('restore:index');
-
-  if (!parsed.length) {
-    console.timeEnd('restore:total');
-    return;
-  }
-
-  // 1b. Reconcile sessions.json against index.ndjson if loaded (#309)
-  if (sessionIndexLoaded) {
-    if (sessionIdx.reconcileMetas(parsed)) {
-      console.log(`\x1b[90m   Session index reconciled: ${sessionIdx.size()} sessions\x1b[0m`);
-    }
-  }
-
-  // 2. Filter by RESTORE_DAYS
-  console.time('restore:parse');
+  // 1. Read the lightweight index by STREAMING lines. #345: the index can
+  // exceed Node's ~512MB single-string limit, so we must not call readIndex()
+  // (readFile utf8) here — it would throw ERR_STRING_TOO_LONG and fail restore.
+  // #348: nor may we hold EVERY parsed meta resident — on a ~314k-line index
+  // that peaks ~3.7GB against Node's default old-space. Out-of-window lines
+  // never enter the working set: the reconcile tally is fed incrementally and
+  // the star pre-pass keeps only a lightweight {id, sessionId, cwd} per line.
+  // The rare full-meta consumers (session-index rebuild on drift / missing
+  // sessions.json) re-stream via readAllMetas() instead.
   let cutoffStr = null;
   if (config.RESTORE_DAYS > 0) {
     const cutoff = new Date();
     cutoff.setDate(cutoff.getDate() - config.RESTORE_DAYS);
     cutoffStr = cutoff.toLocaleString('sv-SE', { timeZone: 'Asia/Taipei' }).slice(0, 10);
   }
-
-  let restored = 0;
-
-  // Star-protection + session pre-count in one pass over pre-parsed data.
   const stars = readStarsSafe();
   const hasAnyStar = stars.projects.length || stars.sessions.length || stars.turns.length || stars.steps.length;
-  let retentionSets = null;
-  if (hasAnyStar && cutoffStr) {
-    const lightweight = [];
-    for (const m of parsed) {
-      if (m && m.id) lightweight.push({ id: m.id, sessionId: m.sessionId, cwd: m.cwd });
+  // Star-protection can retain out-of-window lines, so with stars + a cutoff
+  // the working set is rebuilt by a second streaming pass once the retention
+  // sets are known (pass B below); without either, one pass suffices.
+  const needStarPass = !!(hasAnyStar && cutoffStr);
+  const inWindow = (m) => !(cutoffStr && m.id && m.id.slice(0, 10) < cutoffStr);
+
+  console.time('restore:index');
+  const tally = sessionIndexLoaded ? sessionIdx.createReconcileTally() : null;
+  const starLight = [];
+  const working = [];
+  let parsedCount = 0;
+  for await (const line of config.storage.readIndexLines()) {
+    let m; try { m = JSON.parse(line); } catch { continue; }
+    if (!m) continue;
+    parsedCount++;
+    if (tally) tally.feed(m);
+    if (needStarPass) {
+      if (m.id) starLight.push({ id: m.id, sessionId: m.sessionId, cwd: m.cwd });
+    } else if (inWindow(m)) {
+      working.push(m);
     }
-    retentionSets = computeRetentionSets(lightweight, stars);
+  }
+  console.timeEnd('restore:index');
+
+  if (!parsedCount) {
+    console.timeEnd('restore:total');
+    return;
+  }
+
+  // 1b. Reconcile sessions.json against index.ndjson if loaded (#309). Drift
+  // is rare — only then re-stream the full metas the rebuild needs (#348).
+  if (tally && tally.drift()) {
+    sessionIdx.rebuildFromMetas(await readAllMetas());
+    console.log(`\x1b[90m   Session index reconciled: ${sessionIdx.size()} sessions\x1b[0m`);
+  }
+
+  // 2. Build the working set (RESTORE_DAYS window + star-protected lines)
+  console.time('restore:parse');
+  let restored = 0;
+
+  if (needStarPass) {
+    const retentionSets = computeRetentionSets(starLight, stars);
+    starLight.length = 0;
+    // #348 pass B: re-stream in FILE ORDER now that protection is known —
+    // star-protected out-of-window lines re-enter the working set here.
+    for await (const line of config.storage.readIndexLines()) {
+      let m; try { m = JSON.parse(line); } catch { continue; }
+      if (!m) continue;
+      if (inWindow(m) || isProtectedByStar(m, retentionSets)) working.push(m);
+    }
   }
 
   const sessionTotals = new Map();
-  for (const m of parsed) {
-    if (cutoffStr && m.id && m.id.slice(0, 10) < cutoffStr) {
-      if (!retentionSets || !isProtectedByStar(m, retentionSets)) continue;
-    }
+  for (const m of working) {
     if (m.sessionId) sessionTotals.set(m.sessionId, (sessionTotals.get(m.sessionId) || 0) + 1);
   }
   const oversizedSessions = new Map();
@@ -199,11 +230,9 @@ async function restoreFromLogs() {
   // batch before they enter the store (see the merge block after this loop).
   const restoredList = [];
 
-  for (let meta of parsed) {
-
-    if (cutoffStr && meta.id.slice(0, 10) < cutoffStr) {
-      if (!retentionSets || !isProtectedByStar(meta, retentionSets)) continue;
-    }
+  // The cutoff/star filter already ran during the streaming read — `working`
+  // is the pre-filtered set, in file order (#348).
+  for (let meta of working) {
 
     // Per-session cap: oversized sessions load only the first entry
     if (meta.sessionId && oversizedSessions.has(meta.sessionId)) {
@@ -373,10 +402,11 @@ async function restoreFromLogs() {
   console.timeEnd('restore:titles');
 
   // 5. Session index: rebuild from index.ndjson if sessions.json was missing,
-  //    then replay titles into the session index.
-  if (!sessionIndexLoaded && parsed.length) {
+  //    then replay titles into the session index. #348: re-stream on demand
+  //    rather than keeping 314k parsed metas resident for a rare fallback path.
+  if (!sessionIndexLoaded && parsedCount) {
     console.time('restore:session-index-rebuild');
-    sessionIdx.rebuildFromMetas(parsed);
+    sessionIdx.rebuildFromMetas(await readAllMetas());
     console.timeEnd('restore:session-index-rebuild');
     console.log(`\x1b[90m   Session index rebuilt: ${sessionIdx.size()} sessions\x1b[0m`);
   }

--- a/server/restore.js
+++ b/server/restore.js
@@ -252,10 +252,13 @@ async function restoreFromLogs() {
   // codex R3: buffer live updateFromEntry calls during the restore+rebuild window
   // so they survive the rebuild's clear. Replay into rebuilt state afterwards.
   if (rebuildPending) sessionIdx.beginRestoreBuffer();
-
+  let rebuildRan = false;
   // 2. Build the working set (RESTORE_DAYS window + star-protected lines)
   console.time('restore:parse');
   let restored = 0;
+  let oversizedSessions = new Map();
+
+  try { // finally → endRestoreBuffer; prevents _restoreBuffer leak on throw
 
   if (needStarPass) {
     const retentionSets = computeRetentionSets(starLight, stars);
@@ -274,7 +277,7 @@ async function restoreFromLogs() {
   for (const m of working) {
     if (m.sessionId) sessionTotals.set(m.sessionId, (sessionTotals.get(m.sessionId) || 0) + 1);
   }
-  const oversizedSessions = new Map();
+  oversizedSessions = new Map();
   for (const [sid, count] of sessionTotals) {
     if (count > store.SESSION_ENTRY_CAP) oversizedSessions.set(sid, count);
   }
@@ -429,9 +432,12 @@ async function restoreFromLogs() {
     console.time('restore:session-index-rebuild');
     await sessionIdx.rebuildFromMetasAsync(streamAllMetas(snapshotBytes));
     console.timeEnd('restore:session-index-rebuild');
-    sessionIdx.endRestoreBuffer(true);
+    rebuildRan = true;
     const reason = driftDetected ? 'reconciled' : 'rebuilt';
     console.log(`\x1b[90m   Session index ${reason}: ${sessionIdx.size()} sessions\x1b[0m`);
+  }
+  } finally { // matches try at beginRestoreBuffer
+    if (rebuildPending) sessionIdx.endRestoreBuffer(rebuildRan);
   }
   for (const [sid, meta] of Object.entries(store.sessionMeta)) {
     if (meta.title) sessionIdx.setTitle(sid, meta.title);

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -232,6 +232,7 @@ function reconcile(indexContent) {
 // into the rebuilt state; responseId dedup (_countedRids/_costByRid) makes replay
 // idempotent for entries whose line was also inside the snapshot byte bound.
 let _restoreBuffer = null;
+function _restoreBufferActive() { return _restoreBuffer !== null; }
 function beginRestoreBuffer() { _restoreBuffer = []; }
 function endRestoreBuffer(replay) {
   const buf = _restoreBuffer;
@@ -415,6 +416,6 @@ module.exports = {
   rebuildFromIndexContent, rebuildFromMetas, rebuildFromMetasAsync,
   seedDedupState, seedDedupFromMetas,
   reconcile, reconcileMetas, createReconcileTally,
-  updateFromEntry, beginRestoreBuffer, endRestoreBuffer,
+  updateFromEntry, beginRestoreBuffer, endRestoreBuffer, _restoreBufferActive,
   setTitle, setFirstPrompt, flush, getAll, get, size, setWeather, sessionWindow,
 };

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -178,26 +178,43 @@ function seedDedupState(indexContent) {
 // #333: the entry tally is deduped by responseId so it matches the merged s.count
 // _upsert now keeps; a raw-line tally here would always exceed merged s.count on a
 // duplicate-heavy shared log and rebuild on every reconcile.
+// #348: the tally is incremental (createReconcileTally) so restore's streaming
+// read can feed it line by line without holding every parsed meta resident;
+// only sessionId + responseId are read per meta.
+function createReconcileTally() {
+  const seenSessions = new Set();
+  const seenRid = new Set();
+  let indexEntries = 0;
+  return {
+    feed(m) {
+      if (!m || !m.sessionId) return;
+      // Count once per responseId (merged turns); a line without responseId
+      // (legacy/exempt) has no dedup key ⇒ always counts. Mirrors _upsert.
+      const rid = m.responseId || null;
+      if (!rid || !seenRid.has(rid)) {
+        indexEntries++;
+        if (rid) seenRid.add(rid);
+      }
+      seenSessions.add(m.sessionId);
+    },
+    // True iff the fed tally disagrees with the loaded sessions.json totals.
+    // Logs the drift warning; the caller owns the rebuild.
+    drift() {
+      if (!sessionIndex.size) return false;
+      let totalEntries = 0;
+      for (const s of sessionIndex.values()) totalEntries += s.count;
+      if (seenSessions.size === sessionIndex.size && indexEntries === totalEntries) return false;
+      console.warn(`\x1b[33m[session-index] drift detected: sessions.json has ${sessionIndex.size} sessions / ${totalEntries} entries, index.ndjson has ${seenSessions.size} sessions / ${indexEntries} entries — rebuilding\x1b[0m`);
+      return true;
+    },
+  };
+}
+
 function reconcileMetas(metas) {
   if (!Array.isArray(metas) || !metas.length || !sessionIndex.size) return false;
-  let indexSessions = 0, indexEntries = 0;
-  const seen = new Set();
-  const seenRid = new Set();
-  for (const m of metas) {
-    if (!m || !m.sessionId) continue;
-    // Count once per responseId (merged turns); a line without responseId
-    // (legacy/exempt) has no dedup key ⇒ always counts. Mirrors _upsert.
-    const rid = m.responseId || null;
-    if (!rid || !seenRid.has(rid)) {
-      indexEntries++;
-      if (rid) seenRid.add(rid);
-    }
-    if (!seen.has(m.sessionId)) { seen.add(m.sessionId); indexSessions++; }
-  }
-  let totalEntries = 0;
-  for (const s of sessionIndex.values()) totalEntries += s.count;
-  if (indexSessions === sessionIndex.size && indexEntries === totalEntries) return false;
-  console.warn(`\x1b[33m[session-index] drift detected: sessions.json has ${sessionIndex.size} sessions / ${totalEntries} entries, index.ndjson has ${indexSessions} sessions / ${indexEntries} entries — rebuilding\x1b[0m`);
+  const tally = createReconcileTally();
+  for (const m of metas) tally.feed(m);
+  if (!tally.drift()) return false;
   rebuildFromMetas(metas);
   return true;
 }
@@ -378,6 +395,6 @@ module.exports = {
   loadSessionIndex,
   rebuildFromIndexContent, rebuildFromMetas,
   seedDedupState, seedDedupFromMetas,
-  reconcile, reconcileMetas,
+  reconcile, reconcileMetas, createReconcileTally,
   updateFromEntry, setTitle, setFirstPrompt, flush, getAll, get, size, setWeather, sessionWindow,
 };

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -86,51 +86,53 @@ function _parseLines(indexContent) {
   return out;
 }
 
-// Build session index from an array of parsed index metas.
-function rebuildFromMetas(metas) {
+// Shared rebuild logic: clear state, iterate metas (upsert + weather grouping),
+// compute weather. Called by both sync (array) and async (generator) entry points.
+function _rebuildCore(feedFn) {
   sessionIndex.clear();
   _costByRid.clear();
   _countedRids.clear();
-  if (!Array.isArray(metas)) return;
-  // #333: a shared log holds 2–8 duplicate copies per turn (same responseId).
-  // Both COST and COUNT are deduped by responseId here (_upsert via _costByRid /
-  // _countedRids), so the session card shows merged turns and cost is counted once.
-  // reconcile() dedups its index-side comparison the SAME way — the two must stay
-  // paired: deduping count without deduping reconcile's tally would make merged
-  // s.count (e.g. 15) never equal the raw line total (45) and thrash rebuilds.
-  for (const m of metas) {
-    if (!m || !m.sessionId) continue;
-    _upsert(m.sessionId, m);
-  }
-  // #367: compute weather for all sessions from index metas.
-  // Index metas have all fields assessWeather needs (usage, maxContext, elapsed,
-  // model, toolFail, stopReason). isCompacted is unavailable (client-derived) —
-  // conservative (no false compaction signal).
-  // #385: deduplicate metas by responseId before feeding to weather assessment.
-  // Raw metas from index.ndjson contain 2–8 duplicate copies per turn in multi-writer
-  // scenarios (ADR 0012). Cost/count are already deduped via _upsert (_costByRid /
-  // _countedRids), but weather reads the list directly — duplicates inflate stuck
-  // streaks, error clusters, and cumulative error ratios. Lines without responseId
-  // (legacy/OpenAI exempt) pass through unchanged, matching _upsert's count rule.
   const { assessWeather } = require('../public/weather');
   const _weatherSeenRid = new Set();
   const bySid = new Map();
-  for (const m of metas) {
-    if (!m || !m.sessionId || m.isSubagent) continue;
+  const consume = (m) => {
+    if (!m || !m.sessionId) return;
+    _upsert(m.sessionId, m);
+    if (m.isSubagent) return;
     const rid = m.responseId;
     if (rid) {
-      if (_weatherSeenRid.has(rid)) continue;
+      if (_weatherSeenRid.has(rid)) return;
       _weatherSeenRid.add(rid);
     }
     let arr = bySid.get(m.sessionId);
     if (!arr) { arr = []; bySid.set(m.sessionId, arr); }
     arr.push(m);
-  }
-  for (const [sid, turns] of bySid) {
-    const s = sessionIndex.get(sid);
-    if (s) s.weather = assessWeather(turns);
-  }
-  dirty = true;
+  };
+  const finalize = () => {
+    for (const [sid, turns] of bySid) {
+      const s = sessionIndex.get(sid);
+      if (s) s.weather = assessWeather(turns);
+    }
+    dirty = true;
+  };
+  return { consume, finalize };
+}
+
+// #348: streaming rebuild — accepts async iterable (generator). Single pass:
+// _upsert + weather grouping happen together so the caller can feed a streaming
+// generator that never materializes the full array.
+async function rebuildFromMetasAsync(iter) {
+  const { consume, finalize } = _rebuildCore();
+  for await (const m of iter) consume(m);
+  finalize();
+}
+
+// Build session index from an array of parsed index metas (synchronous).
+function rebuildFromMetas(metas) {
+  if (!Array.isArray(metas)) return;
+  const { consume, finalize } = _rebuildCore();
+  for (const m of metas) consume(m);
+  finalize();
 }
 
 // Back-compat string entry point (tests / small indexes).
@@ -393,7 +395,7 @@ function setWeather(sid, weather) {
 
 module.exports = {
   loadSessionIndex,
-  rebuildFromIndexContent, rebuildFromMetas,
+  rebuildFromIndexContent, rebuildFromMetas, rebuildFromMetasAsync,
   seedDedupState, seedDedupFromMetas,
   reconcile, reconcileMetas, createReconcileTally,
   updateFromEntry, setTitle, setFirstPrompt, flush, getAll, get, size, setWeather, sessionWindow,

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -226,10 +226,27 @@ function reconcile(indexContent) {
   return reconcileMetas(_parseLines(indexContent));
 }
 
+// #348 codex R3: buffer live updates during async rebuild so they survive the
+// clear. beginRestoreBuffer → updateFromEntry still applies live (dashboard stays
+// current) AND pushes to a side buffer. endRestoreBuffer(true) replays the buffer
+// into the rebuilt state; responseId dedup (_countedRids/_costByRid) makes replay
+// idempotent for entries whose line was also inside the snapshot byte bound.
+let _restoreBuffer = null;
+function beginRestoreBuffer() { _restoreBuffer = []; }
+function endRestoreBuffer(replay) {
+  const buf = _restoreBuffer;
+  _restoreBuffer = null;
+  if (replay && buf && buf.length) {
+    for (const entry of buf) _upsert(entry.sessionId, entry);
+    _scheduleDirtyFlush();
+  }
+}
+
 // Upsert a session summary from an entry's index fields.
 function updateFromEntry(entry) {
   if (!entry || !entry.sessionId) return;
   _upsert(entry.sessionId, entry);
+  if (_restoreBuffer) _restoreBuffer.push(entry);
   _recomputeWeather(entry.sessionId);
   _scheduleDirtyFlush();
 }
@@ -398,5 +415,6 @@ module.exports = {
   rebuildFromIndexContent, rebuildFromMetas, rebuildFromMetasAsync,
   seedDedupState, seedDedupFromMetas,
   reconcile, reconcileMetas, createReconcileTally,
-  updateFromEntry, setTitle, setFirstPrompt, flush, getAll, get, size, setWeather, sessionWindow,
+  updateFromEntry, beginRestoreBuffer, endRestoreBuffer,
+  setTitle, setFirstPrompt, flush, getAll, get, size, setWeather, sessionWindow,
 };

--- a/test/restore.test.js
+++ b/test/restore.test.js
@@ -733,4 +733,22 @@ describe('session-index beginRestoreBuffer / endRestoreBuffer (codex R3)', () =>
     assert.equal(si.get('live-b').totalCost, 0.3);
     assert.equal(si.get('rebuilt').count, 1); // unchanged
   });
+
+  it('endRestoreBuffer(false) clears buffer without replay (error path)', () => {
+    si.rebuildFromMetas([]);
+    si.beginRestoreBuffer();
+    assert.equal(si._restoreBufferActive(), true);
+
+    si.updateFromEntry({ sessionId: 'lost', model: 'x', cost: { cost: 1 }, receivedAt: 1 });
+
+    // Simulate error: clear without replay
+    si.endRestoreBuffer(false);
+
+    assert.equal(si._restoreBufferActive(), false, 'buffer must be cleared');
+    // The live upsert went through (beginRestoreBuffer doesn't block it)
+    assert.equal(si.get('lost').count, 1);
+    // But a subsequent updateFromEntry must NOT accumulate into a dead buffer
+    si.updateFromEntry({ sessionId: 'post', model: 'y', cost: { cost: 0.1 }, receivedAt: 2 });
+    assert.equal(si._restoreBufferActive(), false, 'buffer must stay inactive after end');
+  });
 });

--- a/test/restore.test.js
+++ b/test/restore.test.js
@@ -491,3 +491,102 @@ describe('restoreFromLogs — codex resume eligibility', () => {
     assert.equal(summary.resumeCommand, null);
   });
 });
+
+// ── #348: star-protection + RESTORE_DAYS cutoff integration ─────────
+// Verifies that the streaming restore path correctly handles:
+// (a) in-window lines → restored
+// (b) out-of-window but star-protected lines → restored
+// (c) out-of-window unprotected lines → dropped
+// Also verifies file-order preservation.
+
+describe('restoreFromLogs — star-protection + cutoff integration (#348)', () => {
+  const config = require('../server/config');
+  const store = require('../server/store');
+  const { restoreFromLogs } = require('../server/restore');
+  const { _resetSettingsCache } = require('../server/settings');
+  // Use CCXRAY_HOME as the base so settings.json is found by readSettings()
+  const ccxrayHome = process.env.CCXRAY_HOME || path.join(os.tmpdir(), 'ccxray-restore-star-348-' + Date.now());
+  const logsDir = path.join(ccxrayHome, 'logs');
+  let realStorage, realRestoreDays;
+
+  before(async () => {
+    fs.mkdirSync(ccxrayHome, { recursive: true });
+    realStorage = config.storage;
+    realRestoreDays = config.RESTORE_DAYS;
+    const tmpStorage = require('../server/storage/local').createLocalStorage(logsDir);
+    await tmpStorage.init();
+    config.storage = tmpStorage;
+
+    // RESTORE_DAYS=3: entries older than 3 days are out-of-window
+    config.RESTORE_DAYS = 3;
+  });
+
+  after(() => {
+    config.storage = realStorage;
+    config.RESTORE_DAYS = realRestoreDays;
+    _resetSettingsCache();
+    try { fs.unlinkSync(path.join(ccxrayHome, 'settings.json')); } catch {}
+    fs.rmSync(logsDir, { recursive: true, force: true });
+  });
+
+  it('restores in-window + star-protected entries, drops unprotected old entries', async () => {
+    store.entries.length = 0;
+    store.entryIndex.clear();
+    for (const k of Object.keys(store.sessionMeta)) delete store.sessionMeta[k];
+    store.sessionCosts.clear();
+
+    // (a) in-window entry (today)
+    const now = new Date();
+    const todayId = now.toISOString().replace(/[:.]/g, '-').slice(0, -1);
+
+    // (b) out-of-window, will be star-protected via session star
+    const oldProtected = '2020-01-15T10-00-00-000';
+    const protectedSid = 'starred-sess';
+
+    // (c) out-of-window, no star protection
+    const oldUnprotected = '2020-01-15T11-00-00-000';
+    const unprotectedSid = 'unstarred-sess';
+
+    // Write index lines in order: (b), (c), (a) — verify file-order preservation.
+    // (c) uses a different cwd so the star-protected session's project cascade
+    // (computeRetentionSets lifts session→project) doesn't accidentally protect it.
+    const lines = [
+      [oldProtected, protectedSid, '/dev/starred-project'],
+      [oldUnprotected, unprotectedSid, '/dev/other-project'],
+      [todayId, 'today-sess', '/dev/today-project'],
+    ];
+    for (const [id, sid, cwd] of lines) {
+      await config.storage.appendIndex(JSON.stringify({
+        id, ts: id.slice(11).replace(/-/g, ':'),
+        sessionId: sid, provider: 'anthropic', model: 'claude-fable-5[1m]',
+        usage: { input_tokens: 1000, output_tokens: 100 },
+        isSSE: true, status: 200, receivedAt: Date.now(),
+        cwd,
+      }) + '\n');
+    }
+
+    // Write settings.json with a session star on protectedSid
+    _resetSettingsCache();
+    fs.writeFileSync(path.join(ccxrayHome, 'settings.json'), JSON.stringify({
+      starredSessions: [protectedSid],
+    }));
+
+    await restoreFromLogs();
+
+    const ids = store.entries.map(e => e.id);
+
+    // (a) in-window: restored
+    assert.ok(ids.includes(todayId), 'in-window entry must be restored');
+
+    // (b) out-of-window + starred session: restored
+    assert.ok(ids.includes(oldProtected), 'star-protected old entry must be restored');
+
+    // (c) out-of-window + unstarred: dropped
+    assert.ok(!ids.includes(oldUnprotected), 'unprotected old entry must NOT be restored');
+
+    // File-order: (b) before (a) — both are in the set, (b) was written first
+    const idxProtected = ids.indexOf(oldProtected);
+    const idxToday = ids.indexOf(todayId);
+    assert.ok(idxProtected < idxToday, 'file order must be preserved: star-protected before in-window');
+  });
+});

--- a/test/restore.test.js
+++ b/test/restore.test.js
@@ -506,8 +506,7 @@ describe('restoreFromLogs — star-protection + cutoff integration (#348)', () =
   const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-star-348-'));
   const logsDir = path.join(tmpHome, 'logs');
 
-  // Fixed ids — todayId is always within any RESTORE_DAYS window
-  const todayId = '2026-08-01T12-00-00-000';
+  const todayId = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -1);
   const oldProtected = '2020-01-15T10-00-00-000';
   const oldUnprotected = '2020-01-15T11-00-00-000';
   const protectedSid = 'starred-sess';

--- a/test/restore.test.js
+++ b/test/restore.test.js
@@ -569,3 +569,89 @@ describe('restoreFromLogs — star-protection + cutoff integration (#348)', () =
       'file order must be preserved: star-protected before in-window');
   });
 });
+
+// ── #348 codex R2: snapshot byte bound + id guard ────────────────────
+
+describe('restoreFromLogs — snapshot byte bound (codex R2)', () => {
+  const config = require('../server/config');
+  const { boundedIndexLines } = require('../server/restore');
+  const { createLocalStorage } = require('../server/storage/local');
+  const tmpDir = path.join(os.tmpdir(), 'ccxray-bounded-348-' + Date.now());
+  let realStorage;
+
+  before(async () => {
+    realStorage = config.storage;
+    const tmpStorage = createLocalStorage(tmpDir);
+    await tmpStorage.init();
+    config.storage = tmpStorage;
+  });
+
+  after(() => {
+    config.storage = realStorage;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('boundedIndexLines stops at the byte limit', async () => {
+    const lines = [
+      JSON.stringify({ id: 'aaa', sessionId: 's1' }),
+      JSON.stringify({ id: 'bbb', sessionId: 's1' }),
+      JSON.stringify({ id: 'ccc', sessionId: 's1' }),
+    ];
+    // Write all 3 lines
+    for (const l of lines) await config.storage.appendIndex(l + '\n');
+    // Byte limit = first 2 lines (each line + \n)
+    const limit = Buffer.byteLength(lines[0], 'utf8') + 1 + Buffer.byteLength(lines[1], 'utf8') + 1;
+    const collected = [];
+    for await (const l of boundedIndexLines(limit)) collected.push(l);
+    assert.equal(collected.length, 2, 'must yield exactly 2 lines within byte bound');
+    assert.deepEqual(collected, [lines[0], lines[1]]);
+  });
+});
+
+describe('restoreFromLogs — id guard prevents duplicate push (codex R2)', () => {
+  const config = require('../server/config');
+  const store = require('../server/store');
+  const { restoreFromLogs } = require('../server/restore');
+  const { createLocalStorage } = require('../server/storage/local');
+  const tmpDir = path.join(os.tmpdir(), 'ccxray-idguard-348-' + Date.now());
+  let realStorage, realRestoreDays;
+
+  before(async () => {
+    realStorage = config.storage;
+    realRestoreDays = config.RESTORE_DAYS;
+    config.RESTORE_DAYS = 0;
+    const tmpStorage = createLocalStorage(tmpDir);
+    await tmpStorage.init();
+    config.storage = tmpStorage;
+  });
+
+  after(() => {
+    config.storage = realStorage;
+    config.RESTORE_DAYS = realRestoreDays;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('skips an entry whose id is already in entryIndex (live-push race)', async () => {
+    store.entries.length = 0;
+    store.entryIndex.clear();
+
+    const id = '2026-07-30T10-00-00-000';
+    // Simulate a live turn already registered before restore runs
+    const liveEntry = { id, sessionId: 'live-sess', provider: 'anthropic', _loaded: true };
+    store.entries.push(liveEntry);
+    store.entryIndex.set(id, liveEntry);
+
+    // The same id appears in the index (the race scenario)
+    await config.storage.appendIndex(JSON.stringify({
+      id, ts: '10:00:00', sessionId: 'live-sess', provider: 'anthropic',
+      model: 'claude-fable-5[1m]', usage: { input_tokens: 100 },
+      isSSE: true, status: 200, receivedAt: Date.now(),
+    }) + '\n');
+
+    await restoreFromLogs();
+    // The id must appear exactly once in entries
+    const matches = store.entries.filter(e => e.id === id);
+    assert.equal(matches.length, 1, 'id guard must prevent duplicate push');
+    assert.strictEqual(matches[0], liveEntry, 'original live entry must survive');
+  });
+});

--- a/test/restore.test.js
+++ b/test/restore.test.js
@@ -504,12 +504,19 @@ describe('restoreFromLogs — star-protection + cutoff integration (#348)', () =
   const store = require('../server/store');
   const { restoreFromLogs } = require('../server/restore');
   const { _resetSettingsCache } = require('../server/settings');
-  // Use CCXRAY_HOME as the base so settings.json is found by readSettings()
-  const ccxrayHome = process.env.CCXRAY_HOME || path.join(os.tmpdir(), 'ccxray-restore-star-348-' + Date.now());
-  const logsDir = path.join(ccxrayHome, 'logs');
+  const { resolveCcxrayHome } = require('../server/paths');
+  // resolveCcxrayHome() returns the SAME path settings.js resolved SETTINGS_DIR
+  // to at module load time — so settings.json written here is found by readSettings()
+  // regardless of whether CCXRAY_HOME was set (hermetic when set, safe when not).
+  const ccxrayHome = resolveCcxrayHome();
+  const logsDir = path.join(os.tmpdir(), 'ccxray-star-348-logs-' + Date.now());
   let realStorage, realRestoreDays;
+  let settingsExisted = false;
+  const settingsPath = path.join(ccxrayHome, 'settings.json');
 
   before(async () => {
+    // Preserve any pre-existing settings.json (don't clobber real home in bare env)
+    settingsExisted = fs.existsSync(settingsPath);
     fs.mkdirSync(ccxrayHome, { recursive: true });
     realStorage = config.storage;
     realRestoreDays = config.RESTORE_DAYS;
@@ -525,7 +532,8 @@ describe('restoreFromLogs — star-protection + cutoff integration (#348)', () =
     config.storage = realStorage;
     config.RESTORE_DAYS = realRestoreDays;
     _resetSettingsCache();
-    try { fs.unlinkSync(path.join(ccxrayHome, 'settings.json')); } catch {}
+    // Only remove settings.json if we created it (don't destroy user's real file)
+    if (!settingsExisted) { try { fs.unlinkSync(settingsPath); } catch {} }
     fs.rmSync(logsDir, { recursive: true, force: true });
   });
 
@@ -567,7 +575,7 @@ describe('restoreFromLogs — star-protection + cutoff integration (#348)', () =
 
     // Write settings.json with a session star on protectedSid
     _resetSettingsCache();
-    fs.writeFileSync(path.join(ccxrayHome, 'settings.json'), JSON.stringify({
+    fs.writeFileSync(settingsPath, JSON.stringify({
       starredSessions: [protectedSid],
     }));
 

--- a/test/restore.test.js
+++ b/test/restore.test.js
@@ -498,103 +498,75 @@ describe('restoreFromLogs — codex resume eligibility', () => {
 // (b) out-of-window but star-protected lines → restored
 // (c) out-of-window unprotected lines → dropped
 // Also verifies file-order preservation.
+// Runs in a CHILD PROCESS with its own CCXRAY_HOME so the parent never touches
+// the real ~/.ccxray (hermetic per docs/testing.md, pattern: rebuild-index.e2e).
 
 describe('restoreFromLogs — star-protection + cutoff integration (#348)', () => {
-  const config = require('../server/config');
-  const store = require('../server/store');
-  const { restoreFromLogs } = require('../server/restore');
-  const { _resetSettingsCache } = require('../server/settings');
-  const { resolveCcxrayHome } = require('../server/paths');
-  // resolveCcxrayHome() returns the SAME path settings.js resolved SETTINGS_DIR
-  // to at module load time — so settings.json written here is found by readSettings()
-  // regardless of whether CCXRAY_HOME was set (hermetic when set, safe when not).
-  const ccxrayHome = resolveCcxrayHome();
-  const logsDir = path.join(os.tmpdir(), 'ccxray-star-348-logs-' + Date.now());
-  let realStorage, realRestoreDays;
-  let settingsExisted = false;
-  const settingsPath = path.join(ccxrayHome, 'settings.json');
+  const { spawnSync } = require('child_process');
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-star-348-'));
+  const logsDir = path.join(tmpHome, 'logs');
 
-  before(async () => {
-    // Preserve any pre-existing settings.json (don't clobber real home in bare env)
-    settingsExisted = fs.existsSync(settingsPath);
-    fs.mkdirSync(ccxrayHome, { recursive: true });
-    realStorage = config.storage;
-    realRestoreDays = config.RESTORE_DAYS;
-    const tmpStorage = require('../server/storage/local').createLocalStorage(logsDir);
-    await tmpStorage.init();
-    config.storage = tmpStorage;
+  // Fixed ids — todayId is always within any RESTORE_DAYS window
+  const todayId = '2026-08-01T12-00-00-000';
+  const oldProtected = '2020-01-15T10-00-00-000';
+  const oldUnprotected = '2020-01-15T11-00-00-000';
+  const protectedSid = 'starred-sess';
 
-    // RESTORE_DAYS=3: entries older than 3 days are out-of-window
-    config.RESTORE_DAYS = 3;
+  before(() => {
+    fs.mkdirSync(logsDir, { recursive: true });
+
+    // Write index lines in file order: (b), (c), (a)
+    // (c) uses a different cwd so the star cascade doesn't protect it.
+    const indexLines = [
+      [oldProtected, protectedSid, '/dev/starred-project'],
+      [oldUnprotected, 'unstarred-sess', '/dev/other-project'],
+      [todayId, 'today-sess', '/dev/today-project'],
+    ].map(([id, sid, cwd]) => JSON.stringify({
+      id, ts: id.slice(11).replace(/-/g, ':'),
+      sessionId: sid, provider: 'anthropic', model: 'claude-fable-5[1m]',
+      usage: { input_tokens: 1000, output_tokens: 100 },
+      isSSE: true, status: 200, receivedAt: Date.now(), cwd,
+    })).join('\n') + '\n';
+
+    fs.writeFileSync(path.join(logsDir, 'index.ndjson'), indexLines);
+
+    // settings.json with session star
+    fs.writeFileSync(path.join(tmpHome, 'settings.json'), JSON.stringify({
+      starredSessions: [protectedSid],
+    }));
   });
 
   after(() => {
-    config.storage = realStorage;
-    config.RESTORE_DAYS = realRestoreDays;
-    _resetSettingsCache();
-    // Only remove settings.json if we created it (don't destroy user's real file)
-    if (!settingsExisted) { try { fs.unlinkSync(settingsPath); } catch {} }
-    fs.rmSync(logsDir, { recursive: true, force: true });
+    fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  it('restores in-window + star-protected entries, drops unprotected old entries', async () => {
-    store.entries.length = 0;
-    store.entryIndex.clear();
-    for (const k of Object.keys(store.sessionMeta)) delete store.sessionMeta[k];
-    store.sessionCosts.clear();
-
-    // (a) in-window entry (today)
-    const now = new Date();
-    const todayId = now.toISOString().replace(/[:.]/g, '-').slice(0, -1);
-
-    // (b) out-of-window, will be star-protected via session star
-    const oldProtected = '2020-01-15T10-00-00-000';
-    const protectedSid = 'starred-sess';
-
-    // (c) out-of-window, no star protection
-    const oldUnprotected = '2020-01-15T11-00-00-000';
-    const unprotectedSid = 'unstarred-sess';
-
-    // Write index lines in order: (b), (c), (a) — verify file-order preservation.
-    // (c) uses a different cwd so the star-protected session's project cascade
-    // (computeRetentionSets lifts session→project) doesn't accidentally protect it.
-    const lines = [
-      [oldProtected, protectedSid, '/dev/starred-project'],
-      [oldUnprotected, unprotectedSid, '/dev/other-project'],
-      [todayId, 'today-sess', '/dev/today-project'],
-    ];
-    for (const [id, sid, cwd] of lines) {
-      await config.storage.appendIndex(JSON.stringify({
-        id, ts: id.slice(11).replace(/-/g, ':'),
-        sessionId: sid, provider: 'anthropic', model: 'claude-fable-5[1m]',
-        usage: { input_tokens: 1000, output_tokens: 100 },
-        isSSE: true, status: 200, receivedAt: Date.now(),
-        cwd,
-      }) + '\n');
-    }
-
-    // Write settings.json with a session star on protectedSid
-    _resetSettingsCache();
-    fs.writeFileSync(settingsPath, JSON.stringify({
-      starredSessions: [protectedSid],
-    }));
-
-    await restoreFromLogs();
-
-    const ids = store.entries.map(e => e.id);
+  it('restores in-window + star-protected entries, drops unprotected old entries', () => {
+    // Child driver: suppress console output, run restoreFromLogs, print ids as JSON
+    const driver = `
+      console.time = console.timeEnd = console.log = console.warn = () => {};
+      const { restoreFromLogs } = require('./server/restore');
+      const store = require('./server/store');
+      restoreFromLogs().then(() => {
+        process.stdout.write(JSON.stringify(store.entries.map(e => e.id)));
+      }).catch(e => { process.stderr.write(e.stack); process.exit(1); });
+    `;
+    const result = spawnSync(process.execPath, ['-e', driver], {
+      cwd: path.resolve(__dirname, '..'),
+      env: { ...process.env, CCXRAY_HOME: tmpHome, RESTORE_DAYS: '3', CCXRAY_DISABLE_TITLES: '1' },
+      encoding: 'utf8',
+      timeout: 15000,
+    });
+    assert.equal(result.status, 0, `child failed: ${result.stderr}`);
+    const ids = JSON.parse(result.stdout);
 
     // (a) in-window: restored
     assert.ok(ids.includes(todayId), 'in-window entry must be restored');
-
     // (b) out-of-window + starred session: restored
     assert.ok(ids.includes(oldProtected), 'star-protected old entry must be restored');
-
     // (c) out-of-window + unstarred: dropped
     assert.ok(!ids.includes(oldUnprotected), 'unprotected old entry must NOT be restored');
-
-    // File-order: (b) before (a) — both are in the set, (b) was written first
-    const idxProtected = ids.indexOf(oldProtected);
-    const idxToday = ids.indexOf(todayId);
-    assert.ok(idxProtected < idxToday, 'file order must be preserved: star-protected before in-window');
+    // File-order: (b) before (a)
+    assert.ok(ids.indexOf(oldProtected) < ids.indexOf(todayId),
+      'file order must be preserved: star-protected before in-window');
   });
 });

--- a/test/restore.test.js
+++ b/test/restore.test.js
@@ -655,3 +655,82 @@ describe('restoreFromLogs — id guard prevents duplicate push (codex R2)', () =
     assert.strictEqual(matches[0], liveEntry, 'original live entry must survive');
   });
 });
+
+// ── #348 codex R3: healMetaInPlace propagates to rebuild ─────────────
+
+describe('restoreFromLogs — healMetaInPlace propagates to session-index rebuild (codex R3)', () => {
+  const { spawnSync } = require('child_process');
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-heal-r3-'));
+  const logsDir = path.join(tmpHome, 'logs');
+
+  before(() => {
+    fs.mkdirSync(logsDir, { recursive: true });
+    // A single anthropic entry with maxContext=200000 but usage clearly > 200K
+    // (inferMaxContext should heal to 1M). No sessions.json → triggers rebuild.
+    fs.writeFileSync(path.join(logsDir, 'index.ndjson'), JSON.stringify({
+      id: '2026-07-01T10-00-00-000', ts: '10:00:00', sessionId: 'heal-sess',
+      provider: 'anthropic', model: 'claude-opus-4-7',
+      usage: { input_tokens: 632129, output_tokens: 500, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      maxContext: 200000, isSSE: true, status: 200, receivedAt: 1779000000000,
+    }) + '\n');
+  });
+
+  after(() => { fs.rmSync(tmpHome, { recursive: true, force: true }); });
+
+  it('rebuild persists healed maxContext (1M) in sessions.json', () => {
+    const driver = `
+      console.time = console.timeEnd = console.log = console.warn = () => {};
+      const { restoreFromLogs } = require('./server/restore');
+      const si = require('./server/session-index');
+      restoreFromLogs().then(async () => {
+        await si.flush();
+        process.stdout.write(JSON.stringify(si.get('heal-sess')));
+      }).catch(e => { process.stderr.write(e.stack); process.exit(1); });
+    `;
+    const result = spawnSync(process.execPath, ['-e', driver], {
+      cwd: path.resolve(__dirname, '..'),
+      env: { ...process.env, CCXRAY_HOME: tmpHome, RESTORE_DAYS: '0', CCXRAY_DISABLE_TITLES: '1' },
+      encoding: 'utf8', timeout: 15000,
+    });
+    assert.equal(result.status, 0, `child failed: ${result.stderr}`);
+    const sess = JSON.parse(result.stdout);
+    assert.equal(sess.maxContext, 1_000_000, 'rebuild must persist healed maxContext (1M)');
+  });
+});
+
+// ── #348 codex R3: beginRestoreBuffer / endRestoreBuffer ─────────────
+
+describe('session-index beginRestoreBuffer / endRestoreBuffer (codex R3)', () => {
+  const si = require('../server/session-index');
+
+  it('replays buffered updates after rebuild', async () => {
+    // Initial state: one session from a prior rebuild
+    si.rebuildFromMetas([{ sessionId: 'prior', model: 'x', cost: { cost: 0.1 }, receivedAt: 1 }]);
+    assert.equal(si.get('prior').count, 1);
+
+    si.beginRestoreBuffer();
+
+    // Simulate live updates during restore
+    si.updateFromEntry({ sessionId: 'live-a', model: 'y', cost: { cost: 0.5 }, responseId: 'rid-a', receivedAt: 2 });
+    si.updateFromEntry({ sessionId: 'live-b', model: 'z', cost: { cost: 0.3 }, receivedAt: 3 });
+
+    // Rebuild clears everything (simulates streamAllMetas with different data)
+    await si.rebuildFromMetasAsync((async function*() {
+      yield { sessionId: 'rebuilt', model: 'w', cost: { cost: 0.2 }, receivedAt: 4 };
+    })());
+
+    // At this point live-a and live-b are gone (cleared by rebuild)
+    assert.equal(si.get('live-a'), null);
+    assert.equal(si.get('live-b'), null);
+    assert.equal(si.get('rebuilt').count, 1);
+
+    // Replay restores them
+    si.endRestoreBuffer(true);
+
+    assert.equal(si.get('live-a').count, 1);
+    assert.equal(si.get('live-a').totalCost, 0.5);
+    assert.equal(si.get('live-b').count, 1);
+    assert.equal(si.get('live-b').totalCost, 0.3);
+    assert.equal(si.get('rebuilt').count, 1); // unchanged
+  });
+});


### PR DESCRIPTION
## 摘要

修 #348：`restoreFromLogs` 原本把每一行 index 解析後全塞進 `parsed[]`（真實 ~314k 行 index ≈ 597MB heap 常駐），逼近 Node 預設 old-space 上限造成 OOM。改為單次串流：reconcile tally 逐行增量餵入（`createReconcileTally`）、star pre-pass 只留輕量 `{id, sessionId, cwd}`、只有窗內（或 star 保護）行進入 `working[]`；罕見的 rebuild/drift fallback 延後到 restore 迴圈之後、先釋放 `working[]` 再以 async generator（`streamAllMetas`）串流重建，不再駐留第二個全量陣列。

## 改動

- `server/restore.js` — 串流重構主體；star+cutoff 走第二次串流 pass（保持檔案序）；drift/missing-sessions.json rebuild 合併為單一延後站點（`working.length = 0` 先釋放）
- `server/session-index.js` — `reconcileMetas` 抽出 `createReconcileTally()`（增量餵入；drift 語義不變）；新增 `rebuildFromMetasAsync(iter)`（與陣列版共用 `_rebuildCore`）
- `scripts/bench/gen-348-fixture.js` / `bench-348-restore.js` — 合成 fixture 產生器 + bench driver（hermetic，強制 `CCXRAY_HOME`，絕不碰真實 `~/.ccxray`）
- `test/restore.test.js` — 新增 star-protection + cutoff 整合測試（此前該路徑零整合覆蓋；child-process 隔離、動態 todayId）

## 驗證（orchestrator 親自重跑於最終 HEAD；Type: perf 依 docs/verification-principles.md）

主基準固定條件：550k 行 / 502MB 合成 index（`gen-348-fixture.js`）、`RESTORE_DAYS=14`（≈54% 窗內）、200 個 oversized sessions、macOS `/usr/bin/time -l`、各 3 輪取中位數。

| 指標 | 舊碼（origin/main） | 新碼（HEAD） | 差異 |
|---|---|---|---|
| peak RSS 中位數 | 799 MB（798/799/800） | 520 MB（516/520/520，final HEAD 重測） | **−35%** |
| `--max-old-space-size=600` | **OOM，exit 134** | **存活，exit 0**（完整 restore 200 entries） | fail-on-old 對照 |

drift/fallback 路徑（codex R1 P1 發現的回歸，已修並親測；300k 行 / 274MB fixture、驗證 log 均含 `drift detected` 或 rebuild 行——rebuild 成功會回寫治好 sessions.json，每輪驗證前須重新弄壞，否則是假陽性空跑）：

| 情境 @ `--max-old-space-size=400` | origin/main | 修正前（5b3e5bb） | 修正後（HEAD） |
|---|---|---|---|
| sessions.json count 漂移（真 drift rebuild） | exit 0 | OOM，exit 134 | **exit 0**（parity 恢復） |
| sessions.json 缺失（fallback rebuild） | — | — | **exit 0** |

550k 規模 drift @400MB 等價性：舊碼 exit 134（讀取階段即 OOM，未達 drift 偵測）、新碼 exit 134（完成讀取並觸發 drift 後才 OOM）——等規模下新碼嚴格不劣於舊碼。

其他機械閘（皆本機親跑於最終 HEAD）：

- 有界全測試：**1658 tests / 0 fail**（empty `CCXRAY_HOME`）
- 裸環境 hermetic 證明：`env -u CCXRAY_HOME node --test test/restore.test.js` 18/18 綠，且真實 `~/.ccxray/settings.json` **md5 前後一致**（未觸碰）
- star+cutoff 整合測試在舊碼上同樣 PASS（行為不變證據）
- boot smoke（`scripts/boot-smoke.sh`）：exit 0，dashboard HTTP 200
- 孤兒參照掃描：diff 無 top-level symbol 刪除；`parsed` 殘名僅剩註解與 `pruneIndexLines` 既有區域變數；`working` 在釋放點後零讀取者
- `node --check` 兩檔 pass

## codex-loop 二審記錄（4 輪，停損裁決 owner 2026-08-02）

- R1 [P1] drift-recovery 雙陣列駐留 → 兩輪修正（串流 rebuild → 延後 + 釋放 working[]），差異對照見上表
- R1 [P2] 測試隔離 → 兩輪修正（child-process 隔離 + 動態 todayId；第一版 `resolveCcxrayHome` 方案被 orchestrator 打回——裸環境會覆寫真實 settings.json），hermetic 以 md5 機械證明
- R2 [P2]×2 live-append 競態 → 快照位元組界（`boundedIndexLines`）+ restore 迴圈 id 守衛
- R3 [P1]×2 → `healMetaInPlace` 共用治癒進 rebuild 串流；`begin/endRestoreBuffer` 重播護 live updates（+orchestrator 抓的 try/finally 防洩漏）
- R4 [P1] rebuild `bySid` 駐留 → **拒絕**：既有設計、等規模實測不劣於舊碼（550k drift @400 舊碼讀取階段即 OOM、新碼更晚才倒），weather 串流化拆出 → #408
- R4 [P2] pass A 期間 live turn 丟失窗 → **接受為文件化限制**：觸發條件苛刻且自癒（遺失造成 count 漂移 → 下次啟動 drift 偵測 → rebuild 修復，機制已實測）；buffer 提前會把無 responseId 重複計數窗口從 sub-ms 加寬到秒級，不划算。known-limitation 註解在 `beginRestoreBuffer` 呼叫點

## 驗了什麼 / 沒驗什麼

- ✅ 合成 fixture 上的 RSS/OOM 差異（主路徑 + drift/fallback 路徑）、行為不變（全套測試 + 舊碼跑新整合測試）
- ❌ 未在真實 516MB index 上量（hermetic 原則：不讀真實 `~/.ccxray`；合成 fixture 欄位形狀依 `INDEX_FIELDS` 擬真）
- ❌ S3/R2 storage adapter 路徑未實測（僅本地 fs adapter；`readIndexLines()` 為既有共用串流介面）

## Reproduce

```bash
node scripts/bench/gen-348-fixture.js /tmp/ccxray-bench-348 550000
CCXRAY_HOME=/tmp/ccxray-bench-348 RESTORE_DAYS=0 node scripts/bench/bench-348-restore.js   # 建 sessions.json
CCXRAY_HOME=/tmp/ccxray-bench-348 RESTORE_DAYS=14 /usr/bin/time -l node scripts/bench/bench-348-restore.js
CCXRAY_HOME=/tmp/ccxray-bench-348 RESTORE_DAYS=14 node --max-old-space-size=600 scripts/bench/bench-348-restore.js
# drift 路徑：先只留 sessions.json 第一行再跑（每輪都要重弄壞）
```

Fixes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GATE-MANIFEST
issue-lint=pass @962519fd4793f11c3e8bb0b8774018d700a148ad
full-test=0 @962519fd4793f11c3e8bb0b8774018d700a148ad
boot-smoke=0 @962519fd4793f11c3e8bb0b8774018d700a148ad
-->
