### PR TITLE
fix(pricing): retire grok-build lag override, graduate to DEFAULT_PRICING

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ Logs stored in `~/.ccxray/logs/` (not package-relative). Respects `CCXRAY_HOME` 
 2. Search `LITELLM_LAG_OVERRIDES` or `pricing lag override` to find rows to delete.
 3. Lifecycle tests live in `test/pricing.test.js` (`LITELLM_LAG_OVERRIDES lifecycle`).
 
-`DEFAULT_PRICING` (in `server/default-rates.js`) is the offline safety net (Claude/OpenAI/**stable Grok** bare ids). Temporary rates for models LiteLLM still lacks go in `LITELLM_LAG_OVERRIDES` only (currently `grok-build`).
+`DEFAULT_PRICING` (in `server/default-rates.js`) is the offline safety net (Claude/OpenAI/Grok bare ids). Temporary rates for models LiteLLM still lacks go in `LITELLM_LAG_OVERRIDES` only (currently empty — `grok-build` graduated 2026-08-13).
 
 ### Delta Log Storage
 

--- a/server/default-rates.js
+++ b/server/default-rates.js
@@ -61,6 +61,8 @@ const DEFAULT_PRICING = {
   'grok-4.5-build':    { input: 2.00,  output: 6.00, cache_create: 2.00, cache_read: 0.50 },
   'grok-4.3':          { input: 1.25,  output: 2.50, cache_create: 1.25, cache_read: 0.20 },
   'grok-4.3-latest':   { input: 1.25,  output: 2.50, cache_create: 1.25, cache_read: 0.20 },
+  'grok-build':        { input: 1.00,  output: 2.00, cache_create: 1.00, cache_read: 0.20 },
+  'grok-build-0.1':    { input: 1.00,  output: 2.00, cache_create: 1.00, cache_read: 0.20 },
 };
 
 /**
@@ -77,17 +79,8 @@ const DEFAULT_PRICING = {
  * Source of truth for rates: official provider docs (see `source` field).
  */
 const LITELLM_LAG_OVERRIDES = Object.freeze([
-  // grok-4.5 / grok-4.3 retired 2026-07-19: LiteLLM lists xai/grok-4.5 and xai/grok-4.3
-  // (bare names come from mirrorProviderPrefixedKeys). grok-build still missing.
-  Object.freeze({
-    id: 'grok-build',
-    wireIds: Object.freeze(['grok-build', 'grok-build-0.1']),
-    litellmKeys: Object.freeze(['xai/grok-build', 'xai/grok-build-0.1', 'grok-build', 'grok-build-0.1']),
-    rates: Object.freeze({ input: 1.00, output: 2.00, cache_create: 0, cache_read: 0.20 }),
-    source: 'https://docs.x.ai/developers/pricing (Code API grok-build-0.1)',
-    since: '2026-07-09',
-    removeWhen: 'LiteLLM lists xai/grok-build or xai/grok-build-0.1',
-  }),
+  // grok-build retired 2026-08-13: LiteLLM lists xai/grok-build-0.1 and grok-build-0.1.
+  // Rates moved to DEFAULT_PRICING as stable offline fallback.
 ]);
 
 /**

--- a/test/default-rates.test.js
+++ b/test/default-rates.test.js
@@ -38,6 +38,8 @@ describe('default-rates: single source of truth (#397)', () => {
     it('covers grok models', () => {
       assert.ok(DEFAULT_PRICING['grok-4.5']);
       assert.ok(DEFAULT_PRICING['grok-4.3']);
+      assert.ok(DEFAULT_PRICING['grok-build']);
+      assert.ok(DEFAULT_PRICING['grok-build-0.1']);
     });
 
     it('covers OpenAI models', () => {
@@ -59,36 +61,19 @@ describe('default-rates: single source of truth (#397)', () => {
       assert.ok(Array.isArray(result.status));
     });
 
-    it('adds lag override models to the table when not in LiteLLM', () => {
-      const { table } = applyLagOverrides({});
-      for (const entry of LITELLM_LAG_OVERRIDES) {
-        for (const wireId of entry.wireIds) {
-          assert.ok(table[wireId], `lag override ${wireId} missing from table`);
-          assert.equal(table[wireId].input, entry.rates.input);
-        }
-      }
-    });
-
-    it('skips lag override when LiteLLM already has the key', () => {
-      const litellm = {
-        'xai/grok-build': { input: 99, output: 99, cache_create: 0, cache_read: 0 },
-      };
-      const { table, status } = applyLagOverrides(litellm);
-      assert.equal(table['grok-build'], undefined, 'override should not apply');
-      const s = status.find(s => s.id === 'grok-build');
-      assert.ok(s);
-      assert.equal(s.active, false);
+    it('returns empty status when no overrides are defined', () => {
+      const { table, status } = applyLagOverrides({});
+      assert.ok(table);
+      assert.deepEqual(status, []);
     });
   });
 
   describe('getOfflineRates', () => {
-    it('returns DEFAULT_PRICING + lag overrides merged', () => {
+    it('returns DEFAULT_PRICING merged (no active lag overrides)', () => {
       const rates = getOfflineRates();
-      // Has all DEFAULT_PRICING keys
       for (const key of Object.keys(DEFAULT_PRICING)) {
         assert.ok(rates[key], `missing: ${key}`);
       }
-      // Has lag override wire IDs
       assert.ok(rates['grok-build']);
       assert.ok(rates['grok-build-0.1']);
     });
@@ -106,7 +91,7 @@ describe('default-rates: single source of truth (#397)', () => {
       assert.equal(calculateCostSimple(usage1M, 'grok-4.5-build').cost, 2);
     });
 
-    it('matches grok-build to grok-build via lag override ($1/MTok input)', () => {
+    it('matches grok-build to grok-build ($1/MTok input)', () => {
       assert.equal(calculateCostSimple(usage1M, 'grok-build').cost, 1);
     });
 
@@ -143,8 +128,8 @@ describe('default-rates: single source of truth (#397)', () => {
     });
 
     it('longest-prefix-first: grok-4.5-build matches grok-4.5-build not grok-build', () => {
-      // grok-4.5-build has input $2/MTok, grok-build has input $1/MTok.
-      // If prefix matching were insertion-order, grok-build could win.
+      // grok-4.5-build has input $2/MTok (DEFAULT_PRICING), grok-build has $1/MTok.
+      // Longest-prefix-first ensures grok-4.5-build wins.
       assert.equal(calculateCostSimple(usage1M, 'grok-4.5-build').cost, 2);
     });
 
@@ -181,7 +166,7 @@ describe('default-rates: single source of truth (#397)', () => {
       assert.equal(calculateCostSimple(usage1M, null).confidence, 'fallback');
     });
 
-    it('returns exact confidence for lag override model', () => {
+    it('returns exact confidence for grok-build', () => {
       assert.equal(calculateCostSimple(usage1M, 'grok-build').confidence, 'exact');
     });
 

--- a/test/grok-wire.test.js
+++ b/test/grok-wire.test.js
@@ -162,13 +162,12 @@ describe('Grok wire contract', () => {
       assert.ok(line.cost.cost != null);
     });
 
-    it('pricing for grok-4.5 comes from LiteLLM bare mirror; grok-build keeps lag override', () => {
+    it('pricing for grok-4.5 comes from LiteLLM bare mirror; grok-build from DEFAULT_PRICING', () => {
       const table = buildPricingTable({
         'xai/grok-4.5': { input: 2, output: 6, cache_create: 0, cache_read: 0.5 },
       });
       assert.ok(table['grok-4.5'], 'bare wire id mirrors from xai/grok-4.5');
       assert.equal(table['grok-4.5'].input, 2);
-      // Title-gen model still needs local override until LiteLLM lists it
       assert.ok(table['grok-build']);
       assert.equal(table['grok-build'].input, 1);
       const c = calculateCost({

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -52,7 +52,7 @@ describe('pricing', () => {
       assert.equal(table['grok-4.5'].cache_read, 0.5);
     });
 
-    it('returns pricing for grok-build title-gen model via lag override', () => {
+    it('returns pricing for grok-build title-gen model from DEFAULT_PRICING', () => {
       const table = buildPricingTable({});
       assert.ok(table['grok-build']);
       assert.equal(table['grok-build'].input, 1);
@@ -75,44 +75,14 @@ describe('pricing', () => {
   });
 
   describe('LITELLM_LAG_OVERRIDES lifecycle', () => {
-    it('documents each override with litellmKeys + removeWhen (maintenance memory)', () => {
-      assert.ok(LITELLM_LAG_OVERRIDES.length >= 1);
-      for (const entry of LITELLM_LAG_OVERRIDES) {
-        assert.ok(entry.id, 'override needs id');
-        assert.ok(Array.isArray(entry.wireIds) && entry.wireIds.length, 'wireIds');
-        assert.ok(Array.isArray(entry.litellmKeys) && entry.litellmKeys.length, 'litellmKeys to watch');
-        assert.ok(entry.rates && entry.rates.input != null && entry.rates.output != null);
-        assert.ok(entry.source, 'official source URL');
-        assert.ok(entry.since, 'since date');
-        assert.ok(entry.removeWhen, 'human remove condition');
-      }
+    it('no active overrides (all graduated to DEFAULT_PRICING)', () => {
+      assert.equal(LITELLM_LAG_OVERRIDES.length, 0);
     });
 
-    it('stops applying override once LiteLLM lists a watched key (auto-return)', () => {
-      // Simulate LiteLLM catching up with xai/grok-build
-      const litellm = {
-        'xai/grok-build': { input: 1.1, output: 2.1, cache_create: 0, cache_read: 0.21 },
-      };
-      const table = buildPricingTable(litellm);
-      // bare mirror from xai/ + lag override sees litellmKeys present → does NOT overwrite
-      assert.equal(table['grok-build'].input, 1.1, 'LiteLLM rate must win after catch-up');
-      assert.equal(table['xai/grok-build'].input, 1.1);
-    });
-
-    it('applyLagOverrides reports remove-override when LiteLLM has the key', () => {
-      const { status } = (() => {
-        // applyLagOverrides returns table only; status is on module after call
-        applyLagOverrides({
-          'xai/grok-build': { input: 1, output: 2, cache_create: 0, cache_read: 0.2 },
-          'grok-build': { input: 1, output: 2, cache_create: 0, cache_read: 0.2 },
-        });
-        const pricing = require('../server/pricing');
-        return { status: pricing.lastLagOverrideStatus };
-      })();
-      const grokBuild = status.find(s => s.id === 'grok-build');
-      assert.ok(grokBuild);
-      assert.equal(grokBuild.active, false);
-      assert.equal(grokBuild.action, 'remove-override');
+    it('applyLagOverrides produces empty status when no overrides exist', () => {
+      applyLagOverrides({});
+      const pricing = require('../server/pricing');
+      assert.deepEqual(pricing.lastLagOverrideStatus, []);
     });
   });
 


### PR DESCRIPTION
## Summary

- LiteLLM 已收錄 `xai/grok-build-0.1`，退役 `LITELLM_LAG_OVERRIDES` 中的 `grok-build` 條目
- Rates 搬進 `DEFAULT_PRICING` 當穩定離線 fallback，`cache_create` 從 0 更新為 1.00（對齊 LiteLLM 畢業值）
- CLAUDE.md 同步更新，不再標示 `grok-build` 為 active override

## Detail

The startup warning `pricing lag override obsolete: grok-build` has been firing since LiteLLM added `xai/grok-build-0.1`. This PR retires the override and graduates the rates to `DEFAULT_PRICING`.

Key change from the original lag override: `cache_create` was `0` (unknown at time of entry, not an estimate of zero). LiteLLM's graduated value is `1.00` (= input rate), which is now used. Verified via `scripts/verify-rates.js --cached`: `grok-build-0.1` ✓ match.

`LITELLM_LAG_OVERRIDES` array is now empty but the infrastructure is kept for future models.

## Codex review

- R1: P2 cache_create mismatch — **accepted**, fixed `0` → `1.00`
- R2-1: P2 bare wire id live overlay — **rejected** (existing DEFAULT_PRICING behavior, not grok-build-specific)
- R2-2: P2 CLAUDE.md stale — **accepted**, updated

## Test plan

- [x] 1989/1989 tests pass
- [x] `scripts/verify-rates.js --cached` — `grok-build-0.1` ✓ match
- [x] Startup warning no longer fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)