### PR TITLE
feat(pricing): add cost confidence level (#420 Phase 1)

### DIFF
--- a/server/cost-worker.js
+++ b/server/cost-worker.js
@@ -73,9 +73,9 @@ function processFile(filePath, accountId) {
       const totalTokens = (usage.input_tokens || 0) + (usage.output_tokens || 0)
         + (usage.cache_creation_input_tokens || 0) + (usage.cache_read_input_tokens || 0);
       if (totalTokens === 0) return;
-      const costUSD = calculateCostSimple(usage, model);
+      const { cost: costUSD, confidence: costConfidence } = calculateCostSimple(usage, model);
       const sessionId = path.basename(filePath, '.jsonl');
-      localEntries.push({ timestamp: new Date(timestamp).getTime(), usage, costUSD, model, sessionId, messageId, accountId });
+      localEntries.push({ timestamp: new Date(timestamp).getTime(), usage, costUSD, costConfidence, model, sessionId, messageId, accountId });
     });
     rl.on('close', () => resolve(localEntries));
     rl.on('error', () => resolve(localEntries));
@@ -117,10 +117,10 @@ function processCodexFile(filePath, accountId) {
       if (totalTokens === 0) return;
 
       if (!obj.timestamp) return;
-      const costUSD = calculateCostSimple(usage, lastModel);
+      const { cost: costUSD, confidence: costConfidence } = calculateCostSimple(usage, lastModel);
       const tsMs = new Date(obj.timestamp).getTime();
       const messageId = `${tsMs}::${sessionId}`;
-      localEntries.push({ timestamp: tsMs, usage, costUSD, model: lastModel, sessionId, messageId, accountId });
+      localEntries.push({ timestamp: tsMs, usage, costUSD, costConfidence, model: lastModel, sessionId, messageId, accountId });
     });
     rl.on('close', () => resolve(localEntries));
     rl.on('error', () => resolve(localEntries));
@@ -183,12 +183,21 @@ function processGrokIndexEntry(obj, accountId = 'grok-default') {
   if (timestamp == null) return null;
   const model = obj.model || 'unknown';
   let costUSD = entryCostUSD(obj);
-  if (costUSD == null) costUSD = calculateCostSimple(usage, model);
+  let costConfidence;
+  if (costUSD != null) {
+    // Preserve existing confidence from entries that already have cost (codex finding #7)
+    costConfidence = (obj.cost && typeof obj.cost === 'object' && obj.cost.confidence) || 'exact';
+  } else {
+    const result = calculateCostSimple(usage, model);
+    costUSD = result.cost;
+    costConfidence = result.confidence;
+  }
   const messageId = obj.id ? `grok::${obj.id}` : null;
   return {
     timestamp,
     usage,
     costUSD,
+    costConfidence,
     model,
     sessionId: obj.sessionId || null,
     messageId,

--- a/server/cost-worker.js
+++ b/server/cost-worker.js
@@ -185,8 +185,10 @@ function processGrokIndexEntry(obj, accountId = 'grok-default') {
   let costUSD = entryCostUSD(obj);
   let costConfidence;
   if (costUSD != null) {
-    // Preserve existing confidence from entries that already have cost (codex finding #7)
-    costConfidence = (obj.cost && typeof obj.cost === 'object' && obj.cost.confidence) || 'exact';
+    // Preserve existing confidence; if absent, derive from model lookup (not 'exact' — the
+    // stored cost may have been calculated with a prefix match or fallback rate).
+    costConfidence = (obj.cost && typeof obj.cost === 'object' && obj.cost.confidence)
+      || calculateCostSimple(usage, model).confidence;
   } else {
     const result = calculateCostSimple(usage, model);
     costUSD = result.cost;

--- a/server/default-rates.js
+++ b/server/default-rates.js
@@ -162,6 +162,11 @@ const _defaultRate = _perTokenRates['claude-sonnet-4'] ||
  * Used by cost-worker.js (child process) and importer.js (startup import)
  * where the live LiteLLM pricing table is not available.
  *
+ * Returns { cost, confidence } where confidence is one of:
+ *   - 'exact'    — exact hit in the rate table
+ *   - 'prefix'   — matched via model.startsWith(key) or date-strip
+ *   - 'fallback' — fell back to claude-sonnet-4 default rates
+ *
  * Model matching (longest-prefix-first):
  *   1. Exact match against the rate table
  *   2. model.startsWith(key) — covers versioned wire IDs (grok-4.5-build -> grok-4.5)
@@ -171,26 +176,30 @@ const _defaultRate = _perTokenRates['claude-sonnet-4'] ||
  */
 function calculateCostSimple(usage, model) {
   let r = null;
+  let confidence = 'fallback';
   if (model) {
     // Fast path: exact match
     if (_perTokenRates[model]) {
       r = _perTokenRates[model];
+      confidence = 'exact';
     } else {
       // Longest key first so grok-4.5-build -> grok-4.5 (not grok-build).
       for (const k of _sortedKeys) {
         const prefix = k.split('-202')[0];
         if (model.startsWith(k) || model.startsWith(prefix)) {
           r = _perTokenRates[k];
+          confidence = 'prefix';
           break;
         }
       }
     }
   }
   if (!r) r = _defaultRate;
-  return (usage.input_tokens || 0) * r.input
+  const cost = (usage.input_tokens || 0) * r.input
     + (usage.output_tokens || 0) * r.output
     + (usage.cache_read_input_tokens || 0) * r.cache_read
     + (usage.cache_creation_input_tokens || 0) * r.cache_create;
+  return { cost, confidence };
 }
 
 module.exports = {

--- a/server/importer.js
+++ b/server/importer.js
@@ -153,7 +153,7 @@ async function parseSessionFile(filePath, projectSlug) {
     if (!id) continue;
 
     const model = msg.model || 'unknown';
-    const cost = calculateCostSimple(usage, model);
+    const costResult = calculateCostSimple(usage, model);
     const tokens = buildTokens(usage);
     const receivedAt = new Date(obj.timestamp).getTime();
 
@@ -175,7 +175,7 @@ async function parseSessionFile(filePath, projectSlug) {
       // so the import enriches rather than shadows. See docs/decisions/0012.
       responseId: msg.id || null,
       tokens,
-      cost: { cost },
+      cost: { cost: costResult.cost, confidence: costResult.confidence },
       model,
       sessionId,
       title: lastUserText || '(imported)',
@@ -240,7 +240,7 @@ async function parseCodexSessionFile(filePath) {
     if (!id) continue;
 
     const contextWindow = (payload.info && payload.info.model_context_window) || CODEX_CONTEXT_WINDOW;
-    const cost = calculateCostSimple(usage, lastModel);
+    const costResult = calculateCostSimple(usage, lastModel);
     const tokens = buildTokens(usage, contextWindow);
     const receivedAt = new Date(obj.timestamp).getTime();
 
@@ -257,7 +257,7 @@ async function parseCodexSessionFile(filePath) {
       isSSE: false,
       receivedAt,
       tokens,
-      cost: { cost },
+      cost: { cost: costResult.cost, confidence: costResult.confidence },
       model: lastModel,
       // #384: the transcript's model_context_window is authoritative — write it
       // so weather/session-fold/cold-load all see the real denominator.

--- a/server/pricing.js
+++ b/server/pricing.js
@@ -162,30 +162,40 @@ async function fetchPricing() {
   });
 }
 
-function getModelPricing(model) {
-  if (!model) return null;
-  if (pricingTable[model]) return pricingTable[model];
+/**
+ * Look up pricing rates for a model. Returns { rates, confidence } where
+ * confidence is 'exact', 'prefix', or null (not found).
+ * The bare getModelPricing(model) call returns just the rates for backward
+ * compat; getModelPricingWithConfidence returns the full object.
+ */
+function getModelPricingWithConfidence(model) {
+  if (!model) return { rates: null, confidence: null };
+  if (pricingTable[model]) return { rates: pricingTable[model], confidence: 'exact' };
   // LiteLLM provider-prefixed form (xai/grok-4.3) when wire sent bare id
-  if (!model.includes('/') && pricingTable[`xai/${model}`]) return pricingTable[`xai/${model}`];
+  if (!model.includes('/') && pricingTable[`xai/${model}`]) return { rates: pricingTable[`xai/${model}`], confidence: 'exact' };
   // #397: match logic must agree with default-rates.js calculateCostSimple
   const keys = Object.keys(pricingTable).sort((a, b) => b.length - a.length);
   for (const key of keys) {
     const prefix = key.split('-202')[0];
-    if (model.startsWith(key) || model.startsWith(prefix)) return pricingTable[key];
+    if (model.startsWith(key) || model.startsWith(prefix)) return { rates: pricingTable[key], confidence: 'prefix' };
   }
-  return null;
+  return { rates: null, confidence: null };
+}
+
+function getModelPricing(model) {
+  return getModelPricingWithConfidence(model).rates;
 }
 
 function calculateCost(usage, model) {
   if (!usage) return null;
-  const rates = getModelPricing(model);
-  if (!rates) return { cost: null, rates: null, warning: `Unknown model: ${model}` };
+  const { rates, confidence: rateConfidence } = getModelPricingWithConfidence(model);
+  if (!rates) return { cost: null, rates: null, confidence: 'unknown', warning: `Unknown model: ${model}` };
   const cost =
     ((usage.input_tokens || 0) / 1_000_000) * rates.input +
     ((usage.output_tokens || 0) / 1_000_000) * rates.output +
     ((usage.cache_creation_input_tokens || 0) / 1_000_000) * rates.cache_create +
     ((usage.cache_read_input_tokens || 0) / 1_000_000) * rates.cache_read;
-  return { cost, rates };
+  return { cost, rates, confidence: rateConfidence };
 }
 
 function getModelContext(model) {

--- a/test/cost-worker-grok.test.js
+++ b/test/cost-worker-grok.test.js
@@ -64,8 +64,8 @@ describe('cost-worker Grok index source', () => {
 
   it('calculateCostSimple longest-prefix matches grok-4.5-build to grok-4.5 rates', () => {
     const usage = { input_tokens: 1_000_000, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 };
-    assert.equal(calculateCostSimple(usage, 'grok-4.5-build'), 2);
-    assert.equal(calculateCostSimple(usage, 'grok-build'), 1);
+    assert.equal(calculateCostSimple(usage, 'grok-4.5-build').cost, 2);
+    assert.equal(calculateCostSimple(usage, 'grok-build').cost, 1);
   });
 
   it('processGrokIndexFile streams only grok rows', async () => {

--- a/test/cost-worker-grok.test.js
+++ b/test/cost-worker-grok.test.js
@@ -60,6 +60,37 @@ describe('cost-worker Grok index source', () => {
     assert.ok(e);
     // $2 / MTok input → $2.00 for 1M tokens
     assert.equal(e.costUSD, 2);
+    // P1: costUSD must be a number (cost-budget.js:111 does += e.costUSD || 0)
+    assert.equal(typeof e.costUSD, 'number');
+    assert.equal(typeof e.costConfidence, 'string');
+  });
+
+  it('processGrokIndexEntry with stored cost but no confidence derives confidence from model (codex P2)', () => {
+    const e = processGrokIndexEntry({
+      id: '2026-07-19T09-00-00-000',
+      agent: 'grok',
+      model: 'grok-4.5-build',
+      receivedAt: 2_000,
+      cost: 2.00,
+      usage: { input_tokens: 1_000_000, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+    });
+    assert.ok(e);
+    assert.equal(e.costUSD, 2);
+    // Without stored confidence, derives from model lookup — grok-4.5-build is exact in the table
+    assert.equal(e.costConfidence, 'exact');
+  });
+
+  it('processGrokIndexEntry preserves stored confidence when present', () => {
+    const e = processGrokIndexEntry({
+      id: '2026-07-19T09-01-00-000',
+      agent: 'grok',
+      model: 'grok-4.5-build',
+      receivedAt: 3_000,
+      cost: { cost: 2.00, confidence: 'prefix' },
+      usage: { input_tokens: 1_000_000, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+    });
+    assert.ok(e);
+    assert.equal(e.costConfidence, 'prefix');
   });
 
   it('calculateCostSimple longest-prefix matches grok-4.5-build to grok-4.5 rates', () => {

--- a/test/default-rates.test.js
+++ b/test/default-rates.test.js
@@ -103,31 +103,31 @@ describe('default-rates: single source of truth (#397)', () => {
     };
 
     it('matches grok-4.5-build to grok-4.5-build (exact, $2/MTok input)', () => {
-      assert.equal(calculateCostSimple(usage1M, 'grok-4.5-build'), 2);
+      assert.equal(calculateCostSimple(usage1M, 'grok-4.5-build').cost, 2);
     });
 
     it('matches grok-build to grok-build via lag override ($1/MTok input)', () => {
-      assert.equal(calculateCostSimple(usage1M, 'grok-build'), 1);
+      assert.equal(calculateCostSimple(usage1M, 'grok-build').cost, 1);
     });
 
     it('matches dated wire ID claude-sonnet-4-5-20250514 ($3/MTok input)', () => {
-      assert.equal(calculateCostSimple(usage1M, 'claude-sonnet-4-5-20250514'), 3);
+      assert.equal(calculateCostSimple(usage1M, 'claude-sonnet-4-5-20250514').cost, 3);
     });
 
     it('matches dated wire ID claude-haiku-3-5-20241022 ($0.80/MTok input)', () => {
-      assert.equal(calculateCostSimple(usage1M, 'claude-haiku-3-5-20241022'), 0.8);
+      assert.equal(calculateCostSimple(usage1M, 'claude-haiku-3-5-20241022').cost, 0.8);
     });
 
     it('matches claude-fable-5 ($10/MTok input)', () => {
-      assert.equal(calculateCostSimple(usage1M, 'claude-fable-5'), 10);
+      assert.equal(calculateCostSimple(usage1M, 'claude-fable-5').cost, 10);
     });
 
     it('falls back to sonnet-4 rates for unknown model', () => {
-      assert.equal(calculateCostSimple(usage1M, 'totally-unknown'), 3);
+      assert.equal(calculateCostSimple(usage1M, 'totally-unknown').cost, 3);
     });
 
     it('falls back to sonnet-4 rates for null model', () => {
-      assert.equal(calculateCostSimple(usage1M, null), 3);
+      assert.equal(calculateCostSimple(usage1M, null).cost, 3);
     });
 
     it('calculates all four cost components', () => {
@@ -137,31 +137,59 @@ describe('default-rates: single source of truth (#397)', () => {
         cache_read_input_tokens: 1_000_000,
         cache_creation_input_tokens: 1_000_000,
       };
-      const cost = calculateCostSimple(usage, 'claude-sonnet-4');
+      const result = calculateCostSimple(usage, 'claude-sonnet-4');
       // $3 + $15 + $0.30 + $3.75 = $22.05
-      assert.equal(cost, 22.05);
+      assert.equal(result.cost, 22.05);
     });
 
     it('longest-prefix-first: grok-4.5-build matches grok-4.5-build not grok-build', () => {
       // grok-4.5-build has input $2/MTok, grok-build has input $1/MTok.
       // If prefix matching were insertion-order, grok-build could win.
-      assert.equal(calculateCostSimple(usage1M, 'grok-4.5-build'), 2);
+      assert.equal(calculateCostSimple(usage1M, 'grok-4.5-build').cost, 2);
     });
 
     it('bare gpt-5.6 must NOT fall through to gpt-5 (codex review P1)', () => {
       // gpt-5.6 = $5/MTok input (same as gpt-5.6-sol), not gpt-5 at $1.25
-      assert.equal(calculateCostSimple(usage1M, 'gpt-5.6'), 5);
+      assert.equal(calculateCostSimple(usage1M, 'gpt-5.6').cost, 5);
     });
 
     it('getModelPricing uses date-strip parity with calculateCostSimple (codex review P2)', () => {
       const { getModelPricing } = require('../server/pricing');
       // claude-haiku-4-5-20251001 should resolve the same in both matchers
-      const offline = calculateCostSimple(usage1M, 'claude-haiku-4-5-20251001');
+      const offline = calculateCostSimple(usage1M, 'claude-haiku-4-5-20251001').cost;
       const live = getModelPricing('claude-haiku-4-5-20251001');
       assert.ok(live, 'getModelPricing must resolve claude-haiku-4-5-20251001');
       const liveCost = usage1M.input_tokens * live.input / 1e6;
       assert.ok(Math.abs(offline - liveCost) < 0.01,
         `offline=${offline} live=${liveCost} — matchers disagree`);
+    });
+
+    // #420: confidence level tests
+    it('returns exact confidence for exact model match', () => {
+      assert.equal(calculateCostSimple(usage1M, 'claude-opus-4-6').confidence, 'exact');
+    });
+
+    it('returns prefix confidence for dated wire ID', () => {
+      assert.equal(calculateCostSimple(usage1M, 'claude-opus-4-6-20260115').confidence, 'prefix');
+    });
+
+    it('returns fallback confidence for unknown model', () => {
+      assert.equal(calculateCostSimple(usage1M, 'totally-unknown').confidence, 'fallback');
+    });
+
+    it('returns fallback confidence for null model', () => {
+      assert.equal(calculateCostSimple(usage1M, null).confidence, 'fallback');
+    });
+
+    it('returns exact confidence for lag override model', () => {
+      assert.equal(calculateCostSimple(usage1M, 'grok-build').confidence, 'exact');
+    });
+
+    it('returns { cost, confidence } shape', () => {
+      const result = calculateCostSimple(usage1M, 'claude-sonnet-4');
+      assert.ok(typeof result === 'object');
+      assert.ok(typeof result.cost === 'number');
+      assert.ok(['exact', 'prefix', 'fallback'].includes(result.confidence));
     });
   });
 

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -188,5 +188,27 @@ describe('pricing', () => {
       }, 'claude-sonnet-4');
       assert.equal(result.cost, 0);
     });
+
+    // #420: confidence level tests
+    it('returns exact confidence for exact model match', () => {
+      const result = calculateCost({ input_tokens: 100, output_tokens: 50 }, 'claude-sonnet-4');
+      assert.equal(result.confidence, 'exact');
+    });
+
+    it('returns prefix confidence for dated wire ID', () => {
+      const result = calculateCost({ input_tokens: 100, output_tokens: 50 }, 'claude-sonnet-4-20250514');
+      assert.equal(result.confidence, 'prefix');
+    });
+
+    it('returns exact confidence for xai/ mirrored model', () => {
+      const result = calculateCost({ input_tokens: 100, output_tokens: 50 }, 'grok-4.5');
+      assert.equal(result.confidence, 'exact');
+    });
+
+    it('returns unknown confidence for unrecognized model', () => {
+      const result = calculateCost({ input_tokens: 100, output_tokens: 50 }, 'totally-unknown-model');
+      assert.equal(result.confidence, 'unknown');
+      assert.ok(result.warning);
+    });
   });
 });


### PR DESCRIPTION
## 摘要
費用計算加 confidence 欄位（exact/prefix/fallback/unknown），讓 UI 能區分可信和不可信的 cost 數字。Phase 1 只改引擎層，不碰 UI。

## Changes

### `server/default-rates.js`
- `calculateCostSimple` 回傳 `{ cost, confidence }` 取代 bare number
- exact hit → `'exact'`、prefix match → `'prefix'`、fallback → `'fallback'`

### `server/pricing.js`
- 新增 `getModelPricingWithConfidence(model)` 回傳 `{ rates, confidence }`
- `calculateCost` 回傳加 `confidence` 欄位
- `getModelPricing` 向後相容（委託新函式）
- xai/ mirror hit 算 `'exact'`

### `server/cost-worker.js`
- 3 處 caller 解構 `{ cost, confidence }`
- stdout entry 保持 `costUSD` 為 number（premortem: cost-budget.js:111 `+= e.costUSD || 0`），另加 `costConfidence`
- Grok worker: stored cost 無 confidence 時從 model lookup 推導（不硬寫 exact）

### `server/importer.js`
- 2 處 caller 解構，confidence 寫入 imported entry 的 cost object

## Bugs fixed
- Grok worker path 對 legacy rows 硬寫 `exact`，即使 model 是 prefix match（codex review P2）

## 驗證

| 項目 | 結果 |
|------|------|
| Tests | 1701/1701 pass |
| verify-rates | 31 match, 0 mismatch |
| Fail-on-old | `.confidence` 在舊碼 = undefined |
| 真實資料 smoke | 251,262 exact + 392 fallback，兩引擎一致 |
| Codex review | 0 blocker/major, 1 minor 拒絕（legacy Grok lookup 推導優於 unknown） |
| Premortem #5 | costUSD numeric invariant 確認 + 回歸測試 |

## 後續 (Phase 2-3)
- Phase 2: per-turn UI `~` 前綴 + tooltip
- Phase 3: aggregation（session/project/Usage tab）

🤖 Generated with [Claude Code](https://claude.com/claude-code)