### PR TITLE
feat(export): cwd allowlist for summary exporter

### DIFF
--- a/server/export-sync.js
+++ b/server/export-sync.js
@@ -630,11 +630,19 @@ function aggregate(lines, agentId, configDirAllowlist) {
   return { dailyByDt, sessionsByDt, sessionHomeDt };
 }
 
+// ponytail: allowlist gates which repo names leave the machine; unknown → '[other]'
+const _cwdAllowlist = process.env.CCXRAY_EXPORT_CWD_ALLOWLIST
+  ? new Set(process.env.CCXRAY_EXPORT_CWD_ALLOWLIST.split(',').map(s => s.trim()).filter(Boolean))
+  : null;
+
 function repoRoot(cwd) {
   if (!cwd || typeof cwd !== 'string') return null;
   const norm = cwd.replace(/\\/g, '/');
   const parts = norm.split('/').filter(Boolean);
-  return parts.length > 0 ? parts[parts.length - 1] : null;
+  const name = parts.length > 0 ? parts[parts.length - 1] : null;
+  if (!name) return null;
+  if (!_cwdAllowlist) return name;
+  return _cwdAllowlist.has(name) ? name : '[other]';
 }
 
 function finishDaily(daily, summaryId, uploadSeq, partial) {


### PR DESCRIPTION
## 摘要

日摘要 exporter 加入 cwd 白名單，防止私人專案名稱出現在 GCS 上傳的摘要中。

## 改動

`CCXRAY_EXPORT_CWD_ALLOWLIST` env var（逗號分隔的 repo root 名稱）。`repoRoot()` 檢查白名單，非匹配的 repo 寫出為 `[other]`。

- 未設定時行為不變（所有 repo 名稱原樣輸出）
- `[other]` 的 turn/cost 仍計入日摘要（排除等式不壞）
- 白名單是開發者自己設的 env var，管理端無法擴充

## 驗證

118 天真實資料重傳後：
- `SELECT DISTINCT cwd` 只有 `[other]`、`specbase`、`upd5-skills`、`nineyiappshop`
- 排除等式 249,663 = 249,663
- 私人專案名（Justin-Vault 等）不出現

## Second review

grok gate clean — grok 1.0.3。指出 case-sensitive matching 和 default fail-open，兩者為設計選擇非 bug。
