### PR TITLE
feat(weather): add cache_health signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Session cards show Claude Code's generated titles (e.g. `Fix login button on mob
 
 ![Session titles and cache expiry alerts](https://raw.githubusercontent.com/lis186/ccxray/v2.1.0/docs/cache-expiry.png)
 
+### Session Weather
+
+Each session card shows a weather emoji (☀️ sunny → ⛈️ stormy) that condenses eight health signals — context pressure, compaction, truncation, stuck loops, latency drift, error rate, and cache efficiency — into a single at-a-glance indicator. Hover for a breakdown. See [`docs/weather.md`](docs/weather.md) for signal definitions and scoring.
+
 ### Plan Detection
 
 ccxray auto-detects your subscription plan (Pro vs Max 5x vs Max 20x) by reading Anthropic's `cache_creation` usage fields — no configuration needed. Cache TTL and quota thresholds use the detected plan. Override with `CCXRAY_PLAN` if auto-detection gets it wrong.

--- a/docs/weather.md
+++ b/docs/weather.md
@@ -14,9 +14,9 @@ Source of truth: [`public/weather.js`](../public/weather.js).
 | `ctx_pressure` | Last turn's context fill % | 40% &rarr; 0, 100% &rarr; 1.0 (linear) | 1.0 | 1 |
 | `compaction_scar` | Number of compacted turns | 1 = 0.4, 2+ = 0.6 | 0.6 | 1 |
 | `truncation` | Any turn hit `max_tokens` (&ge;16K output) | Fixed 0.5 | 0.5 | 1 |
-| `stuck` | Longest consecutive tool-failure streak | &ge;10 = 0.9, else 0 | 0.9 | 1 |
+| `stuck` | Longest consecutive tool-failure streak | &ge;10 = 0.9, else 0 | 0.9 | 10 consecutive |
 | `latency_drift` | p75 of last 10 turns vs model baseline | 1x &rarr; 0, 3x &rarr; 1.0 | 1.0 | 5 |
-| `error_cluster` | 5-turn sliding window tool error rate | rate / 2.0 | 0.5 | 5 |
+| `error_cluster` | 5-turn sliding window tool error rate | rate / 2.0 | 0.5 | 3 tool_use in window |
 | `error_cumulative` | Session-wide tool error ratio | 20% &rarr; 0.5, 40% &rarr; 1.0 | 1.0 | 10 tool turns |
 | `cache_health` | Median cache hit rate (last 10 turns, skip first 3) | 50% &rarr; 0, 0% &rarr; 0.5 | 0.5 | 3 qualifying |
 
@@ -66,5 +66,7 @@ The hover overlay shows different content depending on the level:
 
 Each signal has a minimum-turns requirement to avoid firing on incomplete
 data. `cache_health` additionally skips the first three turns of the
-window (prompt cache cold start) and ignores turns with fewer than 1,000
-input tokens.
+**session** (prompt cache cold start &mdash; `Math.max(3, len - 10)`) and
+ignores turns with fewer than 1,000 input tokens. For sessions longer
+than 13 turns the full trailing 10 are examined; shorter sessions only
+see turns after the cold-start boundary.

--- a/docs/weather.md
+++ b/docs/weather.md
@@ -1,0 +1,70 @@
+# Session Weather
+
+Session weather is a health indicator shown on each session card. It
+condenses eight independent signals into a single score, displayed as an
+emoji (sunny through stormy) with a hover tooltip that lists the active
+factors.
+
+Source of truth: [`public/weather.js`](../public/weather.js).
+
+## Signals
+
+| Signal | What it watches | Severity curve | Cap | Min turns |
+|--------|----------------|----------------|-----|-----------|
+| `ctx_pressure` | Last turn's context fill % | 40% &rarr; 0, 100% &rarr; 1.0 (linear) | 1.0 | 1 |
+| `compaction_scar` | Number of compacted turns | 1 = 0.4, 2+ = 0.6 | 0.6 | 1 |
+| `truncation` | Any turn hit `max_tokens` (&ge;16K output) | Fixed 0.5 | 0.5 | 1 |
+| `stuck` | Longest consecutive tool-failure streak | &ge;10 = 0.9, else 0 | 0.9 | 1 |
+| `latency_drift` | p75 of last 10 turns vs model baseline | 1x &rarr; 0, 3x &rarr; 1.0 | 1.0 | 5 |
+| `error_cluster` | 5-turn sliding window tool error rate | rate / 2.0 | 0.5 | 5 |
+| `error_cumulative` | Session-wide tool error ratio | 20% &rarr; 0.5, 40% &rarr; 1.0 | 1.0 | 10 tool turns |
+| `cache_health` | Median cache hit rate (last 10 turns, skip first 3) | 50% &rarr; 0, 0% &rarr; 0.5 | 0.5 | 3 qualifying |
+
+### Signal tiers
+
+Severity caps encode relative importance:
+
+- **Functional** (cap 0.9&ndash;1.0): `ctx_pressure`, `stuck`, `error_cumulative`, `latency_drift` &mdash; directly affect whether the agent can complete its work.
+- **Quality** (cap 0.5&ndash;0.6): `compaction_scar`, `truncation`, `error_cluster` &mdash; the agent runs but information or quality is degraded.
+- **Cost/efficiency** (cap 0.5): `cache_health` &mdash; functionality unaffected; the session costs more and runs slower.
+
+### Provider scope
+
+`cache_health` only applies to Anthropic entries (`provider === 'anthropic'`
+or absent). OpenAI/Codex and xAI/Grok entries are skipped because their
+wire parsers normalize cache fields differently.
+
+## Score composition
+
+```
+score = max(severities) + 0.3 * second(severities)
+```
+
+Only the two highest severities contribute. This prevents multiple
+low-severity signals from stacking into a false alarm.
+
+## Levels
+
+| Score range | Level | Emoji | Meaning |
+|-------------|-------|-------|---------|
+| < 0.35 | sunny | &#9728;&#65039; | Operating normally |
+| < 0.55 | fair | &#127780;&#65039; | Minor signals, no action needed |
+| < 0.75 | cloudy | &#9925; | Quality starting to degrade |
+| < 0.95 | rainy | &#127783;&#65039; | Significantly degraded, take action |
+| &ge; 0.95 | stormy | &#9928;&#65039; | Critically degraded, act now |
+
+## Tooltip
+
+The hover overlay shows different content depending on the level:
+
+- **Sunny / Fair**: stats proving health &mdash; context %, error count,
+  cache hit rate, latency ratio, compaction count.
+- **Cloudy / Rainy / Stormy**: active factors sorted by severity, plus an
+  action line linking to the relevant turns (when available).
+
+## Cold-start immunity
+
+Each signal has a minimum-turns requirement to avoid firing on incomplete
+data. `cache_health` additionally skips the first three turns of the
+window (prompt cache cold start) and ignores turns with fewer than 1,000
+input tokens.

--- a/public/weather.js
+++ b/public/weather.js
@@ -134,8 +134,8 @@ function sigErrorCluster(turns) {
 function sigCacheHealth(turns) {
   var rates = [];
   for (var i = Math.max(3, turns.length - 10); i < turns.length; i++) {
+    if (turns[i].provider && turns[i].provider !== 'anthropic') continue;
     var u = turns[i].usage || {};
-    if (u.cache_read_input_tokens == null && u.cache_creation_input_tokens == null) continue;
     var inT = (u.input_tokens || 0) + (u.cache_read_input_tokens || 0) + (u.cache_creation_input_tokens || 0);
     if (inT < 1000) continue;
     rates.push((u.cache_read_input_tokens || 0) / inT);

--- a/public/weather.js
+++ b/public/weather.js
@@ -130,6 +130,24 @@ function sigErrorCluster(turns) {
   return { severity: sev, detail: { windowStart: bestStart, windowEnd: bestEnd, errorRate: Math.round(maxRate * 100) / 100, entryIdStart: turns[bestStart] && turns[bestStart].id || null, entryIdEnd: turns[bestEnd] && turns[bestEnd].id || null } };
 }
 
+// ponytail: sustained low cache hit rate — cost/perf signal, not functionality. Skips first 3 turns (cold start). Expert consensus: 50% threshold (break-even), 0.5 cap.
+function sigCacheHealth(turns) {
+  var rates = [];
+  for (var i = Math.max(3, turns.length - 10); i < turns.length; i++) {
+    var u = turns[i].usage || {};
+    if (u.cache_read_input_tokens == null && u.cache_creation_input_tokens == null) continue;
+    var inT = (u.input_tokens || 0) + (u.cache_read_input_tokens || 0) + (u.cache_creation_input_tokens || 0);
+    if (inT < 1000) continue;
+    rates.push((u.cache_read_input_tokens || 0) / inT);
+  }
+  if (rates.length < 3) return { severity: 0, detail: {} };
+  rates.sort(function(a, b) { return a - b; });
+  var median = percentile(rates, 0.5);
+  // ponytail: 50%→0, 0%→0.5. Aligns with workflow-timeline cache-miss event (<50%) and Anthropic break-even economics (1.4 reads/write).
+  var sev = median >= 0.5 ? 0 : clamp01((0.5 - median) * 1.0);
+  return { severity: sev, detail: { medianHitRate: Math.round(median * 100), recentTurns: rates.length } };
+}
+
 // ponytail: catches chronic tool errors spread across long sessions that error_cluster misses (exp9: ~30 false negatives).
 function sigErrorCumulative(turns) {
   var toolTurns = 0, errTurns = 0, firstErrId = null;
@@ -159,6 +177,7 @@ function assessWeather(turns, opts) {
     { type: 'latency_drift', result: sigLatencyDrift(turns) },
     { type: 'error_cluster', result: sigErrorCluster(turns) },
     { type: 'error_cumulative', result: sigErrorCumulative(turns) },
+    { type: 'cache_health', result: sigCacheHealth(turns) },
   ];
 
   var sevs = signals.map(function(s) { return s.result.severity; }).sort(function(a, b) { return b - a; });
@@ -186,6 +205,7 @@ function assessWeather(turns, opts) {
     errTurns: _sigMap.error_cumulative.detail.errTurns || 0,
     latencyRatio: _sigMap.latency_drift.detail.ratio || null,
     compactions: _sigMap.compaction_scar.detail.compactionCount || 0,
+    cacheHitRate: _sigMap.cache_health.detail.medianHitRate != null ? _sigMap.cache_health.detail.medianHitRate : null,
   };
 
   var tooltip = _buildTooltip(pick.level, factors, stats);
@@ -212,6 +232,7 @@ var _FACTOR_FMT = {
   latency_drift: function(d) { return 'latency ' + (d.ratio || '?') + 'x baseline'; },
   error_cluster: function(d) { return 'error burst ' + Math.round((d.errorRate || 0) * 100) + '% (' + _rangeLink(d.windowStart || 0, d.windowEnd || 0, d.entryIdStart, d.entryIdEnd) + ')'; },
   error_cumulative: function(d) { var label = d.errTurns + '/' + d.toolTurns + ' tool errors (' + Math.round((d.rate || 0) * 100) + '%)'; return d.firstErrId ? _turnLink(label, d.firstErrId) : label; },
+  cache_health: function(d) { return 'cache hit ' + (d.medianHitRate || 0) + '% (last ' + (d.recentTurns || '?') + ' turns)'; },
 };
 
 var _LEVEL_SUMMARY = {
@@ -241,6 +262,7 @@ function _buildTooltip(level, factors, stats) {
       var parts = [];
       parts.push('context ' + (stats.ctxPct || 0) + '%');
       parts.push(stats.errTurns ? stats.errTurns + ' errors' : '0 errors');
+      if (stats.cacheHitRate != null) parts.push('cache ' + stats.cacheHitRate + '%');
       if (stats.latencyRatio != null) parts.push('latency ' + stats.latencyRatio + 'x');
       if (stats.compactions) parts.push('compacted ×' + stats.compactions);
       lines.push(parts.join(' · '));

--- a/test/weather.test.js
+++ b/test/weather.test.js
@@ -526,10 +526,17 @@ describe('assessWeather', function() {
     assert.ok(!hasFactor(r, 'cache_health'), 'tiny turns should not trigger cache signal');
   });
 
-  it('cache_codex_exempt — entries without cache fields are skipped', function() {
-    var turns = repeat(15, { usage: { input_tokens: 30000, output_tokens: 800, cache_read_input_tokens: undefined, cache_creation_input_tokens: undefined } });
+  it('cache_codex_exempt — OpenAI/Codex entries are skipped', function() {
+    // OpenAI parser normalizes cache_read_input_tokens to 0, so null-check alone doesn't work
+    var turns = repeat(15, { provider: 'openai', usage: { input_tokens: 30000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, output_tokens: 800 } });
     var r = assessWeather(turns);
-    assert.ok(!hasFactor(r, 'cache_health'), 'codex/openai entries without cache fields should not trigger cache signal');
+    assert.ok(!hasFactor(r, 'cache_health'), 'codex/openai entries should not trigger cache signal');
+  });
+
+  it('cache_grok_exempt — xAI/Grok entries are skipped', function() {
+    var turns = repeat(15, { provider: 'xai', usage: { input_tokens: 30000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, output_tokens: 800 } });
+    var r = assessWeather(turns);
+    assert.ok(!hasFactor(r, 'cache_health'), 'grok entries should not trigger cache signal');
   });
 
   it('cache stats shown in sunny tooltip', function() {

--- a/test/weather.test.js
+++ b/test/weather.test.js
@@ -11,8 +11,8 @@ function makeTurn(overrides) {
     stopReason: 'end_turn',
     usage: {
       output_tokens: 800,
-      input_tokens: 20000,
-      cache_read_input_tokens: 10000,
+      input_tokens: 2000,
+      cache_read_input_tokens: 28000,
       cache_creation_input_tokens: 2000,
     },
     maxContext: 200000,
@@ -470,5 +470,72 @@ describe('assessWeather', function() {
     // Verify other factors are not affected by the ctx numerator change
     var otherFactors = r.factors.filter(function(f) { return f.type !== 'ctx_pressure'; });
     assert.equal(otherFactors.length, 0, 'no other factors should fire on this fixture');
+  });
+
+  // ── cache_health signal ──
+
+  it('cache_miss — sustained 0% cache hit → severity 0.5', function() {
+    var turns = repeat(15, { usage: { input_tokens: 30000, cache_read_input_tokens: 0, cache_creation_input_tokens: 2000, output_tokens: 800 } });
+    var r = assessWeather(turns);
+    assert.ok(hasFactor(r, 'cache_health'), 'should detect cache miss');
+    var f = r.factors.find(function(f) { return f.type === 'cache_health'; });
+    assert.equal(f.severity, 0.5, 'severity at 0% should be 0.5');
+    assert.equal(f.detail.medianHitRate, 0);
+  });
+
+  it('cache_degraded — 30% hit rate → severity ≈ 0.2', function() {
+    // 9600 / 32000 = 30%
+    var turns = repeat(15, { usage: { input_tokens: 20400, cache_read_input_tokens: 9600, cache_creation_input_tokens: 2000, output_tokens: 800 } });
+    var r = assessWeather(turns);
+    assert.ok(hasFactor(r, 'cache_health'));
+    var f = r.factors.find(function(f) { return f.type === 'cache_health'; });
+    assert.ok(f.severity >= 0.19 && f.severity <= 0.21, 'severity ' + f.severity + ' ≈ 0.2');
+  });
+
+  it('cache_healthy — 80% hit rate → no signal', function() {
+    // 25600 / 32000 = 80%
+    var turns = repeat(15, { usage: { input_tokens: 4400, cache_read_input_tokens: 25600, cache_creation_input_tokens: 2000, output_tokens: 800 } });
+    var r = assessWeather(turns);
+    assert.ok(!hasFactor(r, 'cache_health'));
+  });
+
+  it('cache_cold_start — first 3 turns skipped', function() {
+    // 4 turns total, first 3 have 0% cache, turn 4 has 80%
+    // max(3, 4-10) = 3 → only turn 3 qualifies → < 3 qualifying → no signal
+    var turns = [
+      makeTurn({ usage: { input_tokens: 30000, cache_read_input_tokens: 0, cache_creation_input_tokens: 2000, output_tokens: 800 } }),
+      makeTurn({ usage: { input_tokens: 30000, cache_read_input_tokens: 0, cache_creation_input_tokens: 2000, output_tokens: 800 } }),
+      makeTurn({ usage: { input_tokens: 30000, cache_read_input_tokens: 0, cache_creation_input_tokens: 2000, output_tokens: 800 } }),
+      makeTurn({ usage: { input_tokens: 4400, cache_read_input_tokens: 25600, cache_creation_input_tokens: 2000, output_tokens: 800 } }),
+    ];
+    var r = assessWeather(turns);
+    assert.ok(!hasFactor(r, 'cache_health'), 'cold start turns should be skipped');
+  });
+
+  it('cache_insufficient — only 2 qualifying turns → no signal', function() {
+    var turns = repeat(5);
+    // Only turns 3-4 qualify (after skipping first 3), that's 2 turns — below minimum 3
+    var r = assessWeather(turns);
+    // With 5 turns: max(3, 5-10) = 3 → turns 3,4 → 2 qualifying → no signal
+    assert.ok(!hasFactor(r, 'cache_health'));
+  });
+
+  it('cache_tiny_turns_skipped — turns with < 1K input tokens ignored', function() {
+    var turns = repeat(15, { usage: { input_tokens: 500, cache_read_input_tokens: 0, cache_creation_input_tokens: 200, output_tokens: 100 } });
+    var r = assessWeather(turns);
+    assert.ok(!hasFactor(r, 'cache_health'), 'tiny turns should not trigger cache signal');
+  });
+
+  it('cache_codex_exempt — entries without cache fields are skipped', function() {
+    var turns = repeat(15, { usage: { input_tokens: 30000, output_tokens: 800, cache_read_input_tokens: undefined, cache_creation_input_tokens: undefined } });
+    var r = assessWeather(turns);
+    assert.ok(!hasFactor(r, 'cache_health'), 'codex/openai entries without cache fields should not trigger cache signal');
+  });
+
+  it('cache stats shown in sunny tooltip', function() {
+    var turns = repeat(10);
+    var r = assessWeather(turns);
+    assert.ok(r.stats.cacheHitRate != null, 'stats should include cacheHitRate');
+    assert.ok(r.tooltip.includes('cache'), 'sunny tooltip should show cache stat');
   });
 });


### PR DESCRIPTION
## Summary

- 新增第 8 個 weather signal `cache_health`，監測 prompt cache hit rate
- 50% 閾值（Anthropic break-even 經濟學）、0.5 severity cap（成本/效能信號）
- Codex/OpenAI entries 免疫（無 cache 欄位 → skip，非 cache 壞）
- `docs/weather.md` reference doc + README link

## Design

Expert panel (Shihipar/Cantrill/Dean simulation) consensus:
- **Threshold**: 50% cache hit rate (below = paying more than uncached)
- **Cap**: 0.5 (subordinate to functional signals like stuck/ctx_pressure)
- **Curve**: linear, `sev = median >= 0.5 ? 0 : (0.5 - median) * 1.0`
- **Window**: last 10 turns, skip first 3 (cold start), ≥3 qualifying turns

Tooltip shows cache in both healthy (stats proof) and degraded (factor) states.
No `_ACTION_TABLE` entry — cache miss has no specific turn to link (#336 principle).

## Codex Review

R1: P2 accepted — OpenAI wire parser normalizes cache fields to 0 (not null), so null-check exemption was ineffective. Fixed: gate on `entry.provider !== 'anthropic'`.
R2: P2×2 rejected — cold/capped session persisted weather is a pre-existing limitation affecting all signals, not introduced by this PR.
Docs review: 3/3 accepted — stuck min turns 1→10, error_cluster min 5→3 tool_use in window, cache cold start window→session-relative.

## Verification (docs/verification-principles.md)

5 fail-on-old differential checks via fallback worktree:
- `cache_miss` (0% → sev 0.5): old FAIL → new PASS
- `cache_degraded` (30% → sev ≈0.2): old FAIL → new PASS
- `cache stats in tooltip`: old FAIL → new PASS
- `cache_codex_exempt` (provider=openai): pre-R1 FAIL → post-R1 PASS
- `cache_grok_exempt` (provider=xai): pre-R1 FAIL → post-R1 PASS

## Test plan

- [x] 42/42 weather tests pass (8 new cache_health tests)
- [x] Full suite 1817/1817 pass
- [x] 5 fail-on-old differential checks confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)