### PR TITLE
feat(context): mark a context% whose denominator is assumed

### DIFF
--- a/docs/decisions/0013-beta1m-persist-session-window-derive.md
+++ b/docs/decisions/0013-beta1m-persist-session-window-derive.md
@@ -349,3 +349,14 @@ therefore outside `CCXRAY_HOME` isolation** — the ADR 0015 R4 class. `CCXRAY_P
 overrides the path and `pricing.__setContextTableForTests()` injects a table; a test that
 asserts window behaviour must use one of them or stub `getModelContext`, or it silently
 reads the developer's cache. See `docs/testing.md`.
+### Provenance is derived, never stored
+
+`sessionCtxWindowSource(sid)` returns `declared | observed | default`, and the session
+card marks an assumed denominator (`60% of 200K?` + tooltip) while leaving an evidenced
+one clean. It is computed at render time from persisted facts, exactly as this ADR
+requires of `sessionCtxWindow` — storing it would relaunder an interpretation as a fact.
+
+`declared` is keyed on `beta1m`, NOT on `ctxBeta` presence. Claude Code sends the header
+on every request on a beta account, so keying on presence would mark every session
+measured and silence the marker in precisely the case it exists for: the next unlisted
+1M model rendering against an assumed 200K.

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -10,6 +10,52 @@ let entryCount = 0;
 // session that never showed a 1M signal stays 200K (#211 over-latch guard). Classification
 // (severity / isCompacted / lane placement) deliberately keeps raw per-turn maxContext —
 // this is display only. See docs/decisions/0013-beta1m-persist-session-window-derive.md
+// Where the window above came from, so a display site can tell a measured
+// denominator from an assumed one. Three states, in descending strength:
+//   'declared' — a turn carried the anthropic-beta context-* header (beta1m).
+//   'observed' — no declaration, but a turn's own context exceeded the default,
+//                which is physical proof of a larger window.
+//   'default'  — no evidence at all; 200K is an assumption, and a context% built
+//                on it is an assumption too. Sites that assert pressure (colour,
+//                "compact soon") must not treat this like the other two.
+// INVARIANT: derived at render time from persisted facts, never stored — storing
+// it would relaunder an interpretation as a fact (ADR 0013). A display site that
+// asserts context pressure (colour, "compact soon") must consult this before
+// treating a percentage as measured. See docs/decisions/0013-*.
+function sessionCtxWindowSource(sid) {
+  const DEF = (typeof DEFAULT_MAX_CTX !== 'undefined' ? DEFAULT_MAX_CTX : 200000);
+  let declared = false, observed = false, win = 0;
+  for (let i = 0; i < allEntries.length; i++) {
+    const e = allEntries[i];
+    if (e.sessionId !== sid || e.isSubagent) continue;
+    // `beta1m` only — NOT bare `ctxBeta`. The header rides every request on a beta
+    // account, including turns whose declaration the capability gate refused
+    // (haiku title-gen, a model the gate does not know yet). Treating its mere
+    // presence as a declaration would mark those sessions measured and suppress
+    // the marker in exactly the case it exists for: the next unlisted model
+    // rendering "76% of 200K" when it is really a 1M session. beta1m is the
+    // declaration that actually resolved the window.
+    if (e.beta1m === true) declared = true;
+    if ((e.maxContext || 0) > win) win = e.maxContext;
+    const u = e.usage;
+    if (u) {
+      const used = (u.input_tokens || 0) + (u.cache_creation_input_tokens || 0) + (u.cache_read_input_tokens || 0);
+      if (used > DEF) observed = true;
+    }
+  }
+  const sess = sessionsMap.get(sid);
+  if (sess) {
+    if (sess.beta1m === true) declared = true;
+    if ((sess.maxContext || 0) > win) win = sess.maxContext;
+  }
+  if (declared) return 'declared';
+  if (observed) return 'observed';
+  // A fossil above the default with neither signal in view: a turn we no longer
+  // hold proved it. Treat as observed rather than assumed — the evidence existed.
+  if (win > DEF) return 'observed';
+  return 'default';
+}
+
 function sessionCtxWindow(sid) {
   let win = 0, has1m = false;
   for (let i = 0; i < allEntries.length; i++) {
@@ -1470,8 +1516,13 @@ function renderSessionItem(sess, sid, sessEl) {
   // Context window size formatting (e.g., "1M", "200K"). #339: fold the per-session
   // window at render time (not the stale incremental value) so all turns show one denominator.
   let windowSizeStr = '';
+  let windowAssumed = false;
   if (sess.latestMainCtxUsed) {
     const w = sessionCtxWindow(sid);
+    // An assumed denominator makes the percentage next to it an assumption too.
+    // Mark the denominator rather than the number: the tokens are measured, only
+    // what they are divided by is a guess.
+    windowAssumed = sessionCtxWindowSource(sid) === 'default';
     if (w >= 1000000) {
       windowSizeStr = Math.round(w / 1000000) + 'M';
     } else if (w >= 1000) {
@@ -1524,8 +1575,10 @@ function renderSessionItem(sess, sid, sessEl) {
                                        : 'ctx-alert-dim';
   }
   const ctxAlertHtml = ctxPct > 0
-    ? '<span class="ctx-alert ' + ctxPctClass + '">' + Math.round(ctxPct) + '%' +
-      (windowSizeStr ? ' <span style="color:var(--dim)">' + 'of ' + windowSizeStr + '</span>' : '') +
+    ? '<span class="ctx-alert ' + ctxPctClass + '"' +
+      (windowAssumed ? ' title="No window evidence for this session — ' + windowSizeStr + ' assumed, so this percentage is an upper bound. A turn that declares the context-1m header, or one that exceeds the default, resolves it."' : '') +
+      '>' + Math.round(ctxPct) + '%' +
+      (windowSizeStr ? ' <span style="color:var(--dim)">' + 'of ' + windowSizeStr + (windowAssumed ? '?' : '') + '</span>' : '') +
       '</span>'
     : '';
   // Thin ctx bar with auto-compact reference line; shown only once session has real context.

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -24,7 +24,11 @@ let entryCount = 0;
 // treating a percentage as measured. See docs/decisions/0013-*.
 function sessionCtxWindowSource(sid) {
   const DEF = (typeof DEFAULT_MAX_CTX !== 'undefined' ? DEFAULT_MAX_CTX : 200000);
-  let declared = false, observed = false, win = 0;
+  // Read the window that is actually rendered, then ask what produced it. Deriving
+  // this from the raw signals instead let the two disagree: a turn whose usage
+  // exceeded 200K reported `observed` while the fold still returned 200K, so the
+  // marker went quiet on a denominator the data had already disproved.
+  const win = sessionCtxWindow(sid);
   for (let i = 0; i < allEntries.length; i++) {
     const e = allEntries[i];
     if (e.sessionId !== sid || e.isSubagent) continue;
@@ -35,25 +39,15 @@ function sessionCtxWindowSource(sid) {
     // the marker in exactly the case it exists for: the next unlisted model
     // rendering "76% of 200K" when it is really a 1M session. beta1m is the
     // declaration that actually resolved the window.
-    if (e.beta1m === true) declared = true;
-    if ((e.maxContext || 0) > win) win = e.maxContext;
-    const u = e.usage;
-    if (u) {
-      const used = (u.input_tokens || 0) + (u.cache_creation_input_tokens || 0) + (u.cache_read_input_tokens || 0);
-      if (used > DEF) observed = true;
-    }
+    if (e.beta1m === true) return 'declared';
   }
-  const sess = sessionsMap.get(sid);
-  if (sess) {
-    if (sess.beta1m === true) declared = true;
-    if ((sess.maxContext || 0) > win) win = sess.maxContext;
-  }
-  if (declared) return 'declared';
-  if (observed) return 'observed';
-  // A fossil above the default with neither signal in view: a turn we no longer
-  // hold proved it. Treat as observed rather than assumed — the evidence existed.
-  if (win > DEF) return 'observed';
-  return 'default';
+  if (sessionsMap.get(sid)?.beta1m === true) return 'declared';
+  // A window that differs from the default came from a real per-turn derivation —
+  // a fossil above it (the header at write time, or the usage hatch) or a smaller
+  // model-specific capability below it. Exactly the default is indistinguishable
+  // from the fallback that produces it when nothing was derived at all, so it is
+  // reported as assumed even when some turn happens to carry it.
+  return win === DEF ? 'default' : 'observed';
 }
 
 function sessionCtxWindow(sid) {

--- a/test/session-ctx-window.test.js
+++ b/test/session-ctx-window.test.js
@@ -59,6 +59,7 @@ function loadCtx(includeEntryRendering) {
     this.allEntries = allEntries;
     this.sessionsMap = sessionsMap;
     this.sessionCtxWindow = sessionCtxWindow;
+    this.sessionCtxWindowSource = sessionCtxWindowSource;
     this.turnCtxWindow = turnCtxWindow;
     ${includeEntryRendering ? `
       this.mergeColdSessions = mergeColdSessions;
@@ -237,5 +238,57 @@ describe('#377 recomputeSessionStats — truncated client weather uses the serve
     assert.equal(sess.beta1m, true);
     assert.equal(sess.maxContext, 1000000);
     assert.equal(sess.weather, weather, 'an unchanged window does not trigger recomputation');
+  });
+});
+
+// A window is either measured or assumed, and the display cannot tell the
+// difference from the number alone: 200K with no evidence and 200K proven by a
+// declaration render identically, while only the first makes its percentage an
+// assumption too. See ADR 0013 — derived at render time, never stored.
+describe('sessionCtxWindowSource — measured vs assumed denominator', () => {
+  let ctx;
+  beforeEach(() => { ctx = loadCtx(false); });
+
+  const turn = (over) => ({
+    sessionId: 's1', isSubagent: false, maxContext: 200000,
+    usage: { input_tokens: over ? 260000 : 1000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+  });
+
+  it('reports default when nothing proves the window', () => {
+    ctx.allEntries.push(turn(false));
+    assert.equal(ctx.sessionCtxWindowSource('s1'), 'default');
+    assert.equal(ctx.sessionCtxWindow('s1'), 200000);
+  });
+
+  it('reports declared only when the declaration resolved the window', () => {
+    ctx.allEntries.push({ ...turn(false), beta1m: true, maxContext: 1000000 });
+    assert.equal(ctx.sessionCtxWindowSource('s1'), 'declared');
+  });
+
+  it('a header the gate refused must NOT count as declared (fail-on-old)', () => {
+    // The header rides every request on a beta account, including turns whose
+    // declaration was refused — a haiku title-gen turn, or the next model the
+    // gate does not know yet. If bare presence counted, the marker would go
+    // quiet in exactly the case it exists for: an unlisted 1M model rendering
+    // its usage against an assumed 200K.
+    ctx.allEntries.push({ ...turn(false), ctxBeta: 'context-1m-2025-08-07' });
+    assert.equal(ctx.sessionCtxWindowSource('s1'), 'default');
+  });
+
+  it('reports observed when a turn exceeded the default on its own', () => {
+    ctx.allEntries.push(turn(true));
+    assert.equal(ctx.sessionCtxWindowSource('s1'), 'observed');
+  });
+
+  it('treats a fossil above the default as observed, not assumed', () => {
+    // The turn that proved it may have aged out of allEntries; the evidence existed.
+    ctx.allEntries.push({ ...turn(false), maxContext: 1000000 });
+    assert.equal(ctx.sessionCtxWindowSource('s1'), 'observed');
+  });
+
+  it('ignores subagent turns, like the window fold does', () => {
+    ctx.allEntries.push(turn(false));
+    ctx.allEntries.push({ ...turn(true), isSubagent: true });
+    assert.equal(ctx.sessionCtxWindowSource('s1'), 'default');
   });
 });

--- a/test/session-ctx-window.test.js
+++ b/test/session-ctx-window.test.js
@@ -275,20 +275,39 @@ describe('sessionCtxWindowSource — measured vs assumed denominator', () => {
     assert.equal(ctx.sessionCtxWindowSource('s1'), 'default');
   });
 
-  it('reports observed when a turn exceeded the default on its own', () => {
+  it('an observation the window contradicts is still assumed, not observed (fail-on-old)', () => {
+    // 260K of context cannot fit the 200K this session is being divided by. The
+    // earlier version reported `observed` off the raw usage and suppressed the
+    // marker on a denominator the data had already disproved.
     ctx.allEntries.push(turn(true));
+    assert.equal(ctx.sessionCtxWindow('s1'), 200000);
+    assert.equal(ctx.sessionCtxWindowSource('s1'), 'default');
+  });
+
+  it('reports observed once the window itself reflects the evidence', () => {
+    ctx.allEntries.push({ ...turn(true), maxContext: 1000000 });
+    assert.equal(ctx.sessionCtxWindow('s1'), 1000000);
     assert.equal(ctx.sessionCtxWindowSource('s1'), 'observed');
   });
 
-  it('treats a fossil above the default as observed, not assumed', () => {
-    // The turn that proved it may have aged out of allEntries; the evidence existed.
-    ctx.allEntries.push({ ...turn(false), maxContext: 1000000 });
+  it('a model-specific window below the default is measured, not assumed (fail-on-old)', () => {
+    // A 128K fossil is a real per-model capability; calling it assumed would put a
+    // "?" on a number that was derived, not guessed.
+    ctx.allEntries.push({ ...turn(false), maxContext: 128000 });
+    assert.equal(ctx.sessionCtxWindow('s1'), 128000);
     assert.equal(ctx.sessionCtxWindowSource('s1'), 'observed');
   });
 
   it('ignores subagent turns, like the window fold does', () => {
     ctx.allEntries.push(turn(false));
-    ctx.allEntries.push({ ...turn(true), isSubagent: true });
+    ctx.allEntries.push({ ...turn(true), isSubagent: true, maxContext: 1000000 });
     assert.equal(ctx.sessionCtxWindowSource('s1'), 'default');
+  });
+
+  it('reads the server fold when the client no longer holds the turns', () => {
+    ctx.sessionsMap.set('s2', { beta1m: true, maxContext: 1000000 });
+    assert.equal(ctx.sessionCtxWindowSource('s2'), 'declared');
+    ctx.sessionsMap.set('s3', { beta1m: false, maxContext: 1000000 });
+    assert.equal(ctx.sessionCtxWindowSource('s3'), 'observed');
   });
 });


### PR DESCRIPTION
Stacked on #533 — review that first; this diff is the display half.

## Why

The session card shows one number for the context window and no way to tell whether it was measured or guessed. A session with no window evidence and a session whose header declared 200K render identically — though only the first makes its percentage an assumption too. That is exactly how `76% of 200K` looked like a real reading while the session sat at 13% of a 1M window.

## What

`sessionCtxWindowSource(sid)` returns three states:

| state | meaning |
|---|---|
| `declared` | a turn carried the `anthropic-beta context-*` header **and** the capability gate accepted it |
| `observed` | no declaration, but a turn's own context exceeded the default — physical proof of a larger window |
| `default` | no evidence at all |

The card marks the **denominator**, not the number: `60% of 200K?` with a tooltip, because the tokens are measured and only what they are divided by is a guess. An evidenced window renders clean: `12% of 1M`.

## Two decisions worth reviewing

**Keyed on `beta1m`, not on `ctxBeta` presence.** Claude Code sends that header on every request on a beta account, including turns whose declaration the gate refused. Keying on presence would mark every session measured and silence the marker in precisely the case it exists for — the next model missing from the capability sources, rendering against an assumed 200K. (This was caught in review; the first version had it wrong.)

**Derived at render time, never stored.** Storing provenance would relaunder an interpretation as a fact, the failure ADR 0013 exists to prevent. Every input (`beta1m`, `usage`, `maxContext`) is already persisted, so the source is recomputable at any time.

## Verification

- 5 fail-on-old unit tests, including the "a header the gate refused must NOT count as declared" case.
- Headless-Chrome smoke against a real server with two synthetic sessions:

```
{"text":"60% of 200K?","title":"No window evidence for this session — 200K assumed, …"}
{"text":"12% of 1M","title":""}
```

- Full suite 2018 pass / 0 fail.

## Scope

Only the session card consumes the source so far. Mission Control, the timeline minimap, and the Herdr plugin's sidebar still colour context pressure without asking whether the denominator is evidence — worth extending once this shape is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGjh8PNvctE95PQFBCgXqc

---

## Review status — second review ran on grok, not codex

codex could not run (account weekly quota exhausted; the CLI rejects every model and cannot refresh its catalogue), so at the author's direction this diff was reviewed on **grok** (`grok-4.6-build`). This is not codex-approved and the merge hook still asks for codex evidence.

### Round 1 — one blocker, one major, both real, both fixed in `2791c71`

Same root cause: the source was computed from the same raw signals the fold consumes instead of from the fold's answer, so the two could disagree — and both ways it disagreed defeated the marker's purpose.

1. **blocker** — a turn whose own context exceeded 200K reported `observed` while `sessionCtxWindow` still returned 200000, so the `?` was suppressed on a denominator the data had already disproved. That is precisely the unlisted-1M case this marker exists for (and my own test had encoded the wrong expectation).
2. **major** — `win > DEF` was the only fossil predicate, so a window *below* the default (a 128K model capability) reported `default` and put a "?" on a number that was derived, not guessed.

The fix reads the fold first and lets the label describe it: `declared` on `beta1m`, else `default` iff the rendered window is the default, else `observed`.

Also checked and clean in that round: HTML injection in the new markup (none — the window string is `Math.round` output and the tooltip is a literal), whether anything here is stored or feeds classification (none — `windowAssumed` is a local, and `isCompacted` / severity / lanes are untouched), and subagent handling.

### Round 2 — clean

Both findings confirmed fixed, no new contradiction possible between a label and the window it describes, and the "exactly 200K stays assumed" call endorsed: *"a stored 200000 is the write-path sentinel and a real 200K capability — same number. Marking it observed would revive the blocker."* Genuine 200K sessions carrying a `?` is the accepted collision.

### Verification after the fix

Two fail-on-old tests (one per finding); the other six in the suite pass on both sides and are guards. Browser smoke against a real server unchanged — `60% of 200K?` with tooltip, `12% of 1M` clean. Full suite 2021 pass / 0 fail.
