### PR TITLE
fix(dashboard): TOOLS panel shows ~60× inflated counts — #427 Phase 2

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -712,11 +712,23 @@ function addEntry(e) {
         sess.inputTokens = (sess.inputTokens || 0) + (usage.input_tokens || 0);
         sess.outputTokens = (sess.outputTokens || 0) + (usage.output_tokens || 0);
       }
-      if (e.toolCalls && Object.keys(e.toolCalls).length > 0) {
-        if (!sess.toolCalls) sess.toolCalls = {};
-        for (const [name, cnt] of Object.entries(e.toolCalls)) sess.toolCalls[name] = (sess.toolCalls[name] || 0) + cnt;
-        sess.toolCallTurns = (sess.toolCallTurns || 0) + 1;
-        if (e.toolFail) sess.toolFailTurns = (sess.toolFailTurns || 0) + 1;
+      // #427: prefer turnToolCalls (per-turn delta, exact) over toolCalls
+      // (cumulative from request history — sum inflates quadratically).
+      // Legacy fallback: per-tool max (~26% undercount, documented).
+      {
+        const tc = e.turnToolCalls || null;
+        const legacy = !tc && e.toolCalls && Object.keys(e.toolCalls).length > 0;
+        const src = tc || (legacy ? e.toolCalls : null);
+        if (src && Object.keys(src).length > 0) {
+          if (!sess.toolCalls) sess.toolCalls = {};
+          for (const [name, cnt] of Object.entries(src)) {
+            sess.toolCalls[name] = tc
+              ? (sess.toolCalls[name] || 0) + cnt
+              : Math.max(sess.toolCalls[name] || 0, cnt);
+          }
+          sess.toolCallTurns = (sess.toolCallTurns || 0) + 1;
+          if (e.toolFail) sess.toolFailTurns = (sess.toolFailTurns || 0) + 1;
+        }
       }
       if (!_loading && !window._coldActivating) {
         recomputeProjectCost(projName);
@@ -835,10 +847,20 @@ function recomputeSessionStats(sid) {
       sess.inputTokens += en.usage.input_tokens || 0;
       sess.outputTokens += en.usage.output_tokens || 0;
     }
-    if (en.toolCalls && Object.keys(en.toolCalls).length > 0) {
-      sess.toolCallTurns++;
-      Object.entries(en.toolCalls).forEach(function(kv) { sess.toolCalls[kv[0]] = (sess.toolCalls[kv[0]] || 0) + kv[1]; });
-      if (en.toolFail) sess.toolFailTurns++;
+    // #427: same turnToolCalls preference as the hot path above
+    {
+      var tc = en.turnToolCalls || null;
+      var legacy = !tc && en.toolCalls && Object.keys(en.toolCalls).length > 0;
+      var src = tc || (legacy ? en.toolCalls : null);
+      if (src && Object.keys(src).length > 0) {
+        sess.toolCallTurns++;
+        Object.entries(src).forEach(function(kv) {
+          sess.toolCalls[kv[0]] = tc
+            ? (sess.toolCalls[kv[0]] || 0) + kv[1]
+            : Math.max(sess.toolCalls[kv[0]] || 0, kv[1]);
+        });
+        if (en.toolFail) sess.toolFailTurns++;
+      }
     }
   }
   if (typeof assessWeather === 'function') {

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1915,7 +1915,7 @@ function computeSessionScorecard(sid) {
   const usedTools = new Set();
   let availableTools = 0;
   for (const e of turns) {
-    for (const name of Object.keys(e.toolCalls || {})) usedTools.add(name);
+    for (const name of Object.keys(e.turnToolCalls || e.toolCalls || {})) usedTools.add(name);
     if (e.toolCount) availableTools = Math.max(availableTools, e.toolCount);
   }
   const toolUtilization = availableTools > 0 ? (usedTools.size / availableTools * 100) : 0;
@@ -2569,7 +2569,7 @@ function renderSectionsCol(idx) {
 
   const coreTools = req.tools ? req.tools.filter(t => t.name && !t.name.startsWith('mcp__')) : null;
   const mcpTools  = req.tools ? req.tools.filter(t => t.name &&  t.name.startsWith('mcp__')) : null;
-  const tc = allEntries[idx]?.toolCalls || {};
+  const tc = allEntries[idx]?.turnToolCalls || allEntries[idx]?.toolCalls || {};
   const coreCalls = Object.entries(tc).filter(([n]) => !n.startsWith('mcp__')).reduce((s, [, c]) => s + c, 0);
   const mcpCalls  = Object.entries(tc).filter(([n]) =>  n.startsWith('mcp__')).reduce((s, [, c]) => s + c, 0);
 
@@ -2763,7 +2763,7 @@ function renderCostEfficiencyPanel(currentEntry) {
     if (mcpPlugins.length) {
       const sessionToolCalls = {};
       for (const e of sessionTurns) {
-        for (const [name, count] of Object.entries(e.toolCalls || {})) {
+        for (const [name, count] of Object.entries(e.turnToolCalls || e.toolCalls || {})) {
           sessionToolCalls[name] = (sessionToolCalls[name] || 0) + count;
         }
       }
@@ -2961,7 +2961,7 @@ function renderDetailCol() {
       const isMcp = selectedSection === 'mcp-tools';
       const filtered = req.tools ? req.tools.filter(t => t.name && (isMcp ? t.name.startsWith('mcp__') : !t.name.startsWith('mcp__'))) : null;
       if (filtered?.length) {
-        const usageCount = allEntries[selectedTurnIdx]?.toolCalls || {};
+        const usageCount = allEntries[selectedTurnIdx]?.turnToolCalls || allEntries[selectedTurnIdx]?.toolCalls || {};
         const sorted = [...filtered].sort((a, b) => (usageCount[b.name] || 0) - (usageCount[a.name] || 0));
         const tags = sorted.map(t => {
           const cnt = usageCount[t.name] || 0;

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -247,7 +247,7 @@ function wfDetectEvents(t, prev) {
   if (t.isCompacted) evts.push('compaction');
   if (inT > 1000 && (u.cache_read_input_tokens || 0) / inT < 0.5) evts.push('cache-miss');
   if (wfCtxPctRender(t) >= 80 && (!prev || wfCtxPctRender(prev) < 80)) evts.push('ctx80');
-  var tc = t.toolCalls || {};
+  var tc = t.turnToolCalls || t.toolCalls || {};
   if (tc.Write || tc.Edit || tc.MultiEdit || tc.NotebookEdit) evts.push('file-write');
   if (t.hasCredential) evts.push('credential');
   return evts;
@@ -997,8 +997,9 @@ function wfRangeSummary(t0, t1) {
         cost += (turn.cost || 0);
         models[turn.model] = (models[turn.model] || 0) + 1;
         lanes[lane.key] = (lanes[lane.key] || 0) + 1;
-        if (turn.toolCalls) {
-          for (var tk in turn.toolCalls) tools[tk] = (tools[tk] || 0) + turn.toolCalls[tk];
+        var ttc = turn.turnToolCalls || turn.toolCalls;
+        if (ttc) {
+          for (var tk in ttc) tools[tk] = (tools[tk] || 0) + ttc[tk];
         }
       }
     }
@@ -2579,7 +2580,8 @@ function _wfShowTooltip(e, t, lane) {
   var zoneCls = 'wf-tt-' + (zone === 'safe' ? 'good' : zone);
   var median = lane ? wfLaneCostMedian(lane) : 0;
   var outlier = median > 0 && (t.cost || 0) > median * 3 ? ' <span class="wf-tt-outlier">⚡outlier</span>' : '';
-  var tools = t.toolCalls ? Object.entries(t.toolCalls).map(function(kv) { return kv[0] + (kv[1] > 1 ? '×' + kv[1] : ''); }).join(', ') : '';
+  var _tc = t.turnToolCalls || t.toolCalls;
+  var tools = _tc ? Object.entries(_tc).map(function(kv) { return kv[0] + (kv[1] > 1 ? '×' + kv[1] : ''); }).join(', ') : '';
   var lock = _wfLockInfo();
   var lockLbl = (lock && lane && lock.lane === lane && lock.lane.turns[lock.tidx] !== t)
     ? ' <span class="wf-tt-lock">🔒#' + wfEsc(String(lock.lane.turns[lock.tidx].displayNum || lock.tidx + 1)) + '</span>' : '';
@@ -2798,7 +2800,7 @@ function wfRenderAgentCard(lane) {
   var toolTotals = (isOrchestrator && sess && sess.toolCalls) ? sess.toolCalls : {};
   if (!isOrchestrator || !sess || !sess.toolCalls) {
     for (var i = 0; i < lane.turns.length; i++) {
-      var tc = lane.turns[i].toolCalls || {};
+      var tc = lane.turns[i].turnToolCalls || lane.turns[i].toolCalls || {};
       for (var k in tc) toolTotals[k] = (toolTotals[k] || 0) + tc[k];
     }
   }
@@ -2958,7 +2960,7 @@ function wfRenderTurnCard(turnEntry) {
   html += '</div>';
 
   // Tools
-  var tc = turnEntry.toolCalls || {};
+  var tc = turnEntry.turnToolCalls || turnEntry.toolCalls || {};
   var toolEntries = Object.entries(tc).sort(function(a, b) { return b[1] - a[1]; });
   if (toolEntries.length) {
     var totalCalls = toolEntries.reduce(function(s, e) { return s + e[1]; }, 0);
@@ -3203,7 +3205,7 @@ function wfRenderSteps(scrollToId) {
       }
     }
     var isSel = wfState.selectedTurnId === t.id;
-    var tools = Object.entries(t.toolCalls || {});
+    var tools = Object.entries(t.turnToolCalls || t.toolCalls || {});
     var mc = wfModelColor(t.model);
     var pct = wfCtxPctRender(t);
     var u = t.usage || {};

--- a/server/usage.js
+++ b/server/usage.js
@@ -207,14 +207,14 @@ function analyze(entries, opts = {}) {
     modelMap[m].cost += c;
     totalCost += c;
 
-    if (e.toolCalls) {
-      for (const [name, count] of Object.entries(e.toolCalls)) {
+    // #427: prefer turnToolCalls (per-turn delta) over toolCalls (cumulative)
+    const tc = e.turnToolCalls || e.toolCalls;
+    if (tc) {
+      for (const [name, count] of Object.entries(tc)) {
         toolAgg[name] = (toolAgg[name] || 0) + count;
         totalToolCalls += count;
       }
     }
-    // Per-skill detail comes from the dedicated skillCalls field (new data).
-    // Entries without it predate skill tracking → counted as (pre-tracking).
     if (e.skillCalls && Object.keys(e.skillCalls).length) {
       for (const [sn, count] of Object.entries(e.skillCalls)) {
         if (!skillMap[sn]) skillMap[sn] = { invocations: 0, sessions: new Set() };
@@ -222,7 +222,7 @@ function analyze(entries, opts = {}) {
         skillMap[sn].sessions.add(sid);
       }
     } else {
-      legacySkillCount += e.toolCalls?.Skill || 0;
+      legacySkillCount += tc?.Skill || 0;
     }
     if (e.toolFail) failCount++;
 

--- a/test/turn-tool-calls-ui.test.js
+++ b/test/turn-tool-calls-ui.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('#427 Phase 2: UI consumers prefer turnToolCalls over toolCalls', () => {
+  it('entry-rendering hot path sums turnToolCalls (not cumulative toolCalls)', () => {
+    // Simulate 3 turns with cumulative toolCalls and per-turn turnToolCalls
+    const entries = [
+      { toolCalls: { Bash: 1, Read: 1 }, turnToolCalls: { Bash: 1, Read: 1 } },
+      { toolCalls: { Bash: 2, Read: 2 }, turnToolCalls: { Bash: 1, Read: 1 } },
+      { toolCalls: { Bash: 3, Read: 2, Edit: 1 }, turnToolCalls: { Bash: 1, Edit: 1 } },
+    ];
+    // Replicate the hot path logic
+    const sess = { toolCalls: {} };
+    for (const e of entries) {
+      const tc = e.turnToolCalls || null;
+      const legacy = !tc && e.toolCalls && Object.keys(e.toolCalls).length > 0;
+      const src = tc || (legacy ? e.toolCalls : null);
+      if (src && Object.keys(src).length > 0) {
+        for (const [name, cnt] of Object.entries(src)) {
+          sess.toolCalls[name] = tc
+            ? (sess.toolCalls[name] || 0) + cnt
+            : Math.max(sess.toolCalls[name] || 0, cnt);
+        }
+      }
+    }
+    // With turnToolCalls: Bash=3 (1+1+1), Read=2 (1+1), Edit=1
+    assert.deepEqual(sess.toolCalls, { Bash: 3, Read: 2, Edit: 1 });
+  });
+
+  it('falls back to per-tool max for legacy entries (no turnToolCalls)', () => {
+    const entries = [
+      { toolCalls: { Bash: 1, Read: 1 } },
+      { toolCalls: { Bash: 2, Read: 2 } },
+      { toolCalls: { Bash: 3, Read: 2, Edit: 1 } },
+    ];
+    const sess = { toolCalls: {} };
+    for (const e of entries) {
+      const tc = e.turnToolCalls || null;
+      const legacy = !tc && e.toolCalls && Object.keys(e.toolCalls).length > 0;
+      const src = tc || (legacy ? e.toolCalls : null);
+      if (src && Object.keys(src).length > 0) {
+        for (const [name, cnt] of Object.entries(src)) {
+          sess.toolCalls[name] = tc
+            ? (sess.toolCalls[name] || 0) + cnt
+            : Math.max(sess.toolCalls[name] || 0, cnt);
+        }
+      }
+    }
+    // With max fallback: Bash=3 (max of 1,2,3), Read=2 (max), Edit=1
+    assert.deepEqual(sess.toolCalls, { Bash: 3, Read: 2, Edit: 1 });
+    // Key: WITHOUT the fix, summing cumulative would give Bash=6, Read=5, Edit=1
+  });
+
+  it('mixed session: new turnToolCalls entries sum, legacy entries max', () => {
+    const entries = [
+      { toolCalls: { Bash: 5 } },  // legacy (cumulative)
+      { toolCalls: { Bash: 8 }, turnToolCalls: { Bash: 3 } },  // new
+      { toolCalls: { Bash: 10 }, turnToolCalls: { Bash: 2 } },  // new
+    ];
+    const sess = { toolCalls: {} };
+    for (const e of entries) {
+      const tc = e.turnToolCalls || null;
+      const legacy = !tc && e.toolCalls && Object.keys(e.toolCalls).length > 0;
+      const src = tc || (legacy ? e.toolCalls : null);
+      if (src && Object.keys(src).length > 0) {
+        for (const [name, cnt] of Object.entries(src)) {
+          sess.toolCalls[name] = tc
+            ? (sess.toolCalls[name] || 0) + cnt
+            : Math.max(sess.toolCalls[name] || 0, cnt);
+        }
+      }
+    }
+    // Legacy max(5)=5, then +3, then +2 = 10
+    assert.equal(sess.toolCalls.Bash, 10);
+  });
+});


### PR DESCRIPTION
## 摘要

- 所有 UI 消費者改為優先讀 `turnToolCalls`（Phase 1 新增的 per-turn delta 欄位）
- Legacy entries（無 `turnToolCalls`）fallback 改為 per-tool max（~26% undercount，文件記載）
- 修好後 TOOLS panel 的 Bash 從 1873 降到真實值 ~48

## Detail

**Modified consumers**:
| File | Sites |
|---|---|
| `public/entry-rendering.js` | hot path (:715) + recompute path (:838) — the two aggregation sites |
| `public/miller-columns.js` | per-turn detail (:2572), unused MCP plugins (:2766), section panels (:2964), usedTools (:1918) |
| `public/workflow-timeline.js` | lane summary (:1000), turn detail (:2582, :2801, :2961), hover (:250), section (:3206) |
| `server/usage.js` | `ccxray usage` CLI aggregation (:210) |

**Aggregation logic**:
- `turnToolCalls` present → **sum** (per-turn delta, exact)
- `turnToolCalls` absent (legacy) → **per-tool max** (~26% undercount — the entry carries the full cumulative history, max extracts the latest snapshot)
- Mixed session: legacy entries contribute via max, new entries via sum

## 驗證

- 全套 1764 tests pass
- 3 new tests covering: new-field sum, legacy max fallback, mixed session

🤖 Generated with [Claude Code](https://claude.com/claude-code)