### PR TITLE
feat(importer): extract turnToolCallIds/turnToolResults from source transcripts

### DIFF
--- a/scripts/calibrate-importer-tools.js
+++ b/scripts/calibrate-importer-tools.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+'use strict';
+
+// #500 calibration: run parseSessionFile / parseCodexSessionFile against real
+// transcripts and verify turnToolCallIds / turnToolResults extraction matches
+// the issue's stated data profile.
+//
+// Usage: node scripts/calibrate-importer-tools.js [--codex]
+
+const { parseSessionFile, parseCodexSessionFile, discoverHomes, discoverCodexHomes } = require('../server/importer');
+const fs = require('fs');
+const path = require('path');
+
+const doCodex = process.argv.includes('--codex');
+const doClaude = !doCodex || process.argv.includes('--claude');
+
+async function collectJsonlFiles(dir) {
+  const results = [];
+  try {
+    for (const item of fs.readdirSync(dir)) {
+      if (item.endsWith('.jsonl')) results.push(path.join(dir, item));
+    }
+  } catch {}
+  return results;
+}
+
+async function collectJsonlFilesRecursive(dir, results = []) {
+  try {
+    for (const item of fs.readdirSync(dir)) {
+      const full = path.join(dir, item);
+      const stat = fs.statSync(full);
+      if (stat.isDirectory()) await collectJsonlFilesRecursive(full, results);
+      else if (item.endsWith('.jsonl')) results.push(full);
+    }
+  } catch {}
+  return results;
+}
+
+async function run() {
+  const stats = {
+    files: 0,
+    entries: 0,
+    withToolCallIds: 0,
+    totalToolCalls: 0,
+    withToolResults: 0,
+    totalToolResults: 0,
+    toolFailTrue: 0,
+    toolFailFalse: 0,
+    toolFailUndefined: 0,
+    emptyCallIds: 0,
+    emptyResults: 0,
+  };
+
+  if (doClaude) {
+    console.log('=== Claude transcripts ===');
+    const homes = discoverHomes();
+    for (const { dir } of homes) {
+      let projectDirs;
+      try { projectDirs = fs.readdirSync(dir); } catch { continue; }
+      for (const slug of projectDirs) {
+        const projectPath = path.join(dir, slug);
+        try { if (!fs.statSync(projectPath).isDirectory()) continue; } catch { continue; }
+        const files = await collectJsonlFiles(projectPath);
+        for (const file of files) {
+          stats.files++;
+          const entries = await parseSessionFile(file, slug);
+          for (const e of entries) {
+            stats.entries++;
+            if (e.turnToolCallIds && Object.keys(e.turnToolCallIds).length > 0) {
+              stats.withToolCallIds++;
+              stats.totalToolCalls += Object.keys(e.turnToolCallIds).length;
+            } else if (e.turnToolCallIds !== undefined) {
+              stats.emptyCallIds++;
+            }
+            if (Array.isArray(e.turnToolResults) && e.turnToolResults.length > 0) {
+              stats.withToolResults++;
+              stats.totalToolResults += e.turnToolResults.length;
+              for (const r of e.turnToolResults) {
+                if (r.toolFail === true) stats.toolFailTrue++;
+                else if (r.toolFail === false) stats.toolFailFalse++;
+                else stats.toolFailUndefined++;
+              }
+            } else if (Array.isArray(e.turnToolResults)) {
+              stats.emptyResults++;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (doCodex) {
+    console.log('=== Codex transcripts ===');
+    const homes = discoverCodexHomes();
+    for (const { dir } of homes) {
+      const files = await collectJsonlFilesRecursive(dir);
+      for (const file of files) {
+        stats.files++;
+        const entries = await parseCodexSessionFile(file);
+        for (const e of entries) {
+          stats.entries++;
+          if (e.turnToolCallIds && Object.keys(e.turnToolCallIds).length > 0) {
+            stats.withToolCallIds++;
+            stats.totalToolCalls += Object.keys(e.turnToolCallIds).length;
+          } else if (e.turnToolCallIds !== undefined) {
+            stats.emptyCallIds++;
+          }
+          if (Array.isArray(e.turnToolResults) && e.turnToolResults.length > 0) {
+            stats.withToolResults++;
+            stats.totalToolResults += e.turnToolResults.length;
+            for (const r of e.turnToolResults) {
+              if (r.toolFail === true) stats.toolFailTrue++;
+              else if (r.toolFail === false) stats.toolFailFalse++;
+              else stats.toolFailUndefined++;
+            }
+          } else if (Array.isArray(e.turnToolResults)) {
+            stats.emptyResults++;
+          }
+        }
+      }
+    }
+  }
+
+  console.log('\n--- Calibration results ---');
+  console.log(`Files scanned:          ${stats.files}`);
+  console.log(`Entries parsed:         ${stats.entries}`);
+  console.log(`With turnToolCallIds:   ${stats.withToolCallIds} (${stats.totalToolCalls} total calls)`);
+  console.log(`Empty turnToolCallIds:  ${stats.emptyCallIds} ({}, processed)`);
+  console.log(`With turnToolResults:   ${stats.withToolResults} (${stats.totalToolResults} total results)`);
+  console.log(`Empty turnToolResults:  ${stats.emptyResults} ([], processed)`);
+  console.log(`toolFail breakdown:`);
+  console.log(`  true (error):         ${stats.toolFailTrue}`);
+  console.log(`  false (checked-ok):   ${stats.toolFailFalse}`);
+  console.log(`  undefined (no flag):  ${stats.toolFailUndefined}`);
+
+  // Issue #500 stated profile checks
+  const totalResults = stats.toolFailTrue + stats.toolFailFalse + stats.toolFailUndefined;
+  if (totalResults > 0) {
+    const hasIsErrorPct = ((stats.toolFailTrue + stats.toolFailFalse) / totalResults * 100).toFixed(1);
+    const noIsErrorPct = (stats.toolFailUndefined / totalResults * 100).toFixed(1);
+    console.log(`\n--- Profile check (issue #500 stated: 52% have is_error, 48% don't) ---`);
+    console.log(`  has is_error:  ${hasIsErrorPct}% (${stats.toolFailTrue + stats.toolFailFalse}/${totalResults})`);
+    console.log(`  no is_error:   ${noIsErrorPct}% (${stats.toolFailUndefined}/${totalResults})`);
+  }
+
+  if (stats.entries === 0) {
+    console.log('\n⚠ No entries found. Check transcript paths.');
+    process.exit(1);
+  }
+  console.log('\n✓ Calibration complete');
+}
+
+run().catch(err => { console.error(err); process.exit(1); });

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1180,6 +1180,8 @@ module.exports = {
   extractOpenAIToolCalls,
   extractOpenAIToolCallIds,
   extractOpenAITurnToolFail, extractOpenAITurnToolResults,
+  decodeCodexToolOutput, CODEX_ASYNC_START, aggregateToolFailResults,
+  OPENAI_TOOL_ALIASES, OPENAI_PROCESS_TOOLS,
   extractDuplicateToolCalls,
   scanCredentials,
   scanObjectForCredentials,

--- a/server/importer.js
+++ b/server/importer.js
@@ -152,7 +152,7 @@ async function parseSessionFile(filePath, projectSlug) {
           if (b?.type === 'tool_result') {
             pendingToolResults.push({
               callId: b.tool_use_id || null,
-              toolFail: b.is_error === true ? true : undefined,
+              toolFail: 'is_error' in b ? (b.is_error === true) : undefined,
               eligible: true,
             });
           }

--- a/server/importer.js
+++ b/server/importer.js
@@ -9,6 +9,7 @@ const config = require('./config');
 const { broadcastRaw } = require('./sse-broadcast');
 const { buildIndexLine } = require('./entry');
 const sessionIdx = require('./session-index');
+const helpers = require('./helpers');
 
 const DEFAULT_CONTEXT_WINDOW = 200000;
 const CODEX_CONTEXT_WINDOW = 400000;
@@ -120,6 +121,8 @@ async function parseSessionFile(filePath, projectSlug) {
   const sessionId = path.basename(filePath, '.jsonl');
   let lastUserText = null;
   let cwd = null;
+  // #500: tool_result blocks from the most recent user line, carried to next assistant
+  let pendingToolResults = [];
   // #428: aggregate by message.id — Claude Code writes multiple assistant lines
   // per API response (one per content block), each with a different timestamp.
   // Key = msg.id; value = entry object. Last-seen line wins (richest usage).
@@ -139,9 +142,21 @@ async function parseSessionFile(filePath, projectSlug) {
       const content = obj.message.content;
       if (typeof content === 'string') {
         lastUserText = content.slice(0, 120);
+        pendingToolResults = [];
       } else if (Array.isArray(content)) {
         const textBlock = content.find(b => b.type === 'text');
         if (textBlock) lastUserText = (textBlock.text || '').slice(0, 120);
+        // #500: extract tool_result blocks from user content
+        pendingToolResults = [];
+        for (const b of content) {
+          if (b?.type === 'tool_result') {
+            pendingToolResults.push({
+              callId: b.tool_use_id || null,
+              toolFail: b.is_error === true ? true : undefined,
+              eligible: true,
+            });
+          }
+        }
       }
       continue;
     }
@@ -161,6 +176,16 @@ async function parseSessionFile(filePath, projectSlug) {
     const tokens = buildTokens(usage);
     const receivedAt = new Date(obj.timestamp).getTime();
 
+    // #500: extract tool_use call ids from assistant content
+    const turnToolCallIds = {};
+    if (Array.isArray(msg.content)) {
+      for (const b of msg.content) {
+        if (b.type === 'tool_use' && b.id) {
+          turnToolCallIds[b.id] = b.name || null;
+        }
+      }
+    }
+
     const responseId = msg.id || null;
     const dedupKey = responseId || id;
     const prev = byResponseId.get(dedupKey);
@@ -178,6 +203,8 @@ async function parseSessionFile(filePath, projectSlug) {
       isSSE: false,
       receivedAt: prev ? prev.receivedAt : receivedAt,
       responseId,
+      turnToolCallIds,
+      turnToolResults: pendingToolResults,
       tokens,
       cost: { cost: costResult.cost, confidence: costResult.confidence },
       model,
@@ -197,6 +224,7 @@ async function parseSessionFile(filePath, projectSlug) {
       },
     };
     byResponseId.set(dedupKey, entry);
+    pendingToolResults = [];
   }
   return [...byResponseId.values()];
 }
@@ -210,6 +238,9 @@ async function parseCodexSessionFile(filePath) {
   let sessionId = path.basename(filePath, '.jsonl');
   let cwd = null;
   let lastModel = 'unknown';
+  // #500: accumulate tool calls/results between token_count boundaries
+  let pendingCalls = {};
+  let pendingResults = [];
 
   const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
@@ -223,6 +254,30 @@ async function parseCodexSessionFile(filePath) {
     if (payload.cwd && !cwd) cwd = payload.cwd;
     if (payload.model) lastModel = payload.model;
     if (obj.type === 'session_meta' && typeof payload.session_id === 'string') sessionId = payload.session_id;
+
+    // #500: tool call lines (response side)
+    if (payload.type === 'function_call' || payload.type === 'custom_tool_call') {
+      const callId = payload.call_id || payload.id;
+      if (callId) {
+        const rawName = payload.name || payload.function?.name || payload.tool_name;
+        pendingCalls[callId] = rawName
+          ? (helpers.OPENAI_PROCESS_TOOLS.has(rawName) ? 'Bash' : (helpers.OPENAI_TOOL_ALIASES[rawName] || rawName))
+          : null;
+      }
+      continue;
+    }
+
+    // #500: tool result lines (request side)
+    if (payload.type === 'function_call_output' || payload.type === 'custom_tool_call_output') {
+      const decoded = helpers.decodeCodexToolOutput(payload.output);
+      const isAsyncStart = decoded === helpers.CODEX_ASYNC_START;
+      pendingResults.push({
+        callId: payload.call_id || null,
+        eligible: !isAsyncStart,
+        toolFail: isAsyncStart ? undefined : decoded,
+      });
+      continue;
+    }
 
     if (payload.type !== 'token_count') continue;
     const tu = payload.info && payload.info.last_token_usage;
@@ -258,6 +313,8 @@ async function parseCodexSessionFile(filePath) {
       status: 200,
       isSSE: false,
       receivedAt,
+      turnToolCallIds: pendingCalls,
+      turnToolResults: pendingResults,
       tokens,
       cost: { cost: costResult.cost, confidence: costResult.confidence },
       model: lastModel,
@@ -273,6 +330,8 @@ async function parseCodexSessionFile(filePath) {
       cwd,
       usage,
     });
+    pendingCalls = {};
+    pendingResults = [];
   }
   return entries;
 }

--- a/server/importer.js
+++ b/server/importer.js
@@ -242,9 +242,12 @@ async function parseCodexSessionFile(filePath) {
   let sessionId = path.basename(filePath, '.jsonl');
   let cwd = null;
   let lastModel = 'unknown';
-  // #500: accumulate tool calls/results between token_count boundaries
+  // #500: accumulate tool calls/results between token_count boundaries.
+  // Results carry to the NEXT entry (matching proxy convention: turnToolResults
+  // = what was fed INTO this request, i.e. results from the previous turn).
   let pendingCalls = {};
   let pendingResults = [];
+  let prevResults = [];
 
   const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
@@ -318,7 +321,7 @@ async function parseCodexSessionFile(filePath) {
       isSSE: false,
       receivedAt,
       turnToolCallIds: pendingCalls,
-      turnToolResults: pendingResults,
+      turnToolResults: prevResults,
       tokens,
       cost: { cost: costResult.cost, confidence: costResult.confidence },
       model: lastModel,
@@ -335,6 +338,7 @@ async function parseCodexSessionFile(filePath) {
       usage,
     });
     pendingCalls = {};
+    prevResults = pendingResults;
     pendingResults = [];
   }
   return entries;

--- a/server/importer.js
+++ b/server/importer.js
@@ -190,6 +190,10 @@ async function parseSessionFile(filePath, projectSlug) {
     const dedupKey = responseId || id;
     const prev = byResponseId.get(dedupKey);
 
+    // #500: merge tool evidence across duplicate assistant lines (same msg.id)
+    const mergedToolCallIds = prev ? { ...prev.turnToolCallIds, ...turnToolCallIds } : turnToolCallIds;
+    const mergedToolResults = prev ? prev.turnToolResults : pendingToolResults;
+
     const entry = {
       id: prev ? prev.id : id,
       ts: prev ? prev.ts : obj.timestamp,
@@ -203,8 +207,8 @@ async function parseSessionFile(filePath, projectSlug) {
       isSSE: false,
       receivedAt: prev ? prev.receivedAt : receivedAt,
       responseId,
-      turnToolCallIds,
-      turnToolResults: pendingToolResults,
+      turnToolCallIds: mergedToolCallIds,
+      turnToolResults: mergedToolResults,
       tokens,
       cost: { cost: costResult.cost, confidence: costResult.confidence },
       model,

--- a/server/index.js
+++ b/server/index.js
@@ -91,10 +91,16 @@ if (process.argv[2] === 'secret') {
 // Rebuilds index.ndjson from surviving _req/_res log files. Dry-run by default;
 // --apply atomically writes the merged index. Merge-only and hub-safe.
 if (process.argv[2] === 'rebuild-index') {
-  const { rebuildIndex } = require('./rebuild-index');
-  rebuildIndex({ apply: process.argv.includes('--apply') })
-    .then(r => process.exit(r && r.refused ? 1 : 0))
-    .catch(err => { console.error(`rebuild-index failed: ${err.message}`); process.exit(1); });
+  const { rebuildIndex, reimportEntries } = require('./rebuild-index');
+  if (process.argv.includes('--reimport')) {
+    reimportEntries()
+      .then(r => process.exit(r && r.refused ? 1 : 0))
+      .catch(err => { console.error(`rebuild-index --reimport failed: ${err.message}`); process.exit(1); });
+  } else {
+    rebuildIndex({ apply: process.argv.includes('--apply') })
+      .then(r => process.exit(r && r.refused ? 1 : 0))
+      .catch(err => { console.error(`rebuild-index failed: ${err.message}`); process.exit(1); });
+  }
   return;
 }
 

--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -530,6 +530,11 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
 // #500: --reimport — remove all imported index lines and re-run scanAndImport()
 // so imported entries pick up newly-extracted fields (turnToolCallIds, turnToolResults).
 async function reimportEntries({ storage = config.storage, log = console.log } = {}) {
+  if (process.env.CCXRAY_IMPORT_DISABLE === '1') {
+    log('\x1b[31mCCXRAY_IMPORT_DISABLE=1 — reimport would delete imported lines without replacement. Aborting.\x1b[0m');
+    return { refused: true };
+  }
+
   const blockingHub = liveHubBlocking();
   if (blockingHub) {
     log(`\x1b[31mA ccxray hub is running (pid ${blockingHub.pid}). Stop it first.\x1b[0m`);
@@ -543,21 +548,22 @@ async function reimportEntries({ storage = config.storage, log = console.log } =
     return { refused: true };
   }
 
-  // Count and remove imported lines
+  // Stream-filter: keep non-imported lines, count removed
   const indexPath = path.join(storage.location, 'index.ndjson');
-  const kept = [];
+  const kept = []; // [{ line }] for writeLinesToFile
   let removed = 0;
   for await (const line of storage.readIndexLines()) {
     if (!line.trim()) continue;
     let m;
-    try { m = JSON.parse(line); } catch { kept.push(line); continue; }
+    try { m = JSON.parse(line); } catch { kept.push({ line }); continue; }
     if (m && m.imported) { removed++; continue; }
-    kept.push(line);
+    kept.push({ line });
   }
 
   log(`Removing ${removed} imported line(s) from index...`);
   const tmpPath = `${indexPath}.reimport-${process.pid}.tmp`;
-  fs.writeFileSync(tmpPath, kept.join('\n') + (kept.length ? '\n' : ''), { mode: 0o600 });
+  await writeLinesToFile(tmpPath, kept);
+  try { fs.chmodSync(tmpPath, 0o600); } catch {}
   fs.renameSync(tmpPath, indexPath);
 
   // Rebuild session index from cleaned state

--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -582,6 +582,9 @@ async function reimportEntries({ storage = config.storage, log = console.log } =
   const result = await scanAndImport();
   await storage.drain();
   log(`Re-imported ${result.imported} entries (${result.skipped} duplicates skipped).`);
+  if (result.imported < removed) {
+    log(`\x1b[33m  ⚠ ${removed - result.imported} fewer entries than before — source transcripts may have been deleted or moved\x1b[0m`);
+  }
   return { refused: false, removed, imported: result.imported, skipped: result.skipped };
 }
 

--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -527,4 +527,50 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   return { refused: false, recovered: N, enriched: enrichedResponseIds, enrichedIdentity, total: M, unrecoverable, applied: true, cacheFinalSize: cache.size };
 }
 
-module.exports = { rebuildIndex, reconstructReq, tsFromId, nearestPrecedingSession };
+// #500: --reimport — remove all imported index lines and re-run scanAndImport()
+// so imported entries pick up newly-extracted fields (turnToolCallIds, turnToolResults).
+async function reimportEntries({ storage = config.storage, log = console.log } = {}) {
+  const blockingHub = liveHubBlocking();
+  if (blockingHub) {
+    log(`\x1b[31mA ccxray hub is running (pid ${blockingHub.pid}). Stop it first.\x1b[0m`);
+    return { refused: true };
+  }
+
+  await storage.init();
+
+  if (!storage.supportsDelta || !storage.location) {
+    log('  --reimport needs the local filesystem backend; aborting.');
+    return { refused: true };
+  }
+
+  // Count and remove imported lines
+  const indexPath = path.join(storage.location, 'index.ndjson');
+  const kept = [];
+  let removed = 0;
+  for await (const line of storage.readIndexLines()) {
+    if (!line.trim()) continue;
+    let m;
+    try { m = JSON.parse(line); } catch { kept.push(line); continue; }
+    if (m && m.imported) { removed++; continue; }
+    kept.push(line);
+  }
+
+  log(`Removing ${removed} imported line(s) from index...`);
+  const tmpPath = `${indexPath}.reimport-${process.pid}.tmp`;
+  fs.writeFileSync(tmpPath, kept.join('\n') + (kept.length ? '\n' : ''), { mode: 0o600 });
+  fs.renameSync(tmpPath, indexPath);
+
+  // Rebuild session index from cleaned state
+  const sessionIdx = require('./session-index');
+  const content = fs.readFileSync(indexPath, 'utf8');
+  sessionIdx.rebuildFromIndexContent(content);
+
+  // Re-run importer
+  const { scanAndImport } = require('./importer');
+  const result = await scanAndImport();
+  await storage.drain();
+  log(`Re-imported ${result.imported} entries (${result.skipped} duplicates skipped).`);
+  return { refused: false, removed, imported: result.imported, skipped: result.skipped };
+}
+
+module.exports = { rebuildIndex, reimportEntries, reconstructReq, tsFromId, nearestPrecedingSession };

--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -566,10 +566,16 @@ async function reimportEntries({ storage = config.storage, log = console.log } =
   try { fs.chmodSync(tmpPath, 0o600); } catch {}
   fs.renameSync(tmpPath, indexPath);
 
-  // Rebuild session index from cleaned state
+  // Rebuild session index from cleaned state (streaming — the index can exceed
+  // Node's max string size; readFileSync would throw ERR_STRING_TOO_LONG after
+  // the old index is already replaced, leaving imported history deleted).
   const sessionIdx = require('./session-index');
-  const content = fs.readFileSync(indexPath, 'utf8');
-  sessionIdx.rebuildFromIndexContent(content);
+  async function* parsedLines() {
+    for await (const line of storage.readIndexLines()) {
+      try { yield JSON.parse(line); } catch {}
+    }
+  }
+  await sessionIdx.rebuildFromMetasAsync(parsedLines());
 
   // Re-run importer
   const { scanAndImport } = require('./importer');

--- a/test/importer.test.js
+++ b/test/importer.test.js
@@ -77,7 +77,7 @@ function makeUserWithToolResults(results, opts = {}) {
     type: 'tool_result',
     tool_use_id: r.tool_use_id,
     content: r.content || 'ok',
-    ...(r.is_error ? { is_error: true } : {}),
+    ...('is_error' in r ? { is_error: r.is_error } : {}),
   }));
   return makeLine('user', {
     timestamp: opts.timestamp || '2026-07-15T10:29:55.000Z',
@@ -251,6 +251,23 @@ describe('importer', () => {
       assert.strictEqual(entries[0].turnToolResults.length, 1);
       assert.strictEqual(entries[0].turnToolResults[0].callId, 'toolu_01A');
       assert.strictEqual(entries[0].turnToolResults[0].toolFail, undefined);
+    });
+
+    it('#500: extracts turnToolResults from user tool_result (is_error: false)', async () => {
+      const sessionDir = path.join(importDir, 'test-project');
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const file = path.join(sessionDir, 'sess-tool-ok-explicit.jsonl');
+      fs.writeFileSync(file, [
+        makeUserWithToolResults([{ tool_use_id: 'toolu_01A', is_error: false, content: 'success' }]),
+        makeAssistant({ timestamp: '2026-07-15T10:30:05.000Z' }),
+      ].join('\n'));
+
+      const entries = await parseSessionFile(file, 'test-project');
+      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries[0].turnToolResults.length, 1);
+      assert.strictEqual(entries[0].turnToolResults[0].callId, 'toolu_01A');
+      assert.strictEqual(entries[0].turnToolResults[0].toolFail, false);
+      assert.strictEqual(entries[0].turnToolResults[0].eligible, true);
     });
 
     it('#500: assistant with no tool_use → turnToolCallIds is {} (not undefined)', async () => {

--- a/test/importer.test.js
+++ b/test/importer.test.js
@@ -562,7 +562,7 @@ describe('codex importer', () => {
       assert.deepStrictEqual(entries[0].turnToolCallIds, { call_AAA: 'Bash', call_BBB: 'Read' });
     });
 
-    it('#500: custom_tool_call_output then token_count → turnToolResults populated', async () => {
+    it('#500: call+output in same window, results carry to NEXT entry', async () => {
       const sessDir = path.join(codexDir, '2026', '07', '15');
       fs.mkdirSync(sessDir, { recursive: true });
       const file = path.join(sessDir, 'rollout-tool-result.jsonl');
@@ -570,18 +570,24 @@ describe('codex importer', () => {
       fs.writeFileSync(file, [
         makeCodexSessionMeta({ sessionId: 'codex-tool-2' }),
         makeCodexTurnContext({ model: 'gpt-5.5' }),
+        // Window 0: call + output in same window (real Codex behavior)
+        JSON.stringify({ timestamp: '2026-07-15T10:30:02.000Z', type: 'response_item', payload: { type: 'custom_tool_call', call_id: 'call_AAA', name: 'exec' } }),
         JSON.stringify({ timestamp: '2026-07-15T10:30:03.000Z', type: 'response_item', payload: { type: 'custom_tool_call_output', call_id: 'call_AAA', output } }),
-        makeCodexTokenCount({ timestamp: '2026-07-15T10:30:05.000Z' }),
+        makeCodexTokenCount({ timestamp: '2026-07-15T10:30:04.000Z' }),
+        // Window 1: empty, creates entry that receives the results
+        makeCodexTokenCount({ timestamp: '2026-07-15T10:30:08.000Z' }),
       ].join('\n'));
 
       const entries = await parseCodexSessionFile(file);
-      assert.strictEqual(entries.length, 1);
-      assert.strictEqual(entries[0].turnToolResults.length, 1);
-      assert.strictEqual(entries[0].turnToolResults[0].callId, 'call_AAA');
-      assert.strictEqual(entries[0].turnToolResults[0].eligible, true);
+      assert.strictEqual(entries.length, 2);
+      assert.deepStrictEqual(entries[0].turnToolCallIds, { call_AAA: 'Bash' });
+      assert.deepStrictEqual(entries[0].turnToolResults, []);
+      assert.strictEqual(entries[1].turnToolResults.length, 1);
+      assert.strictEqual(entries[1].turnToolResults[0].callId, 'call_AAA');
+      assert.strictEqual(entries[1].turnToolResults[0].eligible, true);
     });
 
-    it('#500: multiple tool calls/outputs accumulated correctly', async () => {
+    it('#500: multi-tool calls+outputs in same window, results carry to next', async () => {
       const sessDir = path.join(codexDir, '2026', '07', '15');
       fs.mkdirSync(sessDir, { recursive: true });
       const file = path.join(sessDir, 'rollout-tool-multi.jsonl');
@@ -589,19 +595,23 @@ describe('codex importer', () => {
       fs.writeFileSync(file, [
         makeCodexSessionMeta({ sessionId: 'codex-tool-3' }),
         makeCodexTurnContext({ model: 'gpt-5.5' }),
+        // Window 0: two call+output pairs
         JSON.stringify({ timestamp: '2026-07-15T10:30:02.000Z', type: 'response_item', payload: { type: 'custom_tool_call', call_id: 'call_1', name: 'exec' } }),
         JSON.stringify({ timestamp: '2026-07-15T10:30:02.500Z', type: 'response_item', payload: { type: 'custom_tool_call_output', call_id: 'call_1', output } }),
         JSON.stringify({ timestamp: '2026-07-15T10:30:03.000Z', type: 'response_item', payload: { type: 'custom_tool_call', call_id: 'call_2', name: 'apply_patch' } }),
         JSON.stringify({ timestamp: '2026-07-15T10:30:03.500Z', type: 'response_item', payload: { type: 'custom_tool_call_output', call_id: 'call_2', output } }),
         makeCodexTokenCount({ timestamp: '2026-07-15T10:30:05.000Z' }),
+        // Window 1: empty, receives the results
+        makeCodexTokenCount({ timestamp: '2026-07-15T10:30:10.000Z' }),
       ].join('\n'));
 
       const entries = await parseCodexSessionFile(file);
-      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries.length, 2);
       assert.deepStrictEqual(entries[0].turnToolCallIds, { call_1: 'Bash', call_2: 'Edit' });
-      assert.strictEqual(entries[0].turnToolResults.length, 2);
-      assert.strictEqual(entries[0].turnToolResults[0].callId, 'call_1');
-      assert.strictEqual(entries[0].turnToolResults[1].callId, 'call_2');
+      assert.deepStrictEqual(entries[0].turnToolResults, []);
+      assert.strictEqual(entries[1].turnToolResults.length, 2);
+      assert.strictEqual(entries[1].turnToolResults[0].callId, 'call_1');
+      assert.strictEqual(entries[1].turnToolResults[1].callId, 'call_2');
     });
 
     it('#500: no tool lines before token_count → turnToolCallIds {}, turnToolResults []', async () => {

--- a/test/importer.test.js
+++ b/test/importer.test.js
@@ -44,13 +44,14 @@ function makeLine(type, extra = {}) {
 }
 
 function makeAssistant(opts = {}) {
+  const content = opts.content || [{ type: 'text', text: opts.text || 'Hello' }];
   return makeLine('assistant', {
     timestamp: opts.timestamp || '2026-07-15T10:30:00.000Z',
     message: {
       id: opts.msgId,
       model: opts.model || 'claude-sonnet-4-5-20250514',
       role: 'assistant',
-      content: [{ type: 'text', text: opts.text || 'Hello' }],
+      content,
       stop_reason: opts.stop_reason || 'end_turn',
       usage: {
         input_tokens: opts.input ?? 5000,
@@ -68,6 +69,19 @@ function makeUser(text = 'Hello world') {
   return makeLine('user', {
     timestamp: '2026-07-15T10:29:50.000Z',
     message: { role: 'user', content: [{ type: 'text', text }] },
+  });
+}
+
+function makeUserWithToolResults(results, opts = {}) {
+  const content = results.map(r => ({
+    type: 'tool_result',
+    tool_use_id: r.tool_use_id,
+    content: r.content || 'ok',
+    ...(r.is_error ? { is_error: true } : {}),
+  }));
+  return makeLine('user', {
+    timestamp: opts.timestamp || '2026-07-15T10:29:55.000Z',
+    message: { role: 'user', content },
   });
 }
 
@@ -183,6 +197,90 @@ describe('importer', () => {
 
       const entries = await parseSessionFile(file, 'test-project');
       assert.strictEqual(entries.length, 0);
+    });
+
+    it('#500: extracts turnToolCallIds from assistant tool_use blocks', async () => {
+      const sessionDir = path.join(importDir, 'test-project');
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const file = path.join(sessionDir, 'sess-tool-calls.jsonl');
+      fs.writeFileSync(file, [
+        makeUser('run a command'),
+        makeAssistant({
+          timestamp: '2026-07-15T10:30:05.000Z',
+          content: [
+            { type: 'text', text: 'Running...' },
+            { type: 'tool_use', id: 'toolu_01A', name: 'Bash', input: { command: 'ls' } },
+            { type: 'tool_use', id: 'toolu_01B', name: 'Read', input: { path: '/tmp/x' } },
+          ],
+        }),
+      ].join('\n'));
+
+      const entries = await parseSessionFile(file, 'test-project');
+      assert.strictEqual(entries.length, 1);
+      assert.deepStrictEqual(entries[0].turnToolCallIds, { toolu_01A: 'Bash', toolu_01B: 'Read' });
+    });
+
+    it('#500: extracts turnToolResults from user tool_result (is_error: true)', async () => {
+      const sessionDir = path.join(importDir, 'test-project');
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const file = path.join(sessionDir, 'sess-tool-fail.jsonl');
+      fs.writeFileSync(file, [
+        makeUserWithToolResults([{ tool_use_id: 'toolu_01A', is_error: true, content: 'command failed' }]),
+        makeAssistant({ timestamp: '2026-07-15T10:30:05.000Z' }),
+      ].join('\n'));
+
+      const entries = await parseSessionFile(file, 'test-project');
+      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries[0].turnToolResults.length, 1);
+      assert.strictEqual(entries[0].turnToolResults[0].callId, 'toolu_01A');
+      assert.strictEqual(entries[0].turnToolResults[0].toolFail, true);
+      assert.strictEqual(entries[0].turnToolResults[0].eligible, true);
+    });
+
+    it('#500: extracts turnToolResults from user tool_result (no is_error)', async () => {
+      const sessionDir = path.join(importDir, 'test-project');
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const file = path.join(sessionDir, 'sess-tool-ok.jsonl');
+      fs.writeFileSync(file, [
+        makeUserWithToolResults([{ tool_use_id: 'toolu_01A', content: 'success' }]),
+        makeAssistant({ timestamp: '2026-07-15T10:30:05.000Z' }),
+      ].join('\n'));
+
+      const entries = await parseSessionFile(file, 'test-project');
+      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries[0].turnToolResults.length, 1);
+      assert.strictEqual(entries[0].turnToolResults[0].callId, 'toolu_01A');
+      assert.strictEqual(entries[0].turnToolResults[0].toolFail, undefined);
+    });
+
+    it('#500: assistant with no tool_use → turnToolCallIds is {} (not undefined)', async () => {
+      const sessionDir = path.join(importDir, 'test-project');
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const file = path.join(sessionDir, 'sess-no-tools.jsonl');
+      fs.writeFileSync(file, [
+        makeUser('hello'),
+        makeAssistant({ timestamp: '2026-07-15T10:30:05.000Z' }),
+      ].join('\n'));
+
+      const entries = await parseSessionFile(file, 'test-project');
+      assert.strictEqual(entries.length, 1);
+      assert.deepStrictEqual(entries[0].turnToolCallIds, {});
+      assert.ok(entries[0].turnToolCallIds !== undefined);
+    });
+
+    it('#500: no preceding user tool_result → turnToolResults is [] (not undefined)', async () => {
+      const sessionDir = path.join(importDir, 'test-project');
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const file = path.join(sessionDir, 'sess-no-results.jsonl');
+      fs.writeFileSync(file, [
+        makeUser('hello'),
+        makeAssistant({ timestamp: '2026-07-15T10:30:05.000Z' }),
+      ].join('\n'));
+
+      const entries = await parseSessionFile(file, 'test-project');
+      assert.strictEqual(entries.length, 1);
+      assert.deepStrictEqual(entries[0].turnToolResults, []);
+      assert.ok(entries[0].turnToolResults !== undefined);
     });
   });
 
@@ -400,6 +498,81 @@ describe('codex importer', () => {
 
       const entries = await parseCodexSessionFile(file);
       assert.strictEqual(entries.length, 0);
+    });
+
+    it('#500: custom_tool_call then token_count → turnToolCallIds populated', async () => {
+      const sessDir = path.join(codexDir, '2026', '07', '15');
+      fs.mkdirSync(sessDir, { recursive: true });
+      const file = path.join(sessDir, 'rollout-tool-call.jsonl');
+      fs.writeFileSync(file, [
+        makeCodexSessionMeta({ sessionId: 'codex-tool-1' }),
+        makeCodexTurnContext({ model: 'gpt-5.5' }),
+        JSON.stringify({ timestamp: '2026-07-15T10:30:02.000Z', type: 'response_item', payload: { type: 'custom_tool_call', call_id: 'call_AAA', name: 'exec_command' } }),
+        JSON.stringify({ timestamp: '2026-07-15T10:30:03.000Z', type: 'response_item', payload: { type: 'function_call', call_id: 'call_BBB', name: 'read_mcp_resource' } }),
+        makeCodexTokenCount({ timestamp: '2026-07-15T10:30:05.000Z' }),
+      ].join('\n'));
+
+      const entries = await parseCodexSessionFile(file);
+      assert.strictEqual(entries.length, 1);
+      assert.deepStrictEqual(entries[0].turnToolCallIds, { call_AAA: 'Bash', call_BBB: 'Read' });
+    });
+
+    it('#500: custom_tool_call_output then token_count → turnToolResults populated', async () => {
+      const sessDir = path.join(codexDir, '2026', '07', '15');
+      fs.mkdirSync(sessDir, { recursive: true });
+      const file = path.join(sessDir, 'rollout-tool-result.jsonl');
+      const output = [{ type: 'input_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\nhello\n' }];
+      fs.writeFileSync(file, [
+        makeCodexSessionMeta({ sessionId: 'codex-tool-2' }),
+        makeCodexTurnContext({ model: 'gpt-5.5' }),
+        JSON.stringify({ timestamp: '2026-07-15T10:30:03.000Z', type: 'response_item', payload: { type: 'custom_tool_call_output', call_id: 'call_AAA', output } }),
+        makeCodexTokenCount({ timestamp: '2026-07-15T10:30:05.000Z' }),
+      ].join('\n'));
+
+      const entries = await parseCodexSessionFile(file);
+      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries[0].turnToolResults.length, 1);
+      assert.strictEqual(entries[0].turnToolResults[0].callId, 'call_AAA');
+      assert.strictEqual(entries[0].turnToolResults[0].eligible, true);
+    });
+
+    it('#500: multiple tool calls/outputs accumulated correctly', async () => {
+      const sessDir = path.join(codexDir, '2026', '07', '15');
+      fs.mkdirSync(sessDir, { recursive: true });
+      const file = path.join(sessDir, 'rollout-tool-multi.jsonl');
+      const output = [{ type: 'input_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\nok\n' }];
+      fs.writeFileSync(file, [
+        makeCodexSessionMeta({ sessionId: 'codex-tool-3' }),
+        makeCodexTurnContext({ model: 'gpt-5.5' }),
+        JSON.stringify({ timestamp: '2026-07-15T10:30:02.000Z', type: 'response_item', payload: { type: 'custom_tool_call', call_id: 'call_1', name: 'exec' } }),
+        JSON.stringify({ timestamp: '2026-07-15T10:30:02.500Z', type: 'response_item', payload: { type: 'custom_tool_call_output', call_id: 'call_1', output } }),
+        JSON.stringify({ timestamp: '2026-07-15T10:30:03.000Z', type: 'response_item', payload: { type: 'custom_tool_call', call_id: 'call_2', name: 'apply_patch' } }),
+        JSON.stringify({ timestamp: '2026-07-15T10:30:03.500Z', type: 'response_item', payload: { type: 'custom_tool_call_output', call_id: 'call_2', output } }),
+        makeCodexTokenCount({ timestamp: '2026-07-15T10:30:05.000Z' }),
+      ].join('\n'));
+
+      const entries = await parseCodexSessionFile(file);
+      assert.strictEqual(entries.length, 1);
+      assert.deepStrictEqual(entries[0].turnToolCallIds, { call_1: 'Bash', call_2: 'Edit' });
+      assert.strictEqual(entries[0].turnToolResults.length, 2);
+      assert.strictEqual(entries[0].turnToolResults[0].callId, 'call_1');
+      assert.strictEqual(entries[0].turnToolResults[1].callId, 'call_2');
+    });
+
+    it('#500: no tool lines before token_count → turnToolCallIds {}, turnToolResults []', async () => {
+      const sessDir = path.join(codexDir, '2026', '07', '15');
+      fs.mkdirSync(sessDir, { recursive: true });
+      const file = path.join(sessDir, 'rollout-no-tools.jsonl');
+      fs.writeFileSync(file, [
+        makeCodexSessionMeta({ sessionId: 'codex-no-tools' }),
+        makeCodexTurnContext({ model: 'gpt-5.5' }),
+        makeCodexTokenCount({ timestamp: '2026-07-15T10:30:05.000Z' }),
+      ].join('\n'));
+
+      const entries = await parseCodexSessionFile(file);
+      assert.strictEqual(entries.length, 1);
+      assert.deepStrictEqual(entries[0].turnToolCallIds, {});
+      assert.deepStrictEqual(entries[0].turnToolResults, []);
     });
   });
 

--- a/test/importer.test.js
+++ b/test/importer.test.js
@@ -285,6 +285,34 @@ describe('importer', () => {
       assert.ok(entries[0].turnToolCallIds !== undefined);
     });
 
+    it('#500: merges tool evidence across duplicate assistant lines (same msg.id)', async () => {
+      const sessionDir = path.join(importDir, 'test-project');
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const file = path.join(sessionDir, 'sess-merge.jsonl');
+      // Claude Code writes one assistant line per content block, all sharing msg.id
+      const msgId = 'msg_01MERGE';
+      fs.writeFileSync(file, [
+        makeUserWithToolResults([{ tool_use_id: 'toolu_prev', is_error: true }]),
+        // First line: text block
+        makeAssistant({ timestamp: '2026-07-15T10:30:05.000Z', msgId, text: 'Let me check...' }),
+        // Second line: tool_use block (same msg.id, different content)
+        makeAssistant({
+          timestamp: '2026-07-15T10:30:05.100Z',
+          msgId,
+          content: [{ type: 'tool_use', id: 'toolu_01C', name: 'Bash', input: { command: 'ls' } }],
+        }),
+      ].join('\n'));
+
+      const entries = await parseSessionFile(file, 'test-project');
+      assert.strictEqual(entries.length, 1);
+      // Tool call from the second line should be merged in
+      assert.deepStrictEqual(entries[0].turnToolCallIds, { toolu_01C: 'Bash' });
+      // Tool results from the first line should be preserved (not overwritten)
+      assert.strictEqual(entries[0].turnToolResults.length, 1);
+      assert.strictEqual(entries[0].turnToolResults[0].callId, 'toolu_prev');
+      assert.strictEqual(entries[0].turnToolResults[0].toolFail, true);
+    });
+
     it('#500: no preceding user tool_result → turnToolResults is [] (not undefined)', async () => {
       const sessionDir = path.join(importDir, 'test-project');
       fs.mkdirSync(sessionDir, { recursive: true });


### PR DESCRIPTION
## 摘要

- Claude importer 提取 `turnToolCallIds`（assistant tool_use blocks）和 `turnToolResults`（user tool_result blocks）
- Codex importer 提取 `custom_tool_call` → `turnToolCallIds` 和 `custom_tool_call_output` → `turnToolResults`（shifted to next entry per proxy convention）
- `rebuild-index --reimport` 清除並重新匯入所有 imported entries 以回填既有資料
- helpers.js 匯出 `decodeCodexToolOutput`、`CODEX_ASYNC_START`、`aggregateToolFailResults`、`OPENAI_TOOL_ALIASES`、`OPENAI_PROCESS_TOOLS`
- 校準腳本 `scripts/calibrate-importer-tools.js` 驗證真實資料提取結果

## Detail

**Claude**: `turnToolCallIds` = `{tool_use.id → name}` from assistant content; `turnToolResults` = `[{callId, toolFail, eligible}]` from the preceding user tool_result blocks. `is_error: true` → `toolFail: true`, `is_error: false` → `toolFail: false`, absent → `toolFail: undefined`. Duplicate assistant lines (same msg.id, #428) merge tool evidence across copies.

**Codex**: Calls and outputs accumulate within token_count boundaries. Tool results carry to the NEXT entry matching the proxy convention (`turnToolResults` = what was fed INTO this request from the previous turn's calls) so weather's `_openAIToolEvidence` can pair callIds correctly. Name normalization reuses `OPENAI_TOOL_ALIASES`/`OPENAI_PROCESS_TOOLS`.

**rebuild-index --reimport**: Removes all `imported: true` index lines via streaming filter, rebuilds session index with `rebuildFromMetasAsync` (streaming — avoids `ERR_STRING_TOO_LONG` on large indexes), then re-runs `scanAndImport()`. Guarded against `CCXRAY_IMPORT_DISABLE=1` (would delete without replacement) and active hub.

## 驗證

- 28 importer tests (11 new #500 tests) pass — Claude tool_use extraction, tool_result tri-state (true/false/undefined), empty-state {}/[] contract, Codex multi-tool accumulation, result shift
- Full suite: 1930 tests, 0 fail
- Boot smoke: HTTP 200 (port 5603, isolated CCXRAY_HOME)
- Codex review: 2 rounds, all P1 findings resolved
- **校準（真實資料）**: Claude 117,294 entries / 98,910 with calls / is_error 59.2%; Codex 36,603 entries / 25,692 with calls. Tool name normalization verified.
- 未驗：rebuild-index --reimport 未對真實資料執行（破壞性；需隔離環境）

<!-- GATE-MANIFEST
issue-lint=pass @1f44068777e59ea249c7d161fe32f5841006381c
full-test=0 @1f44068777e59ea249c7d161fe32f5841006381c
boot-smoke=0 @1f44068777e59ea249c7d161fe32f5841006381c
-->

Fixes #500