### PR TITLE
feat(pricing): surface cost confidence in per-turn UI (#420 Phase 2)

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -968,9 +968,15 @@ function _patchEntryInPlace(u) {
     }
     // cost arrives as {cost, confidence} from summarizeEntry; allEntries stores
     // bare number + separate costConfidence (codex round-1 M3, #420 Phase 2).
+    // cost and confidence are taken as a unit: confidence only updates when the
+    // cost value is accepted (fable review MINOR-1, ADR 0012 as-a-unit rule).
     if (u.cost != null) {
-      full.cost = (u.cost && u.cost.cost != null) ? u.cost.cost : (typeof u.cost === 'number' ? u.cost : full.cost);
-      if (u.cost?.confidence) full.costConfidence = u.cost.confidence;
+      if (u.cost && u.cost.cost != null) {
+        full.cost = u.cost.cost;
+        if (u.cost.confidence) full.costConfidence = u.cost.confidence;
+      } else if (typeof u.cost === 'number') {
+        full.cost = u.cost;
+      }
     }
     // ctxUsed is derived from usage at add time; recompute it when usage is
     // enriched or the context bar keeps rendering the poor copy's value (codex

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -378,6 +378,7 @@ function addEntry(e) {
   const tok = e.tokens || {};
   const usage = e.usage || null;
   const turnCost = e.cost?.cost != null ? e.cost.cost : (typeof e.cost === 'number' ? e.cost : null);
+  const costConfidence = e.cost?.confidence || null;
 
   // Session tracking — properly deduplicated by ID
   const entryId = e.id || '';
@@ -646,7 +647,7 @@ function addEntry(e) {
     // #339: beta1m rides the client entry so sessionCtxWindow() + the swimlane lane fold
     // can derive a per-session 1M denominator. Only true carries meaning (monotone OR).
     beta1m: e.beta1m === true,
-    tokens: tok, usage, ts: e.ts, model, maxContext: e.maxContext, cost: turnCost, sessionId: sid,
+    tokens: tok, usage, ts: e.ts, model, maxContext: e.maxContext, cost: turnCost, costConfidence, sessionId: sid,
     severity,
     req: e.req || null, res: e.res || null, reqLoaded: !!(e.req || e.res),
     msgCount, toolCount, toolCalls: e.toolCalls || {}, stopReason,
@@ -965,11 +966,11 @@ function _patchEntryInPlace(u) {
       'duplicateToolCalls', 'toolsHash', 'hasCredential']) {
       if (u[k] != null) full[k] = u[k];
     }
-    // cost arrives as {cost:number} from summarizeEntry; allEntries stores a bare
-    // number — normalize exactly as addEntry does or the workflow cost math (.toFixed)
-    // throws (codex round-1 M3).
+    // cost arrives as {cost, confidence} from summarizeEntry; allEntries stores
+    // bare number + separate costConfidence (codex round-1 M3, #420 Phase 2).
     if (u.cost != null) {
       full.cost = (u.cost && u.cost.cost != null) ? u.cost.cost : (typeof u.cost === 'number' ? u.cost : full.cost);
+      if (u.cost?.confidence) full.costConfidence = u.cost.confidence;
     }
     // ctxUsed is derived from usage at add time; recompute it when usage is
     // enriched or the context bar keeps rendering the poor copy's value (codex

--- a/public/format.js
+++ b/public/format.js
@@ -101,6 +101,23 @@ function fmtMin(ms, base) {
   return h + 'h' + (m ? m + 'm' : '');
 }
 
+// #420 Phase 2: confidence-aware cost formatting.
+// fallback → ~$N.NNNN (estimated); unknown → —; null confidence (legacy) → normal.
+function formatCost(cost, confidence, decimals) {
+  if (confidence === 'unknown' || cost == null) return '—';
+  var d = decimals != null ? decimals : 4;
+  var prefix = confidence === 'fallback' ? '~$' : '$';
+  var title = confidence === 'fallback' ? ' title="使用預設費率，可能不準確"' : '';
+  return '<span' + title + '>' + prefix + cost.toFixed(d) + '</span>';
+}
+
+// Plain-text version (no HTML wrapper) for contexts that build their own markup.
+function formatCostText(cost, confidence, decimals) {
+  if (confidence === 'unknown' || cost == null) return '—';
+  var d = decimals != null ? decimals : 4;
+  return (confidence === 'fallback' ? '~$' : '$') + cost.toFixed(d);
+}
+
 function escapeHtml(s) {
   if (typeof s !== 'string') s = JSON.stringify(s, null, 2);
   return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2539,7 +2539,7 @@ function renderSectionsCol(idx) {
   html += '<div class="ch-line2"><span class="' + statusClass + '">' + e.status + '</span> · 🤖 ' + (e.elapsed || '?') + 's';
   if (stopReason) html += ' · ' + escapeHtml(stopReason);
   if (e.thinkingDuration) html += ' · <span style="color:var(--purple)">🧠 ' + e.thinkingDuration.toFixed(1) + 's</span>';
-  if (turnCost != null) html += ' · <span style="color:var(--yellow)">' + formatCostText(turnCost, e.costConfidence, 2) + '</span>';
+  if (turnCost != null || e.costConfidence === 'unknown') html += ' · <span style="color:var(--yellow)">' + formatCostText(turnCost, e.costConfidence, 2) + '</span>';
   html += '</div>';
   const cacheRead = usage.cache_read_input_tokens || 0;
   const cacheCreate = usage.cache_creation_input_tokens || 0;

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2539,7 +2539,7 @@ function renderSectionsCol(idx) {
   html += '<div class="ch-line2"><span class="' + statusClass + '">' + e.status + '</span> · 🤖 ' + (e.elapsed || '?') + 's';
   if (stopReason) html += ' · ' + escapeHtml(stopReason);
   if (e.thinkingDuration) html += ' · <span style="color:var(--purple)">🧠 ' + e.thinkingDuration.toFixed(1) + 's</span>';
-  if (turnCost != null) html += ' · <span style="color:var(--yellow)">$' + turnCost.toFixed(2) + '</span>';
+  if (turnCost != null) html += ' · <span style="color:var(--yellow)">' + formatCostText(turnCost, e.costConfidence, 2) + '</span>';
   html += '</div>';
   const cacheRead = usage.cache_read_input_tokens || 0;
   const cacheCreate = usage.cache_creation_input_tokens || 0;

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -2587,7 +2587,7 @@ function _wfShowTooltip(e, t, lane) {
     + (ttWeather ? row('Health', ttWeather.emoji + ' ' + (ttWeather.tooltip || ttWeather.level).replace(/\n/g, ' · ')) : '')
     + row('Context', '<span class="' + zoneCls + '">' + pct.toFixed(1) + '%</span> (' + zone + ')')
     + row('Cache', _wfFmtTok(cr) + ' read / ' + _wfFmtTok(cc) + ' write')
-    + row('Cost', '$' + (t.cost || 0).toFixed(4) + outlier)
+    + row('Cost', formatCostText(t.cost || 0, t.costConfidence) + outlier)
     + row('Duration', wfFmtDur((parseFloat(t.elapsed) || 0) * 1000))
     + row('Tokens', _wfFmtTok(inT) + ' in / ' + _wfFmtTok(u.output_tokens || 0) + ' out')
     + (tools ? row('Tools', wfEsc(tools)) : '');
@@ -2940,7 +2940,7 @@ function wfRenderTurnCard(turnEntry) {
 
   // Cost
   html += '<div class="wf-ac-section"><div class="wf-ac-section-title">Cost</div>';
-  html += '<div class="wf-ac-row"><span>Turn</span><span class="wf-ac-val">$' + (turnEntry.cost || 0).toFixed(4) + '</span></div>';
+  html += '<div class="wf-ac-row"><span>Turn</span><span class="wf-ac-val">' + formatCost(turnEntry.cost || 0, turnEntry.costConfidence) + '</span></div>';
   if (turnEntry.stopReason) html += '<div class="wf-ac-row"><span>Stop</span><span class="wf-ac-val">' + wfEsc(turnEntry.stopReason) + '</span></div>';
   html += '</div>';
 
@@ -3044,7 +3044,7 @@ function _wfRenderHoverPreview(turn, lane) {
   var html = '<div class="wf-hover-preview" style="border-left:2px dashed ' + color + '">';
   html += '<div class="wf-hp-title" style="background:' + color + '08">#' + displayNum + '  ' + wfEsc(wfShortModel(turn.model)) + ' · ' + wfFmtDur(dur * 1000) + '</div>';
   html += '<div class="wf-hp-row"><span>Context</span><span style="color:' + cz.hex + '">' + pct.toFixed(1) + '%</span></div>';
-  html += '<div class="wf-hp-row"><span>Cost</span><span>$' + (turn.cost || 0).toFixed(4) + '</span></div>';
+  html += '<div class="wf-hp-row"><span>Cost</span><span>' + formatCostText(turn.cost || 0, turn.costConfidence) + '</span></div>';
   html += '<div class="wf-hp-row"><span>Tokens</span><span>' + _wfFmtSessTok(inTok) + ' in / ' + _wfFmtSessTok(outTok) + ' out</span></div>';
   html += '<div class="wf-hp-lane-ctx">lane $' + laneSummary.totalCost.toFixed(2) + ' · this turn ' + turnShare + '%</div>';
   html += '</div>';
@@ -3069,7 +3069,7 @@ function _wfRenderLaneSummary(lane, section) {
       html += '<tr style="cursor:pointer;border-top:1px solid var(--border)" onclick="wfLockTurn(\'' + t.id + '\');wfSelectSection(\'cost-efficiency\')">';
       html += '<td style="padding:4px 8px;color:var(--dim)">' + (i + 1) + '</td>';
       html += '<td style="padding:4px 8px">' + wfEsc(wfShortModel(t.model)) + '</td>';
-      html += '<td style="padding:4px 8px;text-align:right">$' + (t.cost || 0).toFixed(4) + '</td>';
+      html += '<td style="padding:4px 8px;text-align:right">' + formatCost(t.cost || 0, t.costConfidence) + '</td>';
       html += '<td style="padding:4px 8px;text-align:right">' + (allTok / 1000).toFixed(1) + 'K</td>';
       html += '<td style="padding:4px 8px;text-align:right">' + pct + '</td></tr>';
     }

--- a/test/cost-confidence-ui.test.js
+++ b/test/cost-confidence-ui.test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const vm = require('vm');
+const fs = require('fs');
+const path = require('path');
+
+// Load format.js in a VM context to test browser globals
+function loadFormatModule() {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'format.js'), 'utf8');
+  const ctx = vm.createContext({});
+  vm.runInContext(src, ctx);
+  return ctx;
+}
+
+describe('#420 Phase 2: cost confidence UI', () => {
+  describe('formatCostText', () => {
+    const { formatCostText } = loadFormatModule();
+
+    it('exact confidence → normal $', () => {
+      assert.equal(formatCostText(0.1234, 'exact'), '$0.1234');
+    });
+
+    it('prefix confidence → normal $', () => {
+      assert.equal(formatCostText(0.1234, 'prefix'), '$0.1234');
+    });
+
+    it('fallback confidence → ~$ prefix', () => {
+      assert.equal(formatCostText(0.5678, 'fallback'), '~$0.5678');
+    });
+
+    it('unknown confidence → —', () => {
+      assert.equal(formatCostText(null, 'unknown'), '—');
+    });
+
+    it('null confidence (legacy data) → normal $', () => {
+      assert.equal(formatCostText(0.1234, null), '$0.1234');
+    });
+
+    it('undefined confidence (legacy data) → normal $', () => {
+      assert.equal(formatCostText(0.1234, undefined), '$0.1234');
+    });
+
+    it('respects decimal override', () => {
+      assert.equal(formatCostText(0.1234, 'exact', 2), '$0.12');
+      assert.equal(formatCostText(0.1234, 'fallback', 2), '~$0.12');
+    });
+
+    it('cost null + confidence null → —', () => {
+      assert.equal(formatCostText(null, null), '—');
+    });
+
+    it('cost zero + exact → $0.0000', () => {
+      assert.equal(formatCostText(0, 'exact'), '$0.0000');
+    });
+  });
+
+  describe('formatCost (HTML version)', () => {
+    const { formatCost } = loadFormatModule();
+
+    it('fallback → span with title tooltip', () => {
+      const html = formatCost(0.1234, 'fallback');
+      assert.ok(html.includes('~$0.1234'), 'should have ~$ prefix');
+      assert.ok(html.includes('title='), 'should have title attribute');
+    });
+
+    it('exact → span without title', () => {
+      const html = formatCost(0.1234, 'exact');
+      assert.ok(html.includes('$0.1234'));
+      assert.ok(!html.includes('title='), 'should not have title attribute');
+    });
+
+    it('unknown → — (no span wrapper)', () => {
+      assert.equal(formatCost(null, 'unknown'), '—');
+    });
+  });
+
+  describe('costConfidence extraction (addEntry shape)', () => {
+    // Simulate the extraction logic from entry-rendering.js L380-381
+    function extractCostFields(e) {
+      const turnCost = e.cost?.cost != null ? e.cost.cost : (typeof e.cost === 'number' ? e.cost : null);
+      const costConfidence = e.cost?.confidence || null;
+      return { turnCost, costConfidence };
+    }
+
+    it('extracts cost and confidence from Phase 1 cost object', () => {
+      const e = { cost: { cost: 0.1234, rates: {}, confidence: 'exact' } };
+      const { turnCost, costConfidence } = extractCostFields(e);
+      assert.equal(turnCost, 0.1234);
+      assert.equal(costConfidence, 'exact');
+    });
+
+    it('extracts fallback confidence', () => {
+      const e = { cost: { cost: 0.5678, rates: {}, confidence: 'fallback' } };
+      const { turnCost, costConfidence } = extractCostFields(e);
+      assert.equal(turnCost, 0.5678);
+      assert.equal(costConfidence, 'fallback');
+    });
+
+    it('handles legacy bare-number cost (no confidence)', () => {
+      const e = { cost: 0.1234 };
+      const { turnCost, costConfidence } = extractCostFields(e);
+      assert.equal(turnCost, 0.1234);
+      assert.equal(costConfidence, null);
+    });
+
+    it('handles legacy cost object without confidence field', () => {
+      const e = { cost: { cost: 0.1234 } };
+      const { turnCost, costConfidence } = extractCostFields(e);
+      assert.equal(turnCost, 0.1234);
+      assert.equal(costConfidence, null);
+    });
+
+    it('handles unknown model (null cost)', () => {
+      const e = { cost: { cost: null, confidence: 'unknown' } };
+      const { turnCost, costConfidence } = extractCostFields(e);
+      assert.equal(turnCost, null);
+      assert.equal(costConfidence, 'unknown');
+    });
+  });
+
+  describe('_patchEntryInPlace preserves costConfidence', () => {
+    it('patches costConfidence from cost object', () => {
+      // Simulate the patch logic from entry-rendering.js L971-974
+      const full = { cost: 0.1, costConfidence: null };
+      const u = { cost: { cost: 0.2, confidence: 'fallback' } };
+
+      if (u.cost != null) {
+        full.cost = (u.cost && u.cost.cost != null) ? u.cost.cost : (typeof u.cost === 'number' ? u.cost : full.cost);
+        if (u.cost?.confidence) full.costConfidence = u.cost.confidence;
+      }
+
+      assert.equal(full.cost, 0.2);
+      assert.equal(full.costConfidence, 'fallback');
+    });
+
+    it('does not overwrite costConfidence when update has no confidence', () => {
+      const full = { cost: 0.1, costConfidence: 'exact' };
+      const u = { cost: { cost: 0.2 } };
+
+      if (u.cost != null) {
+        full.cost = (u.cost && u.cost.cost != null) ? u.cost.cost : (typeof u.cost === 'number' ? u.cost : full.cost);
+        if (u.cost?.confidence) full.costConfidence = u.cost.confidence;
+      }
+
+      assert.equal(full.cost, 0.2);
+      assert.equal(full.costConfidence, 'exact');
+    });
+  });
+});

--- a/test/cost-confidence-ui.test.js
+++ b/test/cost-confidence-ui.test.js
@@ -120,32 +120,46 @@ describe('#420 Phase 2: cost confidence UI', () => {
     });
   });
 
-  describe('_patchEntryInPlace preserves costConfidence', () => {
-    it('patches costConfidence from cost object', () => {
-      // Simulate the patch logic from entry-rendering.js L971-974
-      const full = { cost: 0.1, costConfidence: null };
-      const u = { cost: { cost: 0.2, confidence: 'fallback' } };
-
+  describe('_patchEntryInPlace preserves costConfidence (as-a-unit)', () => {
+    // Mirror the real patch logic from entry-rendering.js (fable MINOR-1 fix):
+    // confidence only updates when cost.cost is accepted.
+    function applyPatch(full, u) {
       if (u.cost != null) {
-        full.cost = (u.cost && u.cost.cost != null) ? u.cost.cost : (typeof u.cost === 'number' ? u.cost : full.cost);
-        if (u.cost?.confidence) full.costConfidence = u.cost.confidence;
+        if (u.cost && u.cost.cost != null) {
+          full.cost = u.cost.cost;
+          if (u.cost.confidence) full.costConfidence = u.cost.confidence;
+        } else if (typeof u.cost === 'number') {
+          full.cost = u.cost;
+        }
       }
+    }
 
+    it('patches cost and confidence together', () => {
+      const full = { cost: 0.1, costConfidence: null };
+      applyPatch(full, { cost: { cost: 0.2, confidence: 'fallback' } });
       assert.equal(full.cost, 0.2);
       assert.equal(full.costConfidence, 'fallback');
     });
 
     it('does not overwrite costConfidence when update has no confidence', () => {
       const full = { cost: 0.1, costConfidence: 'exact' };
-      const u = { cost: { cost: 0.2 } };
-
-      if (u.cost != null) {
-        full.cost = (u.cost && u.cost.cost != null) ? u.cost.cost : (typeof u.cost === 'number' ? u.cost : full.cost);
-        if (u.cost?.confidence) full.costConfidence = u.cost.confidence;
-      }
-
+      applyPatch(full, { cost: { cost: 0.2 } });
       assert.equal(full.cost, 0.2);
       assert.equal(full.costConfidence, 'exact');
+    });
+
+    it('null-cost patch does NOT poison existing confidence (fable MINOR-1)', () => {
+      const full = { cost: 0.1234, costConfidence: 'exact' };
+      applyPatch(full, { cost: { cost: null, confidence: 'unknown' } });
+      assert.equal(full.cost, 0.1234, 'cost must not change');
+      assert.equal(full.costConfidence, 'exact', 'confidence must not change');
+    });
+
+    it('bare-number patch preserves existing confidence', () => {
+      const full = { cost: 0.1, costConfidence: 'exact' };
+      applyPatch(full, { cost: 0.2 });
+      assert.equal(full.cost, 0.2);
+      assert.equal(full.costConfidence, 'exact', 'confidence preserved');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Phase 1（PR #421）已讓引擎回傳 confidence level（exact/prefix/fallback/unknown）
- 本 PR 將 confidence 帶到每個 per-turn 成本顯示點
- `fallback` → `~$N.NNNN`（含 tooltip 說明預設費率）
- `unknown` → `—`
- `null`（legacy data）→ 正常顯示，不 poison

## Changes

| File | What |
|------|------|
| `public/format.js` | `formatCost()` (HTML) + `formatCostText()` (plain) helpers |
| `public/entry-rendering.js` | Extract `costConfidence` at addEntry, preserve in `_patchEntryInPlace` |
| `public/miller-columns.js` | Turn list cost display |
| `public/workflow-timeline.js` | Tooltip, turn card, hover preview, cost table rows (4 sites) |

## Not in scope (Phase 3)

- `session-index.js` aggregation
- `cost-budget-ui.js` Usage tab
- Session/project totals confidence propagation
- `renderProjectsCol` dirty-check signature (ADR 0002)

## Test plan

- [x] `CCXRAY_HOME=$(mktemp -d) npm test` — 1701 pass, 0 fail
- [x] `node scripts/verify-rates.js` — 0 mismatch
- [x] `formatCostText` edge cases verified (exact/prefix/fallback/unknown/null/zero)
- [x] Browser smoke: real data dashboard, turn card shows `$0.0808` correctly
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)