### PR TITLE
fix(context): give a disproved window its own state instead of a confident 100%

### DIFF
--- a/docs/decisions/0013-beta1m-persist-session-window-derive.md
+++ b/docs/decisions/0013-beta1m-persist-session-window-derive.md
@@ -360,9 +360,17 @@ The fold has a fourth state, `contradicted`, keyed on EVIDENCE rather than on
 provenance: a main turn that carried more context than the window it is divided by
 proves that window wrong, whatever produced it — so it outranks `declared` too. This
 is a different claim from "unverified" and must not share its marker: the percentage
-is not merely uncertain, it is a floor on a ratio whose denominator is already known
-to be too small, and the display's `Math.min(100, …)` clamp otherwise renders it as a
-confident "100%". The card shows `≤100% of 200K✗` instead. Restore's heal pass repairs
+is not merely uncertain, it is a ratio whose denominator is already known to be too
+small, and the display's `Math.min(100, …)` clamp otherwise renders it as a confident
+"100%". The clamp is kept for the bar and the colour — saturation, not a claim — while
+the number reports the real ratio, so the card shows `130% of 200K✗`.
+
+It is keyed on the numerator the card actually renders (`latestMainCtxUsed` from the
+session fold), with the retained entries as a second source. Deriving it from the
+entries alone let the label and the number disagree whenever the overflowing turn had
+been evicted or arrived without usage — which is precisely the cold-load path where
+this state lives. A marker site must switch on the enum; `ctxWindowUnverified()`
+answers only "may I treat this window as measured". Restore's heal pass repairs
 such a window before the client ever sees it (the observation floor), so the state is
 reachable only where the heal does not run: legacy lines with no `provider`, and the
 cold-load path that serves raw index lines.

--- a/docs/decisions/0013-beta1m-persist-session-window-derive.md
+++ b/docs/decisions/0013-beta1m-persist-session-window-derive.md
@@ -356,6 +356,17 @@ card marks an assumed denominator (`60% of 200K?` + tooltip) while leaving an ev
 one clean. It is computed at render time from persisted facts, exactly as this ADR
 requires of `sessionCtxWindow` — storing it would relaunder an interpretation as a fact.
 
+The fold has a fourth state, `contradicted`, keyed on EVIDENCE rather than on
+provenance: a main turn that carried more context than the window it is divided by
+proves that window wrong, whatever produced it — so it outranks `declared` too. This
+is a different claim from "unverified" and must not share its marker: the percentage
+is not merely uncertain, it is a floor on a ratio whose denominator is already known
+to be too small, and the display's `Math.min(100, …)` clamp otherwise renders it as a
+confident "100%". The card shows `≤100% of 200K✗` instead. Restore's heal pass repairs
+such a window before the client ever sees it (the observation floor), so the state is
+reachable only where the heal does not run: legacy lines with no `provider`, and the
+cold-load path that serves raw index lines.
+
 `declared` is keyed on `beta1m`, NOT on `ctxBeta` presence. Claude Code sends the header
 on every request on a beta account, so keying on presence would mark every session
 measured and silence the marker in precisely the case it exists for: the next unlisted

--- a/docs/decisions/0013-beta1m-persist-session-window-derive.md
+++ b/docs/decisions/0013-beta1m-persist-session-window-derive.md
@@ -349,6 +349,7 @@ therefore outside `CCXRAY_HOME` isolation** — the ADR 0015 R4 class. `CCXRAY_P
 overrides the path and `pricing.__setContextTableForTests()` injects a table; a test that
 asserts window behaviour must use one of them or stub `getModelContext`, or it silently
 reads the developer's cache. See `docs/testing.md`.
+
 ### Provenance is derived, never stored
 
 `sessionCtxWindowSource(sid)` returns `declared | observed | default`, and the session

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -29,9 +29,19 @@ function sessionCtxWindowSource(sid) {
   // exceeded 200K reported `observed` while the fold still returned 200K, so the
   // marker went quiet on a denominator the data had already disproved.
   const win = sessionCtxWindow(sid);
+  let declared = false;
   for (let i = 0; i < allEntries.length; i++) {
     const e = allEntries[i];
     if (e.sessionId !== sid || e.isSubagent) continue;
+    // A turn that carried more context than the window it is divided by proves the
+    // window wrong, whatever produced it — evidence outranks provenance, so this
+    // returns even on a declared window. Keeping it below `declared` would let a
+    // stale or under-stated declaration render clean while its own data refutes it.
+    const u = e.usage;
+    if (u) {
+      const usedCtx = (u.input_tokens || 0) + (u.cache_creation_input_tokens || 0) + (u.cache_read_input_tokens || 0);
+      if (usedCtx > win) return 'contradicted';
+    }
     // `beta1m` only — NOT bare `ctxBeta`. The header rides every request on a beta
     // account, including turns whose declaration the capability gate refused
     // (haiku title-gen, a model the gate does not know yet). Treating its mere
@@ -39,9 +49,9 @@ function sessionCtxWindowSource(sid) {
     // the marker in exactly the case it exists for: the next unlisted model
     // rendering "76% of 200K" when it is really a 1M session. beta1m is the
     // declaration that actually resolved the window.
-    if (e.beta1m === true) return 'declared';
+    if (e.beta1m === true) declared = true;
   }
-  if (sessionsMap.get(sid)?.beta1m === true) return 'declared';
+  if (declared || sessionsMap.get(sid)?.beta1m === true) return 'declared';
   // A window that differs from the default came from a real per-turn derivation —
   // a fossil above it (the header at write time, or the usage hatch) or a smaller
   // model-specific capability below it. Exactly the default is indistinguishable
@@ -1511,12 +1521,17 @@ function renderSessionItem(sess, sid, sessEl) {
   // window at render time (not the stale incremental value) so all turns show one denominator.
   let windowSizeStr = '';
   let windowAssumed = false;
+  let windowContradicted = false;
   if (sess.latestMainCtxUsed) {
     const w = sessionCtxWindow(sid);
     // An assumed denominator makes the percentage next to it an assumption too.
     // Mark the denominator rather than the number: the tokens are measured, only
     // what they are divided by is a guess.
-    windowAssumed = sessionCtxWindowSource(sid) === 'default';
+    const ctxSource = sessionCtxWindowSource(sid);
+    windowAssumed = ctxSource === 'default';
+    // A window the session's own usage exceeded is not merely unverified — it is
+    // known to be too small, so the ratio built on it is a floor, not a reading.
+    windowContradicted = ctxSource === 'contradicted';
     if (w >= 1000000) {
       windowSizeStr = Math.round(w / 1000000) + 'M';
     } else if (w >= 1000) {
@@ -1552,6 +1567,10 @@ function renderSessionItem(sess, sid, sessEl) {
     ? '<div class="si-truncated" title="Session too large — only the first turn is loaded into memory">Session too large — ' + sess.totalEntryCount + ' total turns, showing 1</div>'
     : '';
   // #339: divide the latest main turn's raw ctxUsed by the render-time session window.
+  // The clamp keeps a bad denominator from painting an absurd bar, but on a window
+  // the data has already disproved it also erases the disagreement: "100%" reads as
+  // "full" when the truth is "we do not know the window and it is larger than this".
+  // Clamp the bar, mark the number.
   const ctxPct = sess.latestMainCtxUsed ? Math.min(100, sess.latestMainCtxUsed / sessionCtxWindow(sid) * 100) : 0;
   const compactPct = (window.ccxraySettings?.autoCompactPct || 0.835) * 100;
   // Recent-gate: historical sessions (no turn within last hour) should not
@@ -1570,9 +1589,13 @@ function renderSessionItem(sess, sid, sessEl) {
   }
   const ctxAlertHtml = ctxPct > 0
     ? '<span class="ctx-alert ' + ctxPctClass + '"' +
-      (windowAssumed ? ' title="No window evidence for this session — ' + windowSizeStr + ' assumed, so this percentage is an upper bound. A turn that declares the context-1m header, or one that exceeds the default, resolves it."' : '') +
-      '>' + Math.round(ctxPct) + '%' +
-      (windowSizeStr ? ' <span style="color:var(--dim)">' + 'of ' + windowSizeStr + (windowAssumed ? '?' : '') + '</span>' : '') +
+      (windowContradicted
+        ? ' title="This session sent more context than ' + windowSizeStr + ', so that window is wrong — the real one is larger and was never recorded. The percentage is an upper bound, not a reading."'
+        : windowAssumed
+          ? ' title="No window evidence for this session — ' + windowSizeStr + ' assumed, so this percentage is an upper bound. A turn that declares the context-1m header, or one that exceeds the default, resolves it."'
+          : '') +
+      '>' + (windowContradicted ? '\u2264' : '') + Math.round(ctxPct) + '%' +
+      (windowSizeStr ? ' <span style="color:var(--dim)">' + 'of ' + windowSizeStr + (windowContradicted ? '\u2717' : windowAssumed ? '?' : '') + '</span>' : '') +
       '</span>'
     : '';
   // Thin ctx bar with auto-compact reference line; shown only once session has real context.

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -25,7 +25,10 @@ let entryCount = 0;
 // INVARIANT: four states — 'declared' | 'observed' | 'contradicted' | 'default'.
 // A consumer that only special-cases 'default' silently treats 'contradicted' as a
 // resolved window and renders a clamped, unmarked percentage — worse than what it
-// replaced. Handle the enum exhaustively, or ask `ctxWindowUnverified()` instead.
+// replaced. Any site that CHOOSES A MARKER must switch on the enum: collapsing
+// 'contradicted' into 'default' puts a "this is unverified" glyph on a number the
+// data has already disproved. `ctxWindowUnverified()` below is only for the coarser
+// question "may I treat this window as measured", never for picking the marker.
 // See docs/decisions/0013-beta1m-persist-session-window-derive.md.
 function ctxWindowUnverified(sid) {
   const src = sessionCtxWindowSource(sid);

--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -22,6 +22,16 @@ let entryCount = 0;
 // it would relaunder an interpretation as a fact (ADR 0013). A display site that
 // asserts context pressure (colour, "compact soon") must consult this before
 // treating a percentage as measured. See docs/decisions/0013-*.
+// INVARIANT: four states — 'declared' | 'observed' | 'contradicted' | 'default'.
+// A consumer that only special-cases 'default' silently treats 'contradicted' as a
+// resolved window and renders a clamped, unmarked percentage — worse than what it
+// replaced. Handle the enum exhaustively, or ask `ctxWindowUnverified()` instead.
+// See docs/decisions/0013-beta1m-persist-session-window-derive.md.
+function ctxWindowUnverified(sid) {
+  const src = sessionCtxWindowSource(sid);
+  return src === 'default' || src === 'contradicted';
+}
+
 function sessionCtxWindowSource(sid) {
   const DEF = (typeof DEFAULT_MAX_CTX !== 'undefined' ? DEFAULT_MAX_CTX : 200000);
   // Read the window that is actually rendered, then ask what produced it. Deriving
@@ -29,6 +39,12 @@ function sessionCtxWindowSource(sid) {
   // exceeded 200K reported `observed` while the fold still returned 200K, so the
   // marker went quiet on a denominator the data had already disproved.
   const win = sessionCtxWindow(sid);
+  // The numerator the card actually renders. Checking it directly is what makes the
+  // label describe the number rather than a parallel derivation of it: `allEntries`
+  // can be truncated and cold-load rows carry no usage, so an entry scan alone
+  // would report a resolved window for a ratio already over 100%.
+  const foldUsed = sessionsMap.get(sid)?.latestMainCtxUsed || 0;
+  if (foldUsed > win) return 'contradicted';
   let declared = false;
   for (let i = 0; i < allEntries.length; i++) {
     const e = allEntries[i];
@@ -42,6 +58,9 @@ function sessionCtxWindowSource(sid) {
       const usedCtx = (u.input_tokens || 0) + (u.cache_creation_input_tokens || 0) + (u.cache_read_input_tokens || 0);
       if (usedCtx > win) return 'contradicted';
     }
+    // `contradictedByFold` below is the load-bearing half: this loop can only see
+    // turns the client still holds, and the overflowing one may have been evicted
+    // or arrived without a usage object.
     // `beta1m` only — NOT bare `ctxBeta`. The header rides every request on a beta
     // account, including turns whose declaration the capability gate refused
     // (haiku title-gen, a model the gate does not know yet). Treating its mere
@@ -1568,10 +1587,12 @@ function renderSessionItem(sess, sid, sessEl) {
     : '';
   // #339: divide the latest main turn's raw ctxUsed by the render-time session window.
   // The clamp keeps a bad denominator from painting an absurd bar, but on a window
-  // the data has already disproved it also erases the disagreement: "100%" reads as
-  // "full" when the truth is "we do not know the window and it is larger than this".
-  // Clamp the bar, mark the number.
-  const ctxPct = sess.latestMainCtxUsed ? Math.min(100, sess.latestMainCtxUsed / sessionCtxWindow(sid) * 100) : 0;
+  // the data has already disproved it, clamping the NUMBER erases the disagreement:
+  // "100%" reads as "full" when the ratio is genuinely above 100. Clamp the bar,
+  // report the number — a `≤100%` on a clamped value would even assert the opposite
+  // inequality to the one the evidence supports.
+  const ctxRatio = sess.latestMainCtxUsed ? sess.latestMainCtxUsed / sessionCtxWindow(sid) * 100 : 0;
+  const ctxPct = Math.min(100, ctxRatio);
   const compactPct = (window.ccxraySettings?.autoCompactPct || 0.835) * 100;
   // Recent-gate: historical sessions (no turn within last hour) should not
   // light up red/yellow — prevents sea-of-red when scanning the session list.
@@ -1594,7 +1615,7 @@ function renderSessionItem(sess, sid, sessEl) {
         : windowAssumed
           ? ' title="No window evidence for this session — ' + windowSizeStr + ' assumed, so this percentage is an upper bound. A turn that declares the context-1m header, or one that exceeds the default, resolves it."'
           : '') +
-      '>' + (windowContradicted ? '\u2264' : '') + Math.round(ctxPct) + '%' +
+      '>' + Math.round(windowContradicted ? ctxRatio : ctxPct) + '%' +
       (windowSizeStr ? ' <span style="color:var(--dim)">' + 'of ' + windowSizeStr + (windowContradicted ? '\u2717' : windowAssumed ? '?' : '') + '</span>' : '') +
       '</span>'
     : '';

--- a/test/session-ctx-window.test.js
+++ b/test/session-ctx-window.test.js
@@ -60,6 +60,7 @@ function loadCtx(includeEntryRendering) {
     this.sessionsMap = sessionsMap;
     this.sessionCtxWindow = sessionCtxWindow;
     this.sessionCtxWindowSource = sessionCtxWindowSource;
+    this.ctxWindowUnverified = ctxWindowUnverified;
     this.turnCtxWindow = turnCtxWindow;
     ${includeEntryRendering ? `
       this.mergeColdSessions = mergeColdSessions;
@@ -324,6 +325,28 @@ describe('sessionCtxWindowSource — measured vs assumed denominator', () => {
     ctx.allEntries.push(turn(false));
     ctx.allEntries.push({ ...turn(true), isSubagent: true, maxContext: 1000000 });
     assert.equal(ctx.sessionCtxWindowSource('s1'), 'default');
+  });
+
+  it('reports contradicted from the fold when the overflowing turn is gone (fail-on-old)', () => {
+    // The card divides `latestMainCtxUsed` from the server fold, not the entries the
+    // client happens to hold. With the overflowing turn evicted (or a cold-load row
+    // that carries no usage), an entry scan alone reported a resolved window for a
+    // ratio already over 100%.
+    ctx.sessionsMap.set('s4', { latestMainCtxUsed: 260000, maxContext: 200000, beta1m: false });
+    assert.equal(ctx.sessionCtxWindow('s4'), 200000);
+    assert.equal(ctx.sessionCtxWindowSource('s4'), 'contradicted');
+    // …and it outranks a declaration carried by that same fold.
+    ctx.sessionsMap.set('s5', { latestMainCtxUsed: 1200000, maxContext: 1000000, beta1m: true });
+    assert.equal(ctx.sessionCtxWindowSource('s5'), 'contradicted');
+  });
+
+  it('ctxWindowUnverified covers every state that must not read as resolved', () => {
+    ctx.sessionsMap.set('s6', { latestMainCtxUsed: 260000, maxContext: 200000, beta1m: false });
+    assert.equal(ctx.ctxWindowUnverified('s6'), true, 'contradicted');
+    ctx.allEntries.push(turn(false));
+    assert.equal(ctx.ctxWindowUnverified('s1'), true, 'default');
+    ctx.allEntries.push({ ...turn(false), sessionId: 's7', beta1m: true, maxContext: 1000000 });
+    assert.equal(ctx.ctxWindowUnverified('s7'), false, 'declared');
   });
 
   it('reads the server fold when the client no longer holds the turns', () => {

--- a/test/session-ctx-window.test.js
+++ b/test/session-ctx-window.test.js
@@ -275,12 +275,34 @@ describe('sessionCtxWindowSource — measured vs assumed denominator', () => {
     assert.equal(ctx.sessionCtxWindowSource('s1'), 'default');
   });
 
-  it('an observation the window contradicts is still assumed, not observed (fail-on-old)', () => {
-    // 260K of context cannot fit the 200K this session is being divided by. The
-    // earlier version reported `observed` off the raw usage and suppressed the
-    // marker on a denominator the data had already disproved.
+  it('a window the session\'s own usage exceeded is contradicted, not merely assumed (fail-on-old)', () => {
+    // 260K of context cannot fit the 200K this session is divided by. That is a
+    // stronger claim than "unverified": the denominator is known wrong, so the
+    // percentage is a floor. Sharing the assumed marker flattened the two.
     ctx.allEntries.push(turn(true));
     assert.equal(ctx.sessionCtxWindow('s1'), 200000);
+    assert.equal(ctx.sessionCtxWindowSource('s1'), 'contradicted');
+  });
+
+  it('contradiction is keyed on evidence, not on provenance (fail-on-old)', () => {
+    // A declared or fossil-backed window can be exceeded too — by a later turn on
+    // a model switch, or by a fossil that under-states the real window. Evidence
+    // beats provenance in both directions.
+    ctx.allEntries.push({ ...turn(false), beta1m: true, maxContext: 1000000,
+      usage: { input_tokens: 1200000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } });
+    assert.equal(ctx.sessionCtxWindow('s1'), 1000000);
+    assert.equal(ctx.sessionCtxWindowSource('s1'), 'contradicted');
+  });
+
+  it('a turn at exactly the window is not a contradiction', () => {
+    ctx.allEntries.push({ ...turn(false),
+      usage: { input_tokens: 200000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } });
+    assert.equal(ctx.sessionCtxWindowSource('s1'), 'default');
+  });
+
+  it('a subagent that exceeds the parent window does not contradict it', () => {
+    ctx.allEntries.push(turn(false));
+    ctx.allEntries.push({ ...turn(true), isSubagent: true });
     assert.equal(ctx.sessionCtxWindowSource('s1'), 'default');
   });
 


### PR DESCRIPTION
Follow-up to #534 (F1 of the two the measurement turned up).

## The problem

A session whose own turns carried **more** context than the window they are divided by is not a session with an unverified denominator — it is a session whose denominator is **known wrong**. Both rendered identically, because `Math.min(100, …)` clamped the ratio: the card read `100% of 200K?`, which says *full* when the truth is *"we do not know the window and it is certainly larger than this"*.

Measured on the author's real corpus, 32 anthropic main sessions:

| | |
|---|---|
| render an assumed denominator (`?`) | 30 |
| …of which the denominator is **provably wrong** | **7** |

Those 7 are the ones whose number is not merely uncertain but false.

## The change

`sessionCtxWindowSource` gains a fourth state, `contradicted`, keyed on **evidence rather than provenance** — a turn exceeding the rendered window outranks even `declared`, since a stale or under-stated declaration is refuted by the session's own data.

The card renders `130% of 200K✗` with a tooltip saying the window is wrong and the percentage is an upper bound. The clamp is kept for the **bar and the colour** — saturation, not a claim — while the **number** reports the real ratio.

Colour and severity remain ungated on provenance: this is metadata about the denominator, not a health signal (the boundary #534 established).

Reachability: restore's heal pass repairs such a window before the client sees it, via the observation floor added in #533. The state is therefore reachable only where the heal does not run — legacy lines carrying no `provider`, and the cold-load path that serves raw index lines. That is exactly where the 7 corpus sessions live.

## Review (grok — codex quota exhausted, see #533)

**Round 1: one blocker, two majors, all real.**

1. **blocker** — the contradiction was computed by scanning `allEntries` while the card divides `latestMainCtxUsed` from the server fold. With the overflowing turn evicted, or arriving from cold-load without a usage object (the very path where the state lives), the scan found nothing and the card reported `declared`/`observed`/`default` for a ratio already over 100%. *The same mistake as #534's round 1, one level down: a parallel derivation of the number instead of the number.* The fold's numerator is now checked first.
2. **major** — the number was still clamped, so it rendered `≤100%` — asserting the opposite inequality to the evidence. Now `130%`.
3. **major** — nothing stopped a future consumer special-casing only `'default'` from treating `contradicted` as resolved. Added `ctxWindowUnverified()` plus an INVARIANT naming all four states.

**Round 2: clean.** Two documentation corrections came out of it (a stale ADR paragraph, and an INVARIANT that wrongly offered the helper as an alternative for marker sites — it collapses `✗` back into `?`), fixed in `c4ec3e6`.

## Verification

- 5 fail-on-old tests: the state itself; evidence outranking provenance; fold-only contradiction; contradiction outranking a fold-carried declaration; the helper's coverage. Plus guards: a turn exactly at the window is not a contradiction, and a subagent exceeding the parent window does not contradict it.
- Browser smoke against a real server, all three renderings: `130% of 200K✗` (with tooltip), `60% of 200K?`, `12% of 1M` clean.
- Full suite **2025 pass**; the single failure (`test/index-fields.e2e.test.js`, importer case) reproduces identically on unmodified `main` in this environment and is not from this branch.

## Not in this PR

F2: extend `rebuild-index`'s add-only enrichment to derive `maxContext` for legacy anthropic lines that lack it, which converts those 7 sessions to a correct 1M denominator and removes the marker at the source. It needs its own evidence package and touches the backfill path, so it goes separately. F1 is still needed after it: F2 heals *this* corpus, F1 covers every future case where evidence contradicts an assumed window before anyone rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGjh8PNvctE95PQFBCgXqc

---

**grok gate clean** — two rounds. Round 1: one blocker (the label read a parallel derivation of the number instead of the number) and two majors (the clamped `≤100%` asserted the wrong inequality; nothing stopped a future consumer mishandling the new state). Round 2 clean, with two documentation corrections that came out of it. codex could not run — account quota exhausted (see #533).
