### PR TITLE
test(herdr): fix Quick Start close test on Linux CI (util-linux script syntax)

### DIFF
--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -1016,10 +1016,17 @@ describe('Herdr Quick Start close', () => {
     // stdin is held open far longer than the poll window on purpose: otherwise
     // the process would exit on stdin EOF and the test would pass for the wrong
     // reason. Seeing the marker inside the window means `q` itself ended it.
-    const command = `( printf 'q'; sleep 40 ) | script -q /dev/null `
-      + `env CCXRAY_HOME=${JSON.stringify(home)} HERDR_CONFIG_PATH=${JSON.stringify(cfg)} `
+    // BSD script (macOS) takes the command as positional args after the file;
+    // util-linux script (Linux CI) rejects positional commands and needs -c.
+    const run = `env CCXRAY_HOME=${JSON.stringify(home)} HERDR_CONFIG_PATH=${JSON.stringify(cfg)} `
       + `CCXRAY_PRICING_CACHE=/nonexistent/p.json HERDR_PANE_ID= `
-      + `/bin/sh -c ${JSON.stringify(inner)} >/dev/null 2>&1 &\n`
+      + `/bin/sh -c ${JSON.stringify(inner)}`;
+    const pty = process.platform === 'linux'
+      ? `script -qec ${JSON.stringify(run)} /dev/null`
+      : `script -q /dev/null ${run}`;
+    // The job-level redirect covers the feeder subshell too — its inherited
+    // stderr would otherwise hold spawnSync's pipe open until the sleep ends.
+    const command = `{ ( printf 'q'; sleep 12 ) | ${pty}; } >/dev/null 2>&1 &\n`
       + `for i in $(seq 1 40); do [ -f ${JSON.stringify(marker)} ] && break; sleep 0.2; done\n`
       + `[ -f ${JSON.stringify(marker)} ] && echo EXITED || echo LINGERED\n`
       + `pkill -f ${JSON.stringify(onboarding)} 2>/dev/null; true`;


### PR DESCRIPTION
## 摘要

main 從 #544 起 CI 一直紅在 `Herdr Quick Start close › exits the process when the menu is closed`：測試用 BSD 語法呼叫 `script`，util-linux（ubuntu CI）不接受位置參數命令，onboarding 從未啟動、marker 永遠不出現，兩個 Node job 確定性失敗。本 PR 依平台分支 `script` 呼叫方式，並順手修掉測試在 macOS 上每次吃滿 30s timeout 的假延遲（→ ~250ms）。

## Root cause

- BSD `script` (macOS): `script -q /dev/null <command...>` — command as positional args.
- util-linux `script` (ubuntu CI): only accepts a command via `-c`; positional operands after the file are rejected, so the wrapper exited immediately. The inner command (and its `>/dev/null 2>&1`) swallowed the error, the marker was never written, and the poll printed `LINGERED` — deterministic on both Node 20 and 22, every push since the test landed on main.

## Changes

- Branch on `process.platform`: Linux uses `script -qec "<cmd>" /dev/null`, macOS keeps the BSD positional form.
- Redirect the background job as a whole: the keystroke-feeder subshell's inherited stderr was holding `spawnSync`'s pipe open until its `sleep` ended, so even a passing run ate the full 30s timeout. Sleep shrinks 40s → 12s (still well past the 8s poll window).

## Verification

- fail-on-old: every main CI run since bd726f2 fails on exactly this test with `actual: LINGERED` (runs 31993589901, 32014062729, plus the PR #553 run 32010319418).
- pass-on-new (macOS branch): full `test/herdr-plugin.test.js` 132/132 green locally with isolated `CCXRAY_HOME`; the fixed test now completes in ~250ms instead of 30s.
- pass-on-new (Linux branch): no util-linux `script` available locally — this PR's own CI run is the differential evidence.

Note: run 31994476657 (#545) also had a one-off `count_tokens` e2e failure ("proxy did not start") that does not reproduce in the other runs — flaky, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)