### PR TITLE
fix(slides): equal-height fanout comparison images

### DIFF
--- a/docs/slides/coscup2026/index.html
+++ b/docs/slides/coscup2026/index.html
@@ -261,7 +261,7 @@
   .mcrow { display: flex; gap: 2vw; justify-content: center; }
   .mccol { flex: 1 1 0; min-width: 0; transition: opacity .6s ease, transform .6s ease; }
   .mccol .shot { display: inline-block; }
-  .mccol .shot img { max-height: 46vh; width: auto; max-width: 100%; }
+  .mccol .shot img { height: 46vh; width: auto; max-width: 100%; object-fit: contain; }
   .mccol { text-align: center; }
   .mccol .mclabel { font-weight: 900; font-size: clamp(.9rem, 2vw, 1.3rem); margin-bottom: .8vh; text-align: center; }
   .mccol .mcstats { display: flex; gap: 1.2em; justify-content: center; margin-top: 1vh;

--- a/docs/slides/coscup2026/tools/deck-template.html
+++ b/docs/slides/coscup2026/tools/deck-template.html
@@ -261,7 +261,7 @@
   .mcrow { display: flex; gap: 2vw; justify-content: center; }
   .mccol { flex: 1 1 0; min-width: 0; transition: opacity .6s ease, transform .6s ease; }
   .mccol .shot { display: inline-block; }
-  .mccol .shot img { max-height: 46vh; width: auto; max-width: 100%; }
+  .mccol .shot img { height: 46vh; width: auto; max-width: 100%; object-fit: contain; }
   .mccol { text-align: center; }
   .mccol .mclabel { font-weight: 900; font-size: clamp(.9rem, 2vw, 1.3rem); margin-bottom: .8vh; text-align: center; }
   .mccol .mcstats { display: flex; gap: 1.2em; justify-content: center; margin-top: 1vh;


### PR DESCRIPTION
## Summary

- 對照頁兩張圖改成等高（`height: 46vh` + `object-fit: contain`）
- 同步修 deck-template.html

## Codex Review Evidence

2-line CSS change in slides. Codex review not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)