### PR TITLE
fix(dashboard): codex review follow-ups for #427 Phase 2

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -667,7 +667,7 @@ function addEntry(e) {
     tokens: tok, usage, ts: e.ts, model, maxContext: e.maxContext, cost: turnCost, costConfidence, sessionId: sid,
     severity,
     req: e.req || null, res: e.res || null, reqLoaded: !!(e.req || e.res),
-    msgCount, toolCount, toolCalls: e.toolCalls || {}, stopReason,
+    msgCount, toolCount, toolCalls: e.toolCalls || {}, turnToolCalls: e.turnToolCalls || null, stopReason,
     status: e.status, elapsed: e.elapsed, method: e.method, id: e.id,
     // GUARD (_seqFlipped ownership): true iff the seq layer flipped THIS
     // arrival (R2 stitch / reordered recompute) — see _seqApplyFlips guard
@@ -1091,6 +1091,8 @@ function _patchEntryInPlace(u) {
     if (u.toolCalls != null && (Array.isArray(u.toolCalls) ? u.toolCalls.length : Object.keys(u.toolCalls).length)) {
       full.toolCalls = u.toolCalls;
     }
+    // #427: turnToolCalls — always patch (including {} which means "zero calls")
+    if (u.turnToolCalls !== undefined) full.turnToolCalls = u.turnToolCalls;
     // Keep the lightweight entryById record consistent for the mutable field it
     // holds (codex round-1 M4).
     const rec = window.entryById.get(u.id);

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -2799,10 +2799,18 @@ function wfRenderAgentCard(lane) {
   // total would be undercounted to whatever subset the orchestrator itself called).
   var toolTotals = (isOrchestrator && sess && sess.toolCalls) ? sess.toolCalls : {};
   if (!isOrchestrator || !sess || !sess.toolCalls) {
+    // #427: sum turnToolCalls (exact delta); legacy toolCalls → per-tool max
+    var _legacyMax = {};
     for (var i = 0; i < lane.turns.length; i++) {
-      var tc = lane.turns[i].turnToolCalls || lane.turns[i].toolCalls || {};
-      for (var k in tc) toolTotals[k] = (toolTotals[k] || 0) + tc[k];
+      if (lane.turns[i].turnToolCalls) {
+        var _ttc = lane.turns[i].turnToolCalls;
+        for (var k in _ttc) toolTotals[k] = (toolTotals[k] || 0) + _ttc[k];
+      } else if (lane.turns[i].toolCalls) {
+        var _ltc = lane.turns[i].toolCalls;
+        for (var k in _ltc) _legacyMax[k] = Math.max(_legacyMax[k] || 0, _ltc[k]);
+      }
     }
+    for (var k in _legacyMax) toolTotals[k] = (toolTotals[k] || 0) + _legacyMax[k];
   }
   var topTools = Object.entries(toolTotals).sort(function(a, b) { return b[1] - a[1]; }).slice(0, 6);
 

--- a/server/usage.js
+++ b/server/usage.js
@@ -207,10 +207,10 @@ function analyze(entries, opts = {}) {
     modelMap[m].cost += c;
     totalCost += c;
 
-    // #427: prefer turnToolCalls (per-turn delta) over toolCalls (cumulative)
-    const tc = e.turnToolCalls || e.toolCalls;
-    if (tc) {
-      for (const [name, count] of Object.entries(tc)) {
+    // #427: turnToolCalls (per-turn delta) → sum directly into toolAgg.
+    // Legacy toolCalls (cumulative) → per-session max, deferred to post-loop.
+    if (e.turnToolCalls) {
+      for (const [name, count] of Object.entries(e.turnToolCalls)) {
         toolAgg[name] = (toolAgg[name] || 0) + count;
         totalToolCalls += count;
       }
@@ -222,7 +222,7 @@ function analyze(entries, opts = {}) {
         skillMap[sn].sessions.add(sid);
       }
     } else {
-      legacySkillCount += tc?.Skill || 0;
+      legacySkillCount += (e.turnToolCalls || e.toolCalls)?.Skill || 0;
     }
     if (e.toolFail) failCount++;
 
@@ -231,6 +231,23 @@ function analyze(entries, opts = {}) {
       totalCacheCreate += e.usage.cache_creation_input_tokens || 0;
       totalCacheRead += e.usage.cache_read_input_tokens || 0;
       totalOutput += e.usage.output_tokens || 0;
+    }
+  }
+
+  // #427: legacy toolCalls (cumulative) — per-session max then sum into toolAgg.
+  // Done post-loop so each session's max is independent (codex R1).
+  for (const turns of Object.values(bySession)) {
+    const sessMax = {};
+    for (const e of turns) {
+      if (e.turnToolCalls) continue; // already summed in-loop
+      if (!e.toolCalls) continue;
+      for (const [name, count] of Object.entries(e.toolCalls)) {
+        sessMax[name] = Math.max(sessMax[name] || 0, count);
+      }
+    }
+    for (const [name, count] of Object.entries(sessMax)) {
+      toolAgg[name] = (toolAgg[name] || 0) + count;
+      totalToolCalls += count;
     }
   }
 

--- a/test/usage.test.js
+++ b/test/usage.test.js
@@ -58,11 +58,14 @@ describe('usage analyze', () => {
     assert.equal(r.models[0].turns, 1);
   });
 
-  it('aggregates tool calls', () => {
+  it('aggregates tool calls — legacy per-session max, not cumulative sum (#427)', () => {
+    // Both entries are legacy (no turnToolCalls), same session s1.
+    // Default: { Bash: 2, Read: 1 }, override: { Bash: 3, Write: 1 }
+    // Per-session max: Bash=3, Read=1, Write=1 = total 5 (not 7 from old sum)
     const r = analyze([entry(), entry({ toolCalls: { Bash: 3, Write: 1 } })]);
-    assert.equal(r.tools.totalCalls, 7);
+    assert.equal(r.tools.totalCalls, 5);
     assert.equal(r.tools.top[0].name, 'Bash');
-    assert.equal(r.tools.top[0].count, 5);
+    assert.equal(r.tools.top[0].count, 3);
   });
 
   it('caps tools.top at 7 by default; --tools lifts the cap', () => {


### PR DESCRIPTION
## 摘要

事後 codex review 在已 merge 的 #433 上發現 1 P1 + 3 P2，本 PR 修正。

## Detail

| Severity | Issue | Fix |
|---|---|---|
| **P1** | `allEntries.push` whitelist 漏 `turnToolCalls` — Phase 2 的修在 recompute/cold 路徑無效 | 加入 whitelist |
| P2 | `_patchEntryInPlace` 沒 patch `turnToolCalls` — `entry_update` 不會更新 | 加入 patch |
| P2 | `usage.js` legacy path 仍 sum 累積值 → 二次方膨脹 | 改為 per-session max 再 sum |
| P2 | `workflow-timeline` lane totals 同上 | 改為 max + sum |

`test/usage.test.js` 的 `aggregates tool calls` 測試期望值從 7（舊 sum）改為 5（max），這是 #427 的 intended behavioral change。

## 驗證

全套 1764 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)