### PR TITLE
chore(pricing): review follow-ups for #420 Phase 2

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2539,6 +2539,7 @@ function renderSectionsCol(idx) {
   html += '<div class="ch-line2"><span class="' + statusClass + '">' + e.status + '</span> · 🤖 ' + (e.elapsed || '?') + 's';
   if (stopReason) html += ' · ' + escapeHtml(stopReason);
   if (e.thinkingDuration) html += ' · <span style="color:var(--purple)">🧠 ' + e.thinkingDuration.toFixed(1) + 's</span>';
+  // INVARIANT(#420): per-turn cost must use formatCost/formatCostText(cost, confidence) — 5 sites across 3 files
   if (turnCost != null || e.costConfidence === 'unknown') html += ' · <span style="color:var(--yellow)">' + formatCostText(turnCost, e.costConfidence, 2) + '</span>';
   html += '</div>';
   const cacheRead = usage.cache_read_input_tokens || 0;

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -2587,6 +2587,7 @@ function _wfShowTooltip(e, t, lane) {
     + (ttWeather ? row('Health', ttWeather.emoji + ' ' + (ttWeather.tooltip || ttWeather.level).replace(/\n/g, ' · ')) : '')
     + row('Context', '<span class="' + zoneCls + '">' + pct.toFixed(1) + '%</span> (' + zone + ')')
     + row('Cache', _wfFmtTok(cr) + ' read / ' + _wfFmtTok(cc) + ' write')
+    // INVARIANT(#420): per-turn cost must use formatCost/formatCostText(cost, confidence)
     + row('Cost', formatCostText(t.cost || 0, t.costConfidence) + outlier)
     + row('Duration', wfFmtDur((parseFloat(t.elapsed) || 0) * 1000))
     + row('Tokens', _wfFmtTok(inT) + ' in / ' + _wfFmtTok(u.output_tokens || 0) + ' out')
@@ -2938,7 +2939,7 @@ function wfRenderTurnCard(turnEntry) {
   if (cacheCreate) html += '<div class="wf-ac-row"><span>New</span><span class="wf-ac-val">' + _wfFmtSessTok(cacheCreate) + '</span></div>';
   html += '</div>';
 
-  // Cost
+  // Cost — INVARIANT(#420): per-turn cost must use formatCost/formatCostText(cost, confidence)
   html += '<div class="wf-ac-section"><div class="wf-ac-section-title">Cost</div>';
   html += '<div class="wf-ac-row"><span>Turn</span><span class="wf-ac-val">' + formatCost(turnEntry.cost || 0, turnEntry.costConfidence) + '</span></div>';
   if (turnEntry.stopReason) html += '<div class="wf-ac-row"><span>Stop</span><span class="wf-ac-val">' + wfEsc(turnEntry.stopReason) + '</span></div>';
@@ -3044,6 +3045,7 @@ function _wfRenderHoverPreview(turn, lane) {
   var html = '<div class="wf-hover-preview" style="border-left:2px dashed ' + color + '">';
   html += '<div class="wf-hp-title" style="background:' + color + '08">#' + displayNum + '  ' + wfEsc(wfShortModel(turn.model)) + ' · ' + wfFmtDur(dur * 1000) + '</div>';
   html += '<div class="wf-hp-row"><span>Context</span><span style="color:' + cz.hex + '">' + pct.toFixed(1) + '%</span></div>';
+  // INVARIANT(#420): per-turn cost must use formatCost/formatCostText(cost, confidence)
   html += '<div class="wf-hp-row"><span>Cost</span><span>' + formatCostText(turn.cost || 0, turn.costConfidence) + '</span></div>';
   html += '<div class="wf-hp-row"><span>Tokens</span><span>' + _wfFmtSessTok(inTok) + ' in / ' + _wfFmtSessTok(outTok) + ' out</span></div>';
   html += '<div class="wf-hp-lane-ctx">lane $' + laneSummary.totalCost.toFixed(2) + ' · this turn ' + turnShare + '%</div>';
@@ -3069,6 +3071,7 @@ function _wfRenderLaneSummary(lane, section) {
       html += '<tr style="cursor:pointer;border-top:1px solid var(--border)" onclick="wfLockTurn(\'' + t.id + '\');wfSelectSection(\'cost-efficiency\')">';
       html += '<td style="padding:4px 8px;color:var(--dim)">' + (i + 1) + '</td>';
       html += '<td style="padding:4px 8px">' + wfEsc(wfShortModel(t.model)) + '</td>';
+      // INVARIANT(#420): per-turn cost must use formatCost/formatCostText(cost, confidence)
       html += '<td style="padding:4px 8px;text-align:right">' + formatCost(t.cost || 0, t.costConfidence) + '</td>';
       html += '<td style="padding:4px 8px;text-align:right">' + (allTok / 1000).toFixed(1) + 'K</td>';
       html += '<td style="padding:4px 8px;text-align:right">' + pct + '</td></tr>';

--- a/server/forward.js
+++ b/server/forward.js
@@ -701,9 +701,11 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
         const hitRate = (usage.cache_read_input_tokens / totalCtx * 100).toFixed(0);
         text += ' | Cache ' + hitRate + '% hit';
       }
-      // INVARIANT(#420): per-turn cost uses confidence-aware prefix
+      // INVARIANT(#420): per-turn cost display. calculateCost (live path)
+      // returns exact/prefix/unknown — never 'fallback' (that's calculateCostSimple
+      // in cost-worker). Both exact and prefix show plain $ per #420 design table.
       if (costInfo?.cost != null) {
-        text += ' | ' + (costInfo.confidence === 'fallback' ? '~$' : '$') + costInfo.cost.toFixed(4);
+        text += ' | $' + costInfo.cost.toFixed(4);
       }
       // #142: align advice bands to the unified colour thresholds (80/40).
       if (Number(pct) > helpers.CTX_RED_PCT) {

--- a/server/forward.js
+++ b/server/forward.js
@@ -701,8 +701,9 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
         const hitRate = (usage.cache_read_input_tokens / totalCtx * 100).toFixed(0);
         text += ' | Cache ' + hitRate + '% hit';
       }
+      // INVARIANT(#420): per-turn cost uses confidence-aware prefix
       if (costInfo?.cost != null) {
-        text += ' | $' + costInfo.cost.toFixed(4);
+        text += ' | ' + (costInfo.confidence === 'fallback' ? '~$' : '$') + costInfo.cost.toFixed(4);
       }
       // #142: align advice bands to the unified colour thresholds (80/40).
       if (Number(pct) > helpers.CTX_RED_PCT) {

--- a/test/cost-confidence-ui.test.js
+++ b/test/cost-confidence-ui.test.js
@@ -14,6 +14,83 @@ function loadFormatModule() {
   return ctx;
 }
 
+// Reuse the retry-grouping.test.js VM harness pattern — loads the real
+// entry-rendering.js so addEntry / _patchEntryInPlace are the shipped code.
+function loadDashboardContext() {
+  const publicDir = path.join(__dirname, '..', 'public');
+  function el() {
+    return {
+      style: {}, dataset: {}, innerHTML: '', textContent: '',
+      classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+      addEventListener() {}, appendChild() {}, insertBefore() {},
+      insertAdjacentHTML() {},
+      querySelector: () => el(), querySelectorAll: () => [],
+      remove() {},
+    };
+  }
+  const context = {
+    console, window: {},
+    document: {
+      getElementById: () => el(), createElement: () => el(),
+      querySelector: () => el(), querySelectorAll: () => [],
+      addEventListener() {}, body: el(),
+    },
+    localStorage: { getItem: () => null, setItem() {} },
+    sessionStorage: { getItem: () => null, setItem() {} },
+    navigator: {}, location: { search: '', hash: '' }, history: { replaceState() {} },
+    URLSearchParams, setTimeout, clearTimeout,
+  };
+  vm.createContext(context);
+  vm.runInContext(`
+    function updateSysPromptBadge() {}
+    function startQuotaTicker() {}
+    function EventSource() { this.onmessage = null; }
+    function setInterval() { return 0; }
+    function clearInterval() {}
+    window.ccxraySettings = { visibleProviders: [] };
+    function _apiQ(url) { return url; }
+    function fetch() { return Promise.resolve({ ok: false, json() { return Promise.resolve({}); } }); }
+    var wfState = { sessionId: null, mainCoreHash: null, mainConvIds: new Set() };
+    function wfBuildState() {}
+    function renderNotifyButton() {}
+    function prepareTimelineSteps() {}
+    function requestAnimationFrame(cb) { cb(); }
+    function renderProjectsCol() {}
+    function renderSessionsCol() {}
+    var currentSteps = [];
+    var selectedEntryId = null;
+    function layoutMinimapBlocks() {}
+    function initMinimapInteractions() {}
+    function renderSectionsCol() {}
+    function ResizeObserver() { this.observe = function(){}; this.disconnect = function(){}; }
+    function wfAddEntry() { return { lanesChanged: false }; }
+    function wfRenderTimeline() {}
+    function wfDeferRender() {}
+  `, context);
+  for (const f of ['format.js', 'session-label.js', 'miller-columns.js', 'entry-rendering.js']) {
+    vm.runInContext(fs.readFileSync(path.join(publicDir, f), 'utf8'), context);
+  }
+  vm.runInContext(`
+    this.allEntries = allEntries;
+    this.sessionsMap = sessionsMap;
+    this.addEntry = addEntry;
+    this._patchEntryInPlace = _patchEntryInPlace;
+    _loading = true;
+  `, context);
+  return context;
+}
+
+function makeEntry(overrides) {
+  return {
+    id: '2026-08-02T10-00-00-000', ts: '10:00:00', model: 'claude-opus-4-6',
+    status: 200, elapsed: '5.0', method: 'POST', sessionId: 'sess-conf-test',
+    usage: { input_tokens: 5000, output_tokens: 200, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+    maxContext: 200000, isSubagent: false, sessionInferred: false,
+    toolCalls: {}, provider: 'anthropic', receivedAt: Date.now(),
+    ...overrides,
+  };
+}
+
 describe('#420 Phase 2: cost confidence UI', () => {
   describe('formatCostText', () => {
     const { formatCostText } = loadFormatModule();
@@ -76,90 +153,66 @@ describe('#420 Phase 2: cost confidence UI', () => {
     });
   });
 
-  describe('costConfidence extraction (addEntry shape)', () => {
-    // Simulate the extraction logic from entry-rendering.js L380-381
-    function extractCostFields(e) {
-      const turnCost = e.cost?.cost != null ? e.cost.cost : (typeof e.cost === 'number' ? e.cost : null);
-      const costConfidence = e.cost?.confidence || null;
-      return { turnCost, costConfidence };
-    }
-
-    it('extracts cost and confidence from Phase 1 cost object', () => {
-      const e = { cost: { cost: 0.1234, rates: {}, confidence: 'exact' } };
-      const { turnCost, costConfidence } = extractCostFields(e);
-      assert.equal(turnCost, 0.1234);
-      assert.equal(costConfidence, 'exact');
+  describe('addEntry extracts costConfidence from real code', () => {
+    it('exact confidence stored on allEntries entry', () => {
+      const ctx = loadDashboardContext();
+      ctx.addEntry(makeEntry({ cost: { cost: 0.1234, rates: {}, confidence: 'exact' } }));
+      const e = ctx.allEntries[ctx.allEntries.length - 1];
+      assert.equal(e.cost, 0.1234);
+      assert.equal(e.costConfidence, 'exact');
     });
 
-    it('extracts fallback confidence', () => {
-      const e = { cost: { cost: 0.5678, rates: {}, confidence: 'fallback' } };
-      const { turnCost, costConfidence } = extractCostFields(e);
-      assert.equal(turnCost, 0.5678);
-      assert.equal(costConfidence, 'fallback');
+    it('fallback confidence stored on allEntries entry', () => {
+      const ctx = loadDashboardContext();
+      ctx.addEntry(makeEntry({ cost: { cost: 0.5678, rates: {}, confidence: 'fallback' } }));
+      const e = ctx.allEntries[ctx.allEntries.length - 1];
+      assert.equal(e.cost, 0.5678);
+      assert.equal(e.costConfidence, 'fallback');
     });
 
-    it('handles legacy bare-number cost (no confidence)', () => {
-      const e = { cost: 0.1234 };
-      const { turnCost, costConfidence } = extractCostFields(e);
-      assert.equal(turnCost, 0.1234);
-      assert.equal(costConfidence, null);
+    it('legacy bare-number cost → costConfidence null', () => {
+      const ctx = loadDashboardContext();
+      ctx.addEntry(makeEntry({ cost: 0.1234 }));
+      const e = ctx.allEntries[ctx.allEntries.length - 1];
+      assert.equal(e.cost, 0.1234);
+      assert.equal(e.costConfidence, null);
     });
 
-    it('handles legacy cost object without confidence field', () => {
-      const e = { cost: { cost: 0.1234 } };
-      const { turnCost, costConfidence } = extractCostFields(e);
-      assert.equal(turnCost, 0.1234);
-      assert.equal(costConfidence, null);
-    });
-
-    it('handles unknown model (null cost)', () => {
-      const e = { cost: { cost: null, confidence: 'unknown' } };
-      const { turnCost, costConfidence } = extractCostFields(e);
-      assert.equal(turnCost, null);
-      assert.equal(costConfidence, 'unknown');
+    it('unknown confidence with null cost', () => {
+      const ctx = loadDashboardContext();
+      ctx.addEntry(makeEntry({ cost: { cost: null, confidence: 'unknown' } }));
+      const e = ctx.allEntries[ctx.allEntries.length - 1];
+      assert.equal(e.cost, null);
+      assert.equal(e.costConfidence, 'unknown');
     });
   });
 
-  describe('_patchEntryInPlace preserves costConfidence (as-a-unit)', () => {
-    // Mirror the real patch logic from entry-rendering.js (fable MINOR-1 fix):
-    // confidence only updates when cost.cost is accepted.
-    function applyPatch(full, u) {
-      if (u.cost != null) {
-        if (u.cost && u.cost.cost != null) {
-          full.cost = u.cost.cost;
-          if (u.cost.confidence) full.costConfidence = u.cost.confidence;
-        } else if (typeof u.cost === 'number') {
-          full.cost = u.cost;
-        }
-      }
-    }
-
+  describe('_patchEntryInPlace preserves costConfidence (as-a-unit, real code)', () => {
     it('patches cost and confidence together', () => {
-      const full = { cost: 0.1, costConfidence: null };
-      applyPatch(full, { cost: { cost: 0.2, confidence: 'fallback' } });
-      assert.equal(full.cost, 0.2);
-      assert.equal(full.costConfidence, 'fallback');
-    });
-
-    it('does not overwrite costConfidence when update has no confidence', () => {
-      const full = { cost: 0.1, costConfidence: 'exact' };
-      applyPatch(full, { cost: { cost: 0.2 } });
-      assert.equal(full.cost, 0.2);
-      assert.equal(full.costConfidence, 'exact');
+      const ctx = loadDashboardContext();
+      ctx.addEntry(makeEntry({ id: 'patch-test-1', cost: { cost: 0.1, confidence: 'exact' } }));
+      ctx._patchEntryInPlace({ id: 'patch-test-1', cost: { cost: 0.2, confidence: 'fallback' } });
+      const e = ctx.allEntries.find(x => x.id === 'patch-test-1');
+      assert.equal(e.cost, 0.2);
+      assert.equal(e.costConfidence, 'fallback');
     });
 
     it('null-cost patch does NOT poison existing confidence (fable MINOR-1)', () => {
-      const full = { cost: 0.1234, costConfidence: 'exact' };
-      applyPatch(full, { cost: { cost: null, confidence: 'unknown' } });
-      assert.equal(full.cost, 0.1234, 'cost must not change');
-      assert.equal(full.costConfidence, 'exact', 'confidence must not change');
+      const ctx = loadDashboardContext();
+      ctx.addEntry(makeEntry({ id: 'patch-test-2', cost: { cost: 0.1234, confidence: 'exact' } }));
+      ctx._patchEntryInPlace({ id: 'patch-test-2', cost: { cost: null, confidence: 'unknown' } });
+      const e = ctx.allEntries.find(x => x.id === 'patch-test-2');
+      assert.equal(e.cost, 0.1234, 'cost must not change');
+      assert.equal(e.costConfidence, 'exact', 'confidence must not change');
     });
 
     it('bare-number patch preserves existing confidence', () => {
-      const full = { cost: 0.1, costConfidence: 'exact' };
-      applyPatch(full, { cost: 0.2 });
-      assert.equal(full.cost, 0.2);
-      assert.equal(full.costConfidence, 'exact', 'confidence preserved');
+      const ctx = loadDashboardContext();
+      ctx.addEntry(makeEntry({ id: 'patch-test-3', cost: { cost: 0.1, confidence: 'exact' } }));
+      ctx._patchEntryInPlace({ id: 'patch-test-3', cost: 0.2 });
+      const e = ctx.allEntries.find(x => x.id === 'patch-test-3');
+      assert.equal(e.cost, 0.2);
+      assert.equal(e.costConfidence, 'exact', 'confidence preserved');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Codex/Fable review 的三個 follow-up 一次收完
- 測試從 inline copy 改為 VM harness 載入真實程式碼（注入 bug 確認 5/19 紅）

## Changes

| Item | Source | What |
|------|--------|------|
| INVARIANT guard comments | codex MINOR | 5 display sites + forward.js 共 6 處 |
| forward.js HUD `~$` prefix | fable NIT-2 | statusline cost 也走 confidence |
| VM harness rewrite | codex MAJOR | 不再測 inline copy，測真實 addEntry/_patchEntryInPlace |

## Test plan

- [x] 1720 tests pass
- [x] 注入 bug（`costConfidence = null`）→ 5/19 fail，證明 VM harness 有效

🤖 Generated with [Claude Code](https://claude.com/claude-code)