### PR TITLE
ci: add GitHub Pages deployment for presentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,31 @@
+name: Deploy presentation to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths: [docs/presentation/**]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/presentation
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- 新增 `.github/workflows/pages.yml`，把 `docs/presentation/` deploy 到 GitHub Pages
- 只在 `docs/presentation/**` 變動或手動觸發時跑
- URL: https://lis186.github.io/ccxray/

## Codex Review Evidence

Single workflow file, no application code. Codex review not applicable.

## Test plan

- [x] GitHub Pages API 已啟用 (`build_type: workflow`)
- [x] Workflow 語法正確（standard Actions deploy pattern）

🤖 Generated with [Claude Code](https://claude.com/claude-code)