### PR TITLE
chore(hooks): accept a named grok second review, not codex alone

### DIFF
--- a/.claude/hooks/check-codex-review.sh
+++ b/.claude/hooks/check-codex-review.sh
@@ -160,8 +160,25 @@ while [ "${REST#*gh pr merge}" != "$REST" ]; do
     BODY=$(gh pr view "$PR_NUM" --json body --jq '.body' 2>/dev/null || echo "")
   fi
 
-  if ! echo "$BODY" | grep -qiE 'codex gate clean|codex review|codex-exempt'; then
-    block "PR #$PR_NUM body missing codex review evidence — run /codex-loop first"
+  # The gate is "a second reviewer ran to completion and the PR says so", not "codex
+  # specifically". codex is the default; grok is accepted because the codex CLI goes
+  # unavailable on its own account quota, and a gate that cannot be satisfied for a
+  # week gets routed around rather than obeyed (2026-08-17).
+  #
+  # The grok alternative is the COMPLETION MARKER ONLY — `grok gate clean`, the
+  # phrase the review loop terminates with. Not a bare `grok review`, which as an
+  # unanchored substring also matches "TODO: grok review after CI", "please grok
+  # review this" and "grok reviewer signed off": a body that names the reviewer
+  # while saying the review has NOT happened would pass. (The legacy `codex review`
+  # alternative carries that same looseness; it is left alone because existing PR
+  # bodies depend on it, and tightening it belongs in its own change.)
+  #
+  # Same threat model as the rest of this script: a guard against ACCIDENTAL
+  # unreviewed merges by the repo's own trusted agent, not against evasion. It stays
+  # a textual check because the alternative — verifying a review actually happened —
+  # is not something a merge-time hook can do.
+  if ! echo "$BODY" | grep -qiE 'codex gate clean|codex review|codex-exempt|grok gate clean'; then
+    block "PR #$PR_NUM body missing second-review evidence — run /codex-loop (or the grok equivalent) and record which reviewer ran"
   fi
 done
 

--- a/test/check-codex-review-hook.test.js
+++ b/test/check-codex-review-hook.test.js
@@ -72,7 +72,7 @@ describe('check-codex-review hook — cross-repo scope', () => {
       GH_BODY_CROSS: 'no second review here',
     });
     assert.equal(r.status, 2, 'must not validate against the cwd repo PR');
-    assert.match(r.stdout, /missing codex review evidence/);
+    assert.match(r.stdout, /missing second-review evidence/);
   });
 
   it('-R short flag is honored the same as --repo', () => {
@@ -97,6 +97,36 @@ describe('check-codex-review hook — cross-repo scope', () => {
     });
     assert.equal(r.status, 0, r.stdout + r.stderr);
     assert.doesNotMatch(r.spy, /--repo/);
+  });
+
+  it('a named grok review satisfies the gate (fail-on-old)', () => {
+    // The gate is "a second reviewer ran and the PR says so", not "codex
+    // specifically". codex goes unavailable on its own account quota, and a rule
+    // that cannot be satisfied for a week gets routed around instead of obeyed.
+    for (const body of ['grok gate clean', 'Round 2: GROK GATE CLEAN, no findings', 'grok gate clean\n\nrest of body']) {
+      const r = runHook('gh pr merge 42 --squash', { GH_BODY_LOCAL: body });
+      assert.equal(r.status, 0, `expected ${JSON.stringify(body)} to pass: ${r.stdout}${r.stderr}`);
+    }
+  });
+
+  it('a body that names grok without the completion marker still blocks', () => {
+    // "reviewed", "LGTM" and friends stay insufficient: the body must say WHICH
+    // reviewer ran, so a reader can weigh it.
+    // The near-misses are the point: each of these NAMES grok while saying the
+    // review has not happened, or happened without a verdict. A bare `grok review`
+    // alternative would pass every one of them — including this test's own title.
+    for (const body of [
+      'reviewed and clean', 'LGTM', 'second review done',
+      'second review (grok) went fine',
+      'TODO: grok review after CI',
+      'please grok review this',
+      'grok reviewer signed off',
+      'a named grok review satisfies the gate',
+    ]) {
+      const r = runHook('gh pr merge 42 --squash', { GH_BODY_LOCAL: body });
+      assert.equal(r.status, 2, `expected ${JSON.stringify(body)} to block`);
+      assert.match(r.stdout, /missing second-review evidence/);
+    }
   });
 
   it('same-repo merge without evidence still blocks', () => {


### PR DESCRIPTION
## Why

The merge gate asks for evidence that a second reviewer ran. It only recognised codex — and codex goes unavailable on its own account quota. This week it rejects every model with `invalid_request_error … not supported when using Codex with a ChatGPT account` and cannot refresh its model catalogue, so the gate cannot be satisfied at all.

A gate that cannot be satisfied for a week does not get obeyed, it gets routed around. A rule nobody can follow teaches people to route around rules.

## What changes

The gate also accepts **`grok gate clean`** — the phrase the review loop terminates with, and only that.

The first draft accepted a bare `grok review`. Second review caught it: as an unanchored substring that also matches

- `TODO: grok review after CI`
- `please grok review this`
- `grok reviewer signed off`

— bodies that *name* the reviewer while saying the review has **not** happened. It even matched the title of the test that was supposed to prove the rule.

The legacy `codex review` alternative carries the same looseness. It is left alone: existing PR bodies depend on it, and tightening it belongs in its own change rather than riding along here.

## What this does not do

It does not strengthen the gate and does not pretend to. It stays a textual check under the same threat model the rest of the script states: a guard against **accidental** unreviewed merges by the repo's own trusted agent, not against evasion. Verifying that a review actually happened is not something a merge-time hook can do.

## Tests

- The completion marker passes in three shapes (fail-on-old against the pre-change hook).
- Eight near-misses block — five of which name grok, so a looser alternative cannot pass the suite. Verified: against the first draft's regex, those five pass; against the narrowed one they all block.
- One existing assertion updated for the new block wording (`missing second-review evidence`). No other reference to the old wording exists in the repo.

## Review

**grok gate clean** — two rounds. Round 1 raised the unanchored-substring hole and that the reject test did not pin its own rule (every case lacked the substring entirely, so a looser regex would still have passed). Both accepted and fixed; the near-miss list above is the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGjh8PNvctE95PQFBCgXqc