### PR TITLE
fix(wire): Anthropic tool evidence fields + hasToolFailLastTurn tri-state

### DIFF
--- a/server/forward.js
+++ b/server/forward.js
@@ -775,6 +775,9 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
       // Dedup key for read-time merge (#333) — docs/decisions/0012-response-id-read-time-merge.md
       responseId: getParser('anthropic').extractResponseId(events),
       turnToolCalls: getParser('anthropic').extractTurnToolCalls(events),
+      // #486: per-turn tool_use ids from response, set here (not in buildEntryFields)
+      // because the non-SSE path doesn't pass response data to buildEntryFields.
+      turnToolCallIds: getParser('anthropic').extractAnthropicToolCallIds(events),
       edited: ctx.edited, editSummary: ctx.editSummary,
       tokens: null,
       duplicateToolCalls: helpers.extractDuplicateToolCalls(parsedBody?.messages),
@@ -1076,6 +1079,8 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
         // Dedup key for read-time merge (#333) — docs/decisions/0012-response-id-read-time-merge.md
         responseId: getParser('anthropic').extractResponseId(resData),
         turnToolCalls: getParser('anthropic').extractTurnToolCalls(resData),
+        // #486: per-turn tool_use ids from response (non-SSE path, resData is object)
+        turnToolCallIds: getParser('anthropic').extractAnthropicToolCallIds(resData),
         edited: ctx.edited, editSummary: ctx.editSummary,
         tokens: null,
         duplicateToolCalls: helpers.extractDuplicateToolCalls(parsedBody?.messages),

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -666,18 +666,70 @@ function hasToolFail(req) {
 // #438: per-turn tool failure — only checks the LAST user message (the current
 // turn's tool_result blocks), not the full cumulative history. hasToolFail scans
 // all messages and is infected by any prior failure (#427-class bug).
+// #486: tri-state — true=failure, false=checked-clean, undefined=no tool_result blocks.
+// undefined prevents conflation of "tools succeeded" with "no tools ran".
 function hasToolFailLastTurn(messages) {
-  if (!Array.isArray(messages)) return false;
+  if (!Array.isArray(messages)) return undefined;
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i]?.role !== 'user') continue;
     const content = messages[i].content;
-    if (!Array.isArray(content)) return false;
+    if (!Array.isArray(content)) return undefined;
+    let hasToolResult = false;
     for (const b of content) {
-      if (b?.type === 'tool_result' && b.is_error === true) return true;
+      if (b?.type === 'tool_result') {
+        hasToolResult = true;
+        if (b.is_error === true) return true;
+      }
     }
-    return false;
+    return hasToolResult ? false : undefined;
   }
-  return false;
+  return undefined;
+}
+
+// #486: extract tool_result evidence from the last user message (request side).
+// Returns [{callId, toolFail, eligible:true}] — all tool results, no Bash-only filter.
+// Anthropic has explicit is_error, so no output parsing needed.
+function extractAnthropicTurnToolResults(messages) {
+  if (!Array.isArray(messages)) return [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role !== 'user') continue;
+    const content = messages[i].content;
+    if (!Array.isArray(content)) return [];
+    const results = [];
+    for (const b of content) {
+      if (b?.type === 'tool_result') {
+        results.push({
+          callId: b.tool_use_id || null,
+          toolFail: b.is_error === true,
+          eligible: true,
+        });
+      }
+    }
+    return results;
+  }
+  return [];
+}
+
+// #486: extract tool_use call ids from the response (response side).
+// Returns {tool_use.id → tool name} matching the OpenAI extractOpenAIToolCallIds shape.
+function extractAnthropicToolCallIds(resData) {
+  const calls = {};
+  if (!resData) return calls;
+  if (Array.isArray(resData)) {
+    for (const ev of resData) {
+      if (ev.type === 'content_block_start' && ev.content_block?.type === 'tool_use') {
+        const id = ev.content_block.id;
+        if (id) calls[id] = ev.content_block.name || null;
+      }
+    }
+  } else if (resData.content) {
+    for (const b of resData.content) {
+      if (b.type === 'tool_use' && b.id) {
+        calls[b.id] = b.name || null;
+      }
+    }
+  }
+  return calls;
 }
 
 // ── Credential scanning ──────────────────────────────────────────────
@@ -1121,6 +1173,8 @@ module.exports = {
   extractToolResultSummary,
   extractFirstUserText,
   hasToolFail, hasToolFailLastTurn,
+  extractAnthropicTurnToolResults,
+  extractAnthropicToolCallIds,
   extractToolCalls,
   extractSkillCalls,
   extractOpenAIToolCalls,

--- a/server/index.js
+++ b/server/index.js
@@ -1016,14 +1016,17 @@ async function runPostListenStartupTasks() {
     warmUpCosts();
   }
 
-  // #438: hint when legacy entries lack per-turn failure data
+  // #438/#486: hint when legacy entries lack per-turn tool evidence.
+  // turnToolResults is always set on new entries ([] for no-tools, [{...}] for
+  // tools); undefined means truly legacy (pre-#486). turnToolFail alone cannot
+  // distinguish legacy from no-tools after #486's tri-state change.
   if (restoreOk) {
     let legacyCount = 0;
     for (const e of store.entries) {
-      if (e.turnToolFail === undefined && e.provider !== 'openai' && !e.imported) { legacyCount++; if (legacyCount >= 10) break; }
+      if (e.turnToolResults === undefined && e.provider !== 'openai' && !e.imported) { legacyCount++; if (legacyCount >= 10) break; }
     }
     if (legacyCount >= 10) {
-      process.stderr.write('\x1b[33m   ⚠ legacy entries lack per-turn failure data — run `ccxray rebuild-index --apply` to backfill\x1b[0m\n');
+      process.stderr.write('\x1b[33m   ⚠ legacy entries lack per-turn tool evidence — run `ccxray rebuild-index --apply` to backfill\x1b[0m\n');
     }
   }
 

--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -235,6 +235,8 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   let enrichedIdentity = 0;     // #342 legacy identity backfill count
   let enrichedTurnToolCalls = 0; // #427 legacy backfill count
   let enrichedTurnToolFail = 0; // #438 legacy backfill count
+  let enrichedTurnToolCallIds = 0; // #486 legacy backfill count
+  let enrichedTurnToolResults = 0; // #486 legacy backfill count
   // #345: stream lines — a recovered index can exceed Node's ~512MB single-string
   // limit, where readIndex() (readFile utf8) throws ERR_STRING_TOO_LONG.
   for await (const line of storage.readIndexLines()) {
@@ -267,22 +269,35 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
       try { ttc = getParser('anthropic').extractTurnToolCalls(JSON.parse(await storage.read(m.id, '_res.json'))); } catch {}
       if (ttc) { m.turnToolCalls = ttc; outLine = JSON.stringify(m); enrichedTurnToolCalls++; }
     }
-    // #438 add-only turnToolFail backfill: legacy lines predate the per-turn
-    // failure field (tri-state: undefined=legacy, false=checked-clean, true=
-    // failed). It derives from the REQUEST's last user message, so read
-    // _req.json directly — a delta line's stored tail normally ends with the
-    // turn's final user message. A delta slice with NO user message (e.g.
-    // assistant-prefill) cannot be evaluated — the real last-turn evidence is
-    // in the unspliced prefix; leave undefined rather than persist false.
+    // #486 add-only turnToolCallIds backfill: extract {tool_use.id → name} from
+    // _res.json. Same add-only, non-degrading pattern as turnToolCalls.
+    if (m.turnToolCallIds === undefined && m.provider !== 'openai') {
+      let tci = null;
+      try { tci = getParser('anthropic').extractAnthropicToolCallIds(JSON.parse(await storage.read(m.id, '_res.json'))); } catch {}
+      if (tci && Object.keys(tci).length > 0) { m.turnToolCallIds = tci; outLine = JSON.stringify(m); enrichedTurnToolCallIds++; }
+    }
+    // #438/#486 add-only turnToolFail + turnToolResults backfill: derive from
+    // the REQUEST's last user message. turnToolFail tri-state: true=failure,
+    // false=checked-clean, undefined=no tool_result blocks.
+    // turnToolResults: [{callId, toolFail, eligible}] for all tool results.
+    // A delta slice with NO user message (assistant-prefill) cannot be
+    // evaluated — leave undefined rather than persist false/[].
     // Same add-only, non-degrading pattern as responseId/turnToolCalls.
-    if (m.turnToolFail === undefined && m.provider !== 'openai') {
+    if ((m.turnToolFail === undefined || m.turnToolResults === undefined) && m.provider !== 'openai') {
       try {
         const reqBody = JSON.parse(await storage.read(m.id, '_req.json'));
         const msgs = reqBody?.messages;
         if (Array.isArray(msgs) && msgs.length > 0 && msgs.some(m => m.role === 'user')) {
-          m.turnToolFail = helpers.hasToolFailLastTurn(msgs);
+          if (m.turnToolFail === undefined) {
+            m.turnToolFail = helpers.hasToolFailLastTurn(msgs);
+            enrichedTurnToolFail++;
+          }
+          if (m.turnToolResults === undefined) {
+            const results = helpers.extractAnthropicTurnToolResults(msgs);
+            m.turnToolResults = results; // [] for no-tool turns — marks as processed
+            if (results.length > 0) enrichedTurnToolResults++;
+          }
           outLine = JSON.stringify(m);
-          enrichedTurnToolFail++;
         }
       } catch { /* _req pruned → leave verbatim */ }
     }
@@ -385,6 +400,11 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
     }
     let orphanTurnToolCalls = getParser('anthropic').extractTurnToolCalls(events);
     if (orphanTurnToolCalls == null && rawResObj) orphanTurnToolCalls = getParser('anthropic').extractTurnToolCalls(rawResObj);
+    // #486: per-turn tool_use ids from the response
+    let orphanTurnToolCallIds = getParser('anthropic').extractAnthropicToolCallIds(events);
+    if ((!orphanTurnToolCallIds || !Object.keys(orphanTurnToolCallIds).length) && rawResObj) {
+      orphanTurnToolCallIds = getParser('anthropic').extractAnthropicToolCallIds(rawResObj);
+    }
 
     // Session attribution. Explicit metadata.session_id is authoritative (every
     // delta and main-session turn carries it). Otherwise the turn is a subagent /
@@ -443,6 +463,8 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
       responseId: orphanResponseId,
       // #427: per-turn tool calls from the response (computed above, with non-SSE fallback)
       turnToolCalls: orphanTurnToolCalls,
+      // #486: per-turn tool_use ids from the response
+      turnToolCallIds: orphanTurnToolCallIds && Object.keys(orphanTurnToolCallIds).length ? orphanTurnToolCallIds : undefined,
       ...fields,
     };
     recovered.push({ id, line: buildIndexLine(entry) });
@@ -466,10 +488,12 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   if (enrichedIdentity) log(`  backfilled convId/coreHash/agentKey onto ${enrichedIdentity} legacy line(s) (#342)`);
   if (enrichedTurnToolCalls) log(`  backfilled turnToolCalls onto ${enrichedTurnToolCalls} legacy line(s) (#427)`);
   if (enrichedTurnToolFail) log(`  backfilled turnToolFail onto ${enrichedTurnToolFail} legacy line(s) (#438)`);
+  if (enrichedTurnToolCallIds) log(`  backfilled turnToolCallIds onto ${enrichedTurnToolCallIds} legacy line(s) (#486)`);
+  if (enrichedTurnToolResults) log(`  backfilled turnToolResults onto ${enrichedTurnToolResults} legacy line(s) (#486)`);
 
   // A run with no orphans to add can still have enriched existing lines — those
   // rewritten lines must be flushed, so the write is gated on any change.
-  const hasChanges = N > 0 || enrichedResponseIds > 0 || enrichedIdentity > 0 || enrichedTurnToolCalls > 0 || enrichedTurnToolFail > 0;
+  const hasChanges = N > 0 || enrichedResponseIds > 0 || enrichedIdentity > 0 || enrichedTurnToolCalls > 0 || enrichedTurnToolFail > 0 || enrichedTurnToolCallIds > 0 || enrichedTurnToolResults > 0;
   if (!hasChanges) {
     log(apply ? '  nothing to add — index left unchanged.' : '  dry run — nothing to add.');
     return { refused: false, recovered: 0, enriched: 0, enrichedIdentity: 0, total: M, unrecoverable, applied: false, cacheFinalSize: cache.size };

--- a/server/store.js
+++ b/server/store.js
@@ -115,7 +115,8 @@ function _foldEntry(canonical, other) {
   // Tool/skill maps: per-key max union so a partial capture on one copy never
   // drops the other's keys (same response ⇒ equal in practice, but be robust).
   // Object maps only — a non-object shape (legacy array) falls back to fill-if-empty.
-  for (const k of ['toolCalls', 'skillCalls', 'turnToolCalls']) {
+  // #486: turnToolCallIds included (same {id→name} map shape).
+  for (const k of ['toolCalls', 'skillCalls', 'turnToolCalls', 'turnToolCallIds']) {
     const oc = other[k];
     if (oc == null) continue;
     const isMap = v => v && typeof v === 'object' && !Array.isArray(v);
@@ -166,10 +167,15 @@ function _foldEntry(canonical, other) {
   }
   // OR semantics — true if any copy saw it.
   if (other.toolFail) canonical.toolFail = true;
-  // #438: turnToolFail tri-state: undefined=legacy, false=checked-clean, true=failed.
+  // #438/#486: turnToolFail tri-state: undefined=no evidence, false=checked-clean, true=failed.
   // true dominates; false fills undefined; never downgrade true to false.
   if (other.turnToolFail === true) canonical.turnToolFail = true;
   else if (other.turnToolFail === false && canonical.turnToolFail === undefined) canonical.turnToolFail = false;
+  // #486: turnToolResults — array, fill-if-empty (same response ⇒ identical).
+  if (Array.isArray(other.turnToolResults) && other.turnToolResults.length > 0
+    && (!Array.isArray(canonical.turnToolResults) || canonical.turnToolResults.length === 0)) {
+    canonical.turnToolResults = other.turnToolResults;
+  }
   if (other.hasCredential) canonical.hasCredential = true;
   if (other.edited) {
     canonical.edited = true;

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -110,9 +110,13 @@ function buildEntryFields(ctx) {
     title: ctx.title || null,
     thinkingDuration: ctx.thinkingDuration ?? null,
     toolFail: ctx.toolFail != null ? ctx.toolFail : helpers.hasToolFail(parsedBody),
-    // #438: per-turn tool failure. Explicit false = checked, no failure (not legacy).
-    // undefined = legacy/not checked. Do NOT normalize false to undefined.
+    // #486: per-turn tool evidence. turnToolFail tri-state: true=failure,
+    // false=checked-clean, undefined=no tool_result in last user message.
+    // turnToolCallIds set at the entry literal level (forward.js) like turnToolCalls,
+    // because buildEntryFields doesn't receive response data on the non-SSE path.
+    // turnToolResults extracted from the request's last user message here.
     turnToolFail: helpers.hasToolFailLastTurn(parsedBody?.messages),
+    turnToolResults: helpers.extractAnthropicTurnToolResults(parsedBody?.messages),
     sysHash: ctx.sysHash || null,
     toolsHash: ctx.toolsHash || null,
     coreHash: ctx.coreHash || null,
@@ -223,11 +227,18 @@ function extractTurnToolCalls(resData) {
   return counts;
 }
 
+// #486: per-turn tool_use call ids from the response, keyed by id → name.
+// Matches the shape of helpers.extractOpenAIToolCallIds.
+function extractAnthropicToolCallIds(resData) {
+  return helpers.extractAnthropicToolCallIds(resData);
+}
+
 module.exports = {
   isNoiseRequest,
   extractUsage,
   extractResponseId,
   extractTurnToolCalls,
+  extractAnthropicToolCallIds,
   computeConvId,
   detectSession,
   buildEntryFields,

--- a/test/anthropic-tool-evidence.test.js
+++ b/test/anthropic-tool-evidence.test.js
@@ -1,0 +1,155 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const helpers = require('../server/helpers');
+
+describe('#486 Anthropic tool evidence fields', () => {
+  // ── hasToolFailLastTurn tri-state ──
+  describe('hasToolFailLastTurn tri-state', () => {
+    it('returns true when last user message has is_error tool_result', () => {
+      const msgs = [
+        { role: 'user', content: 'q' },
+        { role: 'assistant', content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: {} }] },
+        { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', is_error: true, content: 'fail' }] },
+      ];
+      assert.equal(helpers.hasToolFailLastTurn(msgs), true);
+    });
+
+    it('returns false when last user message has successful tool_result', () => {
+      const msgs = [
+        { role: 'user', content: 'q' },
+        { role: 'assistant', content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: {} }] },
+        { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] },
+      ];
+      assert.equal(helpers.hasToolFailLastTurn(msgs), false);
+    });
+
+    it('returns undefined when last user message has no tool_result blocks', () => {
+      const msgs = [
+        { role: 'user', content: 'just a question' },
+      ];
+      assert.equal(helpers.hasToolFailLastTurn(msgs), undefined);
+    });
+
+    it('returns undefined for null/empty/non-array messages', () => {
+      assert.equal(helpers.hasToolFailLastTurn(null), undefined);
+      assert.equal(helpers.hasToolFailLastTurn([]), undefined);
+      assert.equal(helpers.hasToolFailLastTurn('not an array'), undefined);
+    });
+  });
+
+  // ── extractAnthropicTurnToolResults ──
+  describe('extractAnthropicTurnToolResults', () => {
+    it('extracts all tool_result blocks from last user message', () => {
+      const msgs = [
+        { role: 'user', content: 'q' },
+        { role: 'assistant', content: [
+          { type: 'tool_use', id: 'tu1', name: 'Read', input: {} },
+          { type: 'tool_use', id: 'tu2', name: 'Bash', input: {} },
+        ] },
+        { role: 'user', content: [
+          { type: 'tool_result', tool_use_id: 'tu1', content: 'file contents' },
+          { type: 'tool_result', tool_use_id: 'tu2', is_error: true, content: 'command failed' },
+        ] },
+      ];
+      const results = helpers.extractAnthropicTurnToolResults(msgs);
+      assert.equal(results.length, 2);
+      assert.deepEqual(results[0], { callId: 'tu1', toolFail: false, eligible: true });
+      assert.deepEqual(results[1], { callId: 'tu2', toolFail: true, eligible: true });
+    });
+
+    it('returns empty array when last user message has no tool_result', () => {
+      const msgs = [{ role: 'user', content: 'plain question' }];
+      assert.deepEqual(helpers.extractAnthropicTurnToolResults(msgs), []);
+    });
+
+    it('returns empty array for null/missing messages', () => {
+      assert.deepEqual(helpers.extractAnthropicTurnToolResults(null), []);
+      assert.deepEqual(helpers.extractAnthropicTurnToolResults([]), []);
+    });
+
+    it('writes ALL tool results, not Bash-only', () => {
+      const msgs = [
+        { role: 'user', content: 'q' },
+        { role: 'assistant', content: [
+          { type: 'tool_use', id: 'tu1', name: 'Read', input: {} },
+          { type: 'tool_use', id: 'tu2', name: 'Edit', input: {} },
+          { type: 'tool_use', id: 'tu3', name: 'Bash', input: {} },
+        ] },
+        { role: 'user', content: [
+          { type: 'tool_result', tool_use_id: 'tu1', content: 'ok' },
+          { type: 'tool_result', tool_use_id: 'tu2', content: 'ok' },
+          { type: 'tool_result', tool_use_id: 'tu3', content: 'ok' },
+        ] },
+      ];
+      const results = helpers.extractAnthropicTurnToolResults(msgs);
+      assert.equal(results.length, 3);
+    });
+  });
+
+  // ── extractAnthropicToolCallIds ──
+  describe('extractAnthropicToolCallIds', () => {
+    it('extracts {id → name} from SSE events', () => {
+      const events = [
+        { type: 'message_start', message: { id: 'msg_01' } },
+        { type: 'content_block_start', content_block: { type: 'tool_use', id: 'toolu_01', name: 'Bash' } },
+        { type: 'content_block_start', content_block: { type: 'tool_use', id: 'toolu_02', name: 'Read' } },
+        { type: 'content_block_start', content_block: { type: 'text', text: '' } },
+      ];
+      const ids = helpers.extractAnthropicToolCallIds(events);
+      assert.deepEqual(ids, { toolu_01: 'Bash', toolu_02: 'Read' });
+    });
+
+    it('extracts {id → name} from non-SSE response object', () => {
+      const resData = {
+        content: [
+          { type: 'text', text: 'hello' },
+          { type: 'tool_use', id: 'toolu_01', name: 'Bash', input: {} },
+          { type: 'tool_use', id: 'toolu_02', name: 'Edit', input: {} },
+        ],
+      };
+      const ids = helpers.extractAnthropicToolCallIds(resData);
+      assert.deepEqual(ids, { toolu_01: 'Bash', toolu_02: 'Edit' });
+    });
+
+    it('returns empty object for no tool_use blocks', () => {
+      const events = [
+        { type: 'message_start', message: { id: 'msg_01' } },
+        { type: 'content_block_start', content_block: { type: 'text', text: '' } },
+      ];
+      assert.deepEqual(helpers.extractAnthropicToolCallIds(events), {});
+    });
+
+    it('returns empty object for null/missing response', () => {
+      assert.deepEqual(helpers.extractAnthropicToolCallIds(null), {});
+      assert.deepEqual(helpers.extractAnthropicToolCallIds(undefined), {});
+    });
+  });
+
+  // ── Pairing guard ──
+  it('every emitted callId resolves to a known tool_use.id', () => {
+    const events = [
+      { type: 'content_block_start', content_block: { type: 'tool_use', id: 'toolu_A', name: 'Bash' } },
+      { type: 'content_block_start', content_block: { type: 'tool_use', id: 'toolu_B', name: 'Read' } },
+    ];
+    const callIds = helpers.extractAnthropicToolCallIds(events);
+    const msgs = [
+      { role: 'user', content: 'q' },
+      { role: 'assistant', content: events.filter(e => e.content_block?.type === 'tool_use').map(e => e.content_block) },
+      { role: 'user', content: [
+        { type: 'tool_result', tool_use_id: 'toolu_A', content: 'ok' },
+        { type: 'tool_result', tool_use_id: 'toolu_B', is_error: true, content: 'fail' },
+      ] },
+    ];
+    const results = helpers.extractAnthropicTurnToolResults(msgs);
+    for (const r of results) {
+      assert.ok(r.callId in callIds, `callId ${r.callId} not in turnToolCallIds`);
+    }
+  });
+
+  // ── INDEX_FIELDS ──
+  it('turnToolCallIds and turnToolResults are in INDEX_FIELDS', () => {
+    const { INDEX_FIELDS } = require('../server/entry');
+    assert.ok(INDEX_FIELDS.includes('turnToolCallIds'));
+    assert.ok(INDEX_FIELDS.includes('turnToolResults'));
+  });
+});

--- a/test/turn-tool-fail-backfill.test.js
+++ b/test/turn-tool-fail-backfill.test.js
@@ -197,6 +197,7 @@ describe('#438 turnToolFail backfill in rebuild-index', () => {
 
     const lines = readIndexLines();
     assert.equal(lines.find(l => l.id === idOrphanFail).turnToolFail, true, 'recovered orphan carries true');
-    assert.equal(lines.find(l => l.id === idOrphanClean).turnToolFail, false, 'recovered clean orphan carries explicit false');
+    // #486: no tool_result blocks → undefined (no-tools ≠ checked-clean)
+    assert.equal(lines.find(l => l.id === idOrphanClean).turnToolFail, undefined, 'recovered no-tool orphan carries undefined');
   });
 });

--- a/test/turn-tool-fail.test.js
+++ b/test/turn-tool-fail.test.js
@@ -36,9 +36,9 @@ describe('#438 turnToolFail: per-turn failure from last user message', () => {
     assert.equal(hasToolFailLastTurn(messages), false);
   });
 
-  it('returns false for empty/missing messages', () => {
-    assert.equal(hasToolFailLastTurn(null), false);
-    assert.equal(hasToolFailLastTurn([]), false);
+  it('returns undefined for empty/missing messages (#486: no-tools ≠ clean)', () => {
+    assert.equal(hasToolFailLastTurn(null), undefined);
+    assert.equal(hasToolFailLastTurn([]), undefined);
   });
 
   it('turnToolFail is in INDEX_FIELDS', () => {


### PR DESCRIPTION
## 摘要

- Anthropic 寫入端補齊 `turnToolCallIds`（response tool_use id→name）和 `turnToolResults`（request tool_result evidence）
- `hasToolFailLastTurn` 從 false/true 二態改為 undefined/false/true 三態——解除「無工具」與「工具成功」的混淆（18% 假乾淨率）
- `rebuild-index` backfill 覆蓋 turnToolCallIds + turnToolResults + orphan recovery
- `store.js` merge 加入新欄位處理
- 舊碼偵測改用 `turnToolResults===undefined`，避免三態變更觸發不必要的 rebuild 警告

## Detail

**Part 1 — Missing evidence fields**: `turnToolCallIds` and `turnToolResults` were already in `INDEX_FIELDS` and SSE broadcast but Anthropic `buildEntryFields` only wrote `turnToolFail`. All 40,709 proxy entries had 100% absence rate for the two fields.

**Part 2 — False conflation**: `hasToolFailLastTurn` returned `false` for messages with no `tool_result` blocks, making "tools succeeded" indistinguishable from "no tools ran". Sampled 400 entries: 18.0% false-clean (49.3% of `end_turn` turns).

**Codex review fixes** (P2×3): backfill counters in `hasChanges` gate, orphan recovery `turnToolCallIds`, legacy detection signal.

**Epoch note**: this PR's merge date is a data epoch boundary. All entries after this date carry the new evidence fields; before this date, only cumulative `toolFail`.

## Verified

- fail-on-old: `test/turn-tool-fail.test.js` and `test/turn-tool-fail-backfill.test.js` assert `undefined` for no-tool messages (old code returns `false` → test fails)
- New: `test/anthropic-tool-evidence.test.js` — 14 tests covering tri-state, extraction, pairing guard, INDEX_FIELDS
- Full suite: 1919 pass, 0 fail (`CCXRAY_HOME=$(mktemp -d)`)
- Boot smoke: HTTP 200 on port 5604

## Not verified

- No browser smoke (write-side only, no UI change)
- No real-data backfill run (acceptance deferred to owner)

<!-- GATE-MANIFEST
issue-lint=pass @3814bd2504681c6f218c5aeca51295af7a5db84e
full-test=0 @3814bd2504681c6f218c5aeca51295af7a5db84e
boot-smoke=0 @3814bd2504681c6f218c5aeca51295af7a5db84e
diff-check=0 @3814bd2504681c6f218c5aeca51295af7a5db84e
-->

Fixes #486