### PR TITLE
fix(test): widen WS proxy index-entry poll timeout to 8s

### DIFF
--- a/test/websocket-proxy.test.js
+++ b/test/websocket-proxy.test.js
@@ -71,7 +71,7 @@ function killAndWait(child) {
   });
 }
 
-async function waitForIndexEntry(logsDir, predicate, timeoutMs = 4000) {
+async function waitForIndexEntry(logsDir, predicate, timeoutMs = 8000) {
   const indexPath = path.join(logsDir, 'index.ndjson');
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
@@ -92,7 +92,7 @@ async function waitForIndexEntry(logsDir, predicate, timeoutMs = 4000) {
 // Wait until at least `minCount` index entries match, returning the matches.
 // Polling beats a fixed sleep before reading index.ndjson — the proxy writes
 // from a separate process and a guessed delay flakes under load. See #100.
-async function waitForIndexEntries(logsDir, predicate, minCount, timeoutMs = 4000) {
+async function waitForIndexEntries(logsDir, predicate, minCount, timeoutMs = 8000) {
   const indexPath = path.join(logsDir, 'index.ndjson');
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {


### PR DESCRIPTION
## 摘要
CI Node 22 runner 上 websocket-proxy 測試 flaky——client disconnect 後的 storage flush 超過 4s 預設 timeout（實際 4236ms）。提高到 8s 給 2× headroom。

## 動機
此 flake 持續擋住 `upgrade-stable.sh` 的 CI gate，導致 ccxray-stable 無法自動更新。

## Changes
- `waitForIndexEntry` default timeout: 4000ms → 8000ms
- `waitForIndexEntries` default timeout: 4000ms → 8000ms

## Test plan
- [x] Full test suite passes locally (1663/1663)
- [x] The specific flaky test passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)