### PR TITLE
fix(dashboard): Turn failure rate inflated by cumulative hasToolFail (#438)

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -1103,11 +1103,11 @@ function _patchEntryInPlace(u) {
     }
     // #427: turnToolCalls — always patch (including {} which means "zero calls")
     if (u.turnToolCalls !== undefined) full.turnToolCalls = u.turnToolCalls;
-    // #438: turnToolFail — patch when present; recompute session stats on change
+    // #438: turnToolFail — patch when present; recompute only hot sessions
     if (u.turnToolFail !== undefined && full.turnToolFail !== u.turnToolFail) {
       full.turnToolFail = u.turnToolFail;
       const _sess = sessionsMap.get(full.sessionId);
-      if (_sess) recomputeSessionStats(full.sessionId);
+      if (_sess && !_sess._cold) recomputeSessionStats(full.sessionId);
     } else if (u.turnToolFail !== undefined) {
       full.turnToolFail = u.turnToolFail;
     }

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -675,7 +675,7 @@ function addEntry(e) {
     thinkingDuration: e.thinkingDuration || null,
     duplicateToolCalls: e.duplicateToolCalls || null,
     hasCredential: e.hasCredential || false,
-    toolFail: e.toolFail || false, turnToolFail: e.turnToolFail || undefined,
+    toolFail: e.toolFail || false, turnToolFail: e.turnToolFail,
     toolSources: e.toolSources || null,
     title: e.title || null,
     coreHash: e.coreHash || null,
@@ -730,9 +730,11 @@ function addEntry(e) {
               : Math.max(sess.toolCalls[name] || 0, cnt);
           }
           sess.toolCallTurns = (sess.toolCallTurns || 0) + 1;
-          // #438: prefer turnToolFail (per-turn) over toolFail (cumulative)
-          if (e.turnToolFail !== undefined ? e.turnToolFail : e.toolFail) sess.toolFailTurns = (sess.toolFailTurns || 0) + 1;
         }
+        // #438: toolFailTurns outside the src guard — a terminal end_turn entry
+        // with turnToolFail=true but no tool calls still counts as a failed turn.
+        const _tf = e.turnToolFail !== undefined ? e.turnToolFail : e.toolFail;
+        if (_tf) sess.toolFailTurns = (sess.toolFailTurns || 0) + 1;
       }
       if (!_loading && !window._coldActivating) {
         recomputeProjectCost(projName);
@@ -866,9 +868,9 @@ function recomputeSessionStats(sid) {
             ? (sess.toolCalls[kv[0]] || 0) + kv[1]
             : Math.max(sess.toolCalls[kv[0]] || 0, kv[1]);
         });
-        // #438: prefer turnToolFail (per-turn) over toolFail (cumulative)
-        if (en.turnToolFail !== undefined ? en.turnToolFail : en.toolFail) sess.toolFailTurns++;
       }
+      var _tf = en.turnToolFail !== undefined ? en.turnToolFail : en.toolFail;
+      if (_tf) sess.toolFailTurns++;
     }
   }
   if (typeof assessWeather === 'function') {
@@ -1101,8 +1103,14 @@ function _patchEntryInPlace(u) {
     }
     // #427: turnToolCalls — always patch (including {} which means "zero calls")
     if (u.turnToolCalls !== undefined) full.turnToolCalls = u.turnToolCalls;
-    // #438: turnToolFail — patch when present
-    if (u.turnToolFail !== undefined) full.turnToolFail = u.turnToolFail;
+    // #438: turnToolFail — patch when present; recompute session stats on change
+    if (u.turnToolFail !== undefined && full.turnToolFail !== u.turnToolFail) {
+      full.turnToolFail = u.turnToolFail;
+      const _sess = sessionsMap.get(full.sessionId);
+      if (_sess) recomputeSessionStats(full.sessionId);
+    } else if (u.turnToolFail !== undefined) {
+      full.turnToolFail = u.turnToolFail;
+    }
     // Keep the lightweight entryById record consistent for the mutable field it
     // holds (codex round-1 M4).
     const rec = window.entryById.get(u.id);

--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -675,7 +675,7 @@ function addEntry(e) {
     thinkingDuration: e.thinkingDuration || null,
     duplicateToolCalls: e.duplicateToolCalls || null,
     hasCredential: e.hasCredential || false,
-    toolFail: e.toolFail || false,
+    toolFail: e.toolFail || false, turnToolFail: e.turnToolFail || undefined,
     toolSources: e.toolSources || null,
     title: e.title || null,
     coreHash: e.coreHash || null,
@@ -730,7 +730,8 @@ function addEntry(e) {
               : Math.max(sess.toolCalls[name] || 0, cnt);
           }
           sess.toolCallTurns = (sess.toolCallTurns || 0) + 1;
-          if (e.toolFail) sess.toolFailTurns = (sess.toolFailTurns || 0) + 1;
+          // #438: prefer turnToolFail (per-turn) over toolFail (cumulative)
+          if (e.turnToolFail !== undefined ? e.turnToolFail : e.toolFail) sess.toolFailTurns = (sess.toolFailTurns || 0) + 1;
         }
       }
       if (!_loading && !window._coldActivating) {
@@ -865,7 +866,8 @@ function recomputeSessionStats(sid) {
             ? (sess.toolCalls[kv[0]] || 0) + kv[1]
             : Math.max(sess.toolCalls[kv[0]] || 0, kv[1]);
         });
-        if (en.toolFail) sess.toolFailTurns++;
+        // #438: prefer turnToolFail (per-turn) over toolFail (cumulative)
+        if (en.turnToolFail !== undefined ? en.turnToolFail : en.toolFail) sess.toolFailTurns++;
       }
     }
   }
@@ -1099,6 +1101,8 @@ function _patchEntryInPlace(u) {
     }
     // #427: turnToolCalls — always patch (including {} which means "zero calls")
     if (u.turnToolCalls !== undefined) full.turnToolCalls = u.turnToolCalls;
+    // #438: turnToolFail — patch when present
+    if (u.turnToolFail !== undefined) full.turnToolFail = u.turnToolFail;
     // Keep the lightweight entryById record consistent for the mutable field it
     // holds (codex round-1 M4).
     const rec = window.entryById.get(u.id);

--- a/server/entry.js
+++ b/server/entry.js
@@ -13,6 +13,8 @@ const INDEX_FIELDS = [
   // request history). Null on legacy entries — aggregators prefer this over
   // toolCalls when present.
   'turnToolCalls',
+  // #438: per-turn tool failure from the last user message only (not cumulative).
+  'turnToolFail',
   // INVARIANT: authoritative 1M-window signal — the non-lagging anthropic-beta
   // `context-1m-*` request header (#339). Persisted so restore/cold-load can
   // derive a per-session consistent context% denominator (sessionWindow) instead

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -663,6 +663,23 @@ function hasToolFail(req) {
   return false;
 }
 
+// #438: per-turn tool failure — only checks the LAST user message (the current
+// turn's tool_result blocks), not the full cumulative history. hasToolFail scans
+// all messages and is infected by any prior failure (#427-class bug).
+function hasToolFailLastTurn(messages) {
+  if (!Array.isArray(messages)) return false;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role !== 'user') continue;
+    const content = messages[i].content;
+    if (!Array.isArray(content)) return false;
+    for (const b of content) {
+      if (b?.type === 'tool_result' && b.is_error === true) return true;
+    }
+    return false;
+  }
+  return false;
+}
+
 // ── Credential scanning ──────────────────────────────────────────────
 const CREDENTIAL_PATTERNS = [
   /sk-ant-[a-zA-Z0-9_-]{20,}/,
@@ -956,7 +973,7 @@ module.exports = {
   extractLastUserText,
   extractToolResultSummary,
   extractFirstUserText,
-  hasToolFail,
+  hasToolFail, hasToolFailLastTurn,
   extractToolCalls,
   extractSkillCalls,
   extractOpenAIToolCalls,

--- a/server/sse-broadcast.js
+++ b/server/sse-broadcast.js
@@ -60,7 +60,7 @@ function summarizeEntry(entry) {
     thinkingDuration: entry.thinkingDuration || null,
     duplicateToolCalls: entry.duplicateToolCalls || null,
     toolFail: entry.toolFail || false,
-    turnToolFail: entry.turnToolFail || undefined,
+    turnToolFail: entry.turnToolFail,
     hasCredential: entry.hasCredential || undefined,
     coreHash: entry.coreHash || null,
     agentKey: entry.agentKey || null,

--- a/server/sse-broadcast.js
+++ b/server/sse-broadcast.js
@@ -60,6 +60,7 @@ function summarizeEntry(entry) {
     thinkingDuration: entry.thinkingDuration || null,
     duplicateToolCalls: entry.duplicateToolCalls || null,
     toolFail: entry.toolFail || false,
+    turnToolFail: entry.turnToolFail || undefined,
     hasCredential: entry.hasCredential || undefined,
     coreHash: entry.coreHash || null,
     agentKey: entry.agentKey || null,

--- a/server/store.js
+++ b/server/store.js
@@ -166,6 +166,7 @@ function _foldEntry(canonical, other) {
   }
   // OR semantics — true if any copy saw it.
   if (other.toolFail) canonical.toolFail = true;
+  if (other.turnToolFail) canonical.turnToolFail = true;
   if (other.hasCredential) canonical.hasCredential = true;
   if (other.edited) {
     canonical.edited = true;

--- a/server/store.js
+++ b/server/store.js
@@ -166,7 +166,10 @@ function _foldEntry(canonical, other) {
   }
   // OR semantics — true if any copy saw it.
   if (other.toolFail) canonical.toolFail = true;
-  if (other.turnToolFail) canonical.turnToolFail = true;
+  // #438: turnToolFail tri-state: undefined=legacy, false=checked-clean, true=failed.
+  // true dominates; false fills undefined; never downgrade true to false.
+  if (other.turnToolFail === true) canonical.turnToolFail = true;
+  else if (other.turnToolFail === false && canonical.turnToolFail === undefined) canonical.turnToolFail = false;
   if (other.hasCredential) canonical.hasCredential = true;
   if (other.edited) {
     canonical.edited = true;

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -110,7 +110,9 @@ function buildEntryFields(ctx) {
     title: ctx.title || null,
     thinkingDuration: ctx.thinkingDuration ?? null,
     toolFail: ctx.toolFail != null ? ctx.toolFail : helpers.hasToolFail(parsedBody),
-    turnToolFail: helpers.hasToolFailLastTurn(parsedBody?.messages) || undefined,
+    // #438: per-turn tool failure. Explicit false = checked, no failure (not legacy).
+    // undefined = legacy/not checked. Do NOT normalize false to undefined.
+    turnToolFail: helpers.hasToolFailLastTurn(parsedBody?.messages),
     sysHash: ctx.sysHash || null,
     toolsHash: ctx.toolsHash || null,
     coreHash: ctx.coreHash || null,

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -110,6 +110,7 @@ function buildEntryFields(ctx) {
     title: ctx.title || null,
     thinkingDuration: ctx.thinkingDuration ?? null,
     toolFail: ctx.toolFail != null ? ctx.toolFail : helpers.hasToolFail(parsedBody),
+    turnToolFail: helpers.hasToolFailLastTurn(parsedBody?.messages) || undefined,
     sysHash: ctx.sysHash || null,
     toolsHash: ctx.toolsHash || null,
     coreHash: ctx.coreHash || null,

--- a/test/turn-tool-fail.test.js
+++ b/test/turn-tool-fail.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('#438 turnToolFail: per-turn failure from last user message', () => {
+  const { hasToolFailLastTurn } = require('../server/helpers');
+
+  it('detects is_error in the last user message', () => {
+    const messages = [
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu1', is_error: true, content: 'fail' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu2', content: 'success' }] },
+    ];
+    assert.equal(hasToolFailLastTurn(messages), false, 'last user message has no error');
+  });
+
+  it('returns true when last user message has is_error', () => {
+    const messages = [
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu1', content: 'success' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu2', is_error: true, content: 'fail' }] },
+    ];
+    assert.equal(hasToolFailLastTurn(messages), true);
+  });
+
+  it('is NOT infected by earlier failures (the #427-class bug)', () => {
+    const messages = [
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu1', is_error: true, content: 'early fail' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'recovered' }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu2', content: 'success' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu3', content: 'also success' }] },
+    ];
+    // Old hasToolFail would return true (scans all messages). New per-turn returns false.
+    assert.equal(hasToolFailLastTurn(messages), false);
+  });
+
+  it('returns false for empty/missing messages', () => {
+    assert.equal(hasToolFailLastTurn(null), false);
+    assert.equal(hasToolFailLastTurn([]), false);
+  });
+
+  it('turnToolFail is in INDEX_FIELDS', () => {
+    const { INDEX_FIELDS } = require('../server/entry');
+    assert.ok(INDEX_FIELDS.includes('turnToolFail'));
+  });
+});


### PR DESCRIPTION
## 摘要

`hasToolFail` 掃完整 req.messages 歷史（#427-class），一個 `is_error:true` 感染所有後續 turn → 83.5% 虛報。新增 `hasToolFailLastTurn` 只看最後一個 user message。

## Codex review

3 rounds:
- R1: 2 P1 + 1 P2 accepted (preserve false, align fail counting outside src guard, recompute on patch)
- R2: 2 P2 accepted (tri-state fold, cold-session guard)
- R3: 1 P1 **rejected** — legacy fallback to cumulative toolFail is the same accepted limit as ADR 0018's turnToolCalls legacy fallback; backfill is operational (rebuild-index)

## 驗證

- fail-on-old: 5/5 FAIL → 5/5 PASS
- 全套 1769 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)