### PR TITLE
fix(hooks): check-codex-review gates the merge's target repo via a verifiable grammar

### DIFF
--- a/.claude/hooks/check-codex-review.sh
+++ b/.claude/hooks/check-codex-review.sh
@@ -10,11 +10,19 @@ if [ -z "$CMD" ] || ! echo "$CMD" | grep -qE '^gh pr merge|&& gh pr merge|; gh p
   exit 0
 fi
 
+# Scope all parsing to THIS merge invocation: cut the tail at the next command
+# separator so a later command's arguments (e.g. `&& gh pr view 12 --repo other`)
+# can't leak their repo or number into the check (codex review finding, 2026-08-06).
+MERGE_TAIL=${CMD#*gh pr merge}
+MERGE_ARGS=$(echo "$MERGE_TAIL" | sed -E 's/(&&|\|\||;|\|).*$//')
+
 # Extract PR number: first standalone integer argument after `gh pr merge`
 # (handles both `merge 11 --repo X` and `merge --repo X 11`; a repo name like
-# lis186/ccxray is not a standalone integer so it can't be mistaken for one)
-MERGE_TAIL=${CMD#*gh pr merge}
-PR_NUM=$(echo "$MERGE_TAIL" | grep -oE '(^|[[:space:]])[0-9]+([[:space:]]|$)' | grep -oE '[0-9]+' | head -1)
+# lis186/ccxray is not a standalone integer so it can't be mistaken for one).
+# Known limit: a numeric value of an unrelated flag (`--subject 11 12`) can be
+# misread as the PR number — resolving that needs gh's flag arity table, which
+# is out of proportion for a heuristic guard against accidental merges.
+PR_NUM=$(echo "$MERGE_ARGS" | grep -oE '(^|[[:space:]])[0-9]+([[:space:]]|$)' | grep -oE '[0-9]+' | head -1)
 if [ -z "$PR_NUM" ]; then
   # No PR number (e.g. `gh pr merge` without args) — allow, gh will prompt
   exit 0
@@ -25,8 +33,8 @@ fi
 # body happens to contain "codex review" would silently pass an unreviewed PR
 # (ops docs/solutions/gate-script-vs-runbook-contradictions.md item 3).
 REPO_ARG=""
-if echo "$CMD" | grep -qE '(^|[[:space:]])(-R|--repo)([= ]|$)'; then
-  REPO_ARG=$(echo "$CMD" | sed -nE 's/.*(^|[[:space:]])(-R|--repo)[= ]([^[:space:]]+).*/\3/p' | head -1)
+if echo "$MERGE_ARGS" | grep -qE '(^|[[:space:]])(-R|--repo)([= ]|$)'; then
+  REPO_ARG=$(echo "$MERGE_ARGS" | sed -nE 's/.*(^|[[:space:]])(-R|--repo)[= ]([^[:space:]]+).*/\3/p' | head -1)
   if [ -z "$REPO_ARG" ]; then
     # -R/--repo present but unparseable — fail closed rather than validate the cwd repo
     echo '{"decision":"block","reason":"gh pr merge carries -R/--repo but the hook could not parse the target repo — refusing to validate against the cwd repo PR #'"$PR_NUM"'"}'

--- a/.claude/hooks/check-codex-review.sh
+++ b/.claude/hooks/check-codex-review.sh
@@ -30,12 +30,13 @@ while [ "${REST#*gh pr merge}" != "$REST" ]; do
   REST=$TAIL
   SEG=$(echo "$TAIL" | sed -E 's/(&&|\|\||;|\|).*$//')
 
-  # Quote-aware shell parsing is out of reach for a bash heuristic; a quote inside
-  # the merge segment means the separator cut above may be wrong — fail closed
-  # (codex R2). Merges in this repo's workflow don't need quoted arguments.
+  # Shell-aware parsing is out of reach for a bash heuristic: quotes and escapes
+  # defeat the separator cut (codex R2/R3), and $-substitution means the hook can't
+  # know which PR is being merged. Any of them in the merge segment → fail closed.
+  # Merges in this repo's workflow are plain `gh pr merge <n> [--repo x] --squash`.
   case "$SEG" in
-    *"'"* | *'"'* )
-      block "gh pr merge with quoted arguments cannot be parsed safely by the codex-review hook — run gh pr merge as a standalone command without quotes"
+    *"'"* | *'"'* | *'\'* | *'`'* | *'$'* )
+      block "gh pr merge with quoted, escaped, or dynamic (\$/backtick) arguments cannot be parsed safely by the codex-review hook — run gh pr merge as a standalone command with a literal PR number"
       ;;
   esac
 

--- a/.claude/hooks/check-codex-review.sh
+++ b/.claude/hooks/check-codex-review.sh
@@ -45,19 +45,26 @@ quote_state() {
       for (i = 1; i <= length(line); i++) {
         c = substr(line, i, 1)
         if (s == 0) {
-          if (c == "#" && (i == 1 || substr(line, i-1, 1) ~ /[ \t]/)) break
-          if (c == "\x27") s = 1
+          # comment starts at line start or after a token boundary (codex R7)
+          if (c == "#" && (i == 1 || substr(line, i-1, 1) ~ /[ \t;&|()]/)) break
+          if (c == "\x27") {
+            # ANSI-C $\x27…\x27 quote: backslash escapes inside (codex R7)
+            if (i > 1 && substr(line, i-1, 1) == "$") s = 3; else s = 1
+          }
           else if (c == "\"") s = 2
           else if (c == "\\") i++
         } else if (s == 1) {
           if (c == "\x27") s = 0
+        } else if (s == 3) {
+          if (c == "\\") i++
+          else if (c == "\x27") s = 0
         } else {
           if (c == "\"") s = 0
           else if (c == "\\") i++
         }
       }
     }
-    END { print s + 0 }'
+    END { print (s + 0 == 0) ? 0 : s }'
 }
 
 # Iterate EVERY textual `gh pr merge` occurrence — a preceding occurrence must not

--- a/.claude/hooks/check-codex-review.sh
+++ b/.claude/hooks/check-codex-review.sh
@@ -17,8 +17,15 @@
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
 
+# Threat model: guards the repo's own trusted agent against ACCIDENTAL ungated
+# merges. Deliberate evasion (gh pr \"merge\", m=merge; gh pr \$m, base64 wrappers…)
+# is out of scope — the agent is not an adversary (same stance as ops
+# scrub-output.sh). Whitespace runs are squeezed so an accidental double space
+# doesn't dodge the textual scan.
+CMDS=$(printf '%s' "$CMD" | tr '\t' ' ' | tr -s ' ')
+
 # Fast path: the literal phrase appears nowhere
-case "$CMD" in
+case "$CMDS" in
   *"gh pr merge"*) ;;
   *) exit 0 ;;
 esac
@@ -33,13 +40,28 @@ block() {
 # are parsed: start of line, or after ; & | ( — `||` and newlines included (codex
 # R4). A space-preceded prose mention (commit -m text, echo of docs) is skipped —
 # prose in messages routinely names this command and must not trip the gate.
-REST=$CMD
+REST=$CMDS
+CONSUMED=""
 while [ "${REST#*gh pr merge}" != "$REST" ]; do
   PREFIX=${REST%%gh\ pr\ merge*}
   TAIL=${REST#*gh pr merge}
   REST=$TAIL
-  LASTLINE=${PREFIX##*$'\n'}
-  if [ -n "$LASTLINE" ] && ! printf '%s' "$LASTLINE" | grep -qE '^[[:space:]]*$|[;&|(][[:space:]]*$'; then
+  FULLPREFIX="$CONSUMED$PREFIX"
+  CONSUMED="$FULLPREFIX""gh pr merge"
+
+  # Inside an unclosed quote = prose in a string (commit -m text quoting a merge
+  # command), never a command start — skip. Parity on the FULL prefix from the
+  # start of the command line.
+  DQ=$(printf '%s' "$FULLPREFIX" | tr -cd '"' | wc -c)
+  SQ=$(printf '%s' "$FULLPREFIX" | tr -cd "'" | wc -c)
+  if [ $((DQ % 2)) -eq 1 ] || [ $((SQ % 2)) -eq 1 ]; then
+    continue
+  fi
+
+  LASTLINE=${FULLPREFIX##*$'\n'}
+  # Command start = line start, after ; & | ( {, or after env-assignment /
+  # env / command prefixes (GH_TOKEN=x gh pr merge … is an accidental shape).
+  if [ -n "$LASTLINE" ] && ! printf '%s' "$LASTLINE" | grep -qE '(^[[:space:]]*|[;&|({][[:space:]]*)((env|command)[[:space:]]+|[A-Za-z_][A-Za-z_0-9]*=[^[:space:]]*[[:space:]]+)*$'; then
     continue
   fi
 
@@ -55,8 +77,10 @@ while [ "${REST#*gh pr merge}" != "$REST" ]; do
   esac
 
   # This invocation's own arguments: first line only, cut at the first command
-  # separator or comment start ( ; | & # — covers && and || as prefixes; codex R1/R4)
-  SEG=$(printf '%s' "$FIRST_LINE" | sed -E 's/[;&|#].*$//')
+  # separator ( ; | & — covers && and || as prefixes; codex R1/R4). A comment
+  # starts only where # begins a word ( 11#feature is a branch selector, not a
+  # comment — codex R5; it then falls to the token allowlist and fails closed).
+  SEG=$(printf '%s' "$FIRST_LINE" | sed -E 's/[;&|].*$//; s/(^|[[:space:]])#.*$//')
 
   # Token-level allowlist parse
   PR_NUM=""; REPO_ARG=""; EXPECT_REPO_VAL=0; BAD=""

--- a/.claude/hooks/check-codex-review.sh
+++ b/.claude/hooks/check-codex-review.sh
@@ -1,73 +1,106 @@
 #!/bin/bash
-# PreToolUse hook: block `gh pr merge` unless PR body contains codex review evidence.
-# Exit 0 = allow, exit 2 + JSON = block.
+# PreToolUse hook: block `gh pr merge` unless the target PR's body contains codex
+# review evidence. Exit 0 = allow, exit 2 + JSON = block.
 #
-# This is a heuristic guard against ACCIDENTAL unreviewed merges by the repo's own
-# trusted agent — not an adversarial filter. Where bash-level parsing of a shell
-# command cannot be done safely (quoted arguments), it fails CLOSED: better to ask
-# for a simpler command than to silently pass an unreviewed PR.
+# Design: this is a guard against ACCIDENTAL unreviewed merges by the repo's own
+# trusted agent. Bash cannot fully parse shell, so instead of chasing parser holes
+# (quotes, escapes, comments, substitutions — codex R2/R3/R4) the gate accepts ONE
+# verifiable grammar and fails CLOSED on everything else:
+#
+#   gh pr merge <number | github pull URL>
+#       [--repo owner/repo | -R owner/repo | --repo=x | -Rx]
+#       [--squash|--merge|--rebase|-s|-m|-r] [--delete-branch|-d] [--admin] [--auto]
+#
+# Anything outside that shape (branch selectors, current-branch merge, value-taking
+# flags like --subject, $VARs, quotes, escapes) → block with instructions.
 
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
 
-# If jq fails or command doesn't contain gh pr merge, allow
-if [ -z "$CMD" ] || ! echo "$CMD" | grep -qE '^gh pr merge|&& gh pr merge|; gh pr merge'; then
-  exit 0
-fi
+# Fast path: the literal phrase appears nowhere
+case "$CMD" in
+  *"gh pr merge"*) ;;
+  *) exit 0 ;;
+esac
 
 block() {
   echo '{"decision":"block","reason":"'"$1"'"}'
   exit 2
 }
 
-# Iterate EVERY textual `gh pr merge` occurrence: a quoted 'gh pr merge' inside an
-# earlier argument must not shadow the real invocation (codex R2). Each occurrence
-# is parsed only up to the next command separator so a later command's arguments
-# (e.g. `&& gh pr view 12 --repo other`) can't leak in (codex R1).
+# Iterate EVERY textual `gh pr merge` occurrence — a preceding occurrence must not
+# shadow a later real invocation (codex R2). Only occurrences at a COMMAND START
+# are parsed: start of line, or after ; & | ( — `||` and newlines included (codex
+# R4). A space-preceded prose mention (commit -m text, echo of docs) is skipped —
+# prose in messages routinely names this command and must not trip the gate.
 REST=$CMD
 while [ "${REST#*gh pr merge}" != "$REST" ]; do
+  PREFIX=${REST%%gh\ pr\ merge*}
   TAIL=${REST#*gh pr merge}
   REST=$TAIL
-  SEG=$(echo "$TAIL" | sed -E 's/(&&|\|\||;|\|).*$//')
+  LASTLINE=${PREFIX##*$'\n'}
+  if [ -n "$LASTLINE" ] && ! printf '%s' "$LASTLINE" | grep -qE '^[[:space:]]*$|[;&|(][[:space:]]*$'; then
+    continue
+  fi
 
-  # Shell-aware parsing is out of reach for a bash heuristic: quotes and escapes
-  # defeat the separator cut (codex R2/R3), and $-substitution means the hook can't
-  # know which PR is being merged. Any of them in the merge segment → fail closed.
-  # Merges in this repo's workflow are plain `gh pr merge <n> [--repo x] --squash`.
-  case "$SEG" in
+  # Shell dynamics the gate cannot resolve → fail closed (codex R2/R3): quotes and
+  # escapes defeat any separator logic; $ and backticks mean the merged PR is not
+  # knowable statically. Checked on the raw tail BEFORE cutting, so an escaped or
+  # quoted separator cannot fake an early end of the invocation.
+  FIRST_LINE=$(printf '%s' "$TAIL" | sed -n '1p')
+  case "$FIRST_LINE" in
     *"'"* | *'"'* | *'\'* | *'`'* | *'$'* )
       block "gh pr merge with quoted, escaped, or dynamic (\$/backtick) arguments cannot be parsed safely by the codex-review hook — run gh pr merge as a standalone command with a literal PR number"
       ;;
   esac
 
-  # PR number: first standalone integer argument in this merge invocation
-  # (handles both `merge 11 --repo X` and `merge --repo X 11`; a repo name like
-  # lis186/ccxray is not a standalone integer so it can't be mistaken for one).
-  # Known limit: a numeric value of an unrelated flag (`--subject 11 12`) can be
-  # misread as the PR number — resolving that needs gh's flag arity table, which
-  # is out of proportion for a guard against accidental merges.
-  PR_NUM=$(echo "$SEG" | grep -oE '(^|[[:space:]])[0-9]+([[:space:]]|$)' | grep -oE '[0-9]+' | head -1)
-  if [ -z "$PR_NUM" ]; then
-    # No PR number in this occurrence (e.g. the bare string, or `gh pr merge`
-    # without args where gh will prompt) — nothing checkable here.
-    continue
-  fi
+  # This invocation's own arguments: first line only, cut at the first command
+  # separator or comment start ( ; | & # — covers && and || as prefixes; codex R1/R4)
+  SEG=$(printf '%s' "$FIRST_LINE" | sed -E 's/[;&|#].*$//')
 
-  # Cross-repo: a merge can target another repo via -R/--repo. Without forwarding
-  # it, the body check reads the cwd repo's same-numbered PR — a colliding number
-  # whose body happens to contain "codex review" would silently pass an unreviewed
-  # PR (ops docs/solutions/gate-script-vs-runbook-contradictions.md item 3).
-  # Forms: `--repo X`, `--repo=X`, `-R X`, `-RX` (attached, codex R2).
-  REPO_ARG=""
-  if echo "$SEG" | grep -qE '(^|[[:space:]])(--repo([= ]|$)|-R)'; then
-    REPO_ARG=$(echo "$SEG" | sed -nE 's/.*(^|[[:space:]])(--repo[= ]|-R[= ]?)([^[:space:]]+).*/\3/p' | head -1)
-    if [ -z "$REPO_ARG" ]; then
-      # -R/--repo present but unparseable — fail closed rather than validate the cwd repo
-      block "gh pr merge carries -R/--repo but the hook could not parse the target repo — refusing to validate against the cwd repo PR #$PR_NUM"
+  # Token-level allowlist parse
+  PR_NUM=""; REPO_ARG=""; EXPECT_REPO_VAL=0; BAD=""
+  for tok in $SEG; do
+    if [ "$EXPECT_REPO_VAL" = 1 ]; then
+      REPO_ARG=$tok; EXPECT_REPO_VAL=0; continue
     fi
+    case "$tok" in
+      --repo|-R) EXPECT_REPO_VAL=1 ;;
+      --repo=?*) REPO_ARG=${tok#--repo=} ;;
+      -R?*) REPO_ARG=${tok#-R} ;;
+      --squash|--merge|--rebase|-s|-m|-r|--delete-branch|-d|--admin|--auto) ;;
+      https://github.com/*/pull/*)
+        if [ -n "$PR_NUM" ]; then BAD=$tok; break; fi
+        PR_NUM=$(printf '%s' "$tok" | grep -oE '/pull/[0-9]+' | grep -oE '[0-9]+' | head -1)
+        URL_REPO=$(printf '%s' "$tok" | sed -nE 's#https://github.com/([^/]+/[^/]+)/pull/.*#\1#p')
+        [ -n "$URL_REPO" ] && REPO_ARG=$URL_REPO
+        [ -z "$PR_NUM" ] && { BAD=$tok; break; } ;;
+      *)
+        if printf '%s' "$tok" | grep -qE '^[0-9]+$' && [ -z "$PR_NUM" ]; then
+          PR_NUM=$tok
+        else
+          BAD=$tok; break
+        fi ;;
+    esac
+  done
+
+  if [ -n "$BAD" ]; then
+    # Branch selectors, value-taking flags (--subject/--body/...), or anything else
+    # the gate cannot verify — including a second selector (codex R4).
+    block "codex-review hook cannot verify this merge form (unrecognized argument: $BAD) — use: gh pr merge <number|pull URL> [--repo owner/repo] [--squash|--merge|--rebase] [--delete-branch]"
+  fi
+  if [ "$EXPECT_REPO_VAL" = 1 ]; then
+    block "gh pr merge carries -R/--repo without a value — could not parse the target repo, refusing to validate against the cwd repo"
+  fi
+  if [ -z "$PR_NUM" ]; then
+    # No literal selector. Non-interactively gh merges the CURRENT BRANCH's PR —
+    # an ungated bypass if allowed (codex R4). Require an explicit number/URL.
+    block "gh pr merge without a literal PR number merges the current branch's PR ungated — pass an explicit PR number or pull URL"
   fi
 
-  # Check PR body (in the target repo when one was given)
+  # Check the PR body in the repo the merge actually targets (without forwarding
+  # -R/--repo, a same-numbered cwd PR containing 'codex review' would silently
+  # pass an unreviewed foreign PR — ops gate-script-vs-runbook-contradictions §3).
   if [ -n "$REPO_ARG" ]; then
     BODY=$(gh pr view "$PR_NUM" --repo "$REPO_ARG" --json body --jq '.body' 2>/dev/null || echo "")
   else

--- a/.claude/hooks/check-codex-review.sh
+++ b/.claude/hooks/check-codex-review.sh
@@ -20,9 +20,10 @@ CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
 # Threat model: guards the repo's own trusted agent against ACCIDENTAL ungated
 # merges. Deliberate evasion (gh pr \"merge\", m=merge; gh pr \$m, base64 wrappers…)
 # is out of scope — the agent is not an adversary (same stance as ops
-# scrub-output.sh). Whitespace runs are squeezed so an accidental double space
-# doesn't dodge the textual scan.
-CMDS=$(printf '%s' "$CMD" | tr '\t' ' ' | tr -s ' ')
+# scrub-output.sh). Normalization: backslash-newline continuations are joined
+# (codex R6) and whitespace runs squeezed so accidental line wrapping or a double
+# space doesn't dodge the textual scan.
+CMDS=$(printf '%s' "$CMD" | perl -0pe 's/\\\n//g' | tr '\t' ' ' | tr -s ' ')
 
 # Fast path: the literal phrase appears nowhere
 case "$CMDS" in
@@ -33,6 +34,30 @@ esac
 block() {
   echo '{"decision":"block","reason":"'"$1"'"}'
   exit 2
+}
+
+# Shell quote state at the end of the given text: 0=outside, 1=in-single,
+# 2=in-double. Models escapes and skips #-to-EOL comments while outside quotes
+# (codex R6: raw parity miscounts "don't" and quotes inside comments).
+quote_state() {
+  printf '%s' "$1" | awk '
+    { line = $0
+      for (i = 1; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        if (s == 0) {
+          if (c == "#" && (i == 1 || substr(line, i-1, 1) ~ /[ \t]/)) break
+          if (c == "\x27") s = 1
+          else if (c == "\"") s = 2
+          else if (c == "\\") i++
+        } else if (s == 1) {
+          if (c == "\x27") s = 0
+        } else {
+          if (c == "\"") s = 0
+          else if (c == "\\") i++
+        }
+      }
+    }
+    END { print s + 0 }'
 }
 
 # Iterate EVERY textual `gh pr merge` occurrence — a preceding occurrence must not
@@ -50,11 +75,8 @@ while [ "${REST#*gh pr merge}" != "$REST" ]; do
   CONSUMED="$FULLPREFIX""gh pr merge"
 
   # Inside an unclosed quote = prose in a string (commit -m text quoting a merge
-  # command), never a command start — skip. Parity on the FULL prefix from the
-  # start of the command line.
-  DQ=$(printf '%s' "$FULLPREFIX" | tr -cd '"' | wc -c)
-  SQ=$(printf '%s' "$FULLPREFIX" | tr -cd "'" | wc -c)
-  if [ $((DQ % 2)) -eq 1 ] || [ $((SQ % 2)) -eq 1 ]; then
+  # command), never a command start — skip. Shell-aware state on the FULL prefix.
+  if [ "$(quote_state "$FULLPREFIX")" != "0" ]; then
     continue
   fi
 

--- a/.claude/hooks/check-codex-review.sh
+++ b/.claude/hooks/check-codex-review.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # PreToolUse hook: block `gh pr merge` unless PR body contains codex review evidence.
 # Exit 0 = allow, exit 2 + JSON = block.
+#
+# This is a heuristic guard against ACCIDENTAL unreviewed merges by the repo's own
+# trusted agent — not an adversarial filter. Where bash-level parsing of a shell
+# command cannot be done safely (quoted arguments), it fails CLOSED: better to ask
+# for a simpler command than to silently pass an unreviewed PR.
 
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
@@ -10,48 +15,67 @@ if [ -z "$CMD" ] || ! echo "$CMD" | grep -qE '^gh pr merge|&& gh pr merge|; gh p
   exit 0
 fi
 
-# Scope all parsing to THIS merge invocation: cut the tail at the next command
-# separator so a later command's arguments (e.g. `&& gh pr view 12 --repo other`)
-# can't leak their repo or number into the check (codex review finding, 2026-08-06).
-MERGE_TAIL=${CMD#*gh pr merge}
-MERGE_ARGS=$(echo "$MERGE_TAIL" | sed -E 's/(&&|\|\||;|\|).*$//')
+block() {
+  echo '{"decision":"block","reason":"'"$1"'"}'
+  exit 2
+}
 
-# Extract PR number: first standalone integer argument after `gh pr merge`
-# (handles both `merge 11 --repo X` and `merge --repo X 11`; a repo name like
-# lis186/ccxray is not a standalone integer so it can't be mistaken for one).
-# Known limit: a numeric value of an unrelated flag (`--subject 11 12`) can be
-# misread as the PR number — resolving that needs gh's flag arity table, which
-# is out of proportion for a heuristic guard against accidental merges.
-PR_NUM=$(echo "$MERGE_ARGS" | grep -oE '(^|[[:space:]])[0-9]+([[:space:]]|$)' | grep -oE '[0-9]+' | head -1)
-if [ -z "$PR_NUM" ]; then
-  # No PR number (e.g. `gh pr merge` without args) — allow, gh will prompt
-  exit 0
-fi
+# Iterate EVERY textual `gh pr merge` occurrence: a quoted 'gh pr merge' inside an
+# earlier argument must not shadow the real invocation (codex R2). Each occurrence
+# is parsed only up to the next command separator so a later command's arguments
+# (e.g. `&& gh pr view 12 --repo other`) can't leak in (codex R1).
+REST=$CMD
+while [ "${REST#*gh pr merge}" != "$REST" ]; do
+  TAIL=${REST#*gh pr merge}
+  REST=$TAIL
+  SEG=$(echo "$TAIL" | sed -E 's/(&&|\|\||;|\|).*$//')
 
-# Cross-repo: a merge can target another repo via -R/--repo. Without forwarding it,
-# the body check reads the cwd repo's same-numbered PR — a colliding number whose
-# body happens to contain "codex review" would silently pass an unreviewed PR
-# (ops docs/solutions/gate-script-vs-runbook-contradictions.md item 3).
-REPO_ARG=""
-if echo "$MERGE_ARGS" | grep -qE '(^|[[:space:]])(-R|--repo)([= ]|$)'; then
-  REPO_ARG=$(echo "$MERGE_ARGS" | sed -nE 's/.*(^|[[:space:]])(-R|--repo)[= ]([^[:space:]]+).*/\3/p' | head -1)
-  if [ -z "$REPO_ARG" ]; then
-    # -R/--repo present but unparseable — fail closed rather than validate the cwd repo
-    echo '{"decision":"block","reason":"gh pr merge carries -R/--repo but the hook could not parse the target repo — refusing to validate against the cwd repo PR #'"$PR_NUM"'"}'
-    exit 2
+  # Quote-aware shell parsing is out of reach for a bash heuristic; a quote inside
+  # the merge segment means the separator cut above may be wrong — fail closed
+  # (codex R2). Merges in this repo's workflow don't need quoted arguments.
+  case "$SEG" in
+    *"'"* | *'"'* )
+      block "gh pr merge with quoted arguments cannot be parsed safely by the codex-review hook — run gh pr merge as a standalone command without quotes"
+      ;;
+  esac
+
+  # PR number: first standalone integer argument in this merge invocation
+  # (handles both `merge 11 --repo X` and `merge --repo X 11`; a repo name like
+  # lis186/ccxray is not a standalone integer so it can't be mistaken for one).
+  # Known limit: a numeric value of an unrelated flag (`--subject 11 12`) can be
+  # misread as the PR number — resolving that needs gh's flag arity table, which
+  # is out of proportion for a guard against accidental merges.
+  PR_NUM=$(echo "$SEG" | grep -oE '(^|[[:space:]])[0-9]+([[:space:]]|$)' | grep -oE '[0-9]+' | head -1)
+  if [ -z "$PR_NUM" ]; then
+    # No PR number in this occurrence (e.g. the bare string, or `gh pr merge`
+    # without args where gh will prompt) — nothing checkable here.
+    continue
   fi
-fi
 
-# Check PR body (in the target repo when one was given)
-if [ -n "$REPO_ARG" ]; then
-  BODY=$(gh pr view "$PR_NUM" --repo "$REPO_ARG" --json body --jq '.body' 2>/dev/null || echo "")
-else
-  BODY=$(gh pr view "$PR_NUM" --json body --jq '.body' 2>/dev/null || echo "")
-fi
+  # Cross-repo: a merge can target another repo via -R/--repo. Without forwarding
+  # it, the body check reads the cwd repo's same-numbered PR — a colliding number
+  # whose body happens to contain "codex review" would silently pass an unreviewed
+  # PR (ops docs/solutions/gate-script-vs-runbook-contradictions.md item 3).
+  # Forms: `--repo X`, `--repo=X`, `-R X`, `-RX` (attached, codex R2).
+  REPO_ARG=""
+  if echo "$SEG" | grep -qE '(^|[[:space:]])(--repo([= ]|$)|-R)'; then
+    REPO_ARG=$(echo "$SEG" | sed -nE 's/.*(^|[[:space:]])(--repo[= ]|-R[= ]?)([^[:space:]]+).*/\3/p' | head -1)
+    if [ -z "$REPO_ARG" ]; then
+      # -R/--repo present but unparseable — fail closed rather than validate the cwd repo
+      block "gh pr merge carries -R/--repo but the hook could not parse the target repo — refusing to validate against the cwd repo PR #$PR_NUM"
+    fi
+  fi
 
-if echo "$BODY" | grep -qiE 'codex gate clean|codex review|codex-exempt'; then
-  exit 0
-fi
+  # Check PR body (in the target repo when one was given)
+  if [ -n "$REPO_ARG" ]; then
+    BODY=$(gh pr view "$PR_NUM" --repo "$REPO_ARG" --json body --jq '.body' 2>/dev/null || echo "")
+  else
+    BODY=$(gh pr view "$PR_NUM" --json body --jq '.body' 2>/dev/null || echo "")
+  fi
 
-echo '{"decision":"block","reason":"PR #'"$PR_NUM"' body missing codex review evidence — run /codex-loop first"}'
-exit 2
+  if ! echo "$BODY" | grep -qiE 'codex gate clean|codex review|codex-exempt'; then
+    block "PR #$PR_NUM body missing codex review evidence — run /codex-loop first"
+  fi
+done
+
+exit 0

--- a/.claude/hooks/check-codex-review.sh
+++ b/.claude/hooks/check-codex-review.sh
@@ -10,15 +10,36 @@ if [ -z "$CMD" ] || ! echo "$CMD" | grep -qE '^gh pr merge|&& gh pr merge|; gh p
   exit 0
 fi
 
-# Extract PR number
-PR_NUM=$(echo "$CMD" | grep -oE 'gh pr merge[[:space:]]+([0-9]+)' | grep -oE '[0-9]+' | head -1)
+# Extract PR number: first standalone integer argument after `gh pr merge`
+# (handles both `merge 11 --repo X` and `merge --repo X 11`; a repo name like
+# lis186/ccxray is not a standalone integer so it can't be mistaken for one)
+MERGE_TAIL=${CMD#*gh pr merge}
+PR_NUM=$(echo "$MERGE_TAIL" | grep -oE '(^|[[:space:]])[0-9]+([[:space:]]|$)' | grep -oE '[0-9]+' | head -1)
 if [ -z "$PR_NUM" ]; then
   # No PR number (e.g. `gh pr merge` without args) — allow, gh will prompt
   exit 0
 fi
 
-# Check PR body
-BODY=$(gh pr view "$PR_NUM" --json body --jq '.body' 2>/dev/null || echo "")
+# Cross-repo: a merge can target another repo via -R/--repo. Without forwarding it,
+# the body check reads the cwd repo's same-numbered PR — a colliding number whose
+# body happens to contain "codex review" would silently pass an unreviewed PR
+# (ops docs/solutions/gate-script-vs-runbook-contradictions.md item 3).
+REPO_ARG=""
+if echo "$CMD" | grep -qE '(^|[[:space:]])(-R|--repo)([= ]|$)'; then
+  REPO_ARG=$(echo "$CMD" | sed -nE 's/.*(^|[[:space:]])(-R|--repo)[= ]([^[:space:]]+).*/\3/p' | head -1)
+  if [ -z "$REPO_ARG" ]; then
+    # -R/--repo present but unparseable — fail closed rather than validate the cwd repo
+    echo '{"decision":"block","reason":"gh pr merge carries -R/--repo but the hook could not parse the target repo — refusing to validate against the cwd repo PR #'"$PR_NUM"'"}'
+    exit 2
+  fi
+fi
+
+# Check PR body (in the target repo when one was given)
+if [ -n "$REPO_ARG" ]; then
+  BODY=$(gh pr view "$PR_NUM" --repo "$REPO_ARG" --json body --jq '.body' 2>/dev/null || echo "")
+else
+  BODY=$(gh pr view "$PR_NUM" --json body --jq '.body' 2>/dev/null || echo "")
+fi
 
 if echo "$BODY" | grep -qiE 'codex gate clean|codex review|codex-exempt'; then
   exit 0

--- a/test/check-codex-review-hook.test.js
+++ b/test/check-codex-review-hook.test.js
@@ -338,6 +338,20 @@ describe('check-codex-review hook — cross-repo scope', () => {
     assert.equal(r.status, 2);
   });
 
+  it('comment starting right after ; does not poison quote state (codex R7)', () => {
+    const r = runHook("echo ok;# don't merge manually\ngh pr merge 11 --squash", {
+      GH_BODY_LOCAL: 'no evidence',
+    });
+    assert.equal(r.status, 2);
+  });
+
+  it('ANSI-C quote with escaped apostrophe does not skip the real merge (codex R7)', () => {
+    const r = runHook("echo $'don\\'t forget' && gh pr merge 11 --squash", {
+      GH_BODY_LOCAL: 'no evidence',
+    });
+    assert.equal(r.status, 2);
+  });
+
   it('non-merge command is ignored (exit 0, gh never called)', () => {
     const r = runHook('gh pr view 11 --repo lis186/ccxray-ops');
     assert.equal(r.status, 0);

--- a/test/check-codex-review-hook.test.js
+++ b/test/check-codex-review-hook.test.js
@@ -285,6 +285,40 @@ describe('check-codex-review hook — cross-repo scope', () => {
     assert.equal(r.spy, '', 'gh must never be called for a prose mention');
   });
 
+  it('env-assignment prefix (GH_TOKEN=x gh pr merge) is still gated (codex R5)', () => {
+    const r = runHook('GH_TOKEN=abc gh pr merge 11 --squash', { GH_BODY_LOCAL: 'no evidence' });
+    assert.equal(r.status, 2);
+  });
+
+  it('brace group and accidental double space are still gated (codex R5)', () => {
+    const r1 = runHook('{ gh pr merge 11; }', { GH_BODY_LOCAL: 'no evidence' });
+    assert.equal(r1.status, 2);
+    const r2 = runHook('gh  pr merge 11 --squash', { GH_BODY_LOCAL: 'no evidence' });
+    assert.equal(r2.status, 2);
+  });
+
+  it('11#feature is a branch selector, not a comment → fail closed (codex R5)', () => {
+    const r = runHook('gh pr merge 11#feature --squash', { GH_BODY_LOCAL: 'codex review' });
+    assert.equal(r.status, 2);
+    assert.match(r.stdout, /unrecognized argument: 11#feature/);
+  });
+
+  it('trailing full-word comment is still stripped (codex R4 behavior kept)', () => {
+    const r = runHook('gh pr merge 11 --squash # merged after review', {
+      GH_BODY_LOCAL: 'codex review: clean',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+  });
+
+  it('quoted prose that itself contains an env-prefixed merge is skipped (quote parity)', () => {
+    const r = runHook(
+      'git commit -m "fix: gate GH_TOKEN=x gh pr merge 11 shapes" && git push',
+      { GH_BODY_LOCAL: '' }
+    );
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.equal(r.spy, '', 'gh must never be called for quoted prose');
+  });
+
   it('non-merge command is ignored (exit 0, gh never called)', () => {
     const r = runHook('gh pr view 11 --repo lis186/ccxray-ops');
     assert.equal(r.status, 0);

--- a/test/check-codex-review-hook.test.js
+++ b/test/check-codex-review-hook.test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+// .claude/hooks/check-codex-review.sh — PreToolUse gate on `gh pr merge`.
+// Hermetic: `gh` is a PATH stub (never hits the network); no CCXRAY_HOME involved.
+// The cross-repo defect this pins down: without forwarding -R/--repo, the hook
+// validated the cwd repo's same-numbered PR — a colliding number whose body
+// happens to contain "codex review" silently passed an unreviewed foreign PR
+// (ops docs/solutions/gate-script-vs-runbook-contradictions.md item 3).
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const HOOK = path.join(__dirname, '..', '.claude', 'hooks', 'check-codex-review.sh');
+
+let stubDir;
+
+before(() => {
+  stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-stub-'));
+  // Stub gh: `pr view` prints GH_BODY_CROSS when called with --repo, else
+  // GH_BODY_LOCAL, and appends its argv to GH_SPY for forwarding assertions.
+  const stub = [
+    '#!/bin/bash',
+    'if [ -n "$GH_SPY" ]; then echo "$@" >> "$GH_SPY"; fi',
+    'case "$*" in',
+    '  *--repo*) printf "%s" "$GH_BODY_CROSS" ;;',
+    '  *)        printf "%s" "$GH_BODY_LOCAL" ;;',
+    'esac',
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(stubDir, 'gh'), stub, { mode: 0o755 });
+});
+
+after(() => {
+  fs.rmSync(stubDir, { recursive: true, force: true });
+});
+
+function runHook(command, env = {}) {
+  const spy = path.join(stubDir, `spy-${Math.random().toString(36).slice(2)}.txt`);
+  const r = spawnSync('bash', [HOOK], {
+    input: JSON.stringify({ tool_input: { command } }),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${stubDir}:${process.env.PATH}`,
+      GH_SPY: spy,
+      GH_BODY_LOCAL: '',
+      GH_BODY_CROSS: '',
+      ...env,
+    },
+  });
+  r.spy = fs.existsSync(spy) ? fs.readFileSync(spy, 'utf8') : '';
+  return r;
+}
+
+describe('check-codex-review hook — cross-repo scope', () => {
+  it('forwards --repo to gh pr view and allows when the TARGET repo PR has evidence', () => {
+    const r = runHook('gh pr merge 11 --repo lis186/ccxray-ops --squash', {
+      GH_BODY_CROSS: 'summary\n\ncodex review: pass, 0 findings',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.match(r.spy, /--repo lis186\/ccxray-ops/);
+  });
+
+  it('DANGER direction: cwd repo same-numbered PR has evidence, target repo PR does not → block', () => {
+    // Old code read the cwd repo body (no --repo) and would silently pass.
+    const r = runHook('gh pr merge 11 --repo lis186/ccxray-ops', {
+      GH_BODY_LOCAL: 'unrelated old PR that mentions codex review',
+      GH_BODY_CROSS: 'no second review here',
+    });
+    assert.equal(r.status, 2, 'must not validate against the cwd repo PR');
+    assert.match(r.stdout, /missing codex review evidence/);
+  });
+
+  it('-R short flag is honored the same as --repo', () => {
+    const r = runHook('gh pr merge 7 -R lis186/ccxray-ops', {
+      GH_BODY_CROSS: 'codex gate clean',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.match(r.spy, /--repo lis186\/ccxray-ops/);
+  });
+
+  it('--repo=owner/repo (equals form) is honored', () => {
+    const r = runHook('gh pr merge 7 --repo=lis186/ccxray-ops', {
+      GH_BODY_CROSS: 'codex gate clean',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.match(r.spy, /--repo lis186\/ccxray-ops/);
+  });
+
+  it('same-repo merge is unchanged: no --repo forwarded, local body decides', () => {
+    const r = runHook('gh pr merge 42 --squash', {
+      GH_BODY_LOCAL: 'codex review: clean',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.doesNotMatch(r.spy, /--repo/);
+  });
+
+  it('same-repo merge without evidence still blocks', () => {
+    const r = runHook('gh pr merge 42 --squash', { GH_BODY_LOCAL: 'no review here' });
+    assert.equal(r.status, 2);
+  });
+
+  it('fail-closed: -R/--repo present but unparseable → block, never guess the cwd repo', () => {
+    const r = runHook('gh pr merge 11 --repo', {
+      GH_BODY_LOCAL: 'codex review present locally',
+    });
+    assert.equal(r.status, 2, 'unparseable --repo must fail closed');
+    assert.match(r.stdout, /could not parse the target repo/);
+  });
+
+  it('PR number after flags (merge --repo X 12) is still gated — not silently allowed', () => {
+    // Old code required the number immediately after `merge`; this form slipped
+    // through the "no PR number → allow" path with zero body check.
+    const r = runHook('gh pr merge --repo lis186/ccxray-ops 12', {
+      GH_BODY_CROSS: 'no evidence',
+    });
+    assert.equal(r.status, 2, 'flags-first form must still be gated');
+    assert.match(r.stdout, /PR #12 /);
+  });
+
+  it('repo name digits (lis186) are never mistaken for the PR number', () => {
+    const r = runHook('gh pr merge --repo lis186/ccxray-ops 12', {
+      GH_BODY_CROSS: 'codex gate clean',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.match(r.spy, /pr view 12 /);
+  });
+
+  it('non-merge command is ignored (exit 0, gh never called)', () => {
+    const r = runHook('gh pr view 11 --repo lis186/ccxray-ops');
+    assert.equal(r.status, 0);
+    assert.equal(r.spy, '');
+  });
+});

--- a/test/check-codex-review-hook.test.js
+++ b/test/check-codex-review-hook.test.js
@@ -196,6 +196,26 @@ describe('check-codex-review hook — cross-repo scope', () => {
     assert.match(r.spy, /pr view 12 /);
   });
 
+  it('backslash-escaped separator in merge args → fail closed (codex R3)', () => {
+    // `--subject note\;ready` is ONE command targeting the foreign repo, but a
+    // naive separator cut stops at the escaped semicolon and would validate the
+    // cwd repo's PR instead.
+    const r = runHook('gh pr merge 11 --subject note\\;ready --repo owner/foreign', {
+      GH_BODY_LOCAL: 'codex review',
+      GH_BODY_CROSS: 'codex review',
+    });
+    assert.equal(r.status, 2);
+    assert.match(r.stdout, /cannot be parsed safely/);
+  });
+
+  it('dynamic PR number ($VAR) → fail closed, the gate cannot verify what it cannot resolve', () => {
+    const r = runHook('gh pr merge $PR_NUM --squash', {
+      GH_BODY_LOCAL: 'codex review',
+    });
+    assert.equal(r.status, 2);
+    assert.match(r.stdout, /cannot be parsed safely/);
+  });
+
   it('non-merge command is ignored (exit 0, gh never called)', () => {
     const r = runHook('gh pr view 11 --repo lis186/ccxray-ops');
     assert.equal(r.status, 0);

--- a/test/check-codex-review-hook.test.js
+++ b/test/check-codex-review-hook.test.js
@@ -159,6 +159,43 @@ describe('check-codex-review hook — cross-repo scope', () => {
     assert.match(r.spy, /--repo lis186\/ccxray-ops/);
   });
 
+  it('attached short form -Rowner/repo is honored (codex R2)', () => {
+    const r = runHook('gh pr merge 7 -Rlis186/ccxray-ops', {
+      GH_BODY_CROSS: 'codex gate clean',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.match(r.spy, /--repo lis186\/ccxray-ops/);
+  });
+
+  it('quoted argument inside the merge invocation → fail closed (codex R2)', () => {
+    // A quote defeats the separator cut (`--body 'note; ready'`), so the hook
+    // must refuse to guess rather than mis-parse and validate the wrong repo.
+    const r = runHook("gh pr merge 11 --body 'note; ready' --repo owner/foreign", {
+      GH_BODY_LOCAL: 'codex review',
+      GH_BODY_CROSS: 'codex review',
+    });
+    assert.equal(r.status, 2);
+    assert.match(r.stdout, /quoted arguments/);
+  });
+
+  it("quoted 'gh pr merge' string shadowing a real merge → fail closed, never silently allowed (codex R2)", () => {
+    // Old parsing anchored on the FIRST textual occurrence, found no number in
+    // the echo argument, and exited 0 without checking the real merge.
+    const r = runHook("echo 'gh pr merge' && gh pr merge 11", {
+      GH_BODY_LOCAL: 'no evidence',
+    });
+    assert.equal(r.status, 2, 'must not silently allow the real merge');
+  });
+
+  it('two merges in one line: both are gated (loop covers every occurrence)', () => {
+    const r = runHook('gh pr merge 11 --squash && gh pr merge 12 --squash', {
+      GH_BODY_LOCAL: 'codex review: clean',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.match(r.spy, /pr view 11 /);
+    assert.match(r.spy, /pr view 12 /);
+  });
+
   it('non-merge command is ignored (exit 0, gh never called)', () => {
     const r = runHook('gh pr view 11 --repo lis186/ccxray-ops');
     assert.equal(r.status, 0);

--- a/test/check-codex-review-hook.test.js
+++ b/test/check-codex-review-hook.test.js
@@ -319,6 +319,25 @@ describe('check-codex-review hook — cross-repo scope', () => {
     assert.equal(r.spy, '', 'gh must never be called for quoted prose');
   });
 
+  it("apostrophe in earlier double-quoted prose does not skip the real merge (codex R6)", () => {
+    const r = runHook('echo "don\'t forget" && gh pr merge 11 --squash', {
+      GH_BODY_LOCAL: 'no evidence',
+    });
+    assert.equal(r.status, 2, 'quote-state must see the double-quoted apostrophe as content');
+  });
+
+  it('backslash-newline continuation is joined before scanning (codex R6)', () => {
+    const r = runHook('gh \\\n  pr merge 11 --squash', { GH_BODY_LOCAL: 'no evidence' });
+    assert.equal(r.status, 2, 'continuation-split merge must still be gated');
+  });
+
+  it("apostrophe inside a comment line does not poison the next line's merge (codex R6)", () => {
+    const r = runHook("# don't merge manually\ngh pr merge 11 --squash", {
+      GH_BODY_LOCAL: 'no evidence',
+    });
+    assert.equal(r.status, 2);
+  });
+
   it('non-merge command is ignored (exit 0, gh never called)', () => {
     const r = runHook('gh pr view 11 --repo lis186/ccxray-ops');
     assert.equal(r.status, 0);

--- a/test/check-codex-review-hook.test.js
+++ b/test/check-codex-review-hook.test.js
@@ -130,6 +130,35 @@ describe('check-codex-review hook — cross-repo scope', () => {
     assert.match(r.spy, /pr view 12 /);
   });
 
+  it('compound command: a later gh call\'s --repo must NOT leak into the merge check', () => {
+    // codex review finding (2026-08-06): scanning the whole shell command let
+    // `gh pr merge 11 && gh pr view 12 --repo foreign/repo` validate foreign#11
+    // while actually merging cwd#11.
+    const r = runHook('gh pr merge 11 && gh pr view 12 --repo foreign/repo', {
+      GH_BODY_LOCAL: 'codex review: clean',
+      GH_BODY_CROSS: 'also has codex review words',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.doesNotMatch(r.spy, /--repo/, 'merge check must use the cwd repo');
+    assert.match(r.spy, /pr view 11 /);
+  });
+
+  it('compound command: local body without evidence blocks even if a later --repo body has it', () => {
+    const r = runHook('gh pr merge 11 && gh pr view 12 --repo foreign/repo', {
+      GH_BODY_LOCAL: 'no evidence',
+      GH_BODY_CROSS: 'codex gate clean',
+    });
+    assert.equal(r.status, 2);
+  });
+
+  it('compound command: --repo on the merge segment itself is still forwarded', () => {
+    const r = runHook('git push && gh pr merge 11 --repo lis186/ccxray-ops --squash && echo done', {
+      GH_BODY_CROSS: 'codex gate clean',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.match(r.spy, /--repo lis186\/ccxray-ops/);
+  });
+
   it('non-merge command is ignored (exit 0, gh never called)', () => {
     const r = runHook('gh pr view 11 --repo lis186/ccxray-ops');
     assert.equal(r.status, 0);

--- a/test/check-codex-review-hook.test.js
+++ b/test/check-codex-review-hook.test.js
@@ -175,7 +175,7 @@ describe('check-codex-review hook — cross-repo scope', () => {
       GH_BODY_CROSS: 'codex review',
     });
     assert.equal(r.status, 2);
-    assert.match(r.stdout, /quoted arguments/);
+    assert.match(r.stdout, /cannot be parsed safely/);
   });
 
   it("quoted 'gh pr merge' string shadowing a real merge → fail closed, never silently allowed (codex R2)", () => {

--- a/test/check-codex-review-hook.test.js
+++ b/test/check-codex-review-hook.test.js
@@ -216,6 +216,75 @@ describe('check-codex-review hook — cross-repo scope', () => {
     assert.match(r.stdout, /cannot be parsed safely/);
   });
 
+  it('pull URL selector: repo and number are taken from the URL (codex R4)', () => {
+    const r = runHook('gh pr merge https://github.com/lis186/ccxray-ops/pull/34 --squash', {
+      GH_BODY_CROSS: 'codex gate clean',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.match(r.spy, /pr view 34 --repo lis186\/ccxray-ops/);
+  });
+
+  it('pull URL selector without evidence blocks (previously slipped the allow path)', () => {
+    const r = runHook('gh pr merge https://github.com/lis186/ccxray-ops/pull/34', {
+      GH_BODY_CROSS: 'nothing here',
+    });
+    assert.equal(r.status, 2);
+  });
+
+  it('branch selector cannot be verified → fail closed (codex R4)', () => {
+    const r = runHook('gh pr merge feature-branch --squash', {
+      GH_BODY_LOCAL: 'codex review',
+    });
+    assert.equal(r.status, 2);
+    assert.match(r.stdout, /unrecognized argument: feature-branch/);
+  });
+
+  it('bare merge (current-branch PR) is no longer an ungated bypass (codex R4)', () => {
+    const r = runHook('gh pr merge --squash', { GH_BODY_LOCAL: 'codex review' });
+    assert.equal(r.status, 2);
+    assert.match(r.stdout, /explicit PR number/);
+  });
+
+  it('merge reached via || is still gated (codex R4)', () => {
+    const r = runHook('false || gh pr merge 11 --squash', { GH_BODY_LOCAL: 'no evidence' });
+    assert.equal(r.status, 2);
+  });
+
+  it('shell comment cannot smuggle --repo into the invocation (codex R4)', () => {
+    const r = runHook('gh pr merge 11 --squash # --repo foreign/repo', {
+      GH_BODY_LOCAL: 'codex review: clean',
+      GH_BODY_CROSS: 'also codex review',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.doesNotMatch(r.spy, /--repo/);
+  });
+
+  it('newline-separated follow-up command does not leak into the merge segment (codex R4)', () => {
+    const r = runHook('gh pr merge 11 --squash\ngh pr view 12 --repo foreign/repo', {
+      GH_BODY_LOCAL: 'codex review: clean',
+      GH_BODY_CROSS: 'also codex review',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.doesNotMatch(r.spy, /--repo/);
+    assert.match(r.spy, /pr view 11 /);
+  });
+
+  it('value-taking flags outside the allowlist (--subject) → fail closed', () => {
+    // Removes the old numeric-flag-value misread entirely: the grammar simply
+    // rejects flags the gate cannot account for.
+    const r = runHook('gh pr merge --subject 11 12', { GH_BODY_LOCAL: 'codex review' });
+    assert.equal(r.status, 2);
+    assert.match(r.stdout, /unrecognized argument: --subject/);
+  });
+
+  it('prose mention in a commit message does not trip the gate (command-start preceder)', () => {
+    const r = runHook('git commit -m "docs: the gh pr merge <number> flow is gated" && git push', {
+      GH_BODY_LOCAL: '',
+    });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.equal(r.spy, '', 'gh must never be called for a prose mention');
+  });
+
   it('non-merge command is ignored (exit 0, gh never called)', () => {
     const r = runHook('gh pr view 11 --repo lis186/ccxray-ops');
     assert.equal(r.status, 0);


### PR DESCRIPTION
## 繁中摘要

修 `.claude/hooks/check-codex-review.sh`（PreToolUse merge 閘）的跨 repo 缺陷：
`gh pr view` 沒帶 `--repo`，所以從 ccxray session merge **另一個 repo** 的 PR 時，
hook 讀的是 ccxray 的同號 PR。危險方向是**偽通過**——若 cwd repo 的同號 PR body
剛好含 "codex review"，一個從未二審的外部 PR 會被靜默放行（實測案例：merge ops PR #11
時 hook 讀到的是 ccxray PR #11，一個 2026-04 的舊 PR）。
完整分析：ops repo `docs/solutions/gate-script-vs-runbook-contradictions.md` 第 3 則。

經 7 輪 codex 對抗審查後，修法從「補洞」收斂為**可驗證文法白名單**：
閘門只放行它能完整驗證的形狀——

```
gh pr merge <number | github pull URL>
    [--repo owner/repo | -R owner/repo | --repo=x | -Rx]
    [--squash|--merge|--rebase|-s|-m|-r] [--delete-branch|-d] [--admin] [--auto]
```

其餘一律 fail-closed（引號/跳脫/`$` 動態參數、branch selector、未知 flag、
裸 merge——非互動下裸 merge 會直接 merge 當前分支的 PR，等於繞閘）。
pull URL 同時提供 PR 號與目標 repo。出現點判定含 shell 引號狀態機
（防 commit message 散文提及 merge 指令誤觸、防前導字串遮蔽真實呼叫）。

**威脅模型邊界（檔頭已文件化）**：防的是可信 agent 的**意外**繞閘；蓄意規避
（`gh pr "merge"`、`m=merge; gh pr $m`）不在守備範圍——與 ops scrub-output.sh 同立場。

## Evidence

- Hook 測試：**38/38 pass**（`test/check-codex-review-hook.test.js`，PATH-stub `gh`、
  hermetic、不碰網路與 CCXRAY_HOME）
- 有界全套件：**1810 tests / 1810 pass / 0 fail**（base 1772 + 本 PR 新增 38）
- Differential（bug 類，old-fail/new-pass）：origin/main 版 hook 對第一版測試
  **fail 7/10**（含 DANGER 方向：cwd 同號 PR 有證據、目標 repo 無 → 舊碼偽通過）；
  新碼全綠
- Codex 二審：7 輪迭代（R1 repo 洩漏 → R2/R3 引號/跳脫 → R4 文法白名單重寫 →
  R5 前綴/散文 → R6 引號狀態機/接續行 → R7 註解邊界/ANSI-C），每輪 findings
  逐條驗證後修復或依威脅模型記錄；嚴重度由 P1 收斂至需刻意構造輸入的 P2

## Detail

- Grammar allowlist (token-level parse) replaces integer-grep: URL selectors are
  verified (number + repo from the URL), branch selectors and value-taking flags
  fail closed, bare current-branch merges fail closed.
- Occurrence detection: whitespace squeeze + backslash-newline joining, command-start
  preceders (line start, `; & | ( {`, env-assignment/`env`/`command` prefixes), and a
  shell quote-state machine (single/double/ANSI-C quotes, escapes, `#`-comments at
  token boundaries) so quoted prose never trips the gate and never shadows a real merge.
- Every `gh pr merge` occurrence in a compound command is gated independently.

codex review: 7 rounds run via ops `codex-review.sh`; final round's remaining findings
were fixed in R7 (comment boundary, ANSI-C quotes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
