### PR TITLE
fix(dashboard): hide Turn failure rate for legacy sessions without per-turn data (#438)

### DIFF
--- a/public/entry-rendering.js
+++ b/public/entry-rendering.js
@@ -735,7 +735,10 @@ function addEntry(e) {
         // with turnToolFail=true but no tool calls still counts as a failed turn.
         // #438: legacy toolFail is cumulative (Lie Factor 44×) — never fall back to it.
         // Absence = unknown, not "use the wrong answer" (Kleppmann/Tufte/Hickey consensus).
-        if (e.turnToolFail) sess.toolFailTurns = (sess.toolFailTurns || 0) + 1;
+        if (e.turnToolFail !== undefined) {
+          sess.toolFailKnownTurns = (sess.toolFailKnownTurns || 0) + 1;
+          if (e.turnToolFail) sess.toolFailTurns = (sess.toolFailTurns || 0) + 1;
+        }
       }
       if (!_loading && !window._coldActivating) {
         recomputeProjectCost(projName);
@@ -870,8 +873,10 @@ function recomputeSessionStats(sid) {
             : Math.max(sess.toolCalls[kv[0]] || 0, kv[1]);
         });
       }
-      var _tf = en.turnToolFail; // never fall back to cumulative toolFail (#438)
-      if (_tf) sess.toolFailTurns++;
+      if (en.turnToolFail !== undefined) {
+        sess.toolFailKnownTurns++;
+        if (en.turnToolFail) sess.toolFailTurns++;
+      }
     }
   }
   if (typeof assessWeather === 'function') {

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -2217,7 +2217,7 @@ function zeroSessionStats(s) {
   s.count = 0; s.mainCount = 0; s.subCount = 0; s.retryCount = 0;
   s.totalCost = 0; s.fallbackCost = 0; s.fallbackCount = 0; s.unknownCount = 0;
   s.inputTokens = 0; s.outputTokens = 0;
-  s.toolCalls = {}; s.toolCallTurns = 0; s.toolFailTurns = 0;
+  s.toolCalls = {}; s.toolCallTurns = 0; s.toolFailTurns = 0; s.toolFailKnownTurns = 0;
 }
 
 function selectSession(id) {

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -2864,12 +2864,11 @@ function wfRenderAgentCard(lane) {
     for (var ti = 0; ti < topTools.length; ti++) {
       html += '<div class="wf-ac-row"><span class="wf-ac-tool">' + wfEsc(topTools[ti][0]) + '</span><span class="wf-ac-tool-count">' + topTools[ti][1] + '</span></div>';
     }
-    if (sess && (sess.toolCallTurns || 0) > 0) {
-      // Turn-level, not call-level: a turn with 1 failed call among many still
-      // counts as fully failed (toolFail is a turn boolean, not a per-call
-      // count — codex review flagged the old "Failure rate" label as implying
-      // more precision than this data actually has).
-      var failRate = (sess.toolFailTurns || 0) / sess.toolCallTurns * 100;
+    // #438: only show failure rate when we have per-turn data (toolFailKnownTurns > 0).
+    // Legacy sessions with only cumulative toolFail show nothing — 0% would be a lie,
+    // and the old cumulative rate was a 44× Lie Factor.
+    if (sess && (sess.toolFailKnownTurns || 0) > 0) {
+      var failRate = (sess.toolFailTurns || 0) / sess.toolFailKnownTurns * 100;
       html += '<div class="wf-ac-row"><span title="Turns with 1+ failed tool result, not individual call failures">Turn failure rate</span><span class="wf-ac-val">' + failRate.toFixed(1) + '%</span></div>';
     }
     html += '</div>';


### PR DESCRIPTION
## 摘要

#441 停止 fallback 到 cumulative toolFail 後，legacy session 顯示 0%——同樣不對。
0% 意味「沒有失敗」，但真相是「沒有資料」。

新增 `toolFailKnownTurns` 計數器：只有帶 `turnToolFail` 的 entry 才計入。
顯示端以此為 gate（為 0 不顯示）和分母（取代原本的 `toolCallTurns`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)