### PR TITLE
fix(slides): dark background on first paint

### DIFF
--- a/docs/site/slides/coscup2026/index.html
+++ b/docs/site/slides/coscup2026/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-Hant">
+<html lang="zh-Hant" style="background:#05080c">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/docs/site/slides/coscup2026/tools/deck-template.html
+++ b/docs/site/slides/coscup2026/tools/deck-template.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-Hant">
+<html lang="zh-Hant" style="background:#05080c">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
## Summary

- `<html>` 加 inline `style="background:#05080c"`，載入時不閃白
- 同步 deck-template.html

## Codex Review Evidence

1-attribute CSS change in slides. Codex review not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)