### PR TITLE
fix(weather): remove non-falsifiable _ACTION_TABLE advice (#336)

### DIFF
--- a/public/weather.js
+++ b/public/weather.js
@@ -223,15 +223,7 @@ var _LEVEL_SUMMARY = {
 };
 
 var _ACTION_TABLE = {
-  ctx_pressure: function(d) {
-    return (d.ctxPct || 0) >= 80
-      ? 'Save key decisions to CLAUDE.md before auto-compact'
-      : 'Use subagent for next independent task';
-  },
-  compaction_scar: function() { return 'Save decisions to CLAUDE.md, or start fresh with --resume'; },
-  truncation: function() { return 'Break into smaller steps'; },
   stuck: function(d) { return 'Check ' + _rangeLink(d.turnStart || 0, d.turnEnd || 0, d.entryIdStart, d.entryIdEnd) + ' — usually permissions or paths'; },
-  latency_drift: function() { return 'Use subagent to reduce context load'; },
   error_cluster: function(d) { return 'Check ' + _rangeLink(d.windowStart || 0, d.windowEnd || 0, d.entryIdStart, d.entryIdEnd); },
   error_cumulative: function(d) { return d.firstErrId ? 'Check ' + _turnLink('first error', d.firstErrId) + ' — common: permissions, paths, settings' : 'Check tool errors — common: permissions, paths, settings'; },
 };

--- a/public/weather.js
+++ b/public/weather.js
@@ -225,7 +225,12 @@ var _LEVEL_SUMMARY = {
 var _ACTION_TABLE = {
   stuck: function(d) { return 'Check ' + _rangeLink(d.turnStart || 0, d.turnEnd || 0, d.entryIdStart, d.entryIdEnd) + ' — usually permissions or paths'; },
   error_cluster: function(d) { return 'Check ' + _rangeLink(d.windowStart || 0, d.windowEnd || 0, d.entryIdStart, d.entryIdEnd); },
-  error_cumulative: function(d) { return d.firstErrId ? 'Check ' + _turnLink('first error', d.firstErrId) + ' — common: permissions, paths, settings' : 'Check tool errors — common: permissions, paths, settings'; },
+  // Returns null when there is no turn to link to: an unlinked "Check tool
+  // errors" line is the same non-falsifiable advice this table was pruned of
+  // (#336) — it says to look without saying where. Only reachable when a turn
+  // carries no `id`; stored entries always do, so this is a contract guard
+  // rather than a live path.
+  error_cumulative: function(d) { return d.firstErrId ? 'Check ' + _turnLink('first error', d.firstErrId) + ' — common: permissions, paths, settings' : null; },
 };
 
 function _buildTooltip(level, factors, stats) {
@@ -251,8 +256,11 @@ function _buildTooltip(level, factors, stats) {
   if (level === 'cloudy' || level === 'rainy' || level === 'stormy') {
     var top = factors[0];
     if (top) {
+      // An entry may decline to produce a line (returns null) when it has no
+      // evidence to point at — guard the RESULT, not just the entry's presence.
       var act = _ACTION_TABLE[top.type];
-      if (act) lines.push('→ ' + act(top.detail));
+      var actLine = act ? act(top.detail) : null;
+      if (actLine) lines.push('→ ' + actLine);
     }
   }
   return lines.join('\n');

--- a/test/weather.test.js
+++ b/test/weather.test.js
@@ -331,23 +331,93 @@ describe('assessWeather', function() {
     }
   });
 
-  it('tooltip — cloudy+ has action line', function() {
-    var turns = repeat(30);
-    turns[turns.length - 1] = makeTurn({
+  it('#336 tooltip — only evidence-linked top factors have action lines (fail-on-old)', function() {
+    var ctxTurns = repeat(30);
+    ctxTurns[ctxTurns.length - 1] = makeTurn({
       usage: { input_tokens: 140000, cache_read_input_tokens: 30000, cache_creation_input_tokens: 10000, output_tokens: 800 },
       maxContext: 200000,
     });
-    var r = assessWeather(turns);
-    if (r.level === 'cloudy' || r.level === 'rainy' || r.level === 'stormy') {
-      assert.ok(r.tooltip.includes('→'), 'cloudy+ should have action line');
-    }
-  });
 
-  it('tooltip — stuck has specific action', function() {
-    var turns = [];
-    for (var i = 0; i < 15; i++) turns.push(makeTurn({ stopReason: 'tool_use', toolFail: true }));
-    var r = assessWeather(turns);
-    assert.ok(r.tooltip.includes('permissions'), 'stuck action should mention permissions');
+    var compactionTurns = repeat(20);
+    compactionTurns[5] = makeTurn({ isCompacted: true });
+    compactionTurns[10] = makeTurn({ isCompacted: true });
+    compactionTurns[15] = makeTurn({ isCompacted: true });
+
+    var truncationTurns = repeat(20);
+    truncationTurns[5] = makeTurn({ isCompacted: true });
+    truncationTurns[19] = makeTurn({
+      stopReason: 'max_tokens',
+      usage: { output_tokens: 20000, input_tokens: 20000, cache_read_input_tokens: 10000, cache_creation_input_tokens: 2000 },
+    });
+
+    var stuckTurns = repeat(20, function(i) {
+      return { id: 's' + i, stopReason: 'tool_use' };
+    });
+    for (var i = 20; i < 30; i++) {
+      stuckTurns.push(makeTurn({ id: 's' + i, stopReason: 'tool_use', toolFail: true }));
+    }
+
+    var clusterTurns = repeat(5, function(i) {
+      return { id: 'c' + i, stopReason: 'tool_use', toolFail: true, isCompacted: i === 0 };
+    });
+
+    var cumulativeTurns = repeat(100, function(i) {
+      return { id: 'e' + i, stopReason: 'tool_use', toolFail: i % 4 === 0 };
+    });
+
+    var cases = [
+      {
+        type: 'ctx_pressure',
+        turns: ctxTurns,
+        factors: 'context 90.4%',
+        action: null,
+      },
+      {
+        type: 'compaction_scar',
+        turns: compactionTurns,
+        factors: 'compaction ×3 (info lost)',
+        action: null,
+      },
+      {
+        type: 'truncation',
+        turns: truncationTurns,
+        factors: 'output truncated (turn 19) · compaction ×1 (info lost)',
+        action: null,
+      },
+      {
+        type: 'latency_drift',
+        turns: repeat(10, { elapsed: '33.44' }),
+        factors: 'latency 2.2x baseline',
+        action: null,
+      },
+      {
+        type: 'stuck',
+        turns: stuckTurns,
+        factors: 'stuck 10 failures (turn 20-29) · 10/30 tool errors (33%) · error burst 100% (turn 20-24)',
+        action: '→ Check turn 20-29 — usually permissions or paths',
+      },
+      {
+        type: 'error_cluster',
+        turns: clusterTurns,
+        factors: 'error burst 100% (turn 0-4) · compaction ×1 (info lost)',
+        action: '→ Check turn 0-4',
+      },
+      {
+        type: 'error_cumulative',
+        turns: cumulativeTurns,
+        factors: '25/100 tool errors (25%) · error burst 40% (turn 0-4)',
+        action: '→ Check first error — common: permissions, paths, settings',
+      },
+    ];
+
+    cases.forEach(function(testCase) {
+      var result = assessWeather(testCase.turns);
+      var lines = result.tooltip.split('\n');
+      assert.equal(result.factors[0].type, testCase.type, testCase.type + ' should be the top factor');
+      assert.equal(lines[1], testCase.factors, testCase.type + ' factor formatting should stay unchanged');
+      var actionLines = lines.filter(function(line) { return line.indexOf('→ ') === 0; });
+      assert.deepEqual(actionLines, testCase.action ? [testCase.action] : [], testCase.type + ' action line');
+    });
   });
 
   // ── #387: ctx numerator includes output_tokens (match computeCtxUsed) ──

--- a/test/weather.test.js
+++ b/test/weather.test.js
@@ -365,6 +365,12 @@ describe('assessWeather', function() {
       return { id: 'e' + i, stopReason: 'tool_use', toolFail: i % 4 === 0 };
     });
 
+    // Same shape, no turn ids → firstErrId stays null, so error_cumulative has
+    // nothing to link to and must emit NO action line (#336 codex R1 P2).
+    var cumulativeNoIdTurns = repeat(100, function(i) {
+      return { stopReason: 'tool_use', toolFail: i % 4 === 0 };
+    });
+
     var cases = [
       {
         type: 'ctx_pressure',
@@ -407,6 +413,12 @@ describe('assessWeather', function() {
         turns: cumulativeTurns,
         factors: '25/100 tool errors (25%) · error burst 40% (turn 0-4)',
         action: '→ Check first error — common: permissions, paths, settings',
+      },
+      {
+        type: 'error_cumulative',
+        turns: cumulativeNoIdTurns,
+        factors: '25/100 tool errors (25%) · error burst 40% (turn 0-4)',
+        action: null,
       },
     ];
 


### PR DESCRIPTION
## 繁中摘要

移除 weather tooltip 的 4 個不可證偽建議（`_ACTION_TABLE` 的 `ctx_pressure` / `compaction_scar` / `truncation` / `latency_drift`），保留 3 個會導向實際 turn 的（`stuck` / `error_cluster` / `error_cumulative`）一字不改。

分界：**留下的在導航到證據，刪掉的在教人怎麼做**。「Break into smaller steps」這類建議使用者無法判斷照做後是否改善，屬本專案一貫在移除的類別（ADR 0017 的 fabrication marker、#441 的 Lie Factor 修正）。

範圍依 #336 自身 2026-07-29 留言已縮限，本 PR 未擴張。

## Why this is a pure deletion

The call site already guards on entry absence:

```js
var act = _ACTION_TABLE[top.type];
if (act) lines.push('→ ' + act(top.detail));
```

Removing an entry therefore just stops emitting the action line. `_buildTooltip` is untouched; no fallback copy was added; the 3 evidence-linked entries are byte-identical.

## Evidence

### 1. Differential check (fail-on-old / pass-on-new) — the load-bearing evidence

Same test file, same command, only `public/weather.js` swapped:

| weather.js | `node --test test/weather.test.js` |
|---|---|
| **new (this PR)** | **exit 0** — 33 pass / 0 fail |
| **old (origin/main)** | **exit 1** — 32 pass / **1 fail** |

The failing subtest on old code is precisely the new one, and its first assertion message names the first removed entry:

```
not ok 30 - #336 tooltip — only evidence-linked top factors have action lines (fail-on-old)
    ctx_pressure action line
```

### 2. Rendered DOM before/after (live isolated instance, real render path)

Hovering the **same turn bar** (#7, ctx 76.3%) in the swimlane, reading the `.wf-tooltip` container's row text:

```
BEFORE  Health  ⛅ Quality starting to degrade · context 76.3% · → Use subagent for next independent task
AFTER   Health  ⛅ Quality starting to degrade · context 76.3%
```

Every other row (Context / Cache / Cost / Duration / Tokens / Tools) is identical between the two runs — a controlled comparison, one line differs.

### 3. Full suite

`perl -e 'alarm shift @ARGV; exec @ARGV' 300 sh -c 'node --test test/*.test.js'` → **exit 0, 1772 tests, 1772 pass, 0 fail**

### 4. Boot smoke

`CCXRAY_HOME=$(mktemp -d) bash scripts/boot-smoke.sh` → **exit 0**, `BOOT OK: dashboard HTTP 200`

### 5. Orphan scan

`_ACTION_TABLE.{ctx_pressure,compaction_scar,truncation,latency_drift}` direct references across `public/` `server/` `test/` → **0 each**. The four names still exist as *factor types* (detection side untouched) — that is correct and intended.

### 6. Isomorphic load paths

`public/weather.js` is loaded both by a browser script tag and by Node `require`. `node -e "require('./public/weather.js')"` → exports `assessWeather`, callable. Browser path exercised by the DOM capture in §2.

## 沒驗的部分（誠實界定）

- **GitHub 附件截圖未附**：兩張 before/after 截圖已產出（tooltip 鎖定可見後截圖，內容由真實 hover handler 產生、僅阻止 auto-hide），但 GitHub 無公開 API 可程式化上傳附件，需人工拖放。`evidence-check.sh` 因此會 exit 1，待 owner 補圖或裁定以 §2 的 DOM 文字證據替代。
- **驗收環境的 body 檔不完整**：合成 fixture（`scripts/generate-screenshot-fixtures.js`）只有 index 行與少量 `_req/_res`，所以 TIMELINE 面板顯示「turn data could not be loaded」。**不影響本 PR 的斷言**——swimlane hover tooltip 由 index 欄位（usage / maxContext）計算，不讀 body 檔。
- 其餘 3 個保留的 entry 只驗了「輸出仍含其 `→ Check …` 行」，未逐一驗其連結目標正確性（本 PR 未改它們）。

Fixes #336

<!-- GATE-MANIFEST
issue-lint=pass @f53ba72f8308bc21c97d56f2a659cc07d525402c
full-test=0 @f53ba72f8308bc21c97d56f2a659cc07d525402c
boot-smoke=0 @f53ba72f8308bc21c97d56f2a659cc07d525402c
diff-check=0 @f53ba72f8308bc21c97d56f2a659cc07d525402c
-->


---

## 追加（codex R1 P2 → 選項 B，owner 授權低嚴重度自行裁定）

`error_cumulative` 在 `firstErrId` 缺席時原本仍輸出 `Check tool errors — common: permissions, paths, settings`——**有建議、無證據指向**，正是本 PR 移除的那一類。改為回 `null`，並把呼叫點的守衛從「entry 是否存在」改為「**回傳值**是否存在」，讓任何 entry 都能選擇不輸出。

`_ACTION_TABLE` 現在 3 個 entry 全部滿足「導向證據」：`stuck`／`error_cluster` 必帶區間連結，`error_cumulative` 帶 turn 連結或不輸出。

**可達性（誠實界定）**：只在 turn 無 `id` 時觸發。`id` 是 `INDEX_FIELDS` 首欄且 `store.registerEntry` 以它為 `entryIndex` 的鍵，8 個 `assessWeather` 生產呼叫點餵的都是帶 id 的 turns——所以這是**契約守衛，不是線上路徑修復**。

### 追加改動的差異證據

| weather.js | `node --test test/weather.test.js` |
|---|---|
| 新（`661a542`） | **exit 0** — 33 pass / 0 fail |
| 舊（`e70940c`，即本 PR 的前一個 commit） | **exit 1** — 32 pass / **1 fail**，斷言訊息 `error_cumulative action line` |

新測試 case 餵入**無 id** 的同形 turns，涵蓋原本漏測的路徑。

其餘 gate 重跑：full-test **exit 0 / 1772 pass**、boot-smoke **exit 0**、被移除字串 `Check tool errors` 於 `public/` `server/` `test/` **零殘留**。


---

## 同步 main 後重跑（head `f53ba72`）

合入 main 以取得 #457 的 lockfile 修復（原本 `audit` job 因舊 lockfile 呈紅、分支狀態 BEHIND）。四個 gate 於新 head 重跑：

| gate | 結果 |
|---|---|
| diff-check | 舊 `weather.js`（`f4f48d9`）**exit 1** · `# fail 1`；新 **exit 0** |
| full-test | **exit 0** · `# tests 1772 / # pass 1772 / # fail 0` |
| boot-smoke | **exit 0** · `BOOT OK: dashboard HTTP 200` |
| issue-lint | pass |

合入的內容只有 `package-lock.json` 3 行，與本 PR 的 `public/weather.js` / `test/weather.test.js` 無交集。


---

## codex review（二審，兩輪）

`scripts/pipeline/codex-review.sh --base origin/main`（ops 圍堵版 wrapper）：

| 輪 | 對象 | 結果 |
|---|---|---|
| R1 | `e70940c`（僅移除 4 個 entry） | `verdict: issues（findings: 1；63s）` — P2：`error_cumulative` 在 `firstErrId` 缺席時仍輸出無連結的通用建議 |
| R2 | `661a542`（已修 R1 的 P2） | `verdict: pass（findings: 0；39s）` |

R1 的 finding 經我獨立驗證**成立**（宣稱的分支確實輸出無連結建議），但**生產路徑不可達**（`id` 為 `INDEX_FIELDS` 首欄、`store.registerEntry` 以它為鍵，8 個 `assessWeather` 呼叫點餵的 turns 皆帶 id）。owner 裁定採選項 B 一併修掉，理由與逐條驗證見 PR comment。R2 零 finding。
