### PR TITLE
feat(dashboard): hide weather behind a default-off toggle (#484)

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -1589,7 +1589,7 @@ function renderSessionItem(sess, sid, sessEl) {
     pinBtn +
     '</div>' +
   titleRow +
-    '<div class="si-row2"><span class="turn-model">' + escapeHtml(shortModelStr) + '</span> · ' + (sess.count - (sess.retryCount || 0)) + 't' + (sess.retryCount ? ' <span class="retry-count" title="' + sess.retryCount + ' failed retries (hidden from turn list)">' + sess.retryCount + 'r</span>' : '') + (durationStr ? ' · ' + durationStr : '') + (sess.weather ? '<span class="si-weather" style="float:right;cursor:default" data-weather=\'' + escapeHtml(JSON.stringify(sess.weather)) + '\' onmouseenter="showWeatherOverlay(event,JSON.parse(this.dataset.weather))" onmouseleave="hideWeatherOverlay()">' + sess.weather.emoji + '</span>' : '') + '</div>' +
+    '<div class="si-row2"><span class="turn-model">' + escapeHtml(shortModelStr) + '</span> · ' + (sess.count - (sess.retryCount || 0)) + 't' + (sess.retryCount ? ' <span class="retry-count" title="' + sess.retryCount + ' failed retries (hidden from turn list)">' + sess.retryCount + 'r</span>' : '') + (durationStr ? ' · ' + durationStr : '') + (sess.weather && weatherDisplayEnabled() ? '<span class="si-weather" style="float:right;cursor:default" data-weather=\'' + escapeHtml(JSON.stringify(sess.weather)) + '\' onmouseenter="showWeatherOverlay(event,JSON.parse(this.dataset.weather))" onmouseleave="hideWeatherOverlay()">' + sess.weather.emoji + '</span>' : '') + '</div>' +
     '<div class="si-cost-row"><span class="si-cost">' + costStr + '</span></div>' +
     ctxBarHtml +
     previewRow +

--- a/public/weather.js
+++ b/public/weather.js
@@ -486,4 +486,34 @@ function _dismissWeatherOverlay() {
   if (_weatherOverlayTitleEl && _weatherOverlaySavedTitle != null) { _weatherOverlayTitleEl.title = _weatherOverlaySavedTitle; _weatherOverlayTitleEl = null; _weatherOverlaySavedTitle = null; }
 }
 
-if (typeof module !== 'undefined') module.exports = { assessWeather };
+// #484: weather display toggle — default OFF until tool-failure signals are trustworthy.
+// Computation and persistence keep running; only these render gates are affected.
+// localStorage tri-state: 'on' | 'off' | null (null = program default = OFF).
+// URL param ?weather=1 (also on/off) overrides for one-shot inspection.
+var _WEATHER_STORAGE_KEY = 'ccxray-weather-display';
+var _weatherDisplayDefault = false;
+
+// Latch URL override at load time so syncUrlFromState (miller-columns.js:2183)
+// cannot silently wash it away on the first navigation.
+var _weatherUrlOverride = (function() {
+  try {
+    if (typeof URLSearchParams === 'undefined' || typeof location === 'undefined') return null;
+    var v = new URLSearchParams(location.search).get('weather');
+    if (v === '1' || v === 'on') return true;
+    if (v === '0' || v === 'off') return false;
+  } catch (_) {}
+  return null;
+})();
+
+function weatherDisplayEnabled() {
+  if (_weatherUrlOverride !== null) return _weatherUrlOverride;
+  if (typeof localStorage === 'undefined') return _weatherDisplayDefault;
+  try {
+    var stored = localStorage.getItem(_WEATHER_STORAGE_KEY);
+    if (stored === 'on') return true;
+    if (stored === 'off') return false;
+  } catch (_) {}
+  return _weatherDisplayDefault;
+}
+
+if (typeof module !== 'undefined') module.exports = { assessWeather, weatherDisplayEnabled };

--- a/public/workflow-timeline.js
+++ b/public/workflow-timeline.js
@@ -1564,7 +1564,7 @@ function wfRenderLaneSvg(lane, laneIdx, W, xFn, mainConvs) {
   // text above; the fullTitle <title> only covers the name row's box.
   var _lw = typeof assessWeather === 'function' ? assessWeather(lane.turns) : null;
   svg += '<text x="20" y="26" fill="var(--dim)" style="font-size:10px;font-family:' + WF_MONO + '"><title>' + wfEsc(modelLbl.title) + '</title><tspan fill="' + wfLaneColor(lane) + '">' + wfEsc(modelLbl.text) + '</tspan>' + wfEsc(' · ' + ctxK + 'K') + '</text>';
-  if (_lw) svg += '<foreignObject x="' + (WF_LABEL_W - 22) + '" y="16" width="20" height="14"><span xmlns="http://www.w3.org/1999/xhtml" style="font-size:11px;cursor:default" data-weather=\'' + wfEsc(JSON.stringify(_lw)) + '\' onmouseenter="showWeatherOverlay(event,JSON.parse(this.dataset.weather))" onmouseleave="hideWeatherOverlay()">' + _lw.emoji + '</span></foreignObject>';
+  if (_lw && weatherDisplayEnabled()) svg += '<foreignObject x="' + (WF_LABEL_W - 22) + '" y="16" width="20" height="14"><span xmlns="http://www.w3.org/1999/xhtml" style="font-size:11px;cursor:default" data-weather=\'' + wfEsc(JSON.stringify(_lw)) + '\' onmouseenter="showWeatherOverlay(event,JSON.parse(this.dataset.weather))" onmouseleave="hideWeatherOverlay()">' + _lw.emoji + '</span></foreignObject>';
   // sysprompt versions: distinct coreHash in first-seen order; chip click = jump
   // to the turn where that version first appeared; ↗ opens the System Prompt page
   // Hashes go into innerHTML data attributes — accept hex only (index.ndjson
@@ -2589,7 +2589,7 @@ function _wfShowTooltip(e, t, lane) {
   var ttWeather = typeof assessWeather === 'function' ? assessWeather([t], { sessionWindow: _wfTurnWindow(t) }) : null;
   _wfTooltipEl.innerHTML =
     row('#' + wfEsc(String(t.displayNum || '?')), wfEsc(wfShortModel(t.model)) + (t._wfSeqStitched ? ' · seq-stitched' : '') + lockLbl)
-    + (ttWeather ? row('Health', ttWeather.emoji + ' ' + (ttWeather.tooltip || ttWeather.level).replace(/\n/g, ' · ')) : '')
+    + (ttWeather && weatherDisplayEnabled() ? row('Health', ttWeather.emoji + ' ' + (ttWeather.tooltip || ttWeather.level).replace(/\n/g, ' · ')) : '')
     + row('Context', '<span class="' + zoneCls + '">' + pct.toFixed(1) + '%</span> (' + zone + ')')
     + row('Cache', _wfFmtTok(cr) + ' read / ' + _wfFmtTok(cc) + ' write')
     // INVARIANT(#420): per-turn cost must use formatCost/formatCostText(cost, confidence)
@@ -2822,7 +2822,7 @@ function wfRenderAgentCard(lane) {
   html += '<div class="wf-ac-name">' + wfGlyphHtml(wfLaneShape(lane), 10, color) + ' ' + wfEsc(lane.name) + ' <span class="wf-ac-model" title="' + wfEsc(acModelLbl.title) + '" style="background:' + color + '22;color:' + color + '">' + wfEsc(acModelLbl.text) + '</span></div>';
   // INVARIANT: main/subagent label must use _wfIsMainLane, not lane.spawnParent
   // — see docs/decisions/0007-wf-is-main-lane-not-spawn-parent.md
-  html += '<div class="wf-ac-meta">' + summary.turnCount + ' turns · ' + wfFmtDur(summary.duration) + ' · ' + (isOrchestrator ? 'orchestrator' : 'subagent') + (laneWeather ? ' · <span style="cursor:default" data-weather=\'' + wfEsc(JSON.stringify(laneWeather)) + '\' onmouseenter="showWeatherOverlay(event,JSON.parse(this.dataset.weather))" onmouseleave="hideWeatherOverlay()">' + laneWeather.emoji + '</span>' : '') + '</div>';
+  html += '<div class="wf-ac-meta">' + summary.turnCount + ' turns · ' + wfFmtDur(summary.duration) + ' · ' + (isOrchestrator ? 'orchestrator' : 'subagent') + (laneWeather && weatherDisplayEnabled() ? ' · <span style="cursor:default" data-weather=\'' + wfEsc(JSON.stringify(laneWeather)) + '\' onmouseenter="showWeatherOverlay(event,JSON.parse(this.dataset.weather))" onmouseleave="hideWeatherOverlay()">' + laneWeather.emoji + '</span>' : '') + '</div>';
 
   html += '<div class="wf-ac-section"><div class="wf-ac-section-title">Context</div>';
   html += '<div class="wf-ac-row"><span>Peak</span><span class="wf-ac-val">' + summary.peakCtx.toFixed(1) + '%</span></div>';
@@ -2867,7 +2867,7 @@ function wfRenderAgentCard(lane) {
     // #438: only show failure rate when we have per-turn data (toolFailKnownTurns > 0).
     // Legacy sessions with only cumulative toolFail show nothing — 0% would be a lie,
     // and the old cumulative rate was a 44× Lie Factor.
-    if (sess && (sess.toolFailKnownTurns || 0) > 0) {
+    if (sess && (sess.toolFailKnownTurns || 0) > 0 && weatherDisplayEnabled()) {
       var failRate = (sess.toolFailTurns || 0) / sess.toolFailKnownTurns * 100;
       html += '<div class="wf-ac-row"><span title="Turns with 1+ failed tool result, not individual call failures">Turn failure rate</span><span class="wf-ac-val">' + failRate.toFixed(1) + '%</span></div>';
     }
@@ -2935,7 +2935,7 @@ function wfRenderTurnCard(turnEntry) {
   var html = '<div class="wf-agent-card wf-turn-card" style="border-left:2px solid ' + color + '">';
   html += '<div class="wf-tc-back" onclick="wfBackToLane()">&#8592; back</div>';
   var turnW = typeof assessWeather === 'function' ? assessWeather([turnEntry], { sessionWindow: _wfTurnWindow(turnEntry) }) : null;
-  html += '<div class="wf-tc-title">' + (turnW && turnW.level !== 'sunny' ? '<span style="cursor:default" data-weather=\'' + wfEsc(JSON.stringify(turnW)) + '\' onmouseenter="showWeatherOverlay(event,JSON.parse(this.dataset.weather))" onmouseleave="hideWeatherOverlay()">' + turnW.emoji + '</span> ' : '') + '#' + displayNum + '  ' + wfEsc(wfShortModel(turnEntry.model)) + ' · ' + wfFmtDur(dur * 1000) + '</div>';
+  html += '<div class="wf-tc-title">' + (turnW && turnW.level !== 'sunny' && weatherDisplayEnabled() ? '<span style="cursor:default" data-weather=\'' + wfEsc(JSON.stringify(turnW)) + '\' onmouseenter="showWeatherOverlay(event,JSON.parse(this.dataset.weather))" onmouseleave="hideWeatherOverlay()">' + turnW.emoji + '</span> ' : '') + '#' + displayNum + '  ' + wfEsc(wfShortModel(turnEntry.model)) + ' · ' + wfFmtDur(dur * 1000) + '</div>';
 
   // Breadcrumb
   var laneName = lane ? lane.name : '?';

--- a/test/weather-display.test.js
+++ b/test/weather-display.test.js
@@ -1,0 +1,209 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const publicDir = path.join(__dirname, '..', 'public');
+const weatherSrc = fs.readFileSync(path.join(publicDir, 'weather.js'), 'utf8');
+
+function element() {
+  return {
+    style: {}, dataset: {}, innerHTML: '', textContent: '', className: '',
+    offsetWidth: 0, offsetHeight: 0,
+    classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+    addEventListener() {}, appendChild() {}, insertBefore() {}, insertAdjacentHTML() {},
+    setAttribute() {}, querySelector: () => element(), querySelectorAll: () => [], remove() {},
+  };
+}
+
+function storage(stored) {
+  return {
+    getItem: (key) => key === 'ccxray-weather-display' ? stored ?? null : null,
+    setItem() {},
+  };
+}
+
+function loadWeatherDisplay(opts = {}) {
+  const context = {
+    URLSearchParams,
+    location: { search: opts.search || '' },
+    localStorage: storage(opts.stored),
+  };
+  vm.createContext(context);
+  vm.runInContext(weatherSrc, context);
+  return context;
+}
+
+function loadMillerDisplay(stored) {
+  const context = {
+    console,
+    window: {},
+    document: {
+      getElementById: () => element(), createElement: () => element(),
+      querySelector: () => element(), querySelectorAll: () => [],
+      addEventListener() {}, body: element(),
+    },
+    localStorage: storage(stored), sessionStorage: storage(null),
+    navigator: {}, location: { search: '', hash: '' }, history: { replaceState() {} },
+    URLSearchParams, setTimeout, clearTimeout,
+  };
+  vm.createContext(context);
+  vm.runInContext(`
+    function updateSysPromptBadge() {}
+    function startQuotaTicker() {}
+    function EventSource() { this.onmessage = null; }
+    function setInterval() { return 0; }
+    function clearInterval() {}
+    window.ccxraySettings = { visibleProviders: [], autoCompactPct: 0.835 };
+    function _apiQ(url) { return url; }
+    function fetch() { return Promise.resolve({ ok: false, json() { return Promise.resolve({}); } }); }
+  `, context);
+  for (const file of ['session-label.js', 'format.js', 'weather.js', 'miller-columns.js']) {
+    vm.runInContext(fs.readFileSync(path.join(publicDir, file), 'utf8'), context);
+  }
+  return context;
+}
+
+function loadWorkflowDisplay(stored) {
+  const context = {
+    console,
+    window: { innerWidth: 1200, innerHeight: 800, addEventListener() {} },
+    document: {
+      createElement: () => element(), createElementNS: () => element(),
+      getElementById: () => null, body: element(), documentElement: {},
+    },
+    localStorage: storage(stored), location: { search: '' }, URLSearchParams,
+    getComputedStyle: () => ({ getPropertyValue: () => '' }),
+    requestAnimationFrame: () => 1, cancelAnimationFrame() {},
+    setTimeout: () => 1, clearTimeout() {},
+    allEntries: [], sessionsMap: new Map(),
+    colTurns: { clientWidth: 600, appendChild() {}, querySelectorAll: () => [] },
+    colSections: { innerHTML: '' }, colDetail: { innerHTML: '' },
+    selectTurn() {}, isHttpStatusOk: (status) => status === 101 || (status >= 200 && status < 300),
+    selectedSessionId: null, Set, Map,
+  };
+  vm.createContext(context);
+  for (const file of ['agent-classification.js', 'format.js', 'weather.js', 'workflow-timeline.js']) {
+    vm.runInContext(fs.readFileSync(path.join(publicDir, file), 'utf8'), context);
+  }
+  return context;
+}
+
+function weatherTurn() {
+  return {
+    id: 'turn-1', sessionId: 'session-1', model: 'claude-opus-4-6',
+    receivedAt: 1000, elapsed: 5, maxContext: 200000, ctxUsed: 180000,
+    usage: {
+      input_tokens: 180000, output_tokens: 1000,
+      cache_read_input_tokens: 0, cache_creation_input_tokens: 0,
+    },
+    turnToolCalls: { Bash: 1 }, toolCalls: { Bash: 1 },
+    stopReason: 'tool_use', toolFail: true, status: 200, cost: 0.01,
+    displayNum: 1, agentKey: 'orchestrator', agentLabel: 'Orchestrator',
+  };
+}
+
+function renderAllSites(stored) {
+  const miller = loadMillerDisplay(stored);
+  const sessionHtml = miller.renderSessionItem({
+    model: 'claude-opus-4-6', count: 1, retryCount: 0, totalCost: 0,
+    firstReceivedAt: 0, latestMainCtxUsed: 0,
+    weather: { level: 'rainy', emoji: '🌧️', tooltip: 'Needs attention' },
+  }, 'session-1', null);
+
+  const workflow = loadWorkflowDisplay(stored);
+  const turn = weatherTurn();
+  const lane = {
+    key: 'main', name: 'main', agentLabel: 'Orchestrator',
+    spawnParent: null, turns: [turn],
+  };
+  workflow.wfState = {
+    sessionId: 'session-1', lanes: [lane], selectedLane: lane,
+    selectionLevel: 'L1', selectedSection: 'timeline',
+  };
+  workflow.sessionsMap.set('session-1', {
+    toolCalls: { Bash: 1 }, toolFailKnownTurns: 1, toolFailTurns: 1,
+    inputTokens: 180000, outputTokens: 1000,
+  });
+
+  const laneSvg = workflow.wfRenderLaneSvg(lane, 0, 600, (value) => value, new Set());
+  workflow._wfShowTooltip({ clientX: 0, clientY: 0 }, turn, lane);
+  const tooltipHtml = workflow._wfTooltipEl.innerHTML;
+
+  const panel = element();
+  workflow.document.getElementById = (id) => id === 'wf-agent-card-panel' ? panel : null;
+  workflow.wfRenderAgentCard(lane);
+  const agentHtml = panel.innerHTML;
+  workflow.wfRenderTurnCard(turn);
+
+  return { sessionHtml, laneSvg, tooltipHtml, agentHtml, turnHtml: panel.innerHTML };
+}
+
+describe('#484 weather display toggle', () => {
+  it('defaults to OFF when no preference or URL override is present', () => {
+    const ctx = loadWeatherDisplay();
+    assert.equal(ctx.weatherDisplayEnabled(), false);
+  });
+
+  it("enables display when the stored preference is 'on'", () => {
+    const ctx = loadWeatherDisplay({ stored: 'on' });
+    assert.equal(ctx.weatherDisplayEnabled(), true);
+  });
+
+  it("keeps display disabled for stored 'off' and unknown values", () => {
+    assert.equal(loadWeatherDisplay({ stored: 'off' }).weatherDisplayEnabled(), false);
+    assert.equal(loadWeatherDisplay({ stored: 'unexpected' }).weatherDisplayEnabled(), false);
+  });
+
+  it('lets weather=on temporarily override a stored OFF preference', () => {
+    const ctx = loadWeatherDisplay({ stored: 'off', search: '?weather=on' });
+    assert.equal(ctx.weatherDisplayEnabled(), true);
+  });
+
+  it('accepts the debugLoad-style weather=1 one-shot override', () => {
+    const ctx = loadWeatherDisplay({ stored: 'off', search: '?weather=1' });
+    assert.equal(ctx.weatherDisplayEnabled(), true);
+  });
+
+  it('lets weather=0 temporarily override a stored ON preference', () => {
+    const ctx = loadWeatherDisplay({ stored: 'on', search: '?weather=0' });
+    assert.equal(ctx.weatherDisplayEnabled(), false);
+  });
+});
+
+describe('#484 weather render gates', () => {
+  it('hides all six weather/failure displays by default without hiding neighboring content', () => {
+    const rendered = renderAllSites(null);
+
+    assert.doesNotMatch(rendered.sessionHtml, /si-weather/);
+    assert.match(rendered.sessionHtml, /opus-4-6/);
+    assert.match(rendered.sessionHtml, /1t/);
+
+    assert.doesNotMatch(rendered.laneSvg, /foreignObject/);
+    assert.match(rendered.laneSvg, /main/);
+
+    assert.doesNotMatch(rendered.tooltipHtml, />Health</);
+    assert.match(rendered.tooltipHtml, />Context</);
+
+    assert.doesNotMatch(rendered.agentHtml, /data-weather/);
+    assert.doesNotMatch(rendered.agentHtml, /Turn failure rate/);
+    assert.match(rendered.agentHtml, /1 turns/);
+
+    assert.doesNotMatch(rendered.turnHtml, /data-weather/);
+    assert.match(rendered.turnHtml, /#1/);
+  });
+
+  it('restores all six displays when the stored preference is ON', () => {
+    const rendered = renderAllSites('on');
+
+    assert.match(rendered.sessionHtml, /si-weather/);
+    assert.match(rendered.laneSvg, /<foreignObject[^>]*>.*data-weather/);
+    assert.match(rendered.tooltipHtml, />Health</);
+    assert.match(rendered.agentHtml, /data-weather/);
+    assert.match(rendered.agentHtml, /Turn failure rate/);
+    assert.match(rendered.turnHtml, /data-weather/);
+  });
+});

--- a/test/workflow-timeline.test.js
+++ b/test/workflow-timeline.test.js
@@ -14,6 +14,9 @@ function loadWfModule(opts) {
   const ctx = {
     document: { createElement: () => ({ appendChild() {}, style: {}, id: '' }), createElementNS: () => ({ setAttribute() {}, innerHTML: '' }), getElementById: () => null, body: { appendChild() {} }, documentElement: {} },
     window: { innerHeight: 800, addEventListener() {} },
+    localStorage: { getItem: () => opts && opts.weatherDisplay ? 'on' : null },
+    location: { search: '' },
+    URLSearchParams,
     getComputedStyle: () => ({ getPropertyValue: () => '' }),
     requestAnimationFrame: (fn) => 1,
     cancelAnimationFrame() {},
@@ -188,7 +191,7 @@ describe('workflow-timeline data layer', () => {
   });
 
   it('#377 slice 2: single-turn weather matches the lane-fold context window in tooltip and turn card', () => {
-    const ctx = loadWfModule({ weather: true });
+    const ctx = loadWfModule({ weather: true, weatherDisplay: true });
     const turn = mkEntry('t1', 's1', 'claude-opus-4-6', 1000, 5, {
       maxContext: 200000,
       ctxUsed: 176000,


### PR DESCRIPTION
## Summary

- weather 的工具失敗訊號在四條資料路徑全部失效，止血：把 6 個顯示點以 localStorage tri-state toggle 收起（預設 OFF）
- 計算與持久化完全不動，server 端持續累積 weather 資料供修復後比對驗證
- URL param `?weather=on` 做 one-shot inspection（load-time latch，不被 `syncUrlFromState` 洗掉）

## Test plan

- [x] `test/weather-display.test.js` — 8 tests covering toggle tri-state, URL override, all 6 render sites OFF/ON, no-collateral
- [x] `test/workflow-timeline.test.js` — existing weather test updated with localStorage mock
- [x] Full suite: 1,891 tests / 0 fail (`CCXRAY_HOME=$(mktemp -d) npm test`)
- [ ] Browser smoke: verify session card, lane label, turn tooltip, agent card, turn card all hide weather; `?weather=on` restores

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)