### PR TITLE
docs(adr): 0018 turnToolCalls null-vs-empty contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ These constraints are enforced by structural encapsulation where possible, and g
 - **cost-worker lifecycle: imported mode is side-effect free, executed mode exits by drain** — R1 no handle may ref the loop past the final stdout write; R2 no `process.exit()` on success; R3 one result protocol (stdout JSON); R4 adding an env-derived root obliges updating `isolatedEnv()` in every test that forks the worker — @docs/decisions/0015-cost-worker-lifecycle-drain-exit.md
 - **All restoreFromLogs streaming passes bind to `snapshotBytes`** + id guard (`store.entryIndex.has`) + buffer bridge (`beginRestoreBuffer`/`endRestoreBuffer`); adding a new index-streaming pass without binding to the snapshot byte bound silently re-opens the live-append race — @docs/decisions/0016-restore-stream-snapshot-byte-bound.md
 - **Aggregate cost display goes through `formatAggCost`/`formatAggCostText` with a complete confidence fold** (`fallbackCost`/`fallbackCount`/`unknownCount`/`count`); a site that renders `'$'+total.toFixed()` directly, or omits a component stream from the fold, silently reverts to unmarked fabrication. Per-turn sites keep `formatCost`/`formatCostText` (#422) — @docs/decisions/0017-aggregate-cost-confidence.md
+- **`turnToolCalls` null-vs-empty contract: `null`/`undefined` means legacy or missing response data and permits fallback to cumulative `toolCalls` using per-tool max; `{}` means a parsed response with zero tool calls and must suppress fallback because it is truthy** — @docs/decisions/0018-turn-tool-calls-null-vs-empty.md
 
 ## Smoke Testing
 

--- a/docs/decisions/0018-turn-tool-calls-null-vs-empty.md
+++ b/docs/decisions/0018-turn-tool-calls-null-vs-empty.md
@@ -1,0 +1,64 @@
+# 0018 — `turnToolCalls`: null/undefined versus `{}`
+
+- Status: Accepted
+- Date: 2026-08-04
+- Related: #427 / ADR 0001 (toolCalls versus skillCalls)
+
+## Context
+
+`toolCalls` is cumulative: it is extracted from request history, so summing it
+across turns counts earlier calls repeatedly. `turnToolCalls` is the response-side
+per-turn delta introduced by #427 and is therefore the preferred source for
+aggregates.
+
+The response-side extractor has to distinguish two cases that both contain no
+tool names:
+
+- An old entry, or an entry whose response data is missing, has no usable
+  response-side result. It carries `turnToolCalls` as `null` or leaves it
+  `undefined`.
+- A parsed response with no `tool_use` blocks has a valid empty result, `{}`.
+
+Collapsing `{}` into nullish state makes consumers fall back to cumulative
+`toolCalls`, even though the response was successfully parsed and proves that
+this turn made zero tool calls.
+
+## Decision
+
+`turnToolCalls` has a load-bearing null-vs-empty contract:
+
+- `null`/`undefined` means a legacy entry or missing response data. Consumers
+  may fall back to cumulative `toolCalls`, using a per-tool maximum within each
+  session rather than summing the cumulative snapshots.
+- `{}` means the response was parsed and contained zero tool calls. Consumers
+  must not fall back to `toolCalls` for that turn.
+- A non-empty object is the exact per-turn response delta and is summed directly.
+
+This is intentionally expressed through JavaScript truthiness at the fallback
+sites: `turnToolCalls || toolCalls` short-circuits correctly because `{}` is
+truthy. Replacing the distinction with a generic falsy/empty check, or
+normalizing `{}` to `null`, reintroduces the cumulative overcount.
+
+The fallback sites covered by this contract are:
+
+| Site | Required behavior |
+|------|-------------------|
+| `public/entry-rendering.js` hot path (~line 719) | Use the exact per-turn map; only nullish state uses cumulative `toolCalls` with per-tool max. |
+| `public/entry-rendering.js` recompute path (~line 852) | Same preference and legacy fold as the hot path. |
+| `public/workflow-timeline.js` lane totals (~line 2802) | Sum response deltas; put only nullish turns into the legacy per-tool max fold. |
+| `server/usage.js` legacy fold (~line 237) | Skip response-parsed turns, including `{}`, from the cumulative per-session max fold. |
+
+Guard comments at each site name this ADR. The distinction is part of the
+stored/indexed field contract and must survive transport, restore, and cold-load.
+
+## Consequences
+
+**Good**: a parsed zero-tool response contributes zero without accidentally
+  reusing historical request counts; legacy entries remain usable through the
+  documented per-tool-max fallback; all consumers share one unambiguous test.
+
+**Accepted limit**: legacy entries without response data cannot recover exact
+  per-turn deltas, so their cumulative fallback may undercount when the observed
+  per-tool maximum is incomplete. This is the honest behavior until response
+  data is available; it must not be “healed” by treating an observed `{}` as
+  missing.

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -715,6 +715,9 @@ function addEntry(e) {
       // #427: prefer turnToolCalls (per-turn delta, exact) over toolCalls
       // (cumulative from request history — sum inflates quadratically).
       // Legacy fallback: per-tool max (~26% undercount, documented).
+      // INVARIANT (ADR 0018): null/undefined means legacy or missing response
+      // data; {} means parsed zero-call response and is truthy, so only the
+      // nullish case may fall back to cumulative toolCalls.
       {
         const tc = e.turnToolCalls || null;
         const legacy = !tc && e.toolCalls && Object.keys(e.toolCalls).length > 0;
@@ -848,6 +851,9 @@ function recomputeSessionStats(sid) {
       sess.outputTokens += en.usage.output_tokens || 0;
     }
     // #427: same turnToolCalls preference as the hot path above
+    // INVARIANT (ADR 0018): null/undefined means legacy or missing response
+    // data; {} means parsed zero-call response and is truthy, so only the
+    // nullish case may fall back to cumulative toolCalls.
     {
       var tc = en.turnToolCalls || null;
       var legacy = !tc && en.toolCalls && Object.keys(en.toolCalls).length > 0;

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -2800,6 +2800,8 @@ function wfRenderAgentCard(lane) {
   var toolTotals = (isOrchestrator && sess && sess.toolCalls) ? sess.toolCalls : {};
   if (!isOrchestrator || !sess || !sess.toolCalls) {
     // #427: sum turnToolCalls (exact delta); legacy toolCalls → per-tool max
+    // INVARIANT (ADR 0018): {} is a parsed zero-call response and must take the
+    // turnToolCalls branch; only null/undefined may enter the legacy max fold.
     var _legacyMax = {};
     for (var i = 0; i < lane.turns.length; i++) {
       if (lane.turns[i].turnToolCalls) {

--- a/server/usage.js
+++ b/server/usage.js
@@ -209,6 +209,8 @@ function analyze(entries, opts = {}) {
 
     // #427: turnToolCalls (per-turn delta) → sum directly into toolAgg.
     // Legacy toolCalls (cumulative) → per-session max, deferred to post-loop.
+    // INVARIANT (ADR 0018): {} is a parsed zero-call response and is truthy,
+    // so only null/undefined may fall through to the legacy per-tool max fold.
     if (e.turnToolCalls) {
       for (const [name, count] of Object.entries(e.turnToolCalls)) {
         toolAgg[name] = (toolAgg[name] || 0) + count;
@@ -236,6 +238,8 @@ function analyze(entries, opts = {}) {
 
   // #427: legacy toolCalls (cumulative) — per-session max then sum into toolAgg.
   // Done post-loop so each session's max is independent (codex R1).
+  // INVARIANT (ADR 0018): only null/undefined turnToolCalls may reach this
+  // cumulative fallback; {} was a parsed zero-call response and was handled above.
   for (const turns of Object.values(bySession)) {
     const sessMax = {};
     for (const e of turns) {


### PR DESCRIPTION
ADR 0018 + INVARIANT comments + CLAUDE.md. T2: 99.8% legacy.