### PR TITLE
chore(deps): bump ip-address to 10.4.0 in the lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1295,9 +1295,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## 繁中摘要

把 lockfile 裡的 `ip-address` 從 **10.2.0 → 10.4.0**，讓 `audit` job 轉綠。

這是 stale lockfile，不是缺上游修補：advisory 範圍是 `<=10.3.0`，而 10.4.0 早已存在，且依賴鏈在未釘住時本來就解到它（`puppeteer → @puppeteer/browsers → proxy-agent → socks-proxy-agent → socks@2.8.x`）。本機 pnpm 樹裝的正是 10.4.0，puppeteer 一直正常運作——相容性有現成證據。

**dev 依賴，生產 runtime 不受影響**：diff 裡該項標著 `"dev": true`（經 puppeteer，供 browser e2e 用）。

## 改動範圍

`package-lock.json` 一個檔案、**3 行**（version / resolved / integrity）。`socks` 停在 2.8.7 未動，無任何直接依賴變動。用 `npm audit fix --package-lock-only` 產生。

## Evidence

### 差異證據（fail-on-old / pass-on-new）

同一條 CI 命令 `npm audit --audit-level=high`，只換 lockfile：

| lockfile | 結果 |
|---|---|
| 舊（`origin/main`） | **exit 1** — `1 high severity vulnerability` |
| 新（本 PR） | **exit 0** — `found 0 vulnerabilities` |

### 實裝驗證

`npm ci` → **exit 0**；`node_modules/ip-address/package.json` 的 version = **10.4.0**（確認 lockfile 真的產出預期版本，非只是 audit 過關）。

### 背景：這是 #297 之後剩下的另一半

#297（PR #456）把 audit 拆成獨立 job，讓 advisory 不再讓測試被 `skipped`——那修的是「advisory 不該停掉測試」。本 PR 修的是 advisory 本身。兩者合起來，main 的 CI 才恢復成一眼可判：`test` 綠 = 測試真的跑過且通過，`audit` 綠 = 無 high advisory。

## 補跑結果（2026-08-06，本機）

- **boot-smoke**: `npm ci --omit=dev`（ccxray 生產零依賴，故不需 dev 樹）→ `bash scripts/boot-smoke.sh` → **exit 0**，`BOOT OK: dashboard HTTP 200`
- **full-test**: 由本 PR 的 CI 提供 —— `test (20)` / `test (22)` 皆 success，實際步驟 `Run npm ci` + `Run tests with isolated empty CCXRAY_HOME` 皆 success，計數 **# tests 1773 / # pass 1772 / # fail 0 / # skipped 1**。在乾淨環境從新 lockfile 實裝後跑，比本機更有代表性。

## 仍未驗的部分（誠實界定）

- **本機未跑完整測試套件**。驗證途中本機磁碟用盡（`no space left on device`，根因見下），puppeteer 的 `node_modules` 裝完後空間不足以續跑 e2e。**本 PR 的完整驗證交由 CI**——CI 走的正是 `npm ci` + 空 `CCXRAY_HOME` 全測試，且該路徑已於 #456 修復後恢復實際執行。請以本 PR 的 `test (20)`/`test (22)` 結果為準。
- 未逐一驗證 `ip-address` 10.2→10.4 之間的 API 變動對 `socks` 的影響；依據是本機 pnpm 樹已長期以 10.4.0 運作，以及 socks 的 semver 範圍本就容許。

Fixes the `audit` job failure introduced by GHSA-mwp4-54f8-5fhr / GHSA-4xrf-jv44-h6hh / GHSA-22jq-vg5j-6vgg

<!-- GATE-MANIFEST
issue-lint=pass @d0206ad527db3b4661a8a01c79ec8111977c7bd5
full-test=0 @d0206ad527db3b4661a8a01c79ec8111977c7bd5
boot-smoke=0 @d0206ad527db3b4661a8a01c79ec8111977c7bd5
-->

---

## codex review（二審）

`scripts/pipeline/codex-review.sh --base origin/main`（ops 圍堵版 wrapper）：

```
✓ verdict: pass（findings: 0；18s；out 2875B）
```

零 finding，無需逐條 verify-gate。
