### PR TITLE
feat(rebuild-index): recover a context window the line's own evidence already proves

### DIFF
--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -283,7 +283,16 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
     // storing 200000 would turn "nothing was derived" into a fossil that looks
     // derived, and the provenance fold (ADR 0013) reads exactly that distinction.
     // No file reads — this works for lines whose _req/_res have aged out.
-    if (m.maxContext === undefined && m.provider !== 'openai' && m.model && m.usage) {
+    // Anthropic lines only, named explicitly rather than by excluding the string
+    // 'openai': an OpenAI-wire line whose provider is missing or spelled otherwise
+    // would otherwise get a catalog window frozen onto it by #48, and its real one
+    // comes from the transcript (#384). A provider-less legacy line is claimed only
+    // when its model says claude. `usage` is not required — beta1m / ctxBeta alone
+    // can resolve a window, and without any of them the derivation lands on the
+    // default and the write is skipped anyway.
+    const anthropicLine = m.provider === 'anthropic'
+      || (!m.provider && /^claude-/.test(String(m.model || '')));
+    if (m.maxContext === undefined && anthropicLine && m.model) {
       const win = config.inferMaxContext(m.model, null, m.usage, {
         beta1m: m.beta1m === true,
         ctxBeta: m.ctxBeta,

--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -234,6 +234,7 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   let enrichedResponseIds = 0;  // #333 legacy backfill count
   let enrichedIdentity = 0;     // #342 legacy identity backfill count
   let enrichedTurnToolCalls = 0; // #427 legacy backfill count
+  let enrichedMaxContext = 0; // context-window backfill count
   let enrichedTurnToolFail = 0; // #438 legacy backfill count
   let enrichedTurnToolCallIds = 0; // #486 legacy backfill count
   let enrichedTurnToolResults = 0; // #486 legacy backfill count
@@ -268,6 +269,30 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
       let ttc = null;
       try { ttc = getParser('anthropic').extractTurnToolCalls(JSON.parse(await storage.read(m.id, '_res.json'))); } catch {}
       if (ttc) { m.turnToolCalls = ttc; outLine = JSON.stringify(m); enrichedTurnToolCalls++; }
+    }
+    // Add-only context-window backfill. A legacy or imported anthropic line can
+    // carry no maxContext at all (the Claude importer wrote none before the window
+    // work), so every reader divides by the 200K default — which renders a 1M
+    // session as phantom pressure, and renders a session whose own usage exceeded
+    // 200K as a flat, wrong 100%. The evidence is already on the line: usage is
+    // persisted, and a request that carried more than the default proves a bigger
+    // window. Derived with the SAME function the live path and the restore heal
+    // use, so a backfilled value is identical to a freshly written one.
+    //
+    // Written only when the derivation lands somewhere other than the default:
+    // storing 200000 would turn "nothing was derived" into a fossil that looks
+    // derived, and the provenance fold (ADR 0013) reads exactly that distinction.
+    // No file reads — this works for lines whose _req/_res have aged out.
+    if (m.maxContext === undefined && m.provider !== 'openai' && m.model && m.usage) {
+      const win = config.inferMaxContext(m.model, null, m.usage, {
+        beta1m: m.beta1m === true,
+        ctxBeta: m.ctxBeta,
+      });
+      if (win !== config.DEFAULT_CONTEXT) {
+        m.maxContext = win;
+        outLine = JSON.stringify(m);
+        enrichedMaxContext++;
+      }
     }
     // #486 add-only turnToolCallIds backfill: extract {tool_use.id → name} from
     // _res.json. Same add-only, non-degrading pattern as turnToolCalls.
@@ -487,13 +512,14 @@ async function rebuildIndex({ apply = false, storage = config.storage, log = con
   if (enrichedResponseIds) log(`  backfilled responseId onto ${enrichedResponseIds} legacy line(s) (#333)`);
   if (enrichedIdentity) log(`  backfilled convId/coreHash/agentKey onto ${enrichedIdentity} legacy line(s) (#342)`);
   if (enrichedTurnToolCalls) log(`  backfilled turnToolCalls onto ${enrichedTurnToolCalls} legacy line(s) (#427)`);
+  if (enrichedMaxContext) log(`  backfilled maxContext onto ${enrichedMaxContext} line(s) that had no context window`);
   if (enrichedTurnToolFail) log(`  backfilled turnToolFail onto ${enrichedTurnToolFail} legacy line(s) (#438)`);
   if (enrichedTurnToolCallIds) log(`  backfilled turnToolCallIds onto ${enrichedTurnToolCallIds} legacy line(s) (#486)`);
   if (enrichedTurnToolResults) log(`  backfilled turnToolResults onto ${enrichedTurnToolResults} legacy line(s) (#486)`);
 
   // A run with no orphans to add can still have enriched existing lines — those
   // rewritten lines must be flushed, so the write is gated on any change.
-  const hasChanges = N > 0 || enrichedResponseIds > 0 || enrichedIdentity > 0 || enrichedTurnToolCalls > 0 || enrichedTurnToolFail > 0 || enrichedTurnToolCallIds > 0 || enrichedTurnToolResults > 0;
+  const hasChanges = N > 0 || enrichedResponseIds > 0 || enrichedIdentity > 0 || enrichedMaxContext > 0 || enrichedTurnToolCalls > 0 || enrichedTurnToolFail > 0 || enrichedTurnToolCallIds > 0 || enrichedTurnToolResults > 0;
   if (!hasChanges) {
     log(apply ? '  nothing to add — index left unchanged.' : '  dry run — nothing to add.');
     return { refused: false, recovered: 0, enriched: 0, enrichedIdentity: 0, total: M, unrecoverable, applied: false, cacheFinalSize: cache.size };

--- a/test/rebuild-index.test.js
+++ b/test/rebuild-index.test.js
@@ -115,9 +115,24 @@ describe('rebuild-index', () => {
     writeIndexLine({ id: idD, ts: '13-00-00', sessionId: 's', provider: 'openai', model: 'gpt-5',
       usage: { input_tokens: 500000 }, isSSE: true, status: 200 });
 
+    // A declaration alone resolves a window — no usage needed.
+    const idE = '2026-07-02T14-00-00-000';
+    writeIndexLine({ id: idE, ts: '14:00:00', sessionId: 's', provider: 'anthropic', model: 'claude-opus-4-7',
+      beta1m: true, isSSE: true, status: 200 });
+    // A legacy line with no provider is claimed only when the model says claude.
+    const idF = '2026-07-02T15-00-00-000';
+    writeIndexLine({ id: idF, ts: '15:00:00', sessionId: 's', model: 'claude-opus-4-7',
+      usage: { input_tokens: 10, cache_read_input_tokens: 260000, cache_creation_input_tokens: 0 }, isSSE: true, status: 200 });
+    const idG = '2026-07-02T16-00-00-000';
+    writeIndexLine({ id: idG, ts: '16:00:00', sessionId: 's', model: 'gpt-5',
+      usage: { input_tokens: 500000 }, isSSE: true, status: 200 });
+
     await rebuildIndex({ apply: true, storage, log });
     const lines = readIndexIds();
     assert.equal(lines.find(l => l.id === idA).maxContext, 1_000_000, 'observation above the default recovers the window');
+    assert.equal(lines.find(l => l.id === idE).maxContext, 1_000_000, 'a declaration resolves it without usage');
+    assert.equal(lines.find(l => l.id === idF).maxContext, 1_000_000, 'provider-less claude line is claimed');
+    assert.ok(!('maxContext' in lines.find(l => l.id === idG)), 'provider-less non-claude line is not');
     assert.ok(!('maxContext' in lines.find(l => l.id === idB)), 'nothing proven → no fossil written');
     assert.equal(lines.find(l => l.id === idC).maxContext, 200000, 'existing value untouched');
     assert.ok(!('maxContext' in lines.find(l => l.id === idD)), 'openai exempt');

--- a/test/rebuild-index.test.js
+++ b/test/rebuild-index.test.js
@@ -93,6 +93,36 @@ describe('rebuild-index', () => {
     assert.ok(!('responseId' in lines.find(l => l.id === idC)), 'openai line exempt');
   });
 
+  it('add-only backfills a context window that the evidence on the line already proves', async () => {
+    // A line with no maxContext makes every reader divide by the 200K default. When
+    // the line's own usage exceeded that, the window is provably larger and the
+    // number rendered today is wrong — the evidence needs no file on disk.
+    const idA = '2026-07-02T10-00-00-000';
+    writeIndexLine({ id: idA, ts: '10:00:00', sessionId: 's', provider: 'anthropic', model: 'claude-opus-4-7',
+      usage: { input_tokens: 10, cache_read_input_tokens: 260000, cache_creation_input_tokens: 0 }, isSSE: true, status: 200 });
+    // Usage under the default proves nothing: writing 200000 would turn "nothing was
+    // derived" into a fossil that looks derived, which the provenance fold reads.
+    const idB = '2026-07-02T11-00-00-000';
+    writeIndexLine({ id: idB, ts: '11:00:00', sessionId: 's', provider: 'anthropic', model: 'claude-opus-4-7',
+      usage: { input_tokens: 10, cache_read_input_tokens: 50000, cache_creation_input_tokens: 0 }, isSSE: true, status: 200 });
+    // An existing window is never overwritten (#48 never-degrade).
+    const idC = '2026-07-02T12-00-00-000';
+    writeIndexLine({ id: idC, ts: '12:00:00', sessionId: 's', provider: 'anthropic', model: 'claude-opus-4-7',
+      maxContext: 200000, usage: { input_tokens: 10, cache_read_input_tokens: 260000, cache_creation_input_tokens: 0 },
+      isSSE: true, status: 200 });
+    // OpenAI lines are exempt — they get their window from the transcript (#384).
+    const idD = '2026-07-02T13-00-00-000';
+    writeIndexLine({ id: idD, ts: '13-00-00', sessionId: 's', provider: 'openai', model: 'gpt-5',
+      usage: { input_tokens: 500000 }, isSSE: true, status: 200 });
+
+    await rebuildIndex({ apply: true, storage, log });
+    const lines = readIndexIds();
+    assert.equal(lines.find(l => l.id === idA).maxContext, 1_000_000, 'observation above the default recovers the window');
+    assert.ok(!('maxContext' in lines.find(l => l.id === idB)), 'nothing proven → no fossil written');
+    assert.equal(lines.find(l => l.id === idC).maxContext, 200000, 'existing value untouched');
+    assert.ok(!('maxContext' in lines.find(l => l.id === idD)), 'openai exempt');
+  });
+
   it('#342: add-only backfills identity onto legacy lines whose _req is reconstructable', async () => {
     writeShared();
     const { getParser } = require('../server/wire-parsers');


### PR DESCRIPTION
F2 of the two follow-ups the measurement turned up (F1 is #535). Independent of #535 — this removes the cause, #535 handles what remains.

## The problem

A legacy or imported anthropic line can carry no `maxContext` at all — the Claude importer wrote none before #533 — so every reader divides by the 200K default. That renders a 1M session as phantom pressure, and renders a session whose own usage exceeded 200K as a flat, wrong percentage the display clamp pins at 100%.

The evidence needs no file on disk: `usage` is already persisted on the line, and a request that carried more than the default proves a larger window.

## The change

`rebuild-index` derives a window with the **same function** the live path and the restore heal use, so a backfilled value is identical to a freshly written one — and it works for lines whose `_req`/`_res` aged out.

Add-only, in the shape the surrounding backfills already use: only when the key is absent, never overwriting (#48 never-degrade), anthropic lines only. Written **only when the derivation lands somewhere other than the default** — storing `200000` would turn "nothing was derived" into a fossil that looks derived, and the provenance fold reads exactly that distinction.

## Measured against a copy of the real index

6,128 lines, 32 anthropic main sessions. **332 lines gain a window**, and every one of the 7 sessions whose denominator was provably wrong is repaired, with no other session changing state:

```
6080401d  contradicted 148% of 200K  →  observed 30% of 1M
74ed8e7c  contradicted 239% of 200K  →  observed 48% of 1M
dae83144  contradicted 120% of 200K  →  observed 24% of 1M
9fd5715a  contradicted 101% of 200K  →  observed 20% of 1M
37e862b0  contradicted 120% of 200K  →  observed 24% of 1M
522f84e0  contradicted 105% of 200K  →  observed 21% of 1M
f7ffbe5f  contradicted 173% of 200K  →  observed 35% of 1M

before  {observed: 1, default: 23, contradicted: 7, declared: 1}
after   {observed: 8, default: 23,                  declared: 1}
```

The 23 sessions with no evidence stay `default` and keep their marker. That is the honest outcome: this recovers windows the data proves, it does not invent one.

## Review (grok — codex quota exhausted, see #533)

**Round 1: two majors accepted, one rejected.**

1. **major** — requiring `usage` dropped the authoritative path: `beta1m` / `ctxBeta` can resolve a window alone, and a failed or incomplete turn can carry the declaration without usage. Guard removed; with no signal at all the derivation still lands on the default and the write is still skipped.
2. **minor→accepted** — `provider !== 'openai'` was the wrong shape: an OpenAI-wire line whose provider is missing or spelled otherwise would have had a catalog window frozen onto it by never-degrade, while its real one comes from the transcript (#384). Now anthropic lines are claimed by name, plus provider-less legacy lines whose model says claude.
3. **rejected → and the rejection was wrong.** I argued weather is restamped because this run rebuilds the session index. **It does not** — `rebuildFromMetasAsync` is on the `--reimport` path, not `--apply`. Round 2 caught my false premise. The accurate behaviour: `--apply` leaves `sessions.json` untouched, so the next start finds `index.ndjson` newer, fails the mtime check, and rebuilds the fold — recomputing weather from the backfilled windows. If that check misses, `reconcile` compares counts and will not notice the enrichment, so a stale fold survives until an explicit rebuild.

That residual is **recorded, not fixed**: the owner has de-scoped weather for now, on the grounds that "healthy" is entangled with task nature and personal judgement. `WEATHER_REV` is not implicated either way — the derivation is unchanged, only its inputs.

## Verification

- Differential test, fails on old code: recovered above the default; nothing written when nothing is proven; an existing value untouched; OpenAI exempt; a declaration with no usage resolves a window; a provider-less claude line claimed, a provider-less non-claude line not.
- Corpus replay above, re-run unchanged after the review fixes.
- Full suite **2021 pass**; the single failure (`test/index-fields.e2e.test.js`, importer case) reproduces on unmodified `main` in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGjh8PNvctE95PQFBCgXqc

---

**grok gate clean** — two rounds. Round 1: two majors accepted (requiring `usage` dropped the declaration path; excluding the string `'openai'` was the wrong shape), one rejection of mine that round 2 then proved false — I claimed this run rebuilds the session index, and it does not. Round 2 clean. codex could not run — account quota exhausted (see #533).
