### PR TITLE
feat(server): per-turn tool calls from response — #427 Phase 1

### DIFF
--- a/server/entry.js
+++ b/server/entry.js
@@ -9,6 +9,10 @@ const INDEX_FIELDS = [
   'imported','importSource',
   // Dedup key for read-time merge (#333) — see docs/decisions/0012-response-id-read-time-merge.md
   'responseId',
+  // #427: per-turn tool calls extracted from the response (not the cumulative
+  // request history). Null on legacy entries — aggregators prefer this over
+  // toolCalls when present.
+  'turnToolCalls',
   // INVARIANT: authoritative 1M-window signal — the non-lagging anthropic-beta
   // `context-1m-*` request header (#339). Persisted so restore/cold-load can
   // derive a per-session consistent context% denominator (sessionWindow) instead

--- a/server/forward.js
+++ b/server/forward.js
@@ -774,6 +774,7 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
       receivedAt: startTime,
       // Dedup key for read-time merge (#333) — docs/decisions/0012-response-id-read-time-merge.md
       responseId: getParser('anthropic').extractResponseId(events),
+      turnToolCalls: getParser('anthropic').extractTurnToolCalls(events),
       edited: ctx.edited, editSummary: ctx.editSummary,
       tokens: null,
       duplicateToolCalls: helpers.extractDuplicateToolCalls(parsedBody?.messages),
@@ -1074,6 +1075,7 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
         receivedAt: startTime,
         // Dedup key for read-time merge (#333) — docs/decisions/0012-response-id-read-time-merge.md
         responseId: getParser('anthropic').extractResponseId(resData),
+        turnToolCalls: getParser('anthropic').extractTurnToolCalls(resData),
         edited: ctx.edited, editSummary: ctx.editSummary,
         tokens: null,
         duplicateToolCalls: helpers.extractDuplicateToolCalls(parsedBody?.messages),

--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -233,6 +233,7 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   const sessionCwd = new Map(); // sid → latest cwd, for backfilling inferred turns
   let enrichedResponseIds = 0;  // #333 legacy backfill count
   let enrichedIdentity = 0;     // #342 legacy identity backfill count
+  let enrichedTurnToolCalls = 0; // #427 legacy backfill count
   // #345: stream lines — a recovered index can exceed Node's ~512MB single-string
   // limit, where readIndex() (readFile utf8) throws ERR_STRING_TOO_LONG.
   for await (const line of storage.readIndexLines()) {
@@ -263,7 +264,7 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
     if (m.turnToolCalls === undefined && m.provider !== 'openai') {
       let ttc = null;
       try { ttc = getParser('anthropic').extractTurnToolCalls(JSON.parse(await storage.read(m.id, '_res.json'))); } catch {}
-      if (ttc) { m.turnToolCalls = ttc; outLine = JSON.stringify(m); }
+      if (ttc) { m.turnToolCalls = ttc; outLine = JSON.stringify(m); enrichedTurnToolCalls++; }
     }
     // #342 add-only identity backfill: a legacy line predating identity-field
     // extraction lacks convId/coreHash/agentKey/msgCount/isSubagent, so lane
@@ -414,6 +415,8 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
       elapsed: null,
       // Backfill dedup key onto recovered orphan lines (#333) — docs/decisions/0012.
       responseId: orphanResponseId,
+      // #427: per-turn tool calls from the response (events already loaded above)
+      turnToolCalls: getParser('anthropic').extractTurnToolCalls(events),
       ...fields,
     };
     recovered.push({ id, line: buildIndexLine(entry) });
@@ -435,10 +438,11 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   log(`  index: ${existingIds.size} existing lines${N ? ` + ${N} recovered` : ''}`);
   if (enrichedResponseIds) log(`  backfilled responseId onto ${enrichedResponseIds} legacy line(s) (#333)`);
   if (enrichedIdentity) log(`  backfilled convId/coreHash/agentKey onto ${enrichedIdentity} legacy line(s) (#342)`);
+  if (enrichedTurnToolCalls) log(`  backfilled turnToolCalls onto ${enrichedTurnToolCalls} legacy line(s) (#427)`);
 
   // A run with no orphans to add can still have enriched existing lines — those
   // rewritten lines must be flushed, so the write is gated on any change.
-  const hasChanges = N > 0 || enrichedResponseIds > 0 || enrichedIdentity > 0;
+  const hasChanges = N > 0 || enrichedResponseIds > 0 || enrichedIdentity > 0 || enrichedTurnToolCalls > 0;
   if (!hasChanges) {
     log(apply ? '  nothing to add — index left unchanged.' : '  dry run — nothing to add.');
     return { refused: false, recovered: 0, enriched: 0, enrichedIdentity: 0, total: M, unrecoverable, applied: false, cacheFinalSize: cache.size };

--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -257,6 +257,14 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
       try { rid = getParser('anthropic').extractResponseId(JSON.parse(await storage.read(m.id, '_res.json'))); } catch {}
       if (rid) { m.responseId = rid; outLine = JSON.stringify(m); enrichedResponseIds++; }
     }
+    // #427 add-only turnToolCalls backfill: legacy lines carry only cumulative
+    // toolCalls from request history. When _res.json survives, extract per-turn
+    // counts from the response. Same add-only, non-degrading pattern as responseId.
+    if (m.turnToolCalls === undefined && m.provider !== 'openai') {
+      let ttc = null;
+      try { ttc = getParser('anthropic').extractTurnToolCalls(JSON.parse(await storage.read(m.id, '_res.json'))); } catch {}
+      if (ttc) { m.turnToolCalls = ttc; outLine = JSON.stringify(m); }
+    }
     // #342 add-only identity backfill: a legacy line predating identity-field
     // extraction lacks convId/coreHash/agentKey/msgCount/isSubagent, so lane
     // inference (ADR 0005/0009/0010) defaults it into the main lane — the

--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -356,9 +356,15 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
     // null for, so fall back to the raw parse there (codex round-1 m3) — else the
     // orphan persists responseId:null and the undefined-only backfill never fixes it.
     let orphanResponseId = getParser('anthropic').extractResponseId(events);
-    if (orphanResponseId == null) {
-      try { orphanResponseId = getParser('anthropic').extractResponseId(JSON.parse(await storage.read(id, '_res.json'))); } catch {}
+    // #427: same non-SSE fallback pattern — readResEvents returns null for non-SSE
+    // responses (bare object, not event array), so parse the raw _res.json.
+    let rawResObj = null;
+    if (orphanResponseId == null || events == null) {
+      try { rawResObj = JSON.parse(await storage.read(id, '_res.json')); } catch {}
+      if (orphanResponseId == null && rawResObj) orphanResponseId = getParser('anthropic').extractResponseId(rawResObj);
     }
+    let orphanTurnToolCalls = getParser('anthropic').extractTurnToolCalls(events);
+    if (orphanTurnToolCalls == null && rawResObj) orphanTurnToolCalls = getParser('anthropic').extractTurnToolCalls(rawResObj);
 
     // Session attribution. Explicit metadata.session_id is authoritative (every
     // delta and main-session turn carries it). Otherwise the turn is a subagent /
@@ -415,8 +421,8 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
       elapsed: null,
       // Backfill dedup key onto recovered orphan lines (#333) — docs/decisions/0012.
       responseId: orphanResponseId,
-      // #427: per-turn tool calls from the response (events already loaded above)
-      turnToolCalls: getParser('anthropic').extractTurnToolCalls(events),
+      // #427: per-turn tool calls from the response (computed above, with non-SSE fallback)
+      turnToolCalls: orphanTurnToolCalls,
       ...fields,
     };
     recovered.push({ id, line: buildIndexLine(entry) });

--- a/server/sse-broadcast.js
+++ b/server/sse-broadcast.js
@@ -52,6 +52,7 @@ function summarizeEntry(entry) {
     msgCount: entry.msgCount || 0,
     toolCount: entry.toolCount || 0,
     toolCalls: entry.toolCalls || [],
+    turnToolCalls: entry.turnToolCalls || null,
     isSubagent: entry.isSubagent || false,
     sessionInferred: entry.sessionInferred || false,
     title: entry.title || null,

--- a/server/store.js
+++ b/server/store.js
@@ -115,7 +115,7 @@ function _foldEntry(canonical, other) {
   // Tool/skill maps: per-key max union so a partial capture on one copy never
   // drops the other's keys (same response ⇒ equal in practice, but be robust).
   // Object maps only — a non-object shape (legacy array) falls back to fill-if-empty.
-  for (const k of ['toolCalls', 'skillCalls']) {
+  for (const k of ['toolCalls', 'skillCalls', 'turnToolCalls']) {
     const oc = other[k];
     if (oc == null) continue;
     const isMap = v => v && typeof v === 'object' && !Array.isArray(v);

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -197,10 +197,33 @@ function attributionTurnStep(parsedBody) {
   return helpers.computeTurnStep(parsedBody?.messages);
 }
 
+// #427: per-turn tool calls extracted from the RESPONSE (not the cumulative
+// request history). SSE: count content_block_start events with type=tool_use.
+// Non-SSE: count content[] blocks with type=tool_use.
+function extractTurnToolCalls(resData) {
+  if (!resData) return null;
+  const counts = {};
+  if (Array.isArray(resData)) {
+    for (const ev of resData) {
+      if (ev.type === 'content_block_start' && ev.content_block?.type === 'tool_use' && ev.content_block.name) {
+        counts[ev.content_block.name] = (counts[ev.content_block.name] || 0) + 1;
+      }
+    }
+  } else if (resData.content) {
+    for (const b of resData.content) {
+      if (b.type === 'tool_use' && b.name) {
+        counts[b.name] = (counts[b.name] || 0) + 1;
+      }
+    }
+  }
+  return Object.keys(counts).length ? counts : null;
+}
+
 module.exports = {
   isNoiseRequest,
   extractUsage,
   extractResponseId,
+  extractTurnToolCalls,
   computeConvId,
   detectSession,
   buildEntryFields,

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -216,7 +216,8 @@ function extractTurnToolCalls(resData) {
       }
     }
   }
-  return Object.keys(counts).length ? counts : null;
+  // {} = response parsed, zero tool calls; null = no response data (legacy/missing)
+  return counts;
 }
 
 module.exports = {

--- a/test/turn-tool-calls.test.js
+++ b/test/turn-tool-calls.test.js
@@ -20,16 +20,16 @@ describe('#427 turnToolCalls: response-side extraction', () => {
       assert.deepEqual(result, { Bash: 2, Read: 1 });
     });
 
-    it('returns null when no tool_use blocks', () => {
+    it('returns empty object (not null) when no tool_use blocks — distinguishes from legacy', () => {
       const events = [
         { type: 'message_start', message: { id: 'msg_01', usage: {} } },
         { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
         { type: 'message_delta', delta: { stop_reason: 'end_turn' } },
       ];
-      assert.equal(extractTurnToolCalls(events), null);
+      assert.deepEqual(extractTurnToolCalls(events), {});
     });
 
-    it('returns null for null/undefined input', () => {
+    it('returns null for null/undefined input (legacy/missing)', () => {
       assert.equal(extractTurnToolCalls(null), null);
       assert.equal(extractTurnToolCalls(undefined), null);
     });
@@ -49,9 +49,9 @@ describe('#427 turnToolCalls: response-side extraction', () => {
       assert.deepEqual(extractTurnToolCalls(res), { Edit: 2, Write: 1 });
     });
 
-    it('returns null when no tool_use in content', () => {
+    it('returns empty object when no tool_use in content', () => {
       const res = { id: 'msg_01', content: [{ type: 'text', text: 'done' }] };
-      assert.equal(extractTurnToolCalls(res), null);
+      assert.deepEqual(extractTurnToolCalls(res), {});
     });
   });
 

--- a/test/turn-tool-calls.test.js
+++ b/test/turn-tool-calls.test.js
@@ -55,6 +55,18 @@ describe('#427 turnToolCalls: response-side extraction', () => {
     });
   });
 
+  describe('_foldEntry merges turnToolCalls', () => {
+    it('enriches canonical from duplicate', () => {
+      const store = require('../server/store');
+      const merged = store.mergeByResponseId([
+        { id: 'a', responseId: 'msg_01', receivedAt: 1 },
+        { id: 'b', responseId: 'msg_01', receivedAt: 2, turnToolCalls: { Bash: 2, Read: 1 } },
+      ]);
+      assert.equal(merged.length, 1);
+      assert.deepEqual(merged[0].turnToolCalls, { Bash: 2, Read: 1 });
+    });
+  });
+
   describe('INDEX_FIELDS includes turnToolCalls', () => {
     it('turnToolCalls is in the index field list', () => {
       const { INDEX_FIELDS } = require('../server/entry');

--- a/test/turn-tool-calls.test.js
+++ b/test/turn-tool-calls.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('#427 turnToolCalls: response-side extraction', () => {
+  const { extractTurnToolCalls } = require('../server/wire-parsers/anthropic');
+
+  describe('SSE events (array of events)', () => {
+    it('counts tool_use content_block_start events', () => {
+      const events = [
+        { type: 'message_start', message: { id: 'msg_01', usage: {} } },
+        { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+        { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: 'tu_1', name: 'Bash' } },
+        { type: 'content_block_start', index: 2, content_block: { type: 'tool_use', id: 'tu_2', name: 'Read' } },
+        { type: 'content_block_start', index: 3, content_block: { type: 'tool_use', id: 'tu_3', name: 'Bash' } },
+        { type: 'message_delta', delta: { stop_reason: 'tool_use' } },
+      ];
+      const result = extractTurnToolCalls(events);
+      assert.deepEqual(result, { Bash: 2, Read: 1 });
+    });
+
+    it('returns null when no tool_use blocks', () => {
+      const events = [
+        { type: 'message_start', message: { id: 'msg_01', usage: {} } },
+        { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+        { type: 'message_delta', delta: { stop_reason: 'end_turn' } },
+      ];
+      assert.equal(extractTurnToolCalls(events), null);
+    });
+
+    it('returns null for null/undefined input', () => {
+      assert.equal(extractTurnToolCalls(null), null);
+      assert.equal(extractTurnToolCalls(undefined), null);
+    });
+  });
+
+  describe('non-SSE response (object with content[])', () => {
+    it('counts tool_use content blocks', () => {
+      const res = {
+        id: 'msg_01',
+        content: [
+          { type: 'text', text: 'hello' },
+          { type: 'tool_use', id: 'tu_1', name: 'Edit', input: {} },
+          { type: 'tool_use', id: 'tu_2', name: 'Edit', input: {} },
+          { type: 'tool_use', id: 'tu_3', name: 'Write', input: {} },
+        ],
+      };
+      assert.deepEqual(extractTurnToolCalls(res), { Edit: 2, Write: 1 });
+    });
+
+    it('returns null when no tool_use in content', () => {
+      const res = { id: 'msg_01', content: [{ type: 'text', text: 'done' }] };
+      assert.equal(extractTurnToolCalls(res), null);
+    });
+  });
+
+  describe('INDEX_FIELDS includes turnToolCalls', () => {
+    it('turnToolCalls is in the index field list', () => {
+      const { INDEX_FIELDS } = require('../server/entry');
+      assert.ok(INDEX_FIELDS.includes('turnToolCalls'));
+    });
+
+    it('buildIndexLine includes turnToolCalls when present', () => {
+      const { buildIndexLine } = require('../server/entry');
+      const entry = { id: 'test', turnToolCalls: { Bash: 3, Read: 1 } };
+      const line = JSON.parse(buildIndexLine(entry));
+      assert.deepEqual(line.turnToolCalls, { Bash: 3, Read: 1 });
+    });
+
+    it('buildIndexLine omits turnToolCalls when undefined', () => {
+      const { buildIndexLine } = require('../server/entry');
+      const entry = { id: 'test', toolCalls: { Bash: 10 } };
+      const line = JSON.parse(buildIndexLine(entry));
+      assert.equal(line.turnToolCalls, undefined);
+    });
+  });
+});


### PR DESCRIPTION
## 摘要

- TOOLS panel 顯示 ~60× 膨脹（`extractToolCalls` 從 request 完整歷史提取累積值，UI 再逐筆相加）
- Phase 1：server 端從 response 提取 per-turn `turnToolCalls` + 持久化 + backfill
- Phase 2（UI 消費者改讀新欄位 + legacy fallback）另開 PR

## Detail

**New field**: `turnToolCalls` — per-turn tool call counts extracted from the **response** (not the cumulative request history). SSE: `content_block_start` events with `type=tool_use`. Non-SSE: `content[]` blocks with `type=tool_use`.

**Semantics**: `{}` = response parsed, zero tool calls. `null`/absent = legacy or missing response data. Consumers can distinguish and fall back to `toolCalls` (cumulative, ~26% undercount via per-tool max) for legacy entries.

**Files changed**:
| File | Change |
|---|---|
| `server/wire-parsers/anthropic.js` | `extractTurnToolCalls(resData)` — new extraction function |
| `server/entry.js` | `turnToolCalls` added to `INDEX_FIELDS` |
| `server/forward.js` | SSE + non-SSE entry-assembly sites set `turnToolCalls` |
| `server/sse-broadcast.js` | `summarizeEntry` carries new field to client |
| `server/rebuild-index.js` | Add-only backfill from surviving `_res.json` (same pattern as `responseId`); orphan recovery includes non-SSE fallback |
| `server/store.js` | `_foldEntry` merges `turnToolCalls` during responseId dedup |

## Codex review

3 rounds:
- R1: 4 P2 accepted and fixed (hasChanges gate, null-vs-{} semantics, orphan path, _foldEntry merge)
- R2: 1 P2 accepted and fixed (non-SSE orphan fallback)
- R3: 1 P2 **rejected** — prototype-named tools (`constructor`/`__proto__`) is a theoretical edge case affecting the same `counts = {}` pattern used by existing `extractToolCalls`/`extractSkillCalls`; fixing it belongs in a separate PR covering all three functions

## 驗證

差異檢查：舊碼 7/8 FAIL → 新碼 9/9 PASS
全套 1760 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)