### PR TITLE
feat(export): daily + session summary exporter to GCS

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/justinlee/dev/ccxray/node_modules

--- a/server/export-sync.js
+++ b/server/export-sync.js
@@ -1,0 +1,454 @@
+'use strict';
+
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const readline = require('readline');
+const crypto = require('crypto');
+const https = require('https');
+const { resolveCcxrayHome, resolveLogsDir } = require('./paths');
+
+const LOCK_STALE_MS = 300_000;
+let timer = null;
+let uploader = uploadToGcs;
+let _cachedToken = null;
+let _cachedExpiry = 0;
+
+function exportBucket() {
+  return (process.env.CCXRAY_EXPORT_GCS_BUCKET || '').trim();
+}
+
+function isPidAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+function tryAcquireLock(home) {
+  fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+  const lockPath = path.join(home, 'export.lock');
+  const lock = { pid: process.pid, token: crypto.randomUUID(), acquiredAt: Date.now() };
+  try {
+    fs.writeFileSync(lockPath, JSON.stringify(lock), { flag: 'wx', mode: 0o600 });
+    return lock.token;
+  } catch (err) {
+    if (err.code !== 'EEXIST') return null;
+    try {
+      const current = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+      if (Date.now() - current.acquiredAt <= LOCK_STALE_MS && isPidAlive(current.pid)) return null;
+      const stalePath = `${lockPath}.stale.${process.pid}`;
+      try { fs.renameSync(lockPath, stalePath); fs.unlinkSync(stalePath); } catch { return null; }
+      try {
+        fs.writeFileSync(lockPath, JSON.stringify(lock), { flag: 'wx', mode: 0o600 });
+        return lock.token;
+      } catch { return null; }
+    } catch { return null; }
+  }
+}
+
+function releaseLock(home, token) {
+  const lockPath = path.join(home, 'export.lock');
+  try {
+    const current = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+    if (current.token === token) fs.unlinkSync(lockPath);
+  } catch {}
+}
+
+async function* readIndex() {
+  const input = fs.createReadStream(path.join(resolveLogsDir(), 'index.ndjson'), { encoding: 'utf8' });
+  const rl = readline.createInterface({ input, crlfDelay: Infinity });
+  try {
+    for await (const line of rl) {
+      if (!line) continue;
+      try { yield JSON.parse(line); } catch {}
+    }
+  } catch (e) {
+    if (e.code !== 'ENOENT') throw e;
+  } finally {
+    rl.close();
+    input.destroy();
+  }
+}
+
+async function writeCursor(home, cursor) {
+  const target = path.join(home, 'export-cursor.json');
+  const tmp = `${target}.tmp.${process.pid}.${crypto.randomUUID()}`;
+  await fsp.writeFile(tmp, JSON.stringify(cursor), { mode: 0o600 });
+  await fsp.rename(tmp, target);
+}
+
+async function readCursor(home) {
+  try {
+    const cursor = JSON.parse(await fsp.readFile(path.join(home, 'export-cursor.json'), 'utf8'));
+    if (!cursor || typeof cursor !== 'object' || !Object.hasOwn(cursor, 'lastId')) return null;
+    if (!cursor.seq || typeof cursor.seq !== 'object') cursor.seq = {};
+    return cursor;
+  } catch { return null; }
+}
+
+function sanitizeName(name) {
+  if (!name || typeof name !== 'string') return null;
+  const trimmed = name.slice(0, 64);
+  return trimmed.includes('@') ? null : trimmed;
+}
+
+function addMap(target, values, sanitize = false) {
+  if (!values || typeof values !== 'object' || Array.isArray(values)) return;
+  for (const [rawName, rawCount] of Object.entries(values)) {
+    const name = sanitize ? sanitizeName(rawName) : rawName;
+    const count = Number(rawCount);
+    if (!name || !Number.isFinite(count)) continue;
+    target[name] = (target[name] || 0) + count;
+  }
+}
+
+function entryDate(entry) {
+  if (typeof entry.localDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(entry.localDate)) return entry.localDate;
+  const ms = Number(entry.receivedAt);
+  if (entry.receivedAt != null && Number.isFinite(ms)) return new Date(ms).toISOString().slice(0, 10);
+  return typeof entry.id === 'string' && /^\d{4}-\d{2}-\d{2}/.test(entry.id) ? entry.id.slice(0, 10) : null;
+}
+
+function costFact(entry) {
+  if (typeof entry.cost === 'number') return { value: entry.cost, confidence: 'exact' };
+  if (entry.cost?.cost == null) return { value: 0, confidence: 'unknown' };
+  const confidence = entry.cost.confidence;
+  if (confidence === 'fallback') return { value: Number(entry.cost.cost) || 0, confidence: 'fallback' };
+  if (confidence === 'exact' || confidence === 'prefix' || confidence == null) {
+    return { value: Number(entry.cost.cost) || 0, confidence: 'exact' };
+  }
+  return { value: Number(entry.cost.cost) || 0, confidence: 'unknown' };
+}
+
+function foldConfidence(values) {
+  const kinds = new Set(values);
+  return kinds.size === 1 ? values[0] : 'mixed';
+}
+
+function median(values) {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function makeDaily(dt, entry, agentId) {
+  return {
+    type: 'daily', _summary_schema_version: 1,
+    agent_id: agentId,
+    user_email: entry.userEmail || process.env.CCXRAY_USER_EMAIL || null,
+    team: entry.team || process.env.CCXRAY_TEAM || null,
+    dt, local_date: dt,
+    tz: entry.tz || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
+    provider: entry.provider || 'unknown',
+    cost_total: 0, turn_count: 0, subagent_turn_count: 0,
+    error_count: 0, credential_flag: false, compaction_count: 0,
+    models: {}, tool_usage: {}, skill_usage: {}, tool_sources: {}, stop_reasons: {},
+    tool_fail_count: 0, duplicate_tool_call_count: 0,
+    context_utilization: { '0-40': 0, '40-80': 0, '80+': 0 },
+    _sessions: new Set(), _confidences: [], _firstContexts: [],
+    _sysHashes: new Set(), _toolsHashes: new Set(), _cwdRepos: new Set(),
+  };
+}
+
+function makeSession(sid, dt, agentId) {
+  return {
+    type: 'session', _summary_schema_version: 1, agent_id: agentId, dt,
+    session_id: sid, cost_total: 0, turn_count: 0,
+    _confidences: [], _models: {}, _turns: [], _credential: false, _toolFails: 0,
+  };
+}
+
+function aggregate(entries, agentId) {
+  const dailyByDt = new Map();
+  const sessionsBySid = new Map();
+  for (const entry of entries) {
+    const dt = entryDate(entry);
+    const sid = entry.sessionId;
+    if (!dt || !sid) continue;
+    let daily = dailyByDt.get(dt);
+    if (!daily) { daily = makeDaily(dt, entry, agentId); dailyByDt.set(dt, daily); }
+    let session = sessionsBySid.get(sid);
+    if (!session) { session = makeSession(sid, dt, agentId); sessionsBySid.set(sid, session); }
+
+    const fact = costFact(entry);
+    daily.cost_total += fact.value;
+    daily._confidences.push(fact.confidence);
+    daily.turn_count++;
+    if (entry.isSubagent) daily.subagent_turn_count++;
+    daily._sessions.add(sid);
+    if (Number(entry.status) >= 400) daily.error_count++;
+    if (entry.hasCredential === true) daily.credential_flag = true;
+    if (entry.turnToolFail === true) daily.tool_fail_count++;
+    if (entry.sysHash) daily._sysHashes.add(entry.sysHash);
+    if (entry.toolsHash) daily._toolsHashes.add(entry.toolsHash);
+    // ponytail: cwd is almost always the repo root; would need fs.existsSync to walk up, YAGNI
+    if (entry.cwd) daily._cwdRepos.add(entry.cwd);
+    if (entry.stopReason) daily.stop_reasons[entry.stopReason] = (daily.stop_reasons[entry.stopReason] || 0) + 1;
+    // ADR 0018: turnToolCalls is per-turn for Anthropic; OpenAI toolCalls is already per-turn
+    if (entry.turnToolCalls) addMap(daily.tool_usage, entry.turnToolCalls, true);
+    else if (entry.provider === 'openai' && entry.toolCalls) addMap(daily.tool_usage, entry.toolCalls, true);
+    addMap(daily.skill_usage, entry.skillCalls, true);
+    // toolSources shape is {callId: 'local'|'network'|...}, fold values not keys
+    if (entry.toolSources && typeof entry.toolSources === 'object') {
+      for (const src of Object.values(entry.toolSources)) {
+        if (typeof src === 'string') daily.tool_sources[src] = (daily.tool_sources[src] || 0) + 1;
+      }
+    }
+    if (typeof entry.duplicateToolCalls === 'number') daily.duplicate_tool_call_count += entry.duplicateToolCalls;
+    else if (entry.duplicateToolCalls && typeof entry.duplicateToolCalls === 'object') {
+      daily.duplicate_tool_call_count += Object.values(entry.duplicateToolCalls)
+        .reduce((sum, count) => sum + (Number(count) || 0), 0);
+    }
+
+    const usage = entry.usage || {};
+    const modelName = entry.model || 'unknown';
+    const model = daily.models[modelName] || (daily.models[modelName] = {
+      turns: 0, input: 0, output: 0, cache_read: 0, cache_creation: 0,
+      thinking_turns: 0, beta1m_turns: 0, cost: 0,
+    });
+    model.turns++;
+    model.input += Number(usage.input_tokens) || 0;
+    model.output += Number(usage.output_tokens) || 0;
+    model.cache_read += Number(usage.cache_read_input_tokens) || 0;
+    model.cache_creation += Number(usage.cache_creation_input_tokens) || 0;
+    if (entry.thinkingDuration != null) model.thinking_turns++;
+    if (entry.beta1m === true) model.beta1m_turns++;
+    model.cost += fact.value;
+
+    const maxContext = Number(entry.maxContext);
+    // Full context = input + cache_read + cache_creation (Anthropic input_tokens excludes cache)
+    const fullCtx = (Number(usage.input_tokens) || 0) + (Number(usage.cache_read_input_tokens) || 0)
+      + (Number(usage.cache_creation_input_tokens) || 0);
+    if (maxContext > 0 && fullCtx > 0) {
+      const pct = fullCtx / maxContext * 100;
+      daily.context_utilization[pct < 40 ? '0-40' : pct < 80 ? '40-80' : '80+']++;
+    }
+
+    session.cost_total += fact.value;
+    session._confidences.push(fact.confidence);
+    session.turn_count++;
+    session._models[modelName] = (session._models[modelName] || 0) + 1;
+    session._turns.push(entry);
+    if (entry.hasCredential === true) session._credential = true;
+    if (entry.turnToolFail === true) session._toolFails++;
+  }
+
+  for (const session of sessionsBySid.values()) {
+    session._turns.sort((a, b) => (Number(a.receivedAt) || 0) - (Number(b.receivedAt) || 0));
+    const first = session._turns[0];
+    const firstMax = Number(first?.maxContext);
+    const fu = first?.usage || {};
+    const firstCtx = (Number(fu.input_tokens) || 0) + (Number(fu.cache_read_input_tokens) || 0) + (Number(fu.cache_creation_input_tokens) || 0);
+    if (firstMax > 0 && firstCtx > 0) dailyByDt.get(session.dt)?._firstContexts.push(firstCtx / firstMax * 100);
+    let lastMsgCount = null;
+    for (const turn of session._turns) {
+      const msgCount = Number(turn.msgCount);
+      if (Number.isFinite(msgCount) && lastMsgCount != null && msgCount < lastMsgCount) {
+        const day = dailyByDt.get(entryDate(turn));
+        if (day) day.compaction_count++;
+      }
+      if (Number.isFinite(msgCount)) lastMsgCount = msgCount;
+    }
+  }
+  return { dailyByDt, sessionsBySid };
+}
+
+function finishDaily(daily) {
+  daily.cost_confidence = foldConfidence(daily._confidences);
+  daily.session_count = daily._sessions.size;
+  daily.tool_used_count = Object.keys(daily.tool_usage).length;
+  // ponytail: tool_defined_count omitted, no data source in index; add when tool definition count is indexed
+  daily.first_turn_context_pct_median = median(daily._firstContexts);
+  daily.sys_hash_count = daily._sysHashes.size;
+  daily.tools_hash_count = daily._toolsHashes.size;
+  daily.cwd_repos = [...daily._cwdRepos].sort();
+  for (const key of Object.keys(daily)) if (key.startsWith('_') && key !== '_summary_schema_version') delete daily[key];
+  return daily;
+}
+
+function finishSession(session, daily) {
+  const first = session._turns[0];
+  const flags = [];
+  if (session._credential) flags.push('credential_leak');
+  if (session.turn_count > 200 && session.cost_total > 50) flags.push('runaway');
+  if (session.cost_total > 25) flags.push('high_cost');
+  if (session.turn_count && session._toolFails / session.turn_count > 0.5) flags.push('tool_fail_spike');
+  session.cost_confidence = foldConfidence(session._confidences);
+  session.model_primary = Object.entries(session._models)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0]?.[0] || 'unknown';
+  session.cwd = first?.cwd || null;
+  session.flags = flags;
+  session.summary_id = daily.summary_id;
+  for (const key of Object.keys(session)) if (key.startsWith('_') && key !== '_summary_schema_version') delete session[key];
+  return session;
+}
+
+async function flushExport() {
+  const bucket = exportBucket();
+  if (!bucket) return;
+  const home = resolveCcxrayHome();
+  const token = tryAcquireLock(home);
+  if (!token) return;
+  try {
+    const cursor = await readCursor(home);
+    if (!cursor) {
+      let lastId = null;
+      for await (const entry of readIndex()) if (entry.id) lastId = entry.id;
+      await writeCursor(home, { lastId, partial: true, seq: {} });
+      console.warn('[export-sync] initialized cursor at index tail; no historical data uploaded');
+      return;
+    }
+    // last-writer-wins: scan the ENTIRE index to build full daily snapshots,
+    // but only upload dates that contain entries newer than cursor.lastId.
+    // ponytail: retains parsed index in memory; upgrade to streaming aggregation for >500MB indexes
+    const all = [];
+    let found = cursor.lastId == null;
+    let hasNew = cursor.lastId == null;
+    for await (const entry of readIndex()) {
+      all.push(entry);
+      if (!found && entry.id === cursor.lastId) { found = true; continue; }
+      if (found) hasNew = true;
+    }
+    if (!found) {
+      console.warn('[export-sync] cursor id was pruned; exporting from index start');
+      hasNew = all.length > 0;
+    }
+    if (!hasNew || !all.length) return;
+    const lastId = all.at(-1)?.id;
+    const allow = new Set((process.env.CCXRAY_EXPORT_CONFIG_DIRS || '.claude').split(',').map(s => s.trim()).filter(Boolean));
+    const { sessionMeta } = require('./store');
+    const filtered = all.filter(entry => {
+      const configDir = sessionMeta[entry.sessionId]?.configDir;
+      // ponytail: unknown configDir → include (not exclude). After restart,
+      // sessionMeta lacks configDir; excluding would permanently lose backlog rows.
+      if (!configDir) return true;
+      const base = configDir.split(/[\\/]/).filter(Boolean).at(-1);
+      return allow.has(configDir) || allow.has(base);
+    });
+    const agentId = await getAgentId(home);
+    const { dailyByDt, sessionsBySid } = aggregate(filtered, agentId);
+    const dates = [...dailyByDt.keys()].sort();
+    for (let i = 0; i < dates.length; i++) {
+      const dt = dates[i];
+      const daily = dailyByDt.get(dt);
+      const seq = (Number(cursor.seq[dt]) || 0) + 1;
+      cursor.seq[dt] = seq;
+      daily.upload_seq = seq;
+      daily.summary_id = `${agentId}:${dt}:${crypto.randomUUID().slice(0, 8)}`;
+      daily.partial_day = cursor.partial === true && i === 0;
+      const sessions = [...sessionsBySid.values()]
+        .filter(session => session.dt === dt)
+        .sort((a, b) => a.session_id.localeCompare(b.session_id))
+        .map(session => finishSession(session, daily));
+      const records = [finishDaily(daily), ...sessions];
+      const prefix = process.env.CCXRAY_EXPORT_GCS_PREFIX || 'summaries/';
+      const slashPrefix = prefix.endsWith('/') ? prefix : prefix + '/';
+      const objectName = `${slashPrefix}dt=${dt}/${agentId}--${seq}--${crypto.randomUUID().slice(0, 8)}.jsonl`;
+      await uploader(bucket, objectName, records.map(JSON.stringify).join('\n') + '\n');
+    }
+    cursor.lastId = lastId;
+    if (dates.length) cursor.partial = false;
+    await writeCursor(home, cursor);
+  } finally {
+    releaseLock(home, token);
+  }
+}
+
+function startExportSync() {
+  if (!exportBucket() || timer) return;
+  getAgentId(resolveCcxrayHome()).then(id => console.log(`[export-sync] agent_id=${id}`))
+    .catch(e => console.error('[export-sync] agent id failed:', e.message));
+  timer = setInterval(() => flushExport().catch(e => console.error('Export flush failed:', e.message)), 60_000);
+  timer.unref();
+}
+
+function stopExportSync() {
+  if (timer) clearInterval(timer);
+  timer = null;
+}
+
+async function getAgentId(home) {
+  if (process.env.CCXRAY_AGENT_ID) return process.env.CCXRAY_AGENT_ID;
+  const file = path.join(home, 'export-agent-id');
+  try {
+    const id = (await fsp.readFile(file, 'utf8')).trim();
+    if (id) return id;
+  } catch {}
+  await fsp.mkdir(home, { recursive: true, mode: 0o700 });
+  const id = crypto.randomUUID();
+  await fsp.writeFile(file, id + '\n', { flag: 'wx', mode: 0o600 }).catch(() => {});
+  try { return (await fsp.readFile(file, 'utf8')).trim() || id; } catch { return id; }
+}
+
+function signJwt(keyFile) {
+  const { client_email, private_key } = JSON.parse(fs.readFileSync(keyFile, 'utf8'));
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const now = Math.floor(Date.now() / 1000);
+  const payload = Buffer.from(JSON.stringify({
+    iss: client_email,
+    scope: 'https://www.googleapis.com/auth/devstorage.read_write',
+    aud: 'https://oauth2.googleapis.com/token',
+    iat: now,
+    exp: now + 3600,
+  })).toString('base64url');
+  const sig = crypto.sign('sha256', Buffer.from(`${header}.${payload}`), private_key).toString('base64url');
+  return `${header}.${payload}.${sig}`;
+}
+
+function request(options, body) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(options, res => {
+      const chunks = [];
+      res.on('data', chunk => chunks.push(chunk));
+      res.on('end', () => {
+        const responseBody = Buffer.concat(chunks).toString('utf8');
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          reject(new Error(`GCS HTTP ${res.statusCode}: ${responseBody.slice(0, 500)}`));
+          return;
+        }
+        resolve(responseBody);
+      });
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+async function getAccessToken(keyFile) {
+  if (_cachedToken && Date.now() < _cachedExpiry) return _cachedToken;
+  const assertion = signJwt(keyFile);
+  const body = new URLSearchParams({
+    grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer', assertion,
+  }).toString();
+  const raw = await request({
+    hostname: 'oauth2.googleapis.com', port: 443, path: '/token', method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Length': Buffer.byteLength(body),
+    },
+  }, body);
+  const token = JSON.parse(raw);
+  if (!token.access_token) throw new Error('GCS token response missing access_token');
+  _cachedToken = token.access_token;
+  _cachedExpiry = Date.now() + (Number(token.expires_in) || 3600) * 1000 - 60_000;
+  return _cachedToken;
+}
+
+async function uploadToGcs(bucket, objectName, ndjsonBody) {
+  const keyFile = process.env.CCXRAY_EXPORT_GCS_KEY_FILE;
+  if (!keyFile) throw new Error('CCXRAY_EXPORT_GCS_KEY_FILE is required');
+  const token = await getAccessToken(keyFile);
+  await request({
+    hostname: 'storage.googleapis.com', port: 443,
+    path: `/upload/storage/v1/b/${encodeURIComponent(bucket)}/o?uploadType=media&name=${encodeURIComponent(objectName)}`,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-ndjson',
+      'Content-Length': Buffer.byteLength(ndjsonBody),
+      Authorization: `Bearer ${token}`,
+    },
+  }, ndjsonBody);
+}
+
+function _setUploader(fn) { uploader = fn || uploadToGcs; }
+
+module.exports = { startExportSync, stopExportSync, flushExport, _setUploader };

--- a/server/index.js
+++ b/server/index.js
@@ -34,6 +34,7 @@ const providers = require('./providers');
 const { handleWebSocketUpgrade, drainWebSocketProxy } = require('./ws-proxy');
 const sessionIdx = require('./session-index');
 const { WIRE_PARSERS, getParser } = require('./wire-parsers');
+const { startExportSync, stopExportSync, flushExport } = require('./export-sync');
 // wire-parsers/openai low-level helpers no longer needed in index.js after Phase 2 migration
 
 // ── CLI: parse flags and detect provider launchers ──
@@ -646,6 +647,7 @@ function spawnAgent(command, port, args, onExit) {
 // can never block shutdown.
 async function gracefulExit(code) {
   stopCodexRefresh();
+  stopExportSync();
   const deadline = new Promise(resolve => setTimeout(resolve, 5000));
   const drain = (async () => {
     try { await drainWebSocketProxy(); } catch (e) { console.error('WS drain failed:', e.message); }
@@ -653,6 +655,7 @@ async function gracefulExit(code) {
     // must fire before flush persists the session Map to disk (#309)
     try { await config.storage.drain(); } catch (e) { console.error('Storage drain failed:', e.message); }
     try { await sessionIdx.flush(); } catch (e) { console.error('Session index flush failed:', e.message); }
+    try { await flushExport(); } catch (e) { console.error('Export flush failed:', e.message); }
   })();
   await Promise.race([drain, deadline]);
   process.exit(code);
@@ -1019,6 +1022,7 @@ async function runPostListenStartupTasks() {
 
   await pricingReady;
   if (restoreOk) {
+    try { await flushExport(); } catch (e) { console.error('[export-sync] startup flush failed:', e.message); }
     await pruneLogs();
     warmUpCosts();
   }
@@ -1080,6 +1084,7 @@ async function startServer() {
 
   await config.storage.init();
   startCodexRefresh();
+  startExportSync();
 
   // Agent mode (with --port, standalone): scan up to 10 ports.
   // Hub mode: fixed port, but retry if old hub is still releasing it (race with idle shutdown).

--- a/test/export-sync.test.js
+++ b/test/export-sync.test.js
@@ -1,0 +1,375 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const exportSync = require('../server/export-sync');
+const store = require('../server/store');
+
+function withEnv(values, fn) {
+  const old = {};
+  for (const [key, value] of Object.entries(values)) {
+    old[key] = process.env[key];
+    if (value === undefined) delete process.env[key]; else process.env[key] = value;
+  }
+  return Promise.resolve().then(fn).finally(() => {
+    for (const [key, value] of Object.entries(old)) {
+      if (value === undefined) delete process.env[key]; else process.env[key] = value;
+    }
+  });
+}
+
+function makeHome(lines = []) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-export-test-'));
+  fs.mkdirSync(path.join(home, 'logs'), { recursive: true });
+  fs.writeFileSync(path.join(home, 'logs', 'index.ndjson'), lines.map(JSON.stringify).join('\n') + (lines.length ? '\n' : ''));
+  return home;
+}
+
+function writeCursor(home, cursor) {
+  fs.writeFileSync(path.join(home, 'export-cursor.json'), JSON.stringify({ seq: {}, partial: false, ...cursor }));
+}
+
+function entry(id, overrides = {}) {
+  return {
+    id, sessionId: 's1', localDate: '2026-08-12', receivedAt: Number(id.replace(/\D/g, '')) || 1,
+    provider: 'anthropic', model: 'model-a', isSubagent: false, cwd: '/work/repo',
+    msgCount: 10, maxContext: 1000,
+    usage: { input_tokens: 150, output_tokens: 20, cache_read_input_tokens: 30, cache_creation_input_tokens: 40 },
+    cost: { cost: 1, confidence: 'exact' }, turnToolCalls: {}, skillCalls: {}, toolSources: {},
+    status: 200, stopReason: 'end_turn', sysHash: 'sys', toolsHash: 'tools',
+    ...overrides,
+  };
+}
+
+test('flush is side-effect free when export bucket is unset', async () => {
+  const home = path.join(os.tmpdir(), `ccxray-export-absent-${process.pid}-${Date.now()}`);
+  const oldHome = process.env.CCXRAY_HOME;
+  const oldBucket = process.env.CCXRAY_EXPORT_GCS_BUCKET;
+  process.env.CCXRAY_HOME = home;
+  delete process.env.CCXRAY_EXPORT_GCS_BUCKET;
+  try {
+    exportSync.startExportSync();
+    await exportSync.flushExport();
+    exportSync.stopExportSync();
+    assert.equal(fs.existsSync(home), false);
+  } finally {
+    if (oldHome === undefined) delete process.env.CCXRAY_HOME; else process.env.CCXRAY_HOME = oldHome;
+    if (oldBucket === undefined) delete process.env.CCXRAY_EXPORT_GCS_BUCKET; else process.env.CCXRAY_EXPORT_GCS_BUCKET = oldBucket;
+  }
+});
+
+test('first uploaded day after bootstrap is marked partial', async () => {
+  const home = makeHome([entry('1')]);
+  const uploads = [];
+  store.sessionMeta.s1 = { configDir: '.claude' };
+  try {
+    exportSync._setUploader(async (bucket, name, body) => uploads.push(body));
+    await withEnv({ CCXRAY_HOME: home, CCXRAY_EXPORT_GCS_BUCKET: 'b', CCXRAY_AGENT_ID: 'agent' }, async () => {
+      await exportSync.flushExport();
+      fs.appendFileSync(path.join(home, 'logs', 'index.ndjson'), JSON.stringify(entry('2')) + '\n');
+      await exportSync.flushExport();
+    });
+    assert.equal(JSON.parse(uploads[0].split('\n')[0]).partial_day, true);
+  } finally {
+    delete store.sessionMeta.s1;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('first flush checkpoints the index tail without uploading', async () => {
+  const home = makeHome([{ id: 'one' }, { id: 'two' }]);
+  const uploads = [];
+  try {
+    exportSync._setUploader(async (...args) => uploads.push(args));
+    await withEnv({ CCXRAY_HOME: home, CCXRAY_EXPORT_GCS_BUCKET: 'bucket' }, () => exportSync.flushExport());
+    assert.deepEqual(uploads, []);
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(home, 'export-cursor.json'), 'utf8')), {
+      lastId: 'two', partial: true, seq: {},
+    });
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('exports complete daily and session summaries for new index rows', async () => {
+  const lines = [
+    { id: 'seed' },
+    entry('1', { receivedAt: 1, turnToolCalls: { Read: 1 }, skillCalls: { review: 1 }, toolSources: { call1: 'local', call2: 'local' } }),
+    entry('2', { receivedAt: 2, usage: { input_tokens: 550, output_tokens: 30, cache_read_input_tokens: 40, cache_creation_input_tokens: 50 }, cost: { cost: 2, confidence: 'prefix' }, msgCount: 12, model: 'model-b', turnToolCalls: { Bash: 2 }, duplicateToolCalls: { Bash: 1 } }),
+    entry('3', { receivedAt: 3, usage: { input_tokens: 850, output_tokens: 40 }, cost: { cost: 3, confidence: 'fallback' }, msgCount: 5, isSubagent: true, turnToolFail: true, hasCredential: true, beta1m: true, thinkingDuration: 10 }),
+    entry('4', { receivedAt: 4, sessionId: 's2', model: 'model-b', cost: { cost: 4, confidence: 'exact' }, status: 500, stopReason: 'error' }),
+    entry('5', { receivedAt: 5, sessionId: 's2', model: 'model-b', cost: null, turnToolCalls: { Read: 2 } }),
+  ];
+  const home = makeHome(lines);
+  const uploads = [];
+  store.sessionMeta.s1 = { configDir: '/fake/.claude' };
+  store.sessionMeta.s2 = { configDir: '/fake/.claude' };
+  writeCursor(home, { lastId: 'seed' });
+  try {
+    exportSync._setUploader(async (bucket, name, body) => uploads.push({ bucket, name, body }));
+    await withEnv({
+      CCXRAY_HOME: home, CCXRAY_EXPORT_GCS_BUCKET: 'bucket', CCXRAY_AGENT_ID: 'agent-1',
+      CCXRAY_EXPORT_CONFIG_DIRS: '.claude', CCXRAY_EXPORT_GCS_PREFIX: 'summaries/',
+    }, () => exportSync.flushExport());
+    assert.equal(uploads.length, 1);
+    assert.equal(uploads[0].bucket, 'bucket');
+    assert.match(uploads[0].name, /^summaries\/dt=2026-08-12\/agent-1--1--[a-f0-9]{8}\.jsonl$/);
+    const [daily, ...sessions] = uploads[0].body.trim().split('\n').map(JSON.parse);
+    assert.deepEqual({
+      type: daily.type, version: daily._summary_schema_version, dt: daily.dt,
+      upload_seq: daily.upload_seq, cost_total: daily.cost_total,
+      cost_confidence: daily.cost_confidence, turn_count: daily.turn_count,
+      subagent_turn_count: daily.subagent_turn_count, session_count: daily.session_count,
+      error_count: daily.error_count, credential_flag: daily.credential_flag,
+      compaction_count: daily.compaction_count, tool_fail_count: daily.tool_fail_count,
+      duplicate_tool_call_count: daily.duplicate_tool_call_count,
+    }, {
+      type: 'daily', version: 1, dt: '2026-08-12', upload_seq: 1, cost_total: 10,
+      cost_confidence: 'mixed', turn_count: 5, subagent_turn_count: 1, session_count: 2,
+      error_count: 1, credential_flag: true, compaction_count: 1, tool_fail_count: 1,
+      duplicate_tool_call_count: 1,
+    });
+    assert.deepEqual(daily.context_utilization, { '0-40': 3, '40-80': 1, '80+': 1 });
+    // first-turn context includes cache: s1=(150+30+40)/1000=22%, s2=(150+30+40)/1000=22% → median=22
+    assert.equal(daily.first_turn_context_pct_median, 22);
+    assert.deepEqual(daily.tool_usage, { Read: 3, Bash: 2 });
+    assert.deepEqual(daily.skill_usage, { review: 1 });
+    assert.deepEqual(daily.tool_sources, { local: 2 });
+    assert.equal(daily.tool_used_count, 2);
+    assert.equal(daily.sys_hash_count, 1);
+    assert.equal(daily.tools_hash_count, 1);
+    assert.deepEqual(daily.cwd_repos, ['/work/repo']);
+    assert.deepEqual(daily.models['model-a'], { turns: 2, input: 1000, output: 60, cache_read: 30, cache_creation: 40, thinking_turns: 1, beta1m_turns: 1, cost: 4 });
+    assert.equal(sessions.length, 2);
+    assert.equal(sessions[0].summary_id, daily.summary_id);
+    assert.equal(JSON.parse(fs.readFileSync(path.join(home, 'export-cursor.json'))).lastId, '5');
+    assert.equal(fs.readdirSync(home).some(name => name.includes('.tmp.')), false);
+  } finally {
+    delete store.sessionMeta.s1;
+    delete store.sessionMeta.s2;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('payload omits prompt content, raw hashes, edit metadata, and timestamps', async () => {
+  const bait = 'SECRET-PROMPT-BAIT';
+  const home = makeHome([{ id: 'seed' }, entry('1', {
+    title: bait, editSummary: bait, sysHash: bait, toolsHash: bait,
+    prompt: bait, receivedAt: 123456789, elapsed: '9.9', ts: bait,
+  })]);
+  const uploads = [];
+  store.sessionMeta.s1 = { configDir: '.claude' };
+  writeCursor(home, { lastId: 'seed' });
+  try {
+    exportSync._setUploader(async (bucket, name, body) => uploads.push(body));
+    await withEnv({ CCXRAY_HOME: home, CCXRAY_EXPORT_GCS_BUCKET: 'b', CCXRAY_AGENT_ID: 'agent' }, () => exportSync.flushExport());
+    assert.equal(uploads[0].includes(bait), false);
+    const records = uploads[0].trim().split('\n').map(JSON.parse);
+    for (const record of records) {
+      for (const key of Object.keys(record)) {
+        assert.equal(['receivedAt', 'elapsed', 'time', 'timestamp', 'ts', 'title', 'editSummary', 'prompt'].includes(key), false);
+      }
+    }
+  } finally {
+    delete store.sessionMeta.s1;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('session summaries compute flags, primary model, and all confidence folds', async () => {
+  const rows = [{ id: 'seed' }];
+  rows.push(entry('credential', { sessionId: 'credential', hasCredential: true, cost: { cost: 1, confidence: 'exact' } }));
+  for (let i = 0; i < 201; i++) rows.push(entry(`runaway-${i}`, {
+    sessionId: 'runaway', receivedAt: i + 10, model: i % 2 ? 'z-model' : 'a-model',
+    cost: { cost: 0.3, confidence: i === 0 ? 'prefix' : undefined },
+  }));
+  rows.push(entry('high', { sessionId: 'high', cost: { cost: 26, confidence: 'fallback' } }));
+  rows.push(entry('spike-1', { sessionId: 'spike', turnToolFail: true, cost: null }));
+  rows.push(entry('spike-2', { sessionId: 'spike', turnToolFail: true, cost: null }));
+  rows.push(entry('spike-3', { sessionId: 'spike', turnToolFail: false, cost: null }));
+  rows.push(entry('mixed-1', { sessionId: 'mixed', cost: { cost: 1, confidence: 'exact' } }));
+  rows.push(entry('mixed-2', { sessionId: 'mixed', cost: { cost: 1, confidence: 'fallback' } }));
+  const home = makeHome(rows);
+  const uploads = [];
+  for (const sid of ['credential', 'runaway', 'high', 'spike', 'mixed']) store.sessionMeta[sid] = { configDir: '.claude' };
+  writeCursor(home, { lastId: 'seed' });
+  try {
+    exportSync._setUploader(async (bucket, name, body) => uploads.push(body));
+    await withEnv({ CCXRAY_HOME: home, CCXRAY_EXPORT_GCS_BUCKET: 'b', CCXRAY_AGENT_ID: 'agent' }, () => exportSync.flushExport());
+    const sessions = Object.fromEntries(uploads[0].trim().split('\n').slice(1).map(JSON.parse).map(s => [s.session_id, s]));
+    assert.deepEqual(sessions.credential.flags, ['credential_leak']);
+    assert.deepEqual(sessions.runaway.flags, ['runaway', 'high_cost']);
+    assert.equal(sessions.runaway.model_primary, 'a-model');
+    assert.deepEqual(sessions.high.flags, ['high_cost']);
+    assert.deepEqual(sessions.spike.flags, ['tool_fail_spike']);
+    assert.equal(sessions.credential.cost_confidence, 'exact');
+    assert.equal(sessions.runaway.cost_confidence, 'exact');
+    assert.equal(sessions.high.cost_confidence, 'fallback');
+    assert.equal(sessions.spike.cost_confidence, 'unknown');
+    assert.equal(sessions.mixed.cost_confidence, 'mixed');
+  } finally {
+    for (const sid of ['credential', 'runaway', 'high', 'spike', 'mixed']) delete store.sessionMeta[sid];
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('daily summaries fold exact, fallback, mixed, and unknown cost confidence', async () => {
+  const rows = [
+    { id: 'seed' },
+    entry('exact-1', { sessionId: 'exact', localDate: '2026-08-01', cost: { cost: 1, confidence: 'prefix' } }),
+    entry('fallback-1', { sessionId: 'fallback', localDate: '2026-08-02', cost: { cost: 1, confidence: 'fallback' } }),
+    entry('mixed-1', { sessionId: 'mixed-day', localDate: '2026-08-03', cost: { cost: 1, confidence: 'exact' } }),
+    entry('mixed-2', { sessionId: 'mixed-day', localDate: '2026-08-03', cost: { cost: 1, confidence: 'fallback' } }),
+    entry('unknown-1', { sessionId: 'unknown', localDate: '2026-08-04', cost: null }),
+  ];
+  const home = makeHome(rows);
+  const daily = {};
+  for (const sid of ['exact', 'fallback', 'mixed-day', 'unknown']) store.sessionMeta[sid] = { configDir: '.claude' };
+  writeCursor(home, { lastId: 'seed' });
+  try {
+    exportSync._setUploader(async (bucket, name, body) => {
+      const record = JSON.parse(body.split('\n')[0]);
+      daily[record.dt] = record.cost_confidence;
+    });
+    await withEnv({ CCXRAY_HOME: home, CCXRAY_EXPORT_GCS_BUCKET: 'b', CCXRAY_AGENT_ID: 'agent' }, () => exportSync.flushExport());
+    assert.deepEqual(daily, {
+      '2026-08-01': 'exact', '2026-08-02': 'fallback',
+      '2026-08-03': 'mixed', '2026-08-04': 'unknown',
+    });
+  } finally {
+    for (const sid of ['exact', 'fallback', 'mixed-day', 'unknown']) delete store.sessionMeta[sid];
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('cursor continuation: full daily snapshot (last-writer-wins), cursor advances', async () => {
+  const home = makeHome([entry('1'), entry('2'), entry('3'), entry('4'), entry('5')]);
+  const uploads = [];
+  store.sessionMeta.s1 = { configDir: '.claude' };
+  writeCursor(home, { lastId: '3' });
+  try {
+    exportSync._setUploader(async (bucket, name, body) => uploads.push(body));
+    await withEnv({ CCXRAY_HOME: home, CCXRAY_EXPORT_GCS_BUCKET: 'b', CCXRAY_AGENT_ID: 'agent' }, () => exportSync.flushExport());
+    // last-writer-wins: daily snapshot aggregates ALL 5 entries, not just 4+5
+    assert.equal(JSON.parse(uploads[0].split('\n')[0]).turn_count, 5);
+    const cursor = JSON.parse(fs.readFileSync(path.join(home, 'export-cursor.json'), 'utf8'));
+    assert.equal(cursor.lastId, '5');
+  } finally {
+    delete store.sessionMeta.s1;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('pruned cursor restarts from the first index row', async () => {
+  const home = makeHome([entry('1'), entry('2')]);
+  const uploads = [];
+  store.sessionMeta.s1 = { configDir: '.claude' };
+  writeCursor(home, { lastId: 'pruned' });
+  try {
+    exportSync._setUploader(async (bucket, name, body) => uploads.push(body));
+    await withEnv({ CCXRAY_HOME: home, CCXRAY_EXPORT_GCS_BUCKET: 'b', CCXRAY_AGENT_ID: 'agent' }, () => exportSync.flushExport());
+    assert.equal(JSON.parse(uploads[0].split('\n')[0]).turn_count, 2);
+  } finally {
+    delete store.sessionMeta.s1;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('config-dir whitelist: known-outside excluded, unknown-configDir included', async () => {
+  const home = makeHome([{ id: 'seed' }, entry('1'), entry('2', { sessionId: 'outside' }), entry('3', { sessionId: 'missing' })]);
+  const uploads = [];
+  store.sessionMeta.s1 = { configDir: '/fake/.claude' };
+  store.sessionMeta.outside = { configDir: '/fake/.claude-work' };
+  // 'missing' has no sessionMeta → configDir unknown → included (P2: exclude would lose restart backlog)
+  writeCursor(home, { lastId: 'seed' });
+  try {
+    exportSync._setUploader(async (bucket, name, body) => uploads.push(body));
+    await withEnv({ CCXRAY_HOME: home, CCXRAY_EXPORT_GCS_BUCKET: 'b', CCXRAY_AGENT_ID: 'agent', CCXRAY_EXPORT_CONFIG_DIRS: '.claude' }, () => exportSync.flushExport());
+    const records = uploads[0].trim().split('\n').map(JSON.parse);
+    assert.equal(records[0].turn_count, 2); // s1 + missing (unknown → included)
+    const sids = records.slice(1).map(s => s.session_id).sort();
+    assert.deepEqual(sids, ['missing', 's1']);
+  } finally {
+    delete store.sessionMeta.s1;
+    delete store.sessionMeta.outside;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('tool and skill names are truncated and email-like names are dropped', async () => {
+  const long = 'x'.repeat(65);
+  const home = makeHome([{ id: 'seed' }, entry('1', {
+    turnToolCalls: { [long]: 2, 'drop@example.com': 3 },
+    skillCalls: { [long]: 4, 'drop@example.com': 5 },
+  })]);
+  const uploads = [];
+  store.sessionMeta.s1 = { configDir: '.claude' };
+  writeCursor(home, { lastId: 'seed' });
+  try {
+    exportSync._setUploader(async (bucket, name, body) => uploads.push(body));
+    await withEnv({ CCXRAY_HOME: home, CCXRAY_EXPORT_GCS_BUCKET: 'b', CCXRAY_AGENT_ID: 'agent' }, () => exportSync.flushExport());
+    const daily = JSON.parse(uploads[0].split('\n')[0]);
+    assert.deepEqual(daily.tool_usage, { ['x'.repeat(64)]: 2 });
+    assert.deepEqual(daily.skill_usage, { ['x'.repeat(64)]: 4 });
+  } finally {
+    delete store.sessionMeta.s1;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('exclusive lock skips a concurrent flush and unlocks after completion', async () => {
+  const home = makeHome([{ id: 'seed' }, entry('1')]);
+  const uploads = [];
+  let unblock;
+  const blocked = new Promise(resolve => { unblock = resolve; });
+  let entered;
+  const started = new Promise(resolve => { entered = resolve; });
+  store.sessionMeta.s1 = { configDir: '.claude' };
+  writeCursor(home, { lastId: 'seed' });
+  try {
+    exportSync._setUploader(async (bucket, name, body) => {
+      uploads.push(body);
+      if (uploads.length === 1) { entered(); await blocked; }
+    });
+    await withEnv({ CCXRAY_HOME: home, CCXRAY_EXPORT_GCS_BUCKET: 'b', CCXRAY_AGENT_ID: 'agent' }, async () => {
+      const first = exportSync.flushExport();
+      await started;
+      await exportSync.flushExport();
+      assert.equal(uploads.length, 1);
+      unblock();
+      await first;
+      fs.appendFileSync(path.join(home, 'logs', 'index.ndjson'), JSON.stringify(entry('2')) + '\n');
+      await exportSync.flushExport();
+      assert.equal(uploads.length, 2);
+    });
+  } finally {
+    delete store.sessionMeta.s1;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('upload sequence increments and persistent agent id is reused', async () => {
+  const home = makeHome([{ id: 'seed' }, entry('1')]);
+  const uploads = [];
+  store.sessionMeta.s1 = { configDir: '.claude' };
+  writeCursor(home, { lastId: 'seed' });
+  try {
+    exportSync._setUploader(async (bucket, name, body) => uploads.push({ name, body }));
+    await withEnv({ CCXRAY_HOME: home, CCXRAY_EXPORT_GCS_BUCKET: 'b', CCXRAY_AGENT_ID: undefined }, async () => {
+      await exportSync.flushExport();
+      fs.appendFileSync(path.join(home, 'logs', 'index.ndjson'), JSON.stringify(entry('2')) + '\n');
+      await exportSync.flushExport();
+    });
+    const daily = uploads.map(u => JSON.parse(u.body.split('\n')[0]));
+    assert.deepEqual(daily.map(d => d.upload_seq), [1, 2]);
+    assert.equal(daily[0].agent_id, daily[1].agent_id);
+    assert.equal(fs.readFileSync(path.join(home, 'export-agent-id'), 'utf8').trim(), daily[0].agent_id);
+  } finally {
+    delete store.sessionMeta.s1;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 摘要

日摘要 + session 摘要 exporter。每小時 + shutdown + prune 前上傳完整當日快照（last-writer-wins）到 GCS。預設完全關閉——未設 `CCXRAY_EXPORT_GCS_BUCKET` 時零副作用。

Per-turn 資料留本機。離開機器的只有日級成本 / model / tool / context 彙總 + session 級成本摘要與 flags。不匯出 prompt、response、tool input、程式碼、憑證、絕對路徑。

## codex review

**Round 1**: 4 P1 + 1 P2。全修。
- P1-1 GCS upload method PUT→POST
- P1-2 last-writer-wins snapshot：掃全日 index 而非只看 cursor 後
- P1-3 startup flushExport 加 try/catch（否則 unhandled rejection 殺 proxy）
- P1-4 用 resolveLogsDir() 而非 hardcoded 路徑（LOGS_DIR override）
- P2 configDir unknown → include（restart 後 sessionMeta 無 configDir，排除會永久丟失 backlog）

**Round 2**: 2 P1 + 5 P2。修 5 條，defer 1 條，1 條 N/A。
- P2 context numerator 含 cache tokens（Anthropic input_tokens 不含 cache）
- P2 toolFail→turnToolFail（per-turn signal，非累積的 request history）
- P2 OpenAI toolCalls 直接 sum（ADR 0018：它已是 per-turn）
- P2 toolSources 形狀是 {callId: source}，fold values 不是 keys
- P1 test env scrub：已知限制（開發者若全域設 CCXRAY_EXPORT_*，test server 會嘗試上傳但 GCS auth 會失敗）
- P1 memory（全 index in memory）：deferred — `// ponytail: retains parsed index; upgrade for >500MB`
- P2 node_modules symlink：N/A，gitignored

## 證據

```text
full test suite (isolated CCXRAY_HOME): 1956 pass / 0 fail  exit 0
boot smoke (port 5651): BOOT OK HTTP 200                     exit 0
codex review: round 1 → 5 findings all fixed; round 2 → 7 findings, 5 fixed 1 deferred 1 N/A
```

## 沒驗什麼

1. 真實 GCS 上傳（mock 替換 uploader）
2. >500MB index 的記憶體行為（deferred）
3. 跨進程鎖競爭（unit 測 wx+release，未做雙進程 e2e）

## payload allowlist 待裁決

排除了 sysHash/toolsHash/coreHash/convId/hasCredential/toolSources（嚴格預設）。若需跨機器 prompt 版本關聯，加四個 hash 回去——安全但需更新票文的類別清單。

Fixes #505

<!-- GATE-MANIFEST
issue-lint=pass @8b5ae9ff7605d6b110e4b9d7105e5b9710c5cc31
full-test=0 @8b5ae9ff7605d6b110e4b9d7105e5b9710c5cc31
boot-smoke=0 @8b5ae9ff7605d6b110e4b9d7105e5b9710c5cc31
-->
