### PR TITLE
fix(context): derive the 1M capability from data, persist the header, floor on observation

### DIFF
--- a/docs/decisions/0013-beta1m-persist-session-window-derive.md
+++ b/docs/decisions/0013-beta1m-persist-session-window-derive.md
@@ -272,3 +272,80 @@ the honest limitation, same class as ADR 0002's `sigParts` and ADR 0015's R4.
 This changes nothing about the display/classification boundary: weather remains a
 display/health view, and `isCompacted`, per-turn `severity`, and lane placement
 still read raw per-turn `maxContext`.
+
+## Amended by the 1M-capability work (2026-08-16) — `beta1m` is an interpretation, `ctxBeta` is the fact
+
+This ADR's Decision line reads "**Persist `beta1m` (the fact); derive `sessionWindow`
+(the view)**". Measured against real traffic, `beta1m` was never the fact. It is a
+conclusion drawn at write time from two inputs: the observed `anthropic-beta` header
+AND a model-capability judgement (`SUPPORTS_1M`). Collapsing both into one boolean
+lost information the ADR's own persist-the-fact principle says to keep, and the
+capability half was wrong in both directions the moment a model shipped:
+
+- `claude-opus-5` was absent from the regex, so every 1M Opus 5 session divided by
+  200K. Measured: a session at 13% of its window rendered 76%, and a counterfactual
+  replay of the real corpus (the header as it actually rode the wire) moves 161 turns
+  from 200K to 1M and flips 7 of 32 sessions from red to green.
+- the bare `opus-4` prefix claimed 1M for `claude-opus-4-5`, which serves 200K —
+  hiding real pressure, the more dangerous direction.
+
+### What changes
+
+1. **`ctxBeta` is persisted** (`INDEX_FIELDS`, add-only, appended last): the
+   `context-*` entries of the request header, verbatim, filtered to the window shape
+   `context-<n><k|m>-` so the context-EDITING beta cannot land in a window field.
+   `beta1m` stays, unchanged in meaning, as the capability-gated interpretation.
+   **The two may legitimately disagree**: a header on a model the gate refuses stores
+   `ctxBeta` and no `beta1m`. A consumer that reads `ctxBeta` presence as "this is 1M"
+   reintroduces the #211 over-claim.
+2. **The tier is parsed, not tabulated**: `contextBetaWindow()` reads the size out of
+   the beta id, so a future `context-400k-*` is legible without a code change. Nothing
+   on the wire ships a non-1M tier today — this is why the raw header is kept rather
+   than its boolean.
+3. **The capability gate is a UNION of two sources**, `modelSupports1M()` =
+   hand-list OR LiteLLM `max_input_tokens >= 1M`. LiteLLM may ADD, never DENY: its
+   field is semantically inconsistent (it reports `claude-fable-5` at 1M = capability
+   but `claude-sonnet-4-5` at 200K = default serving window, though Sonnet 4.5 serves
+   1M under the beta), so a capability-decides gate silently demoted a model the list
+   had right. Removing a wrong entry stays a manual edit; no upstream datum is trusted
+   to mean "cannot do 1M".
+4. **"The header was never on disk" is no longer true going forward.** This ADR's
+   no-backfill section stays correct for legacy lines — the fact is gone for those —
+   but new turns carry it, and `restore`'s heal pass re-derives from the line's own
+   persisted signals instead of re-inferring from model+usage alone.
+5. **The observation floor climbs to the smallest covering tier** instead of jumping
+   to a hardcoded 1M (LiteLLM lists real Claude tiers at 80K/100K/128K/200K/409,600/1M),
+   bounded by capability. Non-Claude providers are still never bumped: some report
+   `input_tokens` inclusive of cached tokens, so an un-normalized usage object can sum
+   above its window without the window being wrong, and widening from a possibly
+   double-counted total would hide pressure.
+6. **The Claude importer now derives `maxContext`**, as the Codex importer has since
+   #384. Claude transcripts declare no window and never record the header, so the only
+   evidence there is the observation. Measured on the real corpus: 332 of 750 imported
+   turns gain a larger window, and 7 sessions stop rendering above 100% (148%, 239%, …).
+
+### Trust must be monotone in time, not just consistent in code
+
+The write gate, the marker branch, and `restore`'s `trustStored` share one predicate.
+That is agreement in code, not in time: the predicate's input is a table refreshed
+daily, so a missing cache, a renamed upstream key, or another machine can make the
+same line resolve differently across a restart. `trustStored` therefore ALSO accepts
+`meta.beta1m === true` — a write-time attestation that the header was present and the
+gate accepted it. **Absence of capability data must never act as a deny**, or the
+"every restart erases it" failure returns through a new door.
+
+### Boundary preserved, inputs changed
+
+`isCompacted`, per-turn `severity`, and lane placement still divide by raw per-turn
+`maxContext`; the display fold is still session-global. What changed is HOW the raw
+per-turn value is derived, and only for turns written after this lands — existing lines
+are not rewritten, so nothing reclassifies retroactively and no `WEATHER_REV` bump is
+required (the weather derivation is untouched; only future inputs differ).
+
+### New test-isolation surface
+
+Window resolution now reads `pricing-cache.json`, which is **package-relative and
+therefore outside `CCXRAY_HOME` isolation** — the ADR 0015 R4 class. `CCXRAY_PRICING_CACHE`
+overrides the path and `pricing.__setContextTableForTests()` injects a table; a test that
+asserts window behaviour must use one of them or stub `getModelContext`, or it silently
+reads the developer's cache. See `docs/testing.md`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -154,3 +154,26 @@ a shared home can introduce order-dependence between tests. Rule 1 (each test
 makes its own temp home) is the real guard; CI just stops the real-data
 dependency from going unnoticed. `$HOME` is left untouched so puppeteer's Chrome
 cache stays intact. It costs nothing extra — it doesn't re-run the suite.
+
+## `pricing-cache.json` is a second, non-`CCXRAY_HOME` input
+
+`CCXRAY_HOME` does not isolate everything a test can accidentally read. The
+LiteLLM cache (`pricing-cache.json`) lives **package-relative**, next to
+`package.json`, and since the 1M-capability work it is read synchronously on
+first use to resolve a model's context window — so a test that asserts window
+behaviour resolves differently on a machine that has run the server (cache
+present) than on CI (cache absent). Both directions pass today, which is exactly
+why this is easy to miss: it is the ADR 0015 R4 / #407 class, one module over.
+
+A test that exercises `getMaxContext` / `inferMaxContext` / `modelSupports1M`
+must pin that input, by any of:
+
+- stub `pricing.getModelContext` (the pattern already used throughout
+  `test/config.test.js`, restored in `afterEach`),
+- `pricing.__setContextTableForTests({...})` to inject a table through the real
+  lookup, including its prefix matching, or
+- set `CCXRAY_PRICING_CACHE` to a path that does not exist, for a spawned server
+  or CLI that must resolve windows with no LiteLLM data at all.
+
+The rule of thumb matches rule 1: never let an assertion depend on a file the
+test did not create.

--- a/server/config.js
+++ b/server/config.js
@@ -320,7 +320,7 @@ const DEFAULT_CONTEXT = 200_000;
 // source for them), but a bare `sonnet-4` prefix would also claim 1M for every
 // future minor — the exact `opus-4` over-match that this work had to undo. A
 // dated build (`-20250514`) is the same model; a new minor is not.
-const SUPPORTS_1M = /^claude-(opus-4-6|opus-4-7|opus-4-8|opus-5|sonnet-5|fable-5|mythos)|^claude-sonnet-4(-5)?($|[-@]\d{8})/;
+const SUPPORTS_1M = /^claude-(opus-4-6|opus-4-7|opus-4-8|opus-5|sonnet-4-6|sonnet-5|fable-5|mythos)|^claude-sonnet-4(-5)?($|[-@]\d{8})/;
 
 // Is this model CAPABLE of a 1M window? Two sources, UNION — LiteLLM may only
 // ADD, never DENY.

--- a/server/config.js
+++ b/server/config.js
@@ -307,7 +307,85 @@ const DEFAULT_CONTEXT = 200_000;
 // sends neither and runs 200K. sonnet-5 / mythos are 1M-capable per Anthropic
 // model docs (1M is the API default for fable/mythos; Claude Code still
 // serves 200K sessions unless [1m] is selected).
-const SUPPORTS_1M = /^claude-(opus-4|sonnet-4|sonnet-5|fable-5|mythos)/;
+//
+// This regex is now the OFFLINE FALLBACK only — `modelSupports1M()` prefers
+// LiteLLM's context table, which ccxray already downloads and refreshes daily.
+// A hand-maintained list is wrong in both directions the moment a model ships:
+// it missed claude-opus-5 (1M shown as 200K → phantom context pressure) while
+// the bare `opus-4` prefix claimed 1M for claude-opus-4-5, which serves 200K
+// (real pressure hidden). Keep this list narrow and literal; it only decides
+// models seen before the pricing cache exists.
+// The sonnet-4 family is anchored rather than prefix-matched: `sonnet-4` and
+// `sonnet-4-5` serve 1M (LiteLLM reports both at 200K, so this list is the only
+// source for them), but a bare `sonnet-4` prefix would also claim 1M for every
+// future minor — the exact `opus-4` over-match that this work had to undo. A
+// dated build (`-20250514`) is the same model; a new minor is not.
+const SUPPORTS_1M = /^claude-(opus-4-6|opus-4-7|opus-4-8|opus-5|sonnet-5|fable-5|mythos)|^claude-sonnet-4(-5)?($|[-@]\d{8})/;
+
+// Is this model CAPABLE of a 1M window? Two sources, UNION — LiteLLM may only
+// ADD, never DENY.
+//
+// LiteLLM's max_input_tokens is not a consistent capability signal: it reports
+// claude-fable-5 at 1M (capability) but claude-sonnet-4-5 at 200K (default
+// serving window), even though Sonnet 4.5 serves 1M under the beta. Letting it
+// deny therefore breaks a model the regex had right. Letting it add picks up
+// every newly shipped model it lists at 1M (claude-opus-5 was the miss that
+// started this) without waiting for a release here.
+//
+// Removing a WRONG entry stays a manual edit of the regex above, because no
+// upstream source can be trusted to mean "cannot do 1M".
+//
+// Capability alone never widens a window — getMaxContext still requires the 1M
+// signal — so a haiku title-gen turn carrying the account-level beta header
+// still resolves to 200K.
+// INVARIANT: LiteLLM may ADD, never DENY (its max_input_tokens means capability
+// for some models and default serving window for others), and this predicate's
+// input is a table refreshed daily — so agreement with restore.js's trustStored
+// is agreement in code, not in time. Absence of capability data must never act
+// as a deny. See docs/decisions/0013-*.
+function modelSupports1M(stripped) {
+  if (!stripped) return false;
+  if (SUPPORTS_1M.test(stripped)) return true;
+  const { getModelContext } = require('./pricing');
+  const capability = getModelContext(stripped);
+  return typeof capability === 'number' && capability >= 1_000_000;
+}
+
+// The `anthropic-beta` request header, reduced to its context-* entries. The
+// tier lives in the id (`context-1m-2025-08-07`), so persisting the string keeps
+// a future `context-400k-*` legible instead of collapsing it to "not 1M".
+// Whitelisted deliberately: the rest of that header, and every other request
+// header, stays out of the log.
+function extractContextBeta(headerValue) {
+  if (!headerValue) return null;
+  // Shape-matched, not prefix-matched: `context-` also prefixes betas that have
+  // nothing to do with window size (context-management-*, the context-editing
+  // beta, ships on real traffic). Storing those would put a window-less string
+  // in a window field on nearly every line, and any consumer testing truthiness
+  // would misread it. The filter and contextBetaWindow's parser share one shape.
+  const parts = String(headerValue)
+    .split(',')
+    .map(part => part.trim())
+    .filter(part => /^context-\d+(?:\.\d+)?[km]-/i.test(part));
+  return parts.length ? parts.join(',') : null;
+}
+
+// Window a context-* beta id asks for, e.g. `context-1m-2025-08-07` → 1_000_000
+// and `context-400k-…` → 400_000. Parsed rather than tabulated so an unreleased
+// tier does not need a code change to be readable; an id we cannot parse returns
+// null and the caller falls back to the other signals.
+function contextBetaWindow(ctxBeta) {
+  if (!ctxBeta) return null;
+  let best = null;
+  for (const part of String(ctxBeta).split(',')) {
+    const m = /^context-(\d+(?:\.\d+)?)(k|m)-/i.exec(part.trim());
+    if (!m) continue;
+    const scale = m[2].toLowerCase() === 'm' ? 1_000_000 : 1_000;
+    const size = Math.round(parseFloat(m[1]) * scale);
+    if (size > 0 && (best == null || size > best)) best = size;
+  }
+  return best;
+}
 
 // Extract effective model ID from system prompt (includes [1m] suffix if present).
 // API request model field never includes [1m], but system prompt does:
@@ -329,7 +407,7 @@ function extractModelFromSystem(system) {
 function beta1mIndicates1M(model, system, beta1m) {
   if (beta1m !== true) return false;
   const stripped = (model || extractModelFromSystem(system) || '').replace(/\[.*\]/, '');
-  return SUPPORTS_1M.test(stripped);
+  return modelSupports1M(stripped);
 }
 
 function getMaxContext(model, system, opts = {}) {
@@ -353,11 +431,20 @@ function getMaxContext(model, system, opts = {}) {
   //    client-level flag riding on a haiku request does not over-claim 1M.
   // beta1m branch delegates to the shared helper so the persisted `beta1m` fact
   // (wire-parsers/anthropic.js) can never diverge from this gate (#339 / codex round 2).
-  if (beta1mIndicates1M(model, system, opts.beta1m)) return 1_000_000;
+  const asked = contextBetaWindow(opts.ctxBeta);
+  if (beta1mIndicates1M(model, system, opts.beta1m || asked === 1_000_000)) return 1_000_000;
+  // A context-* beta naming a tier other than 1M (none shipped yet — this is the
+  // reason the raw header is persisted rather than a boolean). Same shape as the
+  // 1M gate: the client asked, the model still has to be able to serve it.
+  if (asked && asked > DEFAULT_CONTEXT) {
+    const { getModelContext } = require('./pricing');
+    const capability = getModelContext(stripped);
+    if (typeof capability === 'number' && capability >= asked) return asked;
+  }
   // [1m] system-marker branch (lagging legacy signal), same SUPPORTS_1M gate.
   const markerMatchesIdentity = !!sysModel && sysModel.replace(/\[.*\]/, '') === stripped;
   const markerSignal = (markerMatchesIdentity && /\[1m\]/i.test(sysModel)) || /\[1m\]/i.test(model || '');
-  if (markerSignal && SUPPORTS_1M.test(stripped)) return 1_000_000;
+  if (markerSignal && modelSupports1M(stripped)) return 1_000_000;
   // 2) Known Claude Code / Codex defaults (200K / 400K)
   const keys = Object.keys(MODEL_CONTEXT_FALLBACK).sort((a, b) => b.length - a.length);
   for (const key of keys) {
@@ -382,10 +469,15 @@ function getMaxContext(model, system, opts = {}) {
 // Usage-aware refinement of getMaxContext. The [1m] marker only appears in
 // Claude Code's system prompt; requests without that prompt (title-gen,
 // some subagent paths) report a bare model name and fall back to 200K — but
-// a Max-plan user may actually be on 1M. When observed usage exceeds the
-// base, bump Claude models up to 1M so the dashboard "X / Y (Z%)" stays
-// self-consistent. Non-Claude models are not bumped because we have no
-// reliable next tier to escalate to.
+// a Max-plan user may actually be on 1M.
+//
+// Observed context is the one signal no table can contradict: a request
+// carrying N tokens proves the window is at least N. Climb to the smallest
+// window that covers the observation — the model's own capability when we know
+// it, the observation itself when the data says that is impossible — instead of
+// jumping to a hardcoded 1M. Two failures that fixed: a model on the real
+// 409,600 tier claimed 1M (2.5x too generous, hiding pressure), and a non-Claude
+// model that exceeded its assumed window kept it and rendered above 100%.
 function inferMaxContext(model, system, usage, opts = {}) {
   const base = getMaxContext(model, system, opts);
   if (!usage) return base;
@@ -395,8 +487,20 @@ function inferMaxContext(model, system, usage, opts = {}) {
   if (used <= base) return base;
   const effective = extractModelFromSystem(system) || model || '';
   const stripped = effective.replace(/\[.*\]/, '');
-  if (stripped.startsWith('claude-') && base < 1_000_000) return 1_000_000;
-  return base;
+  // Non-Claude providers keep their window untouched: some report input_tokens
+  // INCLUSIVE of cached tokens (providers.js normalizeUsageForProvider), so an
+  // un-normalized usage object can sum above the window without the window being
+  // wrong. Inflating it from a possibly double-counted total would hide pressure
+  // — the unsafe direction. A genuine overflow stays visible as ctx > 100%.
+  if (!stripped.startsWith('claude-')) return base;
+  const { getModelContext } = require('./pricing');
+  const capability = getModelContext(stripped);
+  if (typeof capability === 'number' && capability > base) {
+    // The smallest window we can name that still covers what we saw.
+    return capability >= used ? capability : used;
+  }
+  // No usable capability datum: Claude serves 200K or 1M in practice.
+  return base < 1_000_000 ? 1_000_000 : base;
 }
 
 // Logs-dir creation and the one-time legacy-logs migration now live in the
@@ -429,6 +533,9 @@ module.exports = {
   MODEL_CONTEXT_FALLBACK,
   DEFAULT_CONTEXT,
   SUPPORTS_1M,
+  modelSupports1M,
+  extractContextBeta,
+  contextBetaWindow,
   extractModelFromSystem,
   beta1mIndicates1M,
   getMaxContext,

--- a/server/entry.js
+++ b/server/entry.js
@@ -28,6 +28,15 @@ const INDEX_FIELDS = [
   // #504: optional deployment identity, local calendar metadata, and duplicate
   // request-history tool calls. Append-only: existing field order is stable.
   'agentId','userEmail','team','agentType','localDate','tz','duplicateToolCalls',
+  // INVARIANT: `ctxBeta` is the OBSERVATION (the context-* entries of the
+  // anthropic-beta header, verbatim); `beta1m` above is its INTERPRETATION, gated
+  // on model capability. The two may legitimately disagree — a header on a model
+  // the gate refuses stores ctxBeta and no beta1m — so reading ctxBeta presence as
+  // "this turn ran 1M" reintroduces the #211 over-claim. Parse the tier with
+  // config.contextBetaWindow(); never test truthiness. Whitelisted (no other
+  // request header is persisted) and appended last to keep the field order
+  // add-only (test/entry.test.js G1). See docs/decisions/0013-*.
+  'ctxBeta',
 ];
 
 // INVARIANT: A new INDEX_FIELDS field whose no-value state is null rather than

--- a/server/forward.js
+++ b/server/forward.js
@@ -690,7 +690,7 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
         console.log(`\x1b[90m   Context HUD: injecting into session ${reqSessionId.slice(0, 8)}\x1b[0m`);
         _hudLoggedSessions.add(reqSessionId);
       }
-      const maxCtx = config.inferMaxContext(parsedBody?.model, parsedBody?.system, usage, { beta1m: ctx.beta1m });
+      const maxCtx = config.inferMaxContext(parsedBody?.model, parsedBody?.system, usage, { beta1m: ctx.beta1m, ctxBeta: ctx.ctxBeta });
       const pct = (totalCtx / maxCtx * 100).toFixed(1);
       const newIdx = maxBlockIndex + 1;
       const costInfo = calculateCost(usage, parsedBody?.model);
@@ -788,7 +788,7 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
         sysHash: ctx.sysHash, toolsHash: ctx.toolsHash, coreHash: ctx.coreHash,
         agentKey: ctx.agentKey || null, agentLabel: ctx.agentLabel || null,
         cwd: store.sessionMeta[sessionId]?.cwd || null,
-        stopReason, title, thinkingDuration, thinkingStripped, beta1m: ctx.beta1m,
+        stopReason, title, thinkingDuration, thinkingStripped, beta1m: ctx.beta1m, ctxBeta: ctx.ctxBeta,
         isSubagent, toolFail: helpers.hasToolFail(parsedBody), startTime,
       }),
     };
@@ -1095,7 +1095,7 @@ function handleNonSSEResponse(ctx, proxyRes, clientRes) {
           sysHash: ctx.sysHash, toolsHash: ctx.toolsHash, coreHash: ctx.coreHash,
         agentKey: ctx.agentKey || null, agentLabel: ctx.agentLabel || null,
           cwd: store.sessionMeta[sessionId]?.cwd || null,
-          stopReason, title, thinkingDuration: null, thinkingStripped, beta1m: ctx.beta1m,
+          stopReason, title, thinkingDuration: null, thinkingStripped, beta1m: ctx.beta1m, ctxBeta: ctx.ctxBeta,
           isSubagent, toolFail: helpers.hasToolFail(parsedBody), startTime,
         }),
       };

--- a/server/importer.js
+++ b/server/importer.js
@@ -173,7 +173,14 @@ async function parseSessionFile(filePath, projectSlug) {
 
     const model = msg.model || 'unknown';
     const costResult = calculateCostSimple(usage, model);
-    const tokens = buildTokens(usage);
+    // #384 did this for Codex, whose transcript declares model_context_window.
+    // Claude Code's transcript declares nothing and never records the
+    // anthropic-beta header, so the only evidence here is the observation:
+    // a turn carrying more than the default window proves a bigger one. Leaving
+    // maxContext unset instead made every reader fall back to 200K, which is how
+    // a 1M session renders as phantom context pressure.
+    const contextWindow = config.inferMaxContext(model, null, usage);
+    const tokens = buildTokens(usage, contextWindow);
     const receivedAt = new Date(obj.timestamp).getTime();
 
     // #500: extract tool_use call ids from assistant content
@@ -212,6 +219,7 @@ async function parseSessionFile(filePath, projectSlug) {
       tokens,
       cost: { cost: costResult.cost, confidence: costResult.confidence },
       model,
+      maxContext: contextWindow,
       sessionId,
       title: prev ? prev.title : (lastUserText || '(imported)'),
       stopReason: msg.stop_reason || prev?.stopReason || null,

--- a/server/index.js
+++ b/server/index.js
@@ -475,11 +475,17 @@ const server = http.createServer((clientReq, clientRes) => {
     // is the authoritative, non-lagging signal for the context-window denominator.
     // Carried on ctx and fed into inferMaxContext downstream.
     const beta1m = /(^|,)\s*context-1m-/.test(clientReq.headers['anthropic-beta'] || '');
+    // The boolean above collapses the header to "is it 1M". Keep the context-*
+    // entries verbatim as well: the id carries the tier the client asked for, so
+    // a future `context-400k-*` is distinguishable instead of arriving as a
+    // silent false. Whitelisted on purpose — request headers also carry
+    // authorization / x-api-key, which must never reach the log.
+    const ctxBeta = config.extractContextBeta(clientReq.headers['anthropic-beta']);
 
     const ctx = {
       id, ts, startTime, parsedBody, rawBody, clientReq, clientRes, fwdHeaders,
       reqSessionId, reqWritePromise, sysHash, toolsHash, coreHash, agentKey, agentLabel, sessionInferred, upstream,
-      beta1m,
+      beta1m, ctxBeta,
       isSubagent: isSubagentHint,
     };
 

--- a/server/pricing.js
+++ b/server/pricing.js
@@ -16,7 +16,11 @@ const {
 } = require('./default-rates');
 
 // ── Pricing ─────────────────────────────────────────────────────────
-const PRICING_CACHE_PATH = path.join(__dirname, '..', 'pricing-cache.json');
+// Package-relative, so it is outside CCXRAY_HOME isolation. CCXRAY_PRICING_CACHE
+// lets a test (or a read-only install) point it somewhere else or at a path that
+// does not exist, keeping window resolution independent of the developer's cache.
+const PRICING_CACHE_PATH = process.env.CCXRAY_PRICING_CACHE
+  || path.join(__dirname, '..', 'pricing-cache.json');
 const PRICING_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const LITELLM_URL = 'https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json';
 
@@ -96,7 +100,7 @@ async function fetchPricing() {
     const cached = JSON.parse(await fsp.readFile(PRICING_CACHE_PATH, 'utf8'));
     if (Date.now() - cached.fetchedAt < PRICING_TTL_MS) {
       pricingTable = buildPricingTable(cached.pricing || {});
-      if (cached.context) contextTable = mirrorProviderPrefixedKeys(cached.context);
+      if (cached.context) setContextTable(mirrorProviderPrefixedKeys(cached.context));
       console.log(`\x1b[90m   Pricing loaded from cache (${new Date(cached.fetchedAt).toLocaleString('zh-TW', { timeZone: 'Asia/Taipei' })})\x1b[0m`);
       logLagOverrideStatus(lastLagOverrideStatus);
       return;
@@ -136,7 +140,7 @@ async function fetchPricing() {
             context: mirroredCtx,
           }, null, 2)).catch(e => console.error('Write pricing cache failed:', e.message));
           pricingTable = buildPricingTable(fetched);
-          contextTable = mirroredCtx;
+          setContextTable(mirroredCtx);
           console.log(`\x1b[90m   Pricing fetched: ${Object.keys(fetched).length} models, ${Object.keys(fetchedCtx).length} context windows\x1b[0m`);
           logLagOverrideStatus(lastLagOverrideStatus);
         } catch (e) {
@@ -198,12 +202,43 @@ function calculateCost(usage, model) {
   return { cost, rates, confidence: rateConfidence };
 }
 
+// fetchPricing() is async and is awaited AFTER listen() and AFTER
+// restoreFromLogs() (server/index.js), so live turns and the restore heal pass
+// both ask for context windows while contextTable is still empty. Reading the
+// cache synchronously on first use removes that ordering dependency: without
+// it, the same model resolves to a different window before and after the fetch
+// resolves — the intra-session sawtooth ADR 0013 exists to prevent. TTL is
+// deliberately ignored: a model's *capability* does not expire, and the async
+// fetch overwrites this table when it lands.
+let contextTableLoadAttempted = false;
+function ensureContextTable() {
+  if (contextTableLoadAttempted || Object.keys(contextTable).length) return;
+  contextTableLoadAttempted = true;
+  try {
+    const cached = JSON.parse(fs.readFileSync(PRICING_CACHE_PATH, 'utf8'));
+    if (cached.context) setContextTable(mirrorProviderPrefixedKeys(cached.context));
+  } catch {}
+}
+
+// The prefix scan sorts ~4,200 keys. It used to run only for models missing
+// from MODEL_CONTEXT_FALLBACK; the 1M capability gate now consults this table
+// for every Claude turn, so the sort is memoized per table instead of per call.
+let contextKeysByLength = null;
+function setContextTable(next) {
+  contextTable = next;
+  contextKeysByLength = null;
+}
+function contextKeys() {
+  if (!contextKeysByLength) contextKeysByLength = Object.keys(contextTable).sort((a, b) => b.length - a.length);
+  return contextKeysByLength;
+}
+
 function getModelContext(model) {
   if (!model) return null;
+  ensureContextTable();
   if (contextTable[model]) return contextTable[model];
   if (!model.includes('/') && contextTable[`xai/${model}`]) return contextTable[`xai/${model}`];
-  const keys = Object.keys(contextTable).sort((a, b) => b.length - a.length);
-  for (const key of keys) {
+  for (const key of contextKeys()) {
     if (model.startsWith(key)) return contextTable[key];
   }
   return null;
@@ -222,5 +257,11 @@ module.exports = {
   LITELLM_LAG_OVERRIDES,
   applyLagOverrides,
   buildPricingTable,
+  // Tests inject a table instead of reading the developer's pricing-cache.json,
+  // which is package-relative and therefore outside CCXRAY_HOME isolation.
+  __setContextTableForTests(table) {
+    setContextTable(table ? mirrorProviderPrefixedKeys(table) : {});
+    contextTableLoadAttempted = true;
+  },
   get lastLagOverrideStatus() { return lastLagOverrideStatus; },
 };

--- a/server/restore.js
+++ b/server/restore.js
@@ -137,9 +137,24 @@ async function healMetaInPlace(meta) {
   }
   // anthropic: re-apply usage-aware context inference (#211 trustStored logic)
   if (meta.provider === 'anthropic') {
-    const inferred = config.inferMaxContext(meta.model, null, meta.usage);
+    // Re-derive from the signals the line itself persisted (#339 beta1m and the
+    // raw context-* beta): without them the heal pass re-infers from model+usage
+    // alone and cannot reproduce a window the live path knew from the header.
+    const inferred = config.inferMaxContext(meta.model, null, meta.usage, {
+      beta1m: meta.beta1m === true,
+      ctxBeta: meta.ctxBeta,
+    });
     const stripped = (meta.model || '').replace(/\[.*\]/, '');
-    let trustStored = !stripped.startsWith('claude-') || config.SUPPORTS_1M.test(stripped);
+    // INVARIANT (ADR 0013): `beta1m` on the line is a write-time attestation: the header was present AND
+    // the gate accepted it. Trust it independently of today's capability data —
+    // otherwise absence of LiteLLM (missing cache, renamed key, another machine)
+    // acts as a DENY and a restart shrinks a header-attested 1M back to 200K,
+    // which is the "every restart erases it" failure this work exists to close.
+    // Denial must stay as deliberate as the hand-narrowed list, never a side
+    // effect of data being unavailable.
+    let trustStored = meta.beta1m === true
+      || !stripped.startsWith('claude-')
+      || config.modelSupports1M(stripped);
     if (trustStored && (meta.maxContext || 0) > inferred && meta.sysHash) {
       const marker = await sysModelMarker(meta.sysHash);
       const markerMatches = !!marker && marker.replace(/\[.*\]/, '') === stripped;

--- a/server/store.js
+++ b/server/store.js
@@ -98,6 +98,11 @@ function _foldEntry(canonical, other) {
   // header (e.g. an imported copy, #329) inherits it from a proxy copy that saw it. Never
   // downgrades (monotone), matching the sessionCtxWindow fold that consumes it.
   if (other.beta1m === true) canonical.beta1m = true;
+  // ctxBeta is the OBSERVATION behind beta1m (the raw context-* header). Fill it the
+  // same way: an imported canonical never saw the header, and losing it while keeping
+  // the interpretation would discard the more fundamental fact — and with it any tier
+  // the interpretation cannot express. Never overwrites a value already present.
+  if (!canonical.ctxBeta && other.ctxBeta) canonical.ctxBeta = other.ctxBeta;
   // toolSources is a map — fill when canonical is null/undefined OR an EMPTY object
   // ({} must not read as "already populated" and block a real map; round-3 m1).
   {

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -105,6 +105,12 @@ function buildEntryFields(ctx) {
     // only when true (absent = no positive signal; monotone OR-fold). Classification keeps
     // raw per-turn maxContext — never derived from this. See docs/decisions/0013-*.
     beta1m: config.beta1mIndicates1M(model, parsedBody?.system, ctx.beta1m) ? true : undefined,
+    // The raw context-* entries of anthropic-beta. beta1m above is this header's
+    // interpretation ("is it 1M, and can the model serve it"); this is the
+    // observation itself, so a tier we do not yet interpret survives on disk and
+    // a rebuild can re-derive the window without the header being on the wire.
+    // Ungated on purpose: an observation is not a claim.
+    ctxBeta: ctx.ctxBeta || undefined,
     responseMetadata: undefined,
     stopReason: ctx.stopReason || '',
     title: ctx.title || null,

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -807,3 +807,192 @@ describe('getMaxContext — LiteLLM max-capability clamp for Claude models (#211
     assert.equal(getMaxContext('claude-3-7-sonnet', null), 200_000);
   });
 });
+
+// The 1M capability gate is model metadata, not a ccxray opinion. It used to be
+// a hand-maintained regex, which was wrong in both directions the moment a model
+// shipped: claude-opus-5 was missing (a 1M session divided by 200K → phantom
+// context pressure, measured at 76% for a session actually at 13%), while the
+// bare `opus-4` prefix claimed 1M for claude-opus-4-5, which serves 200K (real
+// pressure hidden). LiteLLM's context table — already downloaded and refreshed
+// daily by fetchPricing — is the source; the regex is the offline floor.
+describe('modelSupports1M — capability comes from LiteLLM, regex is the offline floor', () => {
+  const { getMaxContext, modelSupports1M, beta1mIndicates1M, SUPPORTS_1M } = require('../server/config');
+  const pricing = require('../server/pricing');
+  const origGetModelContext = pricing.getModelContext;
+
+  afterEach(() => { pricing.getModelContext = origGetModelContext; });
+
+  it('FIX: a 1M-capable model missing from the regex still gets 1M (fail-on-old)', () => {
+    // The measured case: claude-opus-5 shipped, the regex did not learn it.
+    pricing.getModelContext = (m) => (m === 'claude-opus-5' ? 1_000_000 : null);
+    assert.equal(getMaxContext('claude-opus-5', null, { beta1m: true }), 1_000_000);
+    assert.equal(beta1mIndicates1M('claude-opus-5', null, true), true);
+    const marker1m = [{ type: 'text', text: 'The exact model ID is claude-opus-5[1m].' }];
+    assert.equal(getMaxContext('claude-opus-5', marker1m), 1_000_000);
+  });
+
+  it('FIX: the narrowed regex stops claiming 1M for claude-opus-4-5 (fail-on-old)', () => {
+    // `^claude-opus-4` matched claude-opus-4-5, which serves 200K. Over-claiming
+    // 1M there hides real context pressure — the more dangerous direction.
+    // Note the fix is the hand-narrowed list, NOT LiteLLM: no upstream datum is
+    // trusted to mean "cannot do 1M" (see the sonnet-4-5 guard below).
+    pricing.getModelContext = (m) => (m === 'claude-opus-4-5' ? 200_000 : null);
+    assert.equal(getMaxContext('claude-opus-4-5', null, { beta1m: true }), 200_000);
+    assert.equal(beta1mIndicates1M('claude-opus-4-5', null, true), false);
+  });
+
+  it('GUARD: LiteLLM may add but never deny — claude-sonnet-4-5 keeps its 1M', () => {
+    // LiteLLM lists claude-sonnet-4-5 at 200_000 (its default serving window)
+    // although Sonnet 4.5 serves 1M under the beta, while listing fable-5 at 1M
+    // (its capability). The field is not a consistent capability signal, so a
+    // capability-decides gate silently demoted a model the regex had right.
+    pricing.getModelContext = (m) => (m === 'claude-sonnet-4-5' ? 200_000 : null);
+    assert.equal(getMaxContext('claude-sonnet-4-5', null, { beta1m: true }), 1_000_000);
+    assert.equal(modelSupports1M('claude-sonnet-4-5'), true);
+  });
+
+  it('FIX: a future model unknown to the regex needs no code change', () => {
+    pricing.getModelContext = (m) => (m === 'claude-opus-9' ? 1_000_000 : null);
+    assert.equal(modelSupports1M('claude-opus-9'), true);
+    assert.equal(SUPPORTS_1M.test('claude-opus-9'), false, 'the regex must not be what makes this pass');
+    assert.equal(getMaxContext('claude-opus-9', null, { beta1m: true }), 1_000_000);
+  });
+
+  it('GUARD: the account-level beta header still resolves haiku turns to 200K', () => {
+    // The reason the gate exists: Claude Code sends anthropic-beta context-1m-*
+    // on EVERY request, including haiku title-gen turns that really run 200K.
+    pricing.getModelContext = (m) => (m === 'claude-haiku-4-5' ? 200_000 : null);
+    assert.equal(getMaxContext('claude-haiku-4-5', null, { beta1m: true }), 200_000);
+    assert.equal(beta1mIndicates1M('claude-haiku-4-5', null, true), false);
+  });
+
+  it('GUARD: the offline list matches the sonnet-4 family without claiming future minors', () => {
+    // LiteLLM reports sonnet-4 and sonnet-4-5 at 200K, so this list is their only
+    // source — but a bare `sonnet-4` prefix would claim 1M for every future minor,
+    // which is exactly the `opus-4` over-match this work had to undo. A dated build
+    // is the same model; a new minor is not.
+    pricing.getModelContext = () => null;
+    assert.equal(modelSupports1M('claude-sonnet-4'), true);
+    assert.equal(modelSupports1M('claude-sonnet-4-20250514'), true);
+    assert.equal(modelSupports1M('claude-sonnet-4-5'), true);
+    assert.equal(modelSupports1M('claude-sonnet-4-5-20250929'), true);
+    assert.equal(modelSupports1M('claude-sonnet-4-9'), false, 'an unknown minor is not assumed 1M offline');
+    // …and LiteLLM can still add it when it knows better (union, never deny).
+    pricing.getModelContext = (m) => (m === 'claude-sonnet-4-9' ? 1_000_000 : null);
+    assert.equal(modelSupports1M('claude-sonnet-4-9'), true);
+  });
+
+  it('GUARD: with no LiteLLM data the offline regex decides, and it knows opus-5', () => {
+    pricing.getModelContext = () => null;
+    assert.equal(modelSupports1M('claude-opus-5'), true);
+    assert.equal(modelSupports1M('claude-sonnet-5'), true);
+    assert.equal(modelSupports1M('claude-opus-4-6'), true);
+    assert.equal(modelSupports1M('claude-haiku-4-5'), false);
+    assert.equal(modelSupports1M(''), false);
+  });
+
+  it('GUARD: capability alone never widens a window without a 1M signal', () => {
+    pricing.getModelContext = (m) => (m === 'claude-opus-5' ? 1_000_000 : null);
+    assert.equal(getMaxContext('claude-opus-5', null), 200_000);
+    assert.equal(getMaxContext('claude-opus-5', null, { beta1m: false }), 200_000);
+  });
+});
+
+// Observed context is the one signal no table can contradict: a request that
+// carried N tokens proves the window is at least N. The old rule jumped to a
+// hardcoded 1M for Claude and did nothing for anything else.
+describe('inferMaxContext — the observation floor climbs to the smallest covering tier', () => {
+  const { inferMaxContext } = require('../server/config');
+  const pricing = require('../server/pricing');
+  const origGetModelContext = pricing.getModelContext;
+  const use = n => ({ input_tokens: n, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 });
+
+  afterEach(() => { pricing.getModelContext = origGetModelContext; });
+
+  it('FIX: a model on the real 409,600 tier stops claiming 1M (fail-on-old)', () => {
+    // LiteLLM lists claude models at 80K/100K/128K/200K/409,600/1M. Jumping a
+    // 409,600 model to 1M is 2.5x too generous — it hides real pressure.
+    pricing.getModelContext = (m) => (m === 'claude-mid' ? 409_600 : null);
+    assert.equal(inferMaxContext('claude-mid', null, use(250_000)), 409_600);
+  });
+
+  it('GUARD: non-Claude models are never bumped, even with a capability datum', () => {
+    // Some providers report input_tokens inclusive of cached tokens, so an
+    // un-normalized usage object can sum above the window without the window
+    // being wrong. Widening from that total would hide pressure; an overflow
+    // stays visible as ctx > 100% instead.
+    pricing.getModelContext = (m) => (m === 'gpt-fast' ? 400_000 : null);
+    assert.equal(inferMaxContext('gpt-fast', null, use(450_000)), 400_000);
+  });
+
+  it('GUARD: an observation the capability says is impossible trusts the request', () => {
+    pricing.getModelContext = (m) => (m === 'claude-mid' ? 409_600 : null);
+    assert.equal(inferMaxContext('claude-mid', null, use(600_000)), 600_000);
+  });
+
+  it('GUARD: with no capability datum Claude keeps the 200K → 1M jump', () => {
+    // Claude serves two windows in practice; without data, the old behaviour is
+    // still the best available guess and errs toward under-reporting pressure.
+    pricing.getModelContext = () => null;
+    assert.equal(inferMaxContext('claude-unlisted', null, use(250_000)), 1_000_000);
+  });
+
+  it('GUARD: usage at or below the base never moves the window', () => {
+    pricing.getModelContext = (m) => (m === 'claude-mid' ? 409_600 : null);
+    assert.equal(inferMaxContext('claude-mid', null, use(200_000)), 200_000);
+    assert.equal(inferMaxContext('claude-mid', null, null), 200_000);
+    assert.equal(inferMaxContext('claude-mid', null, { input_tokens: -5 }), 200_000);
+  });
+});
+
+// The anthropic-beta header carries the tier in its id (context-1m-2025-08-07).
+// Persisting only the boolean interpretation of it means a future context-400k-*
+// arrives as a silent false, and a rebuild cannot re-derive a window the live
+// path knew (the header is not in _req.json).
+describe('anthropic-beta context-* persistence', () => {
+  const { getMaxContext, extractContextBeta, contextBetaWindow } = require('../server/config');
+  const pricing = require('../server/pricing');
+  const origGetModelContext = pricing.getModelContext;
+
+  afterEach(() => { pricing.getModelContext = origGetModelContext; });
+
+  it('keeps only window-shaped context betas, not everything prefixed context-', () => {
+    assert.equal(
+      extractContextBeta('oauth-2025-04-20,context-1m-2025-08-07,fine-grained-tool-streaming-2025-05-14'),
+      'context-1m-2025-08-07',
+    );
+    // context-management-* is the context-EDITING beta and ships on real traffic.
+    // It carries no window, so it must not land in a window field.
+    assert.equal(extractContextBeta('context-management-2025-06-27'), null);
+    assert.equal(extractContextBeta('context-management-2025-06-27,context-1m-2025-08-07'), 'context-1m-2025-08-07');
+    assert.equal(extractContextBeta('oauth-2025-04-20'), null);
+    assert.equal(extractContextBeta(''), null);
+    assert.equal(extractContextBeta(undefined), null);
+  });
+
+  it('reads the tier out of the beta id instead of tabulating it', () => {
+    assert.equal(contextBetaWindow('context-1m-2025-08-07'), 1_000_000);
+    assert.equal(contextBetaWindow('context-400k-2026-01-01'), 400_000);
+    assert.equal(contextBetaWindow('context-1m-2025-08-07,context-400k-2026-01-01'), 1_000_000);
+    assert.equal(contextBetaWindow('context-huge-2026'), null);
+    assert.equal(contextBetaWindow(null), null);
+  });
+
+  it('honours a non-1M tier only when the model can serve it', () => {
+    pricing.getModelContext = (m) => (m === 'claude-mid' ? 409_600 : 200_000);
+    assert.equal(getMaxContext('claude-mid', null, { ctxBeta: 'context-400k-2026-01-01' }), 400_000);
+    assert.equal(getMaxContext('claude-small', null, { ctxBeta: 'context-400k-2026-01-01' }), 200_000);
+  });
+
+  it('the raw header alone reproduces the 1M window', () => {
+    // What restore and rebuild get to work with once the header is on disk.
+    pricing.getModelContext = (m) => (m === 'claude-opus-5' ? 1_000_000 : null);
+    assert.equal(getMaxContext('claude-opus-5', null, { ctxBeta: 'context-1m-2025-08-07' }), 1_000_000);
+    assert.equal(getMaxContext('claude-opus-5', null, {}), 200_000);
+  });
+
+  it('GUARD: a header on a model that cannot serve 1M is still ignored', () => {
+    pricing.getModelContext = (m) => (m === 'claude-haiku-4-5' ? 200_000 : null);
+    assert.equal(getMaxContext('claude-haiku-4-5', null, { ctxBeta: 'context-1m-2025-08-07' }), 200_000);
+  });
+});

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -877,6 +877,10 @@ describe('modelSupports1M — capability comes from LiteLLM, regex is the offlin
     assert.equal(modelSupports1M('claude-sonnet-4-5'), true);
     assert.equal(modelSupports1M('claude-sonnet-4-5-20250929'), true);
     assert.equal(modelSupports1M('claude-sonnet-4-9'), false, 'an unknown minor is not assumed 1M offline');
+    // A shipping model must be in the offline list, not left to LiteLLM: on a fresh
+    // install the cache does not exist yet, and sonnet-4-6 is a current model here
+    // (default-rates, weather baselines, the intercept model picker).
+    assert.equal(modelSupports1M('claude-sonnet-4-6'), true);
     // …and LiteLLM can still add it when it knows better (union, never deny).
     pricing.getModelContext = (m) => (m === 'claude-sonnet-4-9' ? 1_000_000 : null);
     assert.equal(modelSupports1M('claude-sonnet-4-9'), true);

--- a/test/entry.test.js
+++ b/test/entry.test.js
@@ -18,6 +18,7 @@ test('G1: INDEX_FIELDS preserves every legacy field name and order, then appends
   assert.deepEqual(INDEX_FIELDS.slice(0, LEGACY_INDEX_FIELDS.length), LEGACY_INDEX_FIELDS);
   assert.deepEqual(INDEX_FIELDS.slice(LEGACY_INDEX_FIELDS.length), [
     'agentId','userEmail','team','agentType','localDate','tz','duplicateToolCalls',
+    'ctxBeta',
   ]);
 });
 

--- a/test/importer.test.js
+++ b/test/importer.test.js
@@ -16,6 +16,10 @@ const store = require('../server/store');
 const config = require('../server/config');
 const sessionIdx = require('../server/session-index');
 const { scanAndImport, parseSessionFile, parseCodexSessionFile, slugToProject, tsToId } = require('../server/importer');
+// The importer now derives maxContext, so these assertions depend on the LiteLLM
+// capability table. It is read from a package-relative pricing-cache.json, which
+// CCXRAY_HOME does not isolate — pin it (docs/testing.md, ADR 0015 R4 class).
+require('../server/pricing').__setContextTableForTests(null);
 
 const INDEX_PATH = path.join(tmpHome, 'logs', 'index.ndjson');
 
@@ -144,6 +148,34 @@ describe('importer', () => {
       assert.strictEqual(entries[0].tokens.output, 200);
       assert.strictEqual(entries[0].model, 'claude-sonnet-4-5-20250514');
       assert.strictEqual(entries[0].stopReason, 'end_turn');
+    });
+
+    it('writes maxContext, and observation alone recovers a window above the default (fail-on-old)', async () => {
+      // The Codex importer has written maxContext since #384; the Claude one wrote
+      // nothing, so every reader fell back to 200K — a 1M session rendered as
+      // phantom context pressure. Claude transcripts declare no window and never
+      // record the anthropic-beta header, so the only evidence is the observation.
+      const sessionDir = path.join(importDir, 'test-project');
+      fs.mkdirSync(sessionDir, { recursive: true });
+
+      const small = path.join(sessionDir, 'sess-window-small.jsonl');
+      fs.writeFileSync(small, [
+        makeUser('hi'),
+        makeAssistant({ timestamp: '2026-07-15T10:31:00.000Z', input: 1000, cacheRead: 1000, cacheCreate: 0 }),
+      ].join('\n'));
+      const under = await parseSessionFile(small, 'test-project');
+      assert.strictEqual(under[0].maxContext, 200_000, 'default window when nothing proves otherwise');
+      assert.strictEqual(under[0].tokens.contextWindow, 200_000);
+
+      const big = path.join(sessionDir, 'sess-window-big.jsonl');
+      fs.writeFileSync(big, [
+        makeUser('hi'),
+        makeAssistant({ timestamp: '2026-07-15T10:32:00.000Z', input: 10, cacheRead: 260_000, cacheCreate: 0 }),
+      ].join('\n'));
+      const over = await parseSessionFile(big, 'test-project');
+      assert.strictEqual(over[0].maxContext, 1_000_000, '260K of context cannot fit a 200K window');
+      assert.strictEqual(over[0].tokens.contextWindow, 1_000_000);
+      assert.ok(over[0].tokens.contextPct < 100, 'context% stops exceeding its own denominator');
     });
 
     it('carries the upstream message id as responseId for #329/#333 merge', async () => {

--- a/test/index-fields.e2e.test.js
+++ b/test/index-fields.e2e.test.js
@@ -72,8 +72,11 @@ const GOLDEN_LEGACY_LINES = {
     '{"id":"<volatile>","ts":"<volatile>","sessionId":"index-fields-ws-session","provider":"openai","agent":"codex","model":"gpt-5.5","msgCount":1,"toolCount":0,"toolCalls":{},"isSubagent":false,"sessionInferred":false,"cwd":"/tmp/index-fields-ws","isSSE":false,"usage":null,"cost":"<volatile>","maxContext":400000,"responseMetadata":{"transport":"websocket","capture":"transport-only","endpoint":"/v1/responses","frameCounts":{"clientToUpstream":1,"upstreamToClient":1},"byteCounts":{"clientToUpstream":179,"upstreamToClient":50},"close":{"side":"client","code":1000,"reason":"test complete"},"error":null},"stopReason":"test complete","title":"hello","thinkingDuration":null,"toolFail":false,"elapsed":"<volatile>","status":101,"receivedAt":"<volatile>","sysHash":"b54cd80f54c1","toolsHash":null,"coreHash":"2db6420c3d64","agentKey":"default","agentLabel":"Codex Default","toolSources":{},"turnToolCallIds":{},"turnToolResults":[]}',
   'rebuild orphan':
     '{"id":"<volatile>","ts":"<volatile>","sessionId":"66666666-6666-4666-8666-666666666666","provider":"anthropic","agent":"claude","model":"claude-sonnet-4-6","msgCount":1,"toolCount":0,"toolCalls":{},"skillCalls":{},"isSubagent":false,"sessionInferred":false,"cwd":"/tmp/index-fields-e2e","isSSE":false,"usage":null,"cost":"<volatile>","maxContext":200000,"stopReason":"","title":"INDEX_FIELDS_REBUILD_SOURCE","thinkingDuration":null,"toolFail":false,"elapsed":"<volatile>","status":null,"receivedAt":"<volatile>","sysHash":"5feeb813d8f1","toolsHash":null,"coreHash":null,"agentKey":null,"agentLabel":null,"convId":"ca0026d0","responseId":"msg_INDEX_FIELDS_REBUILD_SOURCE","turnToolCalls":{},"turnToolResults":[]}',
+  // maxContext joins the imported line: the Claude importer derives a window the
+  // same way the live path does, so a reader no longer has to assume 200K for
+  // every imported turn (the Codex importer has done this since #384).
   'importer':
-    '{"id":"<volatile>","ts":"<volatile>","sessionId":"sess-1","provider":"anthropic","model":"claude-sonnet-4-5-20250514","sessionInferred":false,"cwd":"/tmp/index-fields-import","isSSE":false,"usage":{"input_tokens":5000,"output_tokens":500,"cache_read_input_tokens":1000,"cache_creation_input_tokens":2000},"cost":"<volatile>","stopReason":"end_turn","title":"imported turn","elapsed":"<volatile>","status":200,"receivedAt":"<volatile>","imported":true,"importSource":"claude-code","responseId":"msg_import_fields_1","turnToolCallIds":{},"turnToolResults":[]}',
+    '{"id":"<volatile>","ts":"<volatile>","sessionId":"sess-1","provider":"anthropic","model":"claude-sonnet-4-5-20250514","sessionInferred":false,"cwd":"/tmp/index-fields-import","isSSE":false,"usage":{"input_tokens":5000,"output_tokens":500,"cache_read_input_tokens":1000,"cache_creation_input_tokens":2000},"cost":"<volatile>","maxContext":200000,"stopReason":"end_turn","title":"imported turn","elapsed":"<volatile>","status":200,"receivedAt":"<volatile>","imported":true,"importSource":"claude-code","responseId":"msg_import_fields_1","turnToolCallIds":{},"turnToolResults":[]}',
 };
 
 function normalizedLegacyLine(obj) {
@@ -196,6 +199,11 @@ function isolatedEnv(home, overrides = {}, { identity = 'partial' } = {}) {
     ...base,
     ...overrides,
     CCXRAY_HOME: home,
+    // Window resolution reads a package-relative pricing-cache.json that
+    // CCXRAY_HOME does not isolate; pin it so a spawned server derives windows
+    // from the same input on CI and on a machine that has run ccxray for real.
+    // See docs/testing.md.
+    CCXRAY_PRICING_CACHE: '/nonexistent/ccxray-pricing-cache.json',
     RESTORE_DAYS: '0',
     CCXRAY_IMPORT_DISABLE: '1',
     BROWSER: 'none',

--- a/test/response-merge.test.js
+++ b/test/response-merge.test.js
@@ -112,6 +112,23 @@ describe('store.mergeByResponseId (#333)', () => {
     assert.ok(!mergeByResponseId([n1, n2])[0].beta1m, 'no beta1m anywhere → none fabricated');
   });
 
+  it('carries the raw context-* beta across a merge, not just its interpretation (fail-on-old)', () => {
+    // The merge already ORs beta1m. Keeping the conclusion while dropping the
+    // observation it was drawn from loses the more fundamental fact — and with it
+    // any tier the boolean cannot express — e.g. a canonical copy written before the
+    // header was observed on a later copy of the same response.
+    const canonNoHeader = { id: 'p1', responseId: 'R9', receivedAt: 1, usage: { output_tokens: 5 } };
+    const laterSawHeader = { id: 'p2', responseId: 'R9', receivedAt: 2, beta1m: true, ctxBeta: 'context-1m-2025-08-07' };
+    const out = mergeByResponseId([canonNoHeader, laterSawHeader]);
+    assert.equal(out[0].id, 'p1', 'canonical is the earliest copy, which had no header of its own');
+    assert.equal(out[0].ctxBeta, 'context-1m-2025-08-07');
+    assert.equal(out[0].beta1m, true);
+    // Never overwrites an observation the canonical already has.
+    const a = { id: 'a1', responseId: 'R10', receivedAt: 1, ctxBeta: 'context-1m-2025-08-07' };
+    const b = { id: 'b1', responseId: 'R10', receivedAt: 2, ctxBeta: 'context-400k-2026-01-01' };
+    assert.equal(mergeByResponseId([a, b])[0].ctxBeta, 'context-1m-2025-08-07');
+  });
+
   it('#420 codex R2 M2: on equal usage a priced cost beats an unpriced canonical', () => {
     // Chained-proxy shape: an outdated hop has no rate (unknown, cost null),
     // the updated hop priced the same response. Identical usage tuples tied the

--- a/test/restore.test.js
+++ b/test/restore.test.js
@@ -102,6 +102,11 @@ describe('restoreFromLogs — maxContext re-inference for legacy entries', () =>
   let realRestoreDays;
 
   before(async () => {
+    // Pin the LiteLLM capability table. It is read from a package-relative
+    // pricing-cache.json, which CCXRAY_HOME does not isolate, so without this the
+    // same assertion resolves differently on a machine that has run the server
+    // than on CI (docs/testing.md, ADR 0015 R4 class).
+    require('../server/pricing').__setContextTableForTests(null);
     realStorage = config.storage;
     realRestoreDays = config.RESTORE_DAYS;
     // Bypass the RESTORE_DAYS date-window filter. The synthetic entries below
@@ -150,6 +155,75 @@ describe('restoreFromLogs — maxContext re-inference for legacy entries', () =>
       model: 'claude-opus-4-7',
       usage: { input_tokens: 50000 },
       maxContext: 1_000_000, // originally detected correctly via [1m] in system
+      isSSE: true, status: 200, receivedAt: 1779000000000,
+    }) + '\n');
+
+    await restoreFromLogs();
+    const entry = store.entries.find(e => e.id === id);
+    assert.ok(entry);
+    assert.equal(entry.maxContext, 1_000_000);
+  });
+
+  it('keeps a stored 1M for a 1M-capable model the old regex did not list (fail-on-old)', async () => {
+    store.entries.length = 0;
+    const id = '2026-05-14T14-15-00-000';
+    // Write path and heal path must share one capability predicate. While the
+    // regex lacked claude-opus-5, trustStored was false for it, so restore
+    // discarded the 1M the proxy had just written from the beta header — every
+    // restart silently reverted the session to a 200K denominator.
+    await config.storage.appendIndex(JSON.stringify({
+      id, ts: '14:15:00', sessionId: 'sess-opus5',
+      provider: 'anthropic', agent: 'claude',
+      model: 'claude-opus-5',
+      usage: { input_tokens: 50000 },
+      maxContext: 1_000_000, // written live from anthropic-beta context-1m-*
+      beta1m: true,
+      isSSE: true, status: 200, receivedAt: 1779000000000,
+    }) + '\n');
+
+    await restoreFromLogs();
+    const entry = store.entries.find(e => e.id === id);
+    assert.ok(entry);
+    assert.equal(entry.maxContext, 1_000_000);
+  });
+
+  it('re-derives a 1M window from the persisted context-* beta with no marker (fail-on-old)', async () => {
+    store.entries.length = 0;
+    const id = '2026-05-14T14-20-00-000';
+    // The header is not in _req.json, so before it was persisted the heal pass
+    // could only re-infer from model + usage: a 1M session under 200K of usage
+    // and without the "[1m]" system marker had no way back to its real window.
+    await config.storage.appendIndex(JSON.stringify({
+      id, ts: '14:20:00', sessionId: 'sess-ctxbeta',
+      provider: 'anthropic', agent: 'claude',
+      model: 'claude-opus-4-7',
+      usage: { input_tokens: 50000 },
+      ctxBeta: 'context-1m-2025-08-07',
+      isSSE: true, status: 200, receivedAt: 1779000000000,
+    }) + '\n');
+
+    await restoreFromLogs();
+    const entry = store.entries.find(e => e.id === id);
+    assert.ok(entry);
+    assert.equal(entry.maxContext, 1_000_000);
+  });
+
+  it('keeps an attested 1M when the capability data is unavailable (fail-on-old)', async () => {
+    store.entries.length = 0;
+    const id = '2026-05-14T14-25-00-000';
+    // A model known to be 1M-capable only through LiteLLM: with no pricing cache
+    // (fresh install, another machine, a renamed upstream key) the capability
+    // lookup returns nothing. `beta1m` on the line is a write-time attestation —
+    // the header was present AND the gate accepted it — so absence of today's
+    // capability data must not act as a deny and shrink the window. Without this
+    // the restart-erases-the-fix failure returns through a new door.
+    await config.storage.appendIndex(JSON.stringify({
+      id, ts: '14:25:00', sessionId: 'sess-attested',
+      provider: 'anthropic', agent: 'claude',
+      model: 'claude-unlisted-9',
+      usage: { input_tokens: 50000 },
+      maxContext: 1_000_000,
+      beta1m: true,
       isSSE: true, status: 200, receivedAt: 1779000000000,
     }) + '\n');
 

--- a/test/wire-parsers-build-entry.test.js
+++ b/test/wire-parsers-build-entry.test.js
@@ -171,6 +171,30 @@ test('#339: anthropic beta1m persists to index line only when true (add-only, mo
   assert.equal(nonCapable.beta1m, undefined, 'beta1m not persisted for a non-1M-capable model even with the header');
 });
 
+test('the raw context-* beta persists alongside its interpretation (fail-on-old)', () => {
+  // beta1m is what ccxray concluded; ctxBeta is what it observed. Persisting the
+  // observation keeps a tier we do not interpret yet legible, and lets a restore
+  // re-derive the window without the header being on the wire again. Unlike
+  // beta1m it is NOT gated on capability — an observation is not a claim.
+  assert.ok(INDEX_FIELDS.includes('ctxBeta'), 'ctxBeta is an index field');
+  const base = {
+    provider: 'anthropic', transport: 'sse',
+    parsedBody: { model: 'claude-haiku-4-5', system: [{ type: 'text', text: 'x' }], messages: [{ role: 'user', content: 'go' }] },
+    proxyRes: { statusCode: 200 }, usage: { input_tokens: 10, output_tokens: 10 },
+    sessionId: 's1', sessionInferred: false, stopReason: 'end_turn',
+  };
+  const seen = getParser('anthropic').buildEntryFields({ ...base, beta1m: true, ctxBeta: 'context-1m-2025-08-07' });
+  assert.equal(seen.ctxBeta, 'context-1m-2025-08-07', 'observation kept even on a model that cannot serve it');
+  assert.equal(seen.beta1m, undefined, 'the conclusion is still gated on capability');
+  const line = JSON.parse(buildIndexLine({ id: 'C', ts: 't', status: 200, isSSE: true, receivedAt: 1, ...seen }));
+  assert.equal(line.ctxBeta, 'context-1m-2025-08-07', 'ctxBeta persisted to the index line');
+
+  const none = getParser('anthropic').buildEntryFields({ ...base, beta1m: false });
+  assert.equal(none.ctxBeta, undefined, 'no ctxBeta field when the header was absent');
+  const bare = JSON.parse(buildIndexLine({ id: 'D', ts: 't', status: 200, isSSE: true, receivedAt: 1, ...none }));
+  assert.ok(!('ctxBeta' in bare), 'index line carries no ctxBeta key when the header was absent');
+});
+
 test('anthropic convId: stable across turns of one conversation, distinct across instances, null for no text', () => {
   const base = { provider: 'anthropic', transport: 'sse', proxyRes: { statusCode: 200 }, usage: { input_tokens: 1, output_tokens: 1 }, sessionId: 's1' };
   const mk = (messages) => getParser('anthropic').buildEntryFields({ ...base, parsedBody: { model: 'claude-sonnet-4-6', messages } });


### PR DESCRIPTION
A Claude Opus 5 session with a 1M window rendered as **76% context pressure** while it was actually at ~13%. Three independent causes, all in how the context% denominator is derived.

## What was wrong

**1. The capability gate was a hand-maintained list, wrong in both directions.**

`SUPPORTS_1M` lacked `claude-opus-5` entirely, and its bare `opus-4` prefix claimed 1M for `claude-opus-4-5`, which serves 200K — the second one hides real pressure, the more dangerous direction.

| model | before (with the 1M header) | actual |
|---|---|---|
| claude-opus-5 | 200K | **1M** |
| claude-opus-4-5 | **1M** | 200K |
| claude-haiku-4-5 | 200K | 200K |

The gate exists for a measured reason: Claude Code sends `anthropic-beta: context-1m-*` on **every** request, including haiku title-gen turns that genuinely run 200K. The header alone cannot widen a window — but the capability data does not have to be hand-written. ccxray already downloads LiteLLM's context table (4,205 entries, refreshed daily).

`modelSupports1M()` is now the **union** of the list and that table. **LiteLLM may ADD, never DENY**: its `max_input_tokens` reports capability for some models (`claude-fable-5` → 1M) and the default serving window for others (`claude-sonnet-4-5` → 200K, though Sonnet 4.5 serves 1M under the beta), so a capability-decides gate silently demoted a model the list had right. Removing a wrong entry stays a manual edit — no upstream datum is trusted to mean "cannot do 1M".

**2. The header was never persisted — only the boolean conclusion drawn from it.**

`ctxBeta` (add-only index field) now stores the `context-*` entries of `anthropic-beta` verbatim, shape-filtered so the context-*editing* beta cannot land in a window field. The tier is **parsed** from the beta id, so a future `context-400k-*` is legible without a code change. `beta1m` stays as the capability-gated interpretation; the two may legitimately disagree, and reading `ctxBeta` presence as "this is 1M" would reintroduce the #211 over-claim.

**3. The observation floor jumped to a hardcoded 1M.**

It now climbs to the smallest tier that covers the observation, bounded by capability (LiteLLM lists real Claude tiers at 80K/100K/128K/200K/**409,600**/1M). Non-Claude providers are still never bumped: some report `input_tokens` inclusive of cached tokens, so an un-normalized sum can exceed a window that is not wrong.

## Two trust seams closed

- **restore's `trustStored`** shares the capability predicate with the write gate — but that predicate's input is a table refreshed daily, so agreement in code is not agreement in time. It now also accepts a persisted `beta1m` (a write-time attestation that the header was present and the gate accepted it), so a missing cache or a renamed upstream key cannot act as a deny and shrink an attested 1M on restart.
- **The Claude importer wrote no `maxContext` at all** — 750 of 773 anthropic turns in the real corpus — so every reader assumed 200K. It now derives one the same way the live path does. Claude transcripts declare no window and never record the header, so the only evidence there is the observation.

## Verification

- fail-on-old differential tests for every behavioural change; guards that pass on both sides are labelled as guards.
- **Real corpus, retroactively: zero turns change.** The bug prevented the signal from ever being persisted, so there is nothing on disk to re-derive from — the fix is forward-looking, and saying otherwise would be false.
- **Counterfactual** (same turns, the header as it actually rode the wire): 161 opus-5 turns 200K→1M, 9/32 sessions change window, **7 sessions flip red→green**.
- **Importer**: 332/750 imported turns gain a larger window, 7/31 sessions change, and **7 sessions stop rendering above 100%** (148%, 239%, 120%, …).
- 25-case edge-case sweep over declaration / capability-data-quality / observation.
- Full suite **2018 pass / 0 fail**, run both with and without a pricing cache present.

## Docs

**ADR 0013 is amended, not extended.** Its Decision line reads "persist `beta1m` (the fact)" — measured against real traffic it never was a fact; it is a conclusion drawn from an observation plus a capability judgement. The amendment records the union rule, the parsed tier, the time-monotonicity requirement, and that the display/classification boundary is preserved while only future inputs change (no `WEATHER_REV` bump needed).

`docs/testing.md` gains the pricing-cache isolation rule: it is package-relative and therefore outside `CCXRAY_HOME` — the ADR 0015 R4 / #407 class — and the mechanisms for pinning it (`CCXRAY_PRICING_CACHE`, `pricing.__setContextTableForTests`) are wired into the tests that assert window values.

## Follow-ups deliberately not in this PR

- No startup warning when the hand-narrowed list disagrees with LiteLLM (the repo has this idiom for pricing lag overrides).
- `inferMaxContext` pins denominator = numerator when an observation exceeds capability, while the non-Claude branch argues a visible >100% is the honest direction; the two philosophies should be reconciled.
- The counterfactual numbers are pinned to an unrecorded LiteLLM snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGjh8PNvctE95PQFBCgXqc

---

## Review status — second review ran on grok, not codex

The repo's rule is that a non-trivial PR passes a second review before merge. **codex could not run**: the account's weekly quota is exhausted, and the CLI rejects every model with `invalid_request_error … not supported when using Codex with a ChatGPT account` while failing to refresh its model catalogue. At the author's direction the review was run on **grok** (`grok-4.6-build`) instead. Nothing here is codex-approved; the merge hook still asks for codex evidence, so this PR is deliberately not merged from the CLI.

### grok round 1 — two findings accepted, both fixed in `09acb51`

1. **`claude-sonnet-4-6` fell out of the offline capability list.** Narrowing the `sonnet-4` prefix (so it stops claiming 1M for every future minor) also dropped a model this repo ships support for — default-rates, weather baselines, the intercept model picker. LiteLLM lists it at 1M so it resolved correctly wherever a cache existed, but **on a fresh install the cache does not exist yet** and the window fell back to 200K with the header present: the same failure this PR exists to fix, one model over. Now enumerated explicitly; `claude-sonnet-4-9` still does not match.
2. **The response-id merge kept the interpretation and dropped the observation.** `mergeByResponseId` ORs `beta1m` but had no rule for `ctxBeta`, so a canonical copy that never saw the header inherited the boolean while the raw header — the more fundamental fact — was lost. Filled first-wins.

Rejected from the same round, with reasons: the claim that the marker branch still calls the old regex (it does not — it was changed in this PR); that `trustStored` evaluates false for a persisted 1M (it short-circuits on `beta1m === true`); that non-Claude models should be bumped by observation (deliberate — an un-normalized usage sum can exceed a window that is not wrong); and that `ctxBeta` should be surfaced through `summarizeEntry` (the client derives provenance from `beta1m`, so nothing consumes it yet).

### grok round 2 — clean

Both fixes confirmed correct and complete, no new defects, and the first-wins fill endorsed over union or last-wins: *"Union would invent a header neither copy sent. Last-wins would let a later or imported copy overwrite the preferred observation."*

### Earlier design review (a different model family, before the PR was opened)

Three defects, all fixed before this branch was pushed: restore letting absence of capability data act as a deny; the `context-` whitelist being prefix-matched rather than shape-matched (it captured `context-management-*`); and an earlier draft letting LiteLLM decide, which silently demoted `claude-sonnet-4-5`.

### Live differential — same model, same 1M flag, same prompt, both builds

| | main | this branch |
|---|---|---|
| what Claude Code printed | `24.1% (48,241 / 200,000)` | `4.8% (48,242 / 1,000,000)` |
| persisted `maxContext` | 200000 | 1000000 |
| persisted `beta1m` | absent | `true` |
| persisted `ctxBeta` | absent | `context-1m-2025-08-07` |

A restart's restore pass preserves the 1M.

### Known environment failure, not from this branch

`test/index-fields.e2e.test.js` — "imports a claude-code transcript…" fails on this machine with `expected 1 index lines, found 0`. It reproduces identically on unmodified `main` (df3f1d6) with the same command, so it is not a regression here. CI is green on all three jobs.
