### PR TITLE
fix(importer): aggregate by message.id — one entry per API response (#428)

### DIFF
--- a/server/importer.js
+++ b/server/importer.js
@@ -117,10 +117,14 @@ function buildTokens(usage, contextWindow = DEFAULT_CONTEXT_WINDOW) {
 }
 
 async function parseSessionFile(filePath, projectSlug) {
-  const entries = [];
   const sessionId = path.basename(filePath, '.jsonl');
   let lastUserText = null;
   let cwd = null;
+  // #428: aggregate by message.id — Claude Code writes multiple assistant lines
+  // per API response (one per content block), each with a different timestamp.
+  // Key = msg.id; value = entry object. Last-seen line wins (richest usage).
+  // Lines without msg.id pass through keyed by their timestamp-derived id.
+  const byResponseId = new Map();
 
   const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
@@ -157,9 +161,13 @@ async function parseSessionFile(filePath, projectSlug) {
     const tokens = buildTokens(usage);
     const receivedAt = new Date(obj.timestamp).getTime();
 
-    entries.push({
-      id,
-      ts: obj.timestamp,
+    const responseId = msg.id || null;
+    const dedupKey = responseId || id;
+    const prev = byResponseId.get(dedupKey);
+
+    const entry = {
+      id: prev ? prev.id : id,
+      ts: prev ? prev.ts : obj.timestamp,
       method: 'POST',
       url: '/v1/messages',
       req: null,
@@ -168,23 +176,16 @@ async function parseSessionFile(filePath, projectSlug) {
       elapsed: null,
       status: 200,
       isSSE: false,
-      receivedAt,
-      // #329/#333: the transcript carries the same upstream msg_01… id the proxy
-      // logged, so the read-time merge collapses this imported copy with the proxy
-      // copy. Canonical selection prefers the proxy copy (it has on-disk _req/_res),
-      // so the import enriches rather than shadows. See docs/decisions/0012.
-      responseId: msg.id || null,
+      receivedAt: prev ? prev.receivedAt : receivedAt,
+      responseId,
       tokens,
       cost: { cost: costResult.cost, confidence: costResult.confidence },
       model,
       sessionId,
-      title: lastUserText || '(imported)',
-      stopReason: msg.stop_reason || null,
+      title: prev ? prev.title : (lastUserText || '(imported)'),
+      stopReason: msg.stop_reason || prev?.stopReason || null,
       imported: true,
       importSource: 'claude-code',
-      // The transcript's own sessionId is authoritative (not inferred), so an
-      // importer copy can supply the real session when it merges with a proxy
-      // copy that fell back to direct-api/inferred (#333 M8/M9).
       sessionInferred: false,
       provider: 'anthropic',
       cwd: obj.cwd || cwd || slugToProject(projectSlug),
@@ -194,9 +195,10 @@ async function parseSessionFile(filePath, projectSlug) {
         cache_read_input_tokens: usage.cache_read_input_tokens || 0,
         cache_creation_input_tokens: usage.cache_creation_input_tokens || 0,
       },
-    });
+    };
+    byResponseId.set(dedupKey, entry);
   }
-  return entries;
+  return [...byResponseId.values()];
 }
 
 // Codex transcript lines are {timestamp, type, payload}. `payload.model` and

--- a/test/importer-dedup.test.js
+++ b/test/importer-dedup.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const os = require('os');
+
+describe('#428 importer: aggregate by message.id', () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'ccxray-imp-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeAndParse(lines) {
+    const filePath = path.join(tmpDir, 'test-session.jsonl');
+    await fsp.writeFile(filePath, lines.map(l => JSON.stringify(l)).join('\n') + '\n');
+    const { parseSessionFile } = require('../server/importer');
+    return parseSessionFile(filePath, 'test-project');
+  }
+
+  it('same message.id across multiple assistant lines produces one entry', async () => {
+    const entries = await writeAndParse([
+      { type: 'user', message: { content: 'hello' } },
+      {
+        type: 'assistant', timestamp: '2026-08-02T14:31:57.024Z',
+        message: { id: 'msg_01ABC', model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 10 }, stop_reason: null },
+      },
+      {
+        type: 'assistant', timestamp: '2026-08-02T14:31:57.500Z',
+        message: { id: 'msg_01ABC', model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 30 }, stop_reason: null },
+      },
+      {
+        type: 'assistant', timestamp: '2026-08-02T14:31:58.100Z',
+        message: { id: 'msg_01ABC', model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 50 }, stop_reason: 'end_turn' },
+      },
+    ]);
+
+    assert.equal(entries.length, 1, 'should produce exactly 1 entry for 3 lines with same message.id');
+    assert.equal(entries[0].responseId, 'msg_01ABC');
+    assert.equal(entries[0].usage.output_tokens, 50, 'last line wins for usage');
+    assert.equal(entries[0].stopReason, 'end_turn', 'last line wins for stop_reason');
+  });
+
+  it('different message.ids produce separate entries', async () => {
+    const entries = await writeAndParse([
+      {
+        type: 'assistant', timestamp: '2026-08-02T14:31:57.024Z',
+        message: { id: 'msg_01AAA', model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 10 }, stop_reason: 'end_turn' },
+      },
+      {
+        type: 'assistant', timestamp: '2026-08-02T14:32:00.000Z',
+        message: { id: 'msg_01BBB', model: 'claude-sonnet-4-20250514', usage: { input_tokens: 200, output_tokens: 20 }, stop_reason: 'end_turn' },
+      },
+    ]);
+    assert.equal(entries.length, 2);
+  });
+
+  it('lines without message.id pass through individually', async () => {
+    const entries = await writeAndParse([
+      {
+        type: 'assistant', timestamp: '2026-08-02T14:31:57.024Z',
+        message: { model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 10 }, stop_reason: 'end_turn' },
+      },
+      {
+        type: 'assistant', timestamp: '2026-08-02T14:32:00.000Z',
+        message: { model: 'claude-sonnet-4-20250514', usage: { input_tokens: 200, output_tokens: 20 }, stop_reason: 'end_turn' },
+      },
+    ]);
+    assert.equal(entries.length, 2, 'no message.id = no aggregation');
+  });
+
+  it('first timestamp wins for entry id (rescan idempotency)', async () => {
+    const entries = await writeAndParse([
+      {
+        type: 'assistant', timestamp: '2026-08-02T14:31:57.024Z',
+        message: { id: 'msg_01ABC', model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 10 } },
+      },
+      {
+        type: 'assistant', timestamp: '2026-08-02T14:31:58.100Z',
+        message: { id: 'msg_01ABC', model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 50 }, stop_reason: 'end_turn' },
+      },
+    ]);
+    assert.equal(entries.length, 1);
+    assert.ok(entries[0].id.includes('14-31-57'), 'entry id should use first timestamp');
+    assert.equal(entries[0].receivedAt, new Date('2026-08-02T14:31:57.024Z').getTime());
+  });
+
+  it('title comes from user text before the first assistant line', async () => {
+    const entries = await writeAndParse([
+      { type: 'user', message: { content: 'explain recursion' } },
+      {
+        type: 'assistant', timestamp: '2026-08-02T14:31:57.024Z',
+        message: { id: 'msg_01ABC', model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 10 } },
+      },
+      {
+        type: 'assistant', timestamp: '2026-08-02T14:31:58.100Z',
+        message: { id: 'msg_01ABC', model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 50 }, stop_reason: 'end_turn' },
+      },
+    ]);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].title, 'explain recursion');
+  });
+});


### PR DESCRIPTION
## 摘要

- Claude Code transcript 對同一 API response 寫多行 assistant 行（每個 content block 一行），importer 原本逐行建 entry → 2-4× 重複
- 改為按 `message.id` 聚合，每個 API response 產出一筆 entry

## Detail

**Root cause** (confirmed by 3-way independent verification):

`parseSessionFile` built one entry per JSONL assistant line. Claude Code writes 2-4 lines per response (same `message.id`, different timestamps). Dedup only checked self-generated entry ids (from `tsToId(timestamp)`), so different timestamps → different ids → all pass through.

Real data: session `4e5e7a57` had 146 qualifying lines, 63 unique `message.id`s, producing 129 entries (distribution: `{1:20, 2:23, 3:17, 4:3}` copies per response).

**Fix** (`server/importer.js`):

`parseSessionFile` now uses a `Map<responseId, entry>` to aggregate by `message.id`:
- Same `message.id`: last-seen usage/stopReason wins (richest/final); first-seen id/ts/receivedAt wins (rescan idempotency)
- No `message.id`: falls through keyed by timestamp-derived id (unchanged behavior)

**Out of scope** (diagnostic noted, deliberately not fixed here):
- `tsToId` `slice(0,-2)` cuts the `Z` suffix — changes id collision behavior, left for separate ticket
- Existing duplicate lines on disk — ADR 0012 read-time merge handles them; disk cleanup needs independent design
- In-flight scan lock — rare race, separate concern

## 驗證

差異檢查（`docs/verification-principles.md`）：
- 舊碼: 3/5 FAIL (aggregation tests)
- 新碼: 5/5 PASS
- 全套 1752 tests pass

| Test | Old | New |
|---|---|---|
| same message.id → 1 entry | FAIL (3 entries) | PASS |
| different message.ids → separate | PASS | PASS |
| no message.id → pass through | PASS | PASS |
| first timestamp → entry id | FAIL | PASS |
| title from user text | FAIL | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)