### PR TITLE
docs: verification-trap solutions — drift self-heal false positive, fixture scale pinning

### DIFF
--- a/docs/solutions/drift-verification-self-heal-false-positive.md
+++ b/docs/solutions/drift-verification-self-heal-false-positive.md
@@ -1,0 +1,84 @@
+# drift 驗證的 self-heal 假陽性
+
+- 發現：2026-08-02，#348 / PR #409
+- 適用：drift/reconcile/cache-rebuild 等「修復路徑會回寫、治癒自身觸發條件」的驗證
+
+## 現象
+
+`restoreFromLogs` 的 drift 修復路徑：
+
+```
+createReconcileTally 偵測 sessions.json 與 index.ndjson 不一致
+  → rebuildFromMetasAsync 重建
+  → 成功後 flush 寫回治好的 sessions.json
+```
+
+第一輪驗證在 `--max-old-space-size=400` 下跑 drift → exit 0，dev agent 回報
+「drift 路徑在 400MB 限制下存活」。Orchestrator 重驗時對照組也 exit 0 且 log
+**無 `drift detected` 行** — 根本沒觸發 drift。原因：上一輪的 flush 已把修好的
+`sessions.json` 寫回同一個 `CCXRAY_HOME`，第二輪讀到一致的檔案對，走的是普通
+restore 空路徑。
+
+同一陷阱踩了兩次：dev agent 回報一次、orchestrator 在 pre-P1 對照組又踩一次。
+
+## 為什麼 exit code 不具證據力
+
+drift 修復路徑 exit 0 = 修復成功。普通 restore（無 drift）也 exit 0。沒有
+觸發條件時兩者不可區分。一個「通過」的測試必須先證明被測路徑有被走到。
+
+## 可操作規則
+
+**1. 每輪驗證前重新弄壞輸入。**
+
+drift 類驗證的 fixture 必須在每輪開始前恢復成不一致狀態：
+
+```bash
+# 保存乾淨的壞檔備份（只做一次）
+cp logs/sessions.json sessions.json.bak-broken
+
+# 每輪驗證前
+cp sessions.json.bak-broken logs/sessions.json
+touch logs/sessions.json   # 使 sessions.json 比 index.ndjson 新
+```
+
+注意 mtime 前置條件：`loadSessionIndex` 的 staleness 檢查比較
+`sessions.json` 與 `index.ndjson` 的 mtime——若 index 較新，直接拒載
+sessions.json 走 stale rebuild 路徑，永遠不會印 `drift detected`。drift
+觸發的前提是 sessions.json **能被載入**（mtime ≥ index），但**內容**與
+index 不一致。所以 touch 的對象是 sessions.json（讓它較新、能載入），不是
+index.ndjson。
+
+**2. 驗證 log 必含觸發行。**
+
+exit 0 不是 drift 修復路徑的證據。Log 必須包含 `drift detected`（或等效的
+觸發訊息）才算有效樣本。無此行的 exit code 只能證明「普通 restore 沒掛」。
+
+被驗證的指令必須會終止——長駐 server 會讓 pipeline 永遠跑不到
+grep。用會自然退出的 driver，或觀察到終態後明確停掉 server。
+
+```bash
+set -e -o pipefail  # -e: server crash 後不繼續走到 grep（否則 crash+drift 行都印了 → grep 成功 → exit 0 假陽性）
+CCXRAY_HOME=<fixture> RESTORE_DAYS=14 node scripts/bench/bench-348-restore.js 2>&1 | tee run.log
+grep -q 'drift detected' run.log || { echo "INVALID: drift not triggered" >&2; exit 1; }
+```
+
+**3. 通則：修復路徑會回寫治癒自身觸發條件的系統都適用。**
+
+以下模式都有同樣的陷阱：
+
+| 系統 | 觸發條件 | 修復動作 | 回寫效果 |
+|------|----------|----------|----------|
+| drift reconcile | sessions.json 與 index 不一致 | rebuild + flush | 寫回一致的 sessions.json |
+| cache rebuild | cache miss 或 stale | regenerate + write | 寫回有效 cache |
+| schema migration | version mismatch | migrate + bump version | 寫回新 version |
+
+對這類系統，驗證框架必須：
+- 在每輪開始前**獨立於被測系統**地重建觸發條件
+- 在 log 中確認觸發訊息存在
+- 不信任 exit code 作為「被測路徑有效」的唯一指標
+
+## 相關
+
+- `docs/verification-principles.md`（fail-on-old 規範的上游文件）
+- `docs/solutions/negative-claim-evidence-standard.md`（「測不到東西的測試」第二類 §2-1/§G：負向對照要跑不是要想）
+- #348 / PR #409（streaming index restore）

--- a/docs/solutions/perf-fixture-scale-pinning.md
+++ b/docs/solutions/perf-fixture-scale-pinning.md
@@ -1,0 +1,75 @@
+# 效能對照的 fixture 規模釘死
+
+- 發現：2026-08-02，#348 / PR #409
+- 適用：效能 before/after 對照、OOM 重現、任何讀取 fixture 的 benchmark
+
+## 現象
+
+PR #409 驗證 `--max-old-space-size=400` 下 drift 存活時，共用 fixture
+`/tmp/ccxray-bench-348` 先被 dev agent 從 550k 行 502MB 重生成為 300k 行
+274MB（重現 codex 情境），之後 orchestrator 為最終基準又重生成回 550k。
+Orchestrator 隨後在 300k 校準的預期下（drift @400MB 在 300k 規模可過）對
+已是 550k 的 fixture 跑 drift @400MB → exit 134（OOM kill）→ 誤判為「程式
+回歸」（悲觀方向的假回歸——實際是 fixture 變大了）。
+
+啟動三方對照（舊碼 @550k vs. 新碼 @550k vs. 新碼 @300k）重驗後才定位是
+規模差異而非程式回歸，白跑一整輪。
+
+## 為什麼會出問題
+
+效能對照的因果鏈：**fixture 規模 → 記憶體峰值 → pass/fail 判定**。中途換
+fixture 等於換了自變量但沒更新因變量的預期——OOM 被歸因為程式回歸而非
+規模放大，結果不可比但看起來可比。
+
+## 可操作規則
+
+**1. 對照的 fixture 規模與內容寫進證據表。**
+
+每輪對照結果必須附：
+
+```
+fixture: /tmp/ccxray-bench-348-drift
+lines:   550,123
+bytes:   502,481,920
+sha256:  <hash>（可選，需要位元級一致時）
+```
+
+**2. 每輪對照前驗證 fixture 與宣稱一致。**
+
+```bash
+wc -l < /tmp/ccxray-bench-348-drift/logs/index.ndjson
+ls -l /tmp/ccxray-bench-348-drift/logs/index.ndjson
+```
+
+數字與證據表不符 → 停下，不跑。
+
+**3. 多情境需要不同規模時用獨立目錄。**
+
+```
+/tmp/ccxray-bench-348-drift    # 550k, for OOM regression
+/tmp/ccxray-bench-348-codex    # 300k, for codex scenario repro
+```
+
+絕不重生成共用目錄。兩個 fixture 各自有自己的行數/bytes 紀錄。
+
+**4. 不信任 `/tmp` 的時間穩定性。**
+
+`/tmp` 是共享空間——其他 agent、cron、手動操作都可能碰到同一個路徑。效能
+fixture 的路徑應含足夠的辨識資訊（issue 號 + 情境後綴），且在跑之前驗證
+而非假設。
+
+## 與既有原則的關係
+
+這是 `docs/solutions/negative-claim-evidence-standard.md` §2-2（注入值與被測值
+撞號）的 fixture 版本：當 fixture 的實際規模與預期不符時，你無法區分「程式
+回歸了」和「測試條件變嚴苛了」——方向可以是樂觀（規模縮小假通過）或悲觀
+（規模放大假回歸），本次踩的是悲觀方向。
+
+也呼應 memory `feedback_static_snapshot_for_comparison.md`（比對兩 server 必須
+cp 靜態 index.ndjson；symlink 造成 200+ false diff）——同一個原則：**對照的
+輸入必須是靜態快照，不是活的引用**。
+
+## 相關
+
+- #348 / PR #409（streaming index restore）
+- `docs/solutions/negative-claim-evidence-standard.md`（驗證陷阱的通則）


### PR DESCRIPTION
## 摘要

修 #411：新增兩篇 docs/solutions 驗證陷阱文件（#348/#409 pipeline 實錄沉澱，codex 判定「必要」）：

- `drift-verification-self-heal-false-positive.md` — 修復路徑回寫治癒自身觸發條件 → 下輪驗證空跑假陽性。規則：每輪重弄壞輸入、log 必含觸發行、指令必須會終止。
- `perf-fixture-scale-pinning.md` — 共用 fixture 中途被重生成 → 規模效應被誤判為程式回歸。規則：規模入證據表、跑前驗證、多情境獨立目錄。

## 驗證（orchestrator 親跑）

docs-only（`git diff --stat` 僅兩檔），但**文件的示範指令全部實際執行過**：

| 情境 | 結果 |
|---|---|
| 照文件弄壞 → 跑 driver | `drift detected` 出現、guard exit 0 |
| 健康 home（INVALID 路徑） | `INVALID: drift not triggered` + exit 1 |
| crash 模擬（`set -e -o pipefail` 語義，standalone script） | bash/zsh 均 exit 137，crash 不被遮蔽 |
| 文件字面指令 end-to-end（最終版 snippet） | exit 0 + drift 行存在 |

事實核對：兩篇的事故敘述由 orchestrator（第一手當事者）逐段核對；fixture 篇的誤判方向初稿寫反（樂觀外推 vs 實際的悲觀假回歸），已修正。引用檔案（`negative-claim-evidence-standard.md`、`verification-principles.md`）存在性已驗。

三 gate：issue-lint 0 / full-test 1663 全綠 0 fail / boot-smoke 0。

## codex-loop 記錄（4 輪，這篇「防假陽性」文件自己的 snippet 被抓出三個假陽性——全修）

- R1：弄壞 snippet 方向反了（touch index 使 sessions.json 被 mtime 拒載、永不 drift）；INVALID 路徑 `|| echo` 恆 exit 0
- R2：`pipefail` 缺 `set -e`，crash 後仍走到 grep
- R3：`node server/index.js` 長駐不終止，grep 永遠跑不到 → 改用會退出的 bench driver
- R4 修正即 codex 要求形狀，字面指令 end-to-end 實測收尾

Fixes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GATE-MANIFEST
issue-lint=pass @09c55a20f35a27027b30af9a066a0d8d2eb401ec
full-test=0 @09c55a20f35a27027b30af9a066a0d8d2eb401ec
boot-smoke=0 @09c55a20f35a27027b30af9a066a0d8d2eb401ec
-->
