### PR TITLE
refactor(wire): remove dead turnStepCount from openai parser

### DIFF
--- a/server/wire-parsers/openai.js
+++ b/server/wire-parsers/openai.js
@@ -396,12 +396,6 @@ function getCwd(parsedBody, headers) {
   return getCodexCwd(headers, parsedBody) || extractOpenAICwd(parsedBody);
 }
 
-function turnStepCount(parsedBody) {
-  const input = parsedBody?.input;
-  if (!Array.isArray(input)) return 0;
-  return input.filter(item => item.type === 'function_call' || item.type === 'function_call_output').length;
-}
-
 function attributionTurnStep(_parsedBody) {
   return { turn: 0, step: 0 };
 }
@@ -420,7 +414,6 @@ module.exports = {
   systemPromptHash,
   toolsHash,
   getCwd,
-  turnStepCount,
   attributionTurnStep,
   // Low-level exports for ws-proxy.js compatibility
   getCodexRawSessionId,

--- a/test/wire-parsers-openai.test.js
+++ b/test/wire-parsers-openai.test.js
@@ -337,26 +337,4 @@ describe('wire-parsers/openai', () => {
     });
   });
 
-  describe('turnStepCount', () => {
-    it('counts function_call and function_call_output items in input', () => {
-      const body = {
-        input: [
-          { role: 'user', content: 'hi' },
-          { type: 'function_call', name: 'shell', arguments: '{}' },
-          { type: 'function_call_output', output: 'done' },
-          { role: 'assistant', content: 'ok' },
-        ],
-      };
-      assert.equal(openai.turnStepCount(body), 2);
-    });
-
-    it('returns 0 for empty input', () => {
-      assert.equal(openai.turnStepCount({}), 0);
-      assert.equal(openai.turnStepCount({ input: [] }), 0);
-    });
-
-    it('returns 0 when input is not an array', () => {
-      assert.equal(openai.turnStepCount({ input: 'hello' }), 0);
-    });
-  });
 });


### PR DESCRIPTION
## 摘要（繁中）

移除 `server/wire-parsers/openai.js` 的 `turnStepCount()` —**零 production caller 的死介面**。純刪除，不改行為。

它漏掉 `custom_tool_call_output`，乍看是「Codex turn step 低估」的 bug；但沒有東西在用它，所以那不是 bug，是債。production 走的是 `attributionTurnStep()`（`server/forward.js:448`）。

依 `docs/verification-principles.md:31`（純重構不寫紅），本 PR **刻意不含 fail-on-old 測試**——能寫出在舊碼失敗的測試就代表行為被改了，那是警訊不是成就。驗收改走「綠燈不變 + 客觀結構指標」。

⚠️ **issue 驗收條款 3 的前提已被實測推翻**：它寫「`anthropic.js:187` 的同名函式…確認它有 production caller 後保留」，但全樹搜尋顯示 anthropic 側的 `turnStepCount` **同樣零 production caller**。本 PR 照指令不動它（守住範圍），已於 issue 留更正 comment，是否另開清理單由 owner 決定。

Fixes #474

---

## Detail (English)

### Scope

Three deletions, nothing else:

| Location | Removed |
|---|---|
| `server/wire-parsers/openai.js:399-403` | `turnStepCount()` definition |
| `server/wire-parsers/openai.js:423` | its `module.exports` entry |
| `test/wire-parsers-openai.test.js:340-361` | the matching `describe` block (3 `it()`) |

Untouched by design: `attributionTurnStep` (the real production path) and `server/wire-parsers/anthropic.js`'s independent function of the same name.

### Verification — green-unchanged (refactor contract)

Both runs on the same machine, each with its own throwaway `CCXRAY_HOME`, via
`perl -e 'alarm shift @ARGV; exec @ARGV' 300 sh -c 'node --test test/*.test.js'`:

| | tests | suites | pass | fail |
|---|---|---|---|---|
| baseline `origin/main` (fa18204) | 1831 | 431 | 1831 | 0 |
| this branch | 1828 | 430 | 1828 | 0 |
| delta | −3 | −1 | −3 | **0** |

The −3/−1 delta matches the removed block exactly, which is what distinguishes
"tests correspondingly removed" from "tests silently stopped running".

### Verification — structural metric

`grep -rn 'turnStepCount' server/ public/ test/ scripts/ shared/`

- before: 7 hits on the OpenAI side (2 source + 5 test)
- after: **0** on the OpenAI side; the 7 remaining hits are all `anthropic.js` + its test

### Verification — orphan-reference scan (runbook step 4)

Deleted top-level symbols extracted from `git diff origin/main`: `turnStepCount`.
Residual references in `public/` + `server/`, excluding the unrelated anthropic parser: **0**.
Dynamic-access patterns (`parser[...]`, `['turnStepCount']`, double-quoted variant): no hits.

### Verification — syntax and boot

- `node --check server/wire-parsers/openai.js` — pass (trailing comma in `module.exports` intact)
- `scripts/boot-smoke.sh 5644` — `BOOT OK: dashboard HTTP 200`, exit 0, no orphan listener afterwards
- codex review (contained wrapper, `codex-review.sh --base origin/main`) — verdict **pass**, 0 findings, converged in 31s. codex gate clean.

### Not verified (explicit)

- No browser smoke: this PR does not touch `public/`.
- `attributionTurnStep`'s own correctness is not asserted here — it returns a fixed
  `{turn: 0, step: 0}`, which is pre-existing state and out of scope.
- Whether the anthropic-side `turnStepCount` should also be removed — flagged, not decided.

<!-- GATE-MANIFEST
issue-lint=pass @eede103c4c132d17c0d9e5f90ed51b608f73f3fb
full-test=0 @eede103c4c132d17c0d9e5f90ed51b608f73f3fb
boot-smoke=0 @eede103c4c132d17c0d9e5f90ed51b608f73f3fb
-->
