### PR TITLE
fix(dashboard): session duration off by ±8h when proxy + importer entries mix (#426)

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -397,7 +397,7 @@ function addEntry(e) {
   const entryCwd = e.cwd || null;
   if (!sessionsMap.has(sid)) {
     const shortSid = sid.slice(0, 8);
-    sessionsMap.set(sid, { id: sid, firstTs: e.ts, firstId: entryId, lastId: entryId, count: 0, mainCount: 0, subCount: 0, retryCount: 0, model, totalCost: 0, fallbackCost: 0, fallbackCount: 0, unknownCount: 0, cwd: entryCwd, title: null, titleReqTs: 0, lastAssistantText: null, agent: e.agent || 'claude', provider: e.provider || 'anthropic', latestCacheHitRatio: 0, latestCacheReadTokens: 0, resumeCommand: null, parentSessionId: e.parentSessionId || null });
+    sessionsMap.set(sid, { id: sid, firstTs: e.ts, firstId: entryId, lastId: entryId, count: 0, mainCount: 0, subCount: 0, retryCount: 0, model, totalCost: 0, fallbackCost: 0, fallbackCount: 0, unknownCount: 0, cwd: entryCwd, title: null, titleReqTs: 0, lastAssistantText: null, agent: e.agent || 'claude', provider: e.provider || 'anthropic', latestCacheHitRatio: 0, latestCacheReadTokens: 0, resumeCommand: null, parentSessionId: e.parentSessionId || null, firstReceivedAt: 0 });
     // Live-update visibleProviders when a new provider appears
     const settings = window.ccxraySettings;
     if (!Array.isArray(settings.visibleProviders)) settings.visibleProviders = [];
@@ -454,7 +454,12 @@ function addEntry(e) {
   if (model && model !== '?') sess.model = model;
   if (e.firstPrompt && !sess.firstPrompt) sess.firstPrompt = e.firstPrompt;
   sess.lastId = entryId;
-  if (e.receivedAt) sess.lastReceivedAt = Number(e.receivedAt);
+  // #426: min-fold for duration (finite-positive guard — receivedAt can be null/0)
+  if (e.receivedAt) {
+    var ra = Number(e.receivedAt);
+    if (ra > 0 && (!sess.firstReceivedAt || ra < sess.firstReceivedAt)) sess.firstReceivedAt = ra;
+    sess.lastReceivedAt = ra;
+  }
   // Prefer the server-detected agent identity (from system-prompt content,
   // via agentKey) over the raw isSubagent flag when available — codex review:
   // isAnthropicSubagent() in store.js classifies by !cwd && !session_id, but
@@ -896,6 +901,12 @@ function mergeColdSessions(sessions) {
         existing.maxContext = s.maxContext;
         windowWidened = true;
       }
+      // #426: firstReceivedAt is a monotone min-fold (can only move earlier).
+      // Same exemption as beta1m/maxContext: the server fold covers the whole
+      // session; a hot session truncated by RESTORE_DAYS may lack early entries.
+      if (s.firstReceivedAt > 0 && (!existing.firstReceivedAt || s.firstReceivedAt < existing.firstReceivedAt)) {
+        existing.firstReceivedAt = s.firstReceivedAt;
+      }
       if (windowWidened) widenedSessionIds.add(s.sid);
       // #367: merge cold derived fields ONLY when the hot session truly lacks them.
       // Hot sessions compute these from entries — never overwrite with cold fallbacks.
@@ -918,6 +929,7 @@ function mergeColdSessions(sessions) {
       latestCacheReadTokens: s.latestCacheReadTokens || 0,
       cacheBreaks: s.cacheBreaks || 0,
       resumeCommand: null, parentSessionId: null,
+      firstReceivedAt: s.firstReceivedAt || 0,
       lastReceivedAt: s.lastReceivedAt || 0, _cold: true,
       weather: s.weather || null,
     });

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1453,20 +1453,17 @@ function renderSessionItem(sess, sid, sessEl) {
   const costStr = sess.totalCost > 0 ? formatAggCost(sess.totalCost, sess, 2) : '—';
   const dateStr = sess.lastId ? formatRelativeTime(sess.lastId) : (sess.firstId ? formatEntryDate(sess.firstId) : escapeHtml(sess.firstTs || ''));
 
-  // Duration: from firstId to lastReceivedAt (or now if ongoing)
+  // #426: duration from epoch-ms fields, never parsed from entry ID (timezone-safe)
   let durationStr = '';
-  if (sess.firstId && sess.firstId.length >= 19) {
-    const startTs = new Date(sess.firstId.slice(0, 10) + 'T' + sess.firstId.slice(11, 19).replace(/-/g, ':')).getTime();
-    if (!isNaN(startTs)) {
-      const endTs = sess.lastReceivedAt ? Number(sess.lastReceivedAt) : Date.now();
-      const durationMs = endTs - startTs;
-      if (durationMs >= 86400000) { // >= 24h
-        durationStr = (durationMs / 86400000).toFixed(1) + 'd';
-      } else if (durationMs >= 3600000) { // >= 1h
-        durationStr = (durationMs / 3600000).toFixed(1) + 'h';
-      } else if (durationMs >= 60000) { // >= 1m
-        durationStr = Math.floor(durationMs / 60000) + 'm';
-      }
+  if (sess.firstReceivedAt > 0) {
+    const endTs = sess.lastReceivedAt ? Number(sess.lastReceivedAt) : Date.now();
+    const durationMs = endTs - sess.firstReceivedAt;
+    if (durationMs >= 86400000) {
+      durationStr = (durationMs / 86400000).toFixed(1) + 'd';
+    } else if (durationMs >= 3600000) {
+      durationStr = (durationMs / 3600000).toFixed(1) + 'h';
+    } else if (durationMs >= 60000) {
+      durationStr = Math.floor(durationMs / 60000) + 'm';
     }
   }
 

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -2864,7 +2864,8 @@ function wfRenderAgentCard(lane) {
   }
 
   if (sess) {
-    var startMs = _wfParseIdMs(sess.firstId);
+    // #426: use epoch-ms field, never parse entry ID (timezone-safe)
+    var startMs = sess.firstReceivedAt > 0 ? sess.firstReceivedAt : null;
     var durationMs = (startMs != null && sess.lastReceivedAt) ? (sess.lastReceivedAt - startMs) : null;
     var activeMs = durationMs != null ? Math.max(0, durationMs - (sess.idleMs || 0)) : null;
     html += '<div class="wf-ac-section"><div class="wf-ac-section-title">Time</div>';

--- a/server/session-index.js
+++ b/server/session-index.js
@@ -58,12 +58,12 @@ async function loadSessionIndex() {
         if (s && s.sid) sessionIndex.set(s.sid, s);
       } catch {}
     }
-    // #368/#420: force rebuild when sessions.json predates maxContext or the
-    // aggregate cost-confidence fold. After rebuild, _upsert repopulates both
-    // from index.ndjson entries.
+    // #368/#420/#426: force rebuild when sessions.json predates maxContext,
+    // the aggregate cost-confidence fold, or firstReceivedAt. After rebuild,
+    // _upsert repopulates all from index.ndjson entries.
     let needsMigration = false;
     for (const s of sessionIndex.values()) {
-      if (s.count > 0 && (s.maxContext === undefined || s.fallbackCount === undefined)) { needsMigration = true; break; }
+      if (s.count > 0 && (s.maxContext === undefined || s.fallbackCount === undefined || s.firstReceivedAt === undefined)) { needsMigration = true; break; }
     }
     if (needsMigration) {
       console.log('\x1b[33m[session-index] schema migration (maxContext/aggregate cost confidence) — will rebuild\x1b[0m');
@@ -290,7 +290,7 @@ function _upsert(sid, entry) {
   if (!s) {
     // INVARIANT(#420/ADR 0017): session aggregate confidence is folded beside
     // totalCost/count so every persisted session can render the same view.
-    s = { sid, firstId: null, lastId: null, count: 0, model: null, cwd: null, totalCost: 0, fallbackCost: 0, fallbackCount: 0, unknownCount: 0, title: null, firstPrompt: null, lastReceivedAt: 0, provider: null, agent: null };
+    s = { sid, firstId: null, lastId: null, count: 0, model: null, cwd: null, totalCost: 0, fallbackCost: 0, fallbackCount: 0, unknownCount: 0, title: null, firstPrompt: null, firstReceivedAt: 0, lastReceivedAt: 0, provider: null, agent: null };
     sessionIndex.set(sid, s);
   }
   // #333: bump COUNT once per responseId so the session card shows merged turns,
@@ -376,6 +376,9 @@ function _upsert(sid, entry) {
     s.title = getSessionTitle(sid) || (entry.title ? stripInjectedTags(entry.title) : null) || null;
   }
   const recvAt = entry.receivedAt || 0;
+  // #426: min-fold for duration — finite-positive guard because rebuild-index
+  // emits receivedAt:null for orphan lines (Number(null)===0 would poison to 1970).
+  if (recvAt > 0 && (!s.firstReceivedAt || recvAt < s.firstReceivedAt)) s.firstReceivedAt = recvAt;
   if (recvAt > (s.lastReceivedAt || 0)) s.lastReceivedAt = recvAt;
   if (entry.provider) s.provider = entry.provider;
   if (entry.agent) s.agent = entry.agent;

--- a/test/duration-epoch.test.js
+++ b/test/duration-epoch.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const os = require('os');
+
+describe('#426 duration: firstReceivedAt epoch-ms min-fold', () => {
+  let tmpDir, origLogsDir, origCcxrayHome;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'ccxray-dur-'));
+    await fsp.mkdir(path.join(tmpDir, 'logs'), { recursive: true });
+    origCcxrayHome = process.env.CCXRAY_HOME;
+    process.env.CCXRAY_HOME = tmpDir;
+    const config = require('../server/config');
+    origLogsDir = config.LOGS_DIR;
+    Object.defineProperty(config, 'LOGS_DIR', { value: path.join(tmpDir, 'logs'), writable: true, configurable: true });
+  });
+
+  afterEach(async () => {
+    const config = require('../server/config');
+    Object.defineProperty(config, 'LOGS_DIR', { value: origLogsDir, writable: true, configurable: true });
+    if (origCcxrayHome === undefined) delete process.env.CCXRAY_HOME;
+    else process.env.CCXRAY_HOME = origCcxrayHome;
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+    delete require.cache[require.resolve('../server/session-index')];
+  });
+
+  it('_upsert tracks firstReceivedAt as min of positive receivedAt values', () => {
+    const si = require('../server/session-index');
+    si.updateFromEntry({ sessionId: 's1', id: 'a', receivedAt: 1000 });
+    si.updateFromEntry({ sessionId: 's1', id: 'b', receivedAt: 500 });
+    si.updateFromEntry({ sessionId: 's1', id: 'c', receivedAt: 2000 });
+    const s = si.get('s1');
+    assert.equal(s.firstReceivedAt, 500, 'should be the minimum');
+    assert.equal(s.lastReceivedAt, 2000, 'should be the maximum');
+  });
+
+  it('null/zero receivedAt does not poison firstReceivedAt', () => {
+    const si = require('../server/session-index');
+    si.updateFromEntry({ sessionId: 's1', id: 'a', receivedAt: null });
+    si.updateFromEntry({ sessionId: 's1', id: 'b', receivedAt: 0 });
+    si.updateFromEntry({ sessionId: 's1', id: 'c', receivedAt: 1000 });
+    const s = si.get('s1');
+    assert.equal(s.firstReceivedAt, 1000, 'null/zero must not set firstReceivedAt');
+  });
+
+  it('schema migration forces rebuild when firstReceivedAt is missing', async () => {
+    const config = require('../server/config');
+    const logsDir = path.join(tmpDir, 'logs');
+    // Write a sessions.json missing firstReceivedAt but having maxContext + fallbackCount
+    const old = { sid: 's1', firstId: 'x', lastId: 'y', count: 1, model: 'm', cwd: '/', totalCost: 0, fallbackCost: 0, fallbackCount: 0, unknownCount: 0, title: null, firstPrompt: null, lastReceivedAt: 0, provider: 'anthropic', agent: 'claude', maxContext: 200000 };
+    await fsp.writeFile(path.join(logsDir, 'sessions.json'), JSON.stringify(old) + '\n');
+    // Make sessions.json newer than index so the stale check doesn't interfere
+    const indexPath = path.join(logsDir, 'index.ndjson');
+    await fsp.writeFile(indexPath, '');
+    const now = new Date();
+    await fsp.utimes(indexPath, now, new Date(now.getTime() - 10000));
+    const si = require('../server/session-index');
+    const loaded = await si.loadSessionIndex();
+    assert.equal(loaded, false, 'should reject sessions.json missing firstReceivedAt');
+  });
+
+  it('rebuild from index lines populates firstReceivedAt', () => {
+    const si = require('../server/session-index');
+    const metas = [
+      { sessionId: 's1', id: 'a', receivedAt: 3000, model: 'm' },
+      { sessionId: 's1', id: 'b', receivedAt: 1000, model: 'm' },
+      { sessionId: 's1', id: 'c', receivedAt: 5000, model: 'm' },
+    ];
+    si.rebuildFromMetas(metas);
+    const s = si.get('s1');
+    assert.equal(s.firstReceivedAt, 1000);
+    assert.equal(s.lastReceivedAt, 5000);
+  });
+
+  it('mixed proxy+importer IDs: duration comes from epoch, not ID parsing', () => {
+    const si = require('../server/session-index');
+    // Simulate: importer entry (UTC id, earlier lexicographically) and proxy entry (Taipei id)
+    // Same real moment: 2026-08-02T14:31:57 UTC = 2026-08-02T22:31:57 Taipei
+    const importerEntry = {
+      sessionId: 's1',
+      id: '2026-08-02T14-31-57-24',  // UTC format (importer)
+      receivedAt: 1722608117024,       // the real epoch ms
+      model: 'm',
+    };
+    const proxyEntry = {
+      sessionId: 's1',
+      id: '2026-08-02T22-31-57-822',  // Taipei format (proxy)
+      receivedAt: 1722608117822,        // ~800ms later (same real moment)
+      model: 'm',
+    };
+    const laterEntry = {
+      sessionId: 's1',
+      id: '2026-08-03T02-26-21-750',
+      receivedAt: 1722622381750,
+      model: 'm',
+    };
+    si.updateFromEntry(importerEntry);
+    si.updateFromEntry(proxyEntry);
+    si.updateFromEntry(laterEntry);
+    const s = si.get('s1');
+    // Duration from epoch: ~3.96h, not ~11.9h (the 8h-offset bug)
+    const durationH = (s.lastReceivedAt - s.firstReceivedAt) / 3600000;
+    assert.ok(durationH < 5, `duration ${durationH.toFixed(2)}h should be <5h, not ~12h`);
+    assert.ok(durationH > 0, 'duration should be positive');
+    // firstId is still the lexicographic min (importer wins) — preserved for display
+    assert.equal(s.firstId, '2026-08-02T14-31-57-24');
+  });
+
+  it('firstReceivedAt persists through flush (no underscore prefix)', async () => {
+    const si = require('../server/session-index');
+    si.updateFromEntry({ sessionId: 's1', id: 'a', receivedAt: 42000 });
+    await si.flush();
+    const config = require('../server/config');
+    const raw = await fsp.readFile(path.join(config.LOGS_DIR, 'sessions.json'), 'utf8');
+    const obj = JSON.parse(raw.trim());
+    assert.equal(obj.firstReceivedAt, 42000, 'firstReceivedAt must be in persisted JSON');
+  });
+});


### PR DESCRIPTION
## 摘要

- duration 改由 epoch-ms 欄位 (`firstReceivedAt` min-fold / `lastReceivedAt` max-fold) 計算，不再解析 entry ID 字串
- entry ID 的時區因來源而異（proxy=Asia/Taipei，importer=UTC），解析為 local time 會產生 ±UTC-offset 偏差
- `firstId`/`lastId` 保留（顯示日期 + 識別用途）

## Detail

**Server** (`server/session-index.js`):
- `_upsert`: add `firstReceivedAt` min-fold with finite-positive guard (rebuild-index emits `receivedAt:null` for orphan lines; `Number(null)===0` would poison to 1970)
- Schema migration: force rebuild when `firstReceivedAt` missing (same pattern as #368/#420)

**Client** (`public/entry-rendering.js`):
- `addEntry`: min-fold on `firstReceivedAt`
- `mergeColdSessions`: monotone min-merge for hot sessions (same ADR 0013 exemption as `beta1m`/`maxContext`); copy field for new cold sessions

**UI** (2 sites):
- `public/miller-columns.js`: duration reads `sess.firstReceivedAt` instead of parsing `firstId`
- `public/workflow-timeline.js`: agent card duration reads `sess.firstReceivedAt` instead of `_wfParseIdMs(sess.firstId)`

## 驗證

差異檢查（`docs/verification-principles.md`）：
- 舊碼 (566c11e): 6/6 FAIL
- 新碼: 6/6 PASS
- 全套 1747 tests pass (`CCXRAY_HOME=$(mktemp -d) npm test`)

真實資料：
| session | 類型 | before | after |
|---|---|---|---|
| 019fc1b1 | 純 importer | ~8.10h | 0.10h |
| 4e5e7a57 | 混合 | ~11.91h | 3.91h |
| 純 proxy | guard | 不變 | 不變 |

瀏覽器驗證（browser-harness）：session card + workflow timeline agent card 皆顯示修正後數值。

## 範圍外（刻意不修）

- `formatEntryDate(firstId)` 的 Started / 相對日期顯示有同樣的時區問題 → 另開票
- #427 / #428 不在本票範圍

🤖 Generated with [Claude Code](https://claude.com/claude-code)