### PR TITLE
chore(deps): bump js-yaml 4.3.0 → 4.3.1 (CVE-2026-59870)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1395,9 +1395,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- js-yaml 4.3.0 → 4.3.1 修 CVE-2026-59870（high severity, quadratic CPU in !!omap）
- 只改 `package-lock.json`，cosmiconfig 的 `^4.1.0` 已涵蓋 4.3.1
- `npm audit` 從 1 high → 0 vulnerabilities

## Codex Review Evidence

Lockfile-only dependency bump — no application code changed. Codex review not applicable.

## Test plan

- [x] `CCXRAY_HOME=$(mktemp -d) npm test` — 1891/1891 pass
- [x] `npm audit` — 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)