### PR TITLE
ci: move npm audit to a separate non-blocking job (#297)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
-      - name: Audit dependencies (high+)
-        run: npm audit --audit-level=high
       # Run against an empty CCXRAY_HOME so a test that forgets to isolate
       # (rule 1 in docs/testing.md) can't read the real ~/.ccxray and starts
       # from an empty log dir. $HOME is left untouched so puppeteer's Chrome
@@ -33,3 +31,27 @@ jobs:
         run: |
           mkdir -p "$RUNNER_TEMP/empty-ccxray"
           CCXRAY_HOME="$RUNNER_TEMP/empty-ccxray" npm test
+
+  # Separate, non-blocking job (#297). It used to be a step inside `test`, ahead
+  # of the test run — so a new advisory against ANY transitive dep failed the
+  # step and left `npm test` SKIPPED. That happened for real: an `ip-address`
+  # high advisory landed 2026-08-04 and the next 8 main runs never executed a
+  # single test, while the red badge read as "audit is red" rather than "nothing
+  # was verified".
+  #
+  # Non-blocking is achieved by job separation, NOT by continue-on-error: branch
+  # protection requires only `test (20)` / `test (22)`, so this job stays visibly
+  # red without gating merge. Deliberately no continue-on-error — swallowing the
+  # failure into a green check would hide the advisory, which is the opposite of
+  # the goal.
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Audit dependencies (high+)
+        run: npm audit --audit-level=high


### PR DESCRIPTION
## 繁中摘要

把 `npm audit --audit-level=high` 從 `test` job 的步驟移出，改成獨立的 `audit` job。

**這不是預防性整理，是修一個正在發生的故障。** audit 原本排在測試之前的同一個 job 裡，所以任一 transitive dep 出現 high advisory 就會讓該步驟 exit 1，而後面的 `npm test` 直接被 **skipped**。

## 故障實況（發現於派工 #336 時撞到）

`ip-address` 的 3 個 high advisory 於 2026-08-04 出現後，main 的 CI 連續 8 次全紅，**每一次的測試步驟都是 skipped**：

| 日期 | commit | 結果 |
|---|---|---|
| 2026-08-03 | `609c533` | success ← 最後一次真的跑過測試 |
| 2026-08-04 | `ab3fe04` | failure（audit 紅、test skipped） |
| 2026-08-04 | `db384f2` `9d01d91` `9b73941` `0b935be` `c5a8bc2` `7016532` | failure（同上） |
| 2026-08-05 | `d2291dd` | failure（同上） |

兩個後果，第二個比第一個嚴重：

1. 每個 PR 都 merge 不了（strict protection 要求 `test (20)`/`test (22)`）
2. **CI 對這 8 個 commit 沒有任何驗證效力** —— 紅燈被解讀為「audit 紅」，掩蓋了「測試根本沒執行」

## 修法

`audit` 獨立成 job。**非阻塞來自 job 分離，不是 `continue-on-error`** —— branch protection 只要求 `test (20)`/`test (22)`，所以新的 `audit` job 會**明顯地紅**但不擋 merge。刻意不加 `continue-on-error`：把失敗吞成綠燈會藏掉 advisory，與本 issue 的目的相反。

audit 不隨 node 版本矩陣跑（與版本無關），單跑一次。

## Evidence

### 1. 結構驗證（真實 YAML 解析，非 grep）

```
jobs = ['test', 'audit']
npm audit → job: audit      npm test → job: test
test steps = 4              audit steps = 4
test job 內含 audit: False
continue-on-error 鍵: 不存在（僅註解提及，說明為何刻意不用）
```

### 2. 差異證據 —— 本 PR 自己的 CI run 就是證據

- **舊行為**：`Run tests with isolated empty CCXRAY_HOME` = `skipped`
- **新行為預期**：`test (20)`/`test (22)` 實際執行測試並回報真實結果；`audit` job 獨立紅（advisory 仍在）

這是可在本 PR 的 Checks 頁直接核對的 old-fail/new-pass。**請以此 run 的實際 step 狀態為準**，不要只看總體紅綠。

## 沒驗的部分（誠實界定）

- **`ip-address` advisory 本身未處理**。本 PR 只讓 advisory 不再停掉測試；要不要 `npm audit fix`、或需等上游，是另一件事，刻意不綁在一起（把兩件事混在一個 PR 會讓「CI 不該因 advisory 停跑測試」這個結論失焦）。
- **branch protection 的 required checks 未改動**。新的 `audit` job 之所以非阻塞，是因為它不在 required 清單裡；若日後有人把它加進 required，本 PR 的效果會被逆轉。
- 未在本機模擬 GitHub Actions 執行（無 act），結構正確性靠 YAML 解析 + 本 PR 的真實 run 驗證。

Fixes #297

<!-- GATE-MANIFEST
issue-lint=pass @584cf49c4a3e505ad5048a652b4e2a6c10b0aa94
full-test=0 @584cf49c4a3e505ad5048a652b4e2a6c10b0aa94
boot-smoke=0 @584cf49c4a3e505ad5048a652b4e2a6c10b0aa94
-->

---

### 本機 gate 實數（非 `n/a`）

| gate | 指令 | 結果 |
|---|---|---|
| full-test | `alarm 300 node --test test/*.test.js` | **exit 0** · 1773 tests / 1773 pass / 0 fail |
| boot-smoke | `CCXRAY_HOME=$(mktemp -d) bash scripts/boot-smoke.sh` | **exit 0** · `BOOT OK: dashboard HTTP 200` |
| issue-lint | `issue-lint.sh 297` | **pass** |

（1773 與 #455 的 1772 差一支，是因為 #455 用 1 支測試替換掉 2 支——同一個 base，數字一致。）


---

## codex review（二審）

`scripts/pipeline/codex-review.sh --base origin/main`（ops 圍堵版 wrapper，非 `codex review --base`）：

```
✓ verdict: pass（findings: 0；18s；out 3993B）
```

收斂乾淨、零 finding。依 wrapper 規則 verdict 是注意力提示非裁決，但此處無 finding 需逐條 verify-gate。
