### PR TITLE
fix(herdr): share pane-independent reports across the badge fan-out; E3 isolation audit (#543)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -171,7 +171,13 @@ process, a throwaway `$HOME` is not an option (it would take the puppeteer cache
 with it). Set **`CCXRAY_IMPORT_HOMES`** instead: it is the same knob
 `server/importer.js` honours, and the plugin treats its value as the `projects/`
 root verbatim. A test that exercises staleness without it silently reads the
-developer's real transcripts. Fixture shape: a `<cwd with every non-alphanumeric
+developer's real transcripts. Two mechanisms enforce this in
+`test/herdr-plugin.test.js`: direct `sessionSummaryDetails` call sites are
+covered by a source-scan audit test (`audit: sessionSummaryDetails call sites
+pin CCXRAY_IMPORT_HOMES` — a `CCXRAY_HOME` in the opts without
+`CCXRAY_IMPORT_HOMES` fails the suite), and spawned scripts are covered by
+`pluginEnv()` defaulting `CCXRAY_IMPORT_HOMES` to the empty `NO_TRANSCRIPTS`
+root (overridable per test). Fixture shape: a `<cwd with every non-alphanumeric
 flattened to '-'>/<sessionId>.jsonl` holding at least one `{type:'assistant',
 timestamp, message.usage}` line — metadata-only records (`system`, `last-prompt`,
 `mode`, `permission-mode`, `file-history-snapshot`) deliberately do NOT count as

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -171,13 +171,15 @@ process, a throwaway `$HOME` is not an option (it would take the puppeteer cache
 with it). Set **`CCXRAY_IMPORT_HOMES`** instead: it is the same knob
 `server/importer.js` honours, and the plugin treats its value as the `projects/`
 root verbatim. A test that exercises staleness without it silently reads the
-developer's real transcripts. Two mechanisms enforce this in
-`test/herdr-plugin.test.js`: direct `sessionSummaryDetails` call sites are
-covered by a source-scan audit test (`audit: sessionSummaryDetails call sites
-pin CCXRAY_IMPORT_HOMES` — a `CCXRAY_HOME` in the opts without
-`CCXRAY_IMPORT_HOMES` fails the suite), and spawned scripts are covered by
-`pluginEnv()` defaulting `CCXRAY_IMPORT_HOMES` to the empty `NO_TRANSCRIPTS`
-root (overridable per test). Fixture shape: a `<cwd with every non-alphanumeric
+developer's real transcripts. Two mechanisms guard this in
+`test/herdr-plugin.test.js`. The structural one is `pluginEnv()` defaulting
+`CCXRAY_IMPORT_HOMES` to the empty `NO_TRANSCRIPTS` root for every spawned
+script (overridable per test). The second is a lint-class audit test (`audit:
+sessionSummaryDetails call sites pin CCXRAY_IMPORT_HOMES`): any
+`sessionSummaryDetails` call span that literally contains `CCXRAY_HOME`
+without `CCXRAY_IMPORT_HOMES` fails the suite. The audit scans literal call
+spans only — an env object assembled outside the call escapes it, so it is a
+tripwire for the common inline-opts shape, not proof of isolation. Fixture shape: a `<cwd with every non-alphanumeric
 flattened to '-'>/<sessionId>.jsonl` holding at least one `{type:'assistant',
 timestamp, message.usage}` line — metadata-only records (`system`, `last-prompt`,
 `mode`, `permission-mode`, `file-history-snapshot`) deliberately do NOT count as

--- a/plugins/herdr/README.md
+++ b/plugins/herdr/README.md
@@ -99,6 +99,12 @@ that fixes it: the scan is throttled to once per 10 minutes and guarded by a
 lockfile, so many panes noticing at once still produce one scan.
 `CCXRAY_BADGE_IMPORT_DISABLE=1` keeps the marker but stops the rescan.
 
+`refresh-all-badges` (the startup fan-out) runs the pane-independent `ccxray
+status` and `ccxray usage` reports once and shares them with every per-pane
+refresh, so each child only pays for its own sidebar writes. Each child is
+capped at 10 seconds (`CCXRAY_BADGE_CHILD_TIMEOUT_MS` overrides); a child
+killed at the cap is reported as `timed out`, separately from `failed`.
+
 The context row is width-aware. `refresh-badges` first honors `CCXRAY_HERDR_SIDEBAR_COLS`, then Herdr plugin context sidebar fields, then uses `herdr pane layout` as a width estimate. Wider sidebars show more recent turns and may append one compact signal such as `near full`, `fail 2x`, or `cache 92%`.
 
 Context colors are mutually exclusive: unknown is neutral gray, `ctx <= 40%` is green, `40% < ctx <= 80%` is yellow, and `ctx > 80%` is red. A pane without exact ccxray identity remains unknown; the plugin never borrows telemetry from another session in the project.

--- a/plugins/herdr/README.md
+++ b/plugins/herdr/README.md
@@ -101,9 +101,12 @@ lockfile, so many panes noticing at once still produce one scan.
 
 `refresh-all-badges` (the startup fan-out) runs the pane-independent `ccxray
 status` and `ccxray usage` reports once and shares them with every per-pane
-refresh, so each child only pays for its own sidebar writes. Each child is
-capped at 10 seconds (`CCXRAY_BADGE_CHILD_TIMEOUT_MS` overrides); a child
-killed at the cap is reported as `timed out`, separately from `failed`.
+refresh, so each child's remaining work is its own session matching, layout
+lookup, and sidebar writes. Only reports that succeeded are shared — a child
+that finds its report missing recomputes its own, so a transient failure
+degrades one pane instead of painting all of them. Each child is capped at 10
+seconds (`CCXRAY_BADGE_CHILD_TIMEOUT_MS` overrides); a child killed at the cap
+is reported as `timed out`, separately from `failed`.
 
 The context row is width-aware. `refresh-badges` first honors `CCXRAY_HERDR_SIDEBAR_COLS`, then Herdr plugin context sidebar fields, then uses `herdr pane layout` as a width estimate. Wider sidebars show more recent turns and may append one compact signal such as `near full`, `fail 2x`, or `cache 92%`.
 

--- a/plugins/herdr/bin/refresh-all-badges.js
+++ b/plugins/herdr/bin/refresh-all-badges.js
@@ -32,28 +32,39 @@ function main() {
   // of raising the cap we run the shared reports once and hand the result to
   // every child. The children's own per-call timeouts remain as defense
   // against a hung CLI, not as a budget.
-  const shared = {
-    status: statusReport(),
-    usage: usageReport({ last: process.env.CCXRAY_HERDR_LAST || '24h' }),
-  };
-  const sharedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-badge-shared-'));
-  const sharedFile = path.join(sharedDir, 'report.json');
-  fs.writeFileSync(sharedFile, JSON.stringify(shared));
+  const status = statusReport();
+  const usage = usageReport({ last: process.env.CCXRAY_HERDR_LAST || '24h' });
+  // Only usable reports are shared. A transient failure here must not be
+  // broadcast to every pane as "no hub / not linked": a child that finds its
+  // report missing recomputes its own copy — the pre-share behavior, but
+  // confined to that child. The payload is a minimal DTO, not the raw
+  // spawnSync result (whose Error does not survive JSON anyway).
+  const shared = {};
+  if (status.ok) shared.status = { ok: true, parsed: status.parsed };
+  if (usage.ok) shared.usage = { ok: true, data: usage.data };
 
   const timeoutMs = childTimeoutMs();
   let refreshed = 0;
   let failed = 0;
   let timedOut = 0;
+  let sharedDir = null;
   try {
+    sharedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-badge-shared-'));
+    const sharedFile = path.join(sharedDir, 'report.json');
+    fs.writeFileSync(sharedFile, JSON.stringify(shared));
     for (const agent of agents) {
       const context = {
         focused_pane_id: agent.pane_id,
         focused_pane_cwd: agent.foreground_cwd || agent.cwd || null,
         workspace_id: agent.workspace_id || null,
         tab_id: agent.tab_id || null,
-        // We already hold the agent list; passing the session spares each
-        // child its own `herdr agent list` round trip.
+        // We already hold the agent list; passing the resolution (even "this
+        // pane has no session id") spares each child its own
+        // `herdr agent list` round trip. The explicit flag is what the child
+        // trusts — a null agent_session alone could come from any context
+        // author.
         agent_session: agent.agent_session || null,
+        agent_session_known: true,
       };
       const result = spawnSync(process.execPath, [path.join(__dirname, 'refresh-badges.js')], {
         env: {
@@ -75,7 +86,7 @@ function main() {
       else failed++;
     }
   } finally {
-    try { fs.rmSync(sharedDir, { recursive: true, force: true }); } catch {}
+    if (sharedDir) { try { fs.rmSync(sharedDir, { recursive: true, force: true }); } catch {} }
   }
 
   const parts = [`${refreshed} refreshed`];

--- a/plugins/herdr/bin/refresh-all-badges.js
+++ b/plugins/herdr/bin/refresh-all-badges.js
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
 'use strict';
 
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
-const { herdrAgentReport } = require('./lib/ccxray');
+const { herdrAgentReport, statusReport, usageReport } = require('./lib/ccxray');
+
+function childTimeoutMs(env = process.env) {
+  const value = Number(env.CCXRAY_BADGE_CHILD_TIMEOUT_MS);
+  return Number.isFinite(value) && value >= 100 ? value : 10000;
+}
 
 function main() {
   const report = herdrAgentReport({ env: process.env, timeoutMs: 3000 });
@@ -12,34 +19,70 @@ function main() {
     process.exit(0);
   }
 
-  let refreshed = 0;
-  let failed = 0;
-  for (const agent of report.agents) {
-    if (!agent.pane_id) continue;
-    const context = {
-      focused_pane_id: agent.pane_id,
-      focused_pane_cwd: agent.foreground_cwd || agent.cwd || null,
-      workspace_id: agent.workspace_id || null,
-      tab_id: agent.tab_id || null,
-    };
-    const result = spawnSync(process.execPath, [path.join(__dirname, 'refresh-badges.js')], {
-      env: {
-        ...process.env,
-        HERDR_PANE_ID: agent.pane_id,
-        HERDR_WORKSPACE_ID: agent.workspace_id || '',
-        HERDR_TAB_ID: agent.tab_id || '',
-        HERDR_PLUGIN_CONTEXT_JSON: JSON.stringify(context),
-        CCXRAY_BADGE_EVENT_DELAY_MS: '0',
-      },
-      encoding: 'utf8',
-      timeout: 10000,
-    });
-    if (result.status === 0) refreshed++;
-    else failed++;
+  const agents = report.agents.filter(agent => agent.pane_id);
+  if (!agents.length) {
+    console.log('ccxray sidebar sync: 0 refreshed');
+    process.exit(0);
   }
 
-  console.log(`ccxray sidebar sync: ${refreshed} refreshed${failed ? `, ${failed} failed` : ''}`);
-  process.exit(failed ? 1 : 0);
+  // #543: statusReport (5s) + usageReport (12s) are pane-independent, but each
+  // child used to re-run both — alone already over the per-child cap below, so
+  // a slow-but-healthy refresh was killed mid-write. The wall-clock budget
+  // belongs to this layer (serial fan-out: the user waits N × cap), so instead
+  // of raising the cap we run the shared reports once and hand the result to
+  // every child. The children's own per-call timeouts remain as defense
+  // against a hung CLI, not as a budget.
+  const shared = {
+    status: statusReport(),
+    usage: usageReport({ last: process.env.CCXRAY_HERDR_LAST || '24h' }),
+  };
+  const sharedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-badge-shared-'));
+  const sharedFile = path.join(sharedDir, 'report.json');
+  fs.writeFileSync(sharedFile, JSON.stringify(shared));
+
+  const timeoutMs = childTimeoutMs();
+  let refreshed = 0;
+  let failed = 0;
+  let timedOut = 0;
+  try {
+    for (const agent of agents) {
+      const context = {
+        focused_pane_id: agent.pane_id,
+        focused_pane_cwd: agent.foreground_cwd || agent.cwd || null,
+        workspace_id: agent.workspace_id || null,
+        tab_id: agent.tab_id || null,
+        // We already hold the agent list; passing the session spares each
+        // child its own `herdr agent list` round trip.
+        agent_session: agent.agent_session || null,
+      };
+      const result = spawnSync(process.execPath, [path.join(__dirname, 'refresh-badges.js')], {
+        env: {
+          ...process.env,
+          HERDR_PANE_ID: agent.pane_id,
+          HERDR_WORKSPACE_ID: agent.workspace_id || '',
+          HERDR_TAB_ID: agent.tab_id || '',
+          HERDR_PLUGIN_CONTEXT_JSON: JSON.stringify(context),
+          CCXRAY_BADGE_EVENT_DELAY_MS: '0',
+          CCXRAY_BADGE_SHARED_REPORT: sharedFile,
+        },
+        encoding: 'utf8',
+        timeout: timeoutMs,
+      });
+      if (result.status === 0) refreshed++;
+      // A killed child never got to report what it knows (refresh-badges's own
+      // exit code is honest since #553); say "timed out", not just "failed".
+      else if (result.error && result.error.code === 'ETIMEDOUT') timedOut++;
+      else failed++;
+    }
+  } finally {
+    try { fs.rmSync(sharedDir, { recursive: true, force: true }); } catch {}
+  }
+
+  const parts = [`${refreshed} refreshed`];
+  if (failed) parts.push(`${failed} failed`);
+  if (timedOut) parts.push(`${timedOut} timed out (over ${timeoutMs}ms)`);
+  console.log(`ccxray sidebar sync: ${parts.join(', ')}`);
+  process.exit(failed || timedOut ? 1 : 0);
 }
 
 main();

--- a/plugins/herdr/bin/refresh-badges.js
+++ b/plugins/herdr/bin/refresh-badges.js
@@ -44,15 +44,22 @@ function eventContext(env = process.env) {
 // #543: the fan-out parent (refresh-all-badges) precomputes the
 // pane-independent status/usage reports once and shares them via a temp file,
 // because re-running them here costs up to 17s against the parent's 10s cap.
-// Fail open: anything short of a well-formed file means "compute our own", so
-// the event-driven single-pane path is byte-identical to before.
+// Per-report fail open: the parent only shares reports that succeeded, and
+// anything missing or malformed means "compute our own" — so a transient
+// parent failure degrades one report for one child back to the pre-share
+// behavior instead of painting every pane "no hub / not linked". The
+// event-driven single-pane path (no env var) is byte-identical to before.
 function sharedReports(env = process.env) {
-  if (!env.CCXRAY_BADGE_SHARED_REPORT) return null;
+  if (!env.CCXRAY_BADGE_SHARED_REPORT) return {};
   try {
     const parsed = JSON.parse(fs.readFileSync(env.CCXRAY_BADGE_SHARED_REPORT, 'utf8'));
-    if (parsed && parsed.status && parsed.status.parsed && parsed.usage) return parsed;
+    if (!parsed || typeof parsed !== 'object') return {};
+    return {
+      status: parsed.status && parsed.status.ok && parsed.status.parsed ? parsed.status : null,
+      usage: parsed.usage && parsed.usage.ok && parsed.usage.data ? parsed.usage : null,
+    };
   } catch {}
-  return null;
+  return {};
 }
 
 function waitForTelemetry(env = process.env) {
@@ -127,15 +134,18 @@ function main() {
   };
   const runtime = herdrRuntime(env);
   const shared = sharedReports();
-  const status = shared ? shared.status : statusReport();
-  const usage = shared ? shared.usage : usageReport({ last: process.env.CCXRAY_HERDR_LAST || '24h' });
+  const status = shared.status || statusReport();
+  const usage = shared.usage || usageReport({ last: process.env.CCXRAY_HERDR_LAST || '24h' });
   const context = runtime.context || {};
   const targetPaneId = runtime.paneId || context.focused_pane_id || null;
   let nativeSessionId = event.sessionId || null;
   if (!nativeSessionId && context.agent_session?.kind === 'id') {
     nativeSessionId = context.agent_session.value;
   }
-  if (!nativeSessionId && targetPaneId) {
+  // agent_session_known means the context author already consulted the agent
+  // list for this pane — including the "no session id" answer — so re-listing
+  // here could only repeat that answer more slowly.
+  if (!nativeSessionId && targetPaneId && !context.agent_session_known) {
     const report = herdrAgentReport({ env });
     const agent = report.agents.find(item => item.pane_id === targetPaneId);
     if (agent?.agent_session?.kind === 'id') nativeSessionId = agent.agent_session.value;

--- a/plugins/herdr/bin/refresh-badges.js
+++ b/plugins/herdr/bin/refresh-badges.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
+const fs = require('fs');
 const {
   contextSidebarColumns,
   formatPercent,
@@ -38,6 +39,20 @@ function eventContext(env = process.env) {
   } catch {
     return {};
   }
+}
+
+// #543: the fan-out parent (refresh-all-badges) precomputes the
+// pane-independent status/usage reports once and shares them via a temp file,
+// because re-running them here costs up to 17s against the parent's 10s cap.
+// Fail open: anything short of a well-formed file means "compute our own", so
+// the event-driven single-pane path is byte-identical to before.
+function sharedReports(env = process.env) {
+  if (!env.CCXRAY_BADGE_SHARED_REPORT) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(env.CCXRAY_BADGE_SHARED_REPORT, 'utf8'));
+    if (parsed && parsed.status && parsed.status.parsed && parsed.usage) return parsed;
+  } catch {}
+  return null;
 }
 
 function waitForTelemetry(env = process.env) {
@@ -111,11 +126,15 @@ function main() {
     HERDR_TAB_ID: process.env.HERDR_TAB_ID || event.tabId || '',
   };
   const runtime = herdrRuntime(env);
-  const status = statusReport();
-  const usage = usageReport({ last: process.env.CCXRAY_HERDR_LAST || '24h' });
+  const shared = sharedReports();
+  const status = shared ? shared.status : statusReport();
+  const usage = shared ? shared.usage : usageReport({ last: process.env.CCXRAY_HERDR_LAST || '24h' });
   const context = runtime.context || {};
   const targetPaneId = runtime.paneId || context.focused_pane_id || null;
   let nativeSessionId = event.sessionId || null;
+  if (!nativeSessionId && context.agent_session?.kind === 'id') {
+    nativeSessionId = context.agent_session.value;
+  }
   if (!nativeSessionId && targetPaneId) {
     const report = herdrAgentReport({ env });
     const agent = report.agents.find(item => item.pane_id === targetPaneId);

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -25,6 +25,10 @@ function pluginEnv(overrides = {}) {
     env[key] = value;
   }
   env.CCXRAY_HOME = isolatedHome();
+  // Spawn-layer twin of the NO_TRANSCRIPTS rule below: a spawned script's own
+  // sessionSummaryDetails call sees the child's env, where an unset
+  // CCXRAY_IMPORT_HOMES means the developer's real $HOME/.claude*/projects.
+  env.CCXRAY_IMPORT_HOMES = NO_TRANSCRIPTS;
   return { ...env, ...overrides };
 }
 
@@ -3150,3 +3154,41 @@ describe('refresh-all-badges shares the pane-independent reports (#543)', () => 
   });
 });
 
+// The E3 audit (handoff 2026-08-17): sessionSummaryDetails consults the Claude
+// transcript tree, and an unset CCXRAY_IMPORT_HOMES means the developer's real
+// $HOME/.claude*/projects (the #407 shape — green only because the real data
+// happens to be empty). The #553 session fixed the call sites and verified
+// 7 → 0 real-path accesses, but that instrumentation was evidence, not
+// enforcement. This is the mechanism: same recursive-source-scan class as
+// test/invariant-encapsulation.test.js. See ADR 0015 R4 and docs/testing.md.
+describe('audit: sessionSummaryDetails call sites pin CCXRAY_IMPORT_HOMES', () => {
+  it('every call whose opts set CCXRAY_HOME also sets CCXRAY_IMPORT_HOMES', () => {
+    const source = fs.readFileSync(__filename, 'utf8');
+    const marker = 'sessionSummaryDetails(';
+    const spans = [];
+    let from = 0;
+    for (;;) {
+      const start = source.indexOf(marker, from);
+      if (start === -1) break;
+      let depth = 0;
+      let end = -1;
+      for (let i = start + marker.length - 1; i < source.length; i++) {
+        if (source[i] === '(') depth++;
+        else if (source[i] === ')') {
+          depth--;
+          if (depth === 0) { end = i; break; }
+        }
+      }
+      assert.notEqual(end, -1, `unbalanced parens after offset ${start}`);
+      spans.push(source.slice(start, end + 1));
+      from = end + 1;
+    }
+    assert.ok(spans.length >= 10, `expected the known call sites, found ${spans.length}`);
+    for (const span of spans) {
+      if (!span.includes('CCXRAY_HOME')) continue;
+      assert.ok(span.includes('CCXRAY_IMPORT_HOMES'),
+        `sessionSummaryDetails call sets CCXRAY_HOME without pinning CCXRAY_IMPORT_HOMES `
+        + `(stats the developer's real transcripts):\n${span.slice(0, 200)}`);
+    }
+  });
+});

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -3045,3 +3045,108 @@ describe('Herdr plugin commands', () => {
     assert.match(out, /Link a local plugin/);
   });
 });
+
+// #543: statusReport (5s) + usageReport (12s) are pane-independent but were
+// re-run by every fan-out child against the parent's 10s cap — a slow but
+// healthy refresh got killed mid-write and the serial fan-out blocked startup
+// for N × cap. The parent now runs both once and shares them; a child killed
+// at the cap is reported as timed out, never folded into "failed" silently.
+describe('refresh-all-badges shares the pane-independent reports (#543)', () => {
+  function makeCountingCcxray() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-counting-bin-'));
+    const bin = path.join(dir, 'ccxray');
+    const log = path.join(dir, 'calls.log');
+    fs.writeFileSync(bin, [
+      '#!/usr/bin/env node',
+      `require('fs').appendFileSync(${JSON.stringify(log)}, process.argv.slice(2).join(' ') + '\\n');`,
+      "if (process.argv[2] === 'usage') process.stdout.write(JSON.stringify({ meta: { totalEntries: 0 }, sessions: {}, models: [] }) + '\\n');",
+      "else process.stdout.write('No hub running\\n');",
+      '',
+    ].join('\n'));
+    fs.chmodSync(bin, 0o755);
+    return { bin, log };
+  }
+
+  function makeFanoutHerdr(agents, { sleepMs = 0 } = {}) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-fanout-herdr-'));
+    const bin = path.join(dir, 'herdr');
+    const log = path.join(dir, 'args.log');
+    const agentList = JSON.stringify({ id: 't', result: { type: 'agent_list', agents } });
+    fs.writeFileSync(bin, [
+      '#!/usr/bin/env node',
+      `require('fs').appendFileSync(${JSON.stringify(log)}, process.argv.slice(2).join(' ') + '\\n');`,
+      "if (process.argv[2] === 'agent' && process.argv[3] === 'list') {",
+      `  process.stdout.write(${JSON.stringify(agentList + '\n')});`,
+      `} else if (${sleepMs}) {`,
+      `  setTimeout(() => process.exit(0), ${sleepMs});`,
+      '} else {',
+      `  process.stdout.write(${JSON.stringify(JSON.stringify({ id: 't', result: { type: 'ok' } }) + '\n')});`,
+      '}',
+      '',
+    ].join('\n'));
+    fs.chmodSync(bin, 0o755);
+    return { bin, log };
+  }
+
+  const twoAgents = [
+    { pane_id: 'w1:p1', workspace_id: 'w1', agent_session: { kind: 'id', value: 'sess-1' } },
+    { pane_id: 'w1:p2', workspace_id: 'w1', agent_session: { kind: 'id', value: 'sess-2' } },
+  ];
+
+  // FAIL-ON-OLD: pre-fix, each child runs `ccxray status` + `ccxray usage` and
+  // its own `herdr agent list` — the counts below read 2/2/3 instead of 1/1/1.
+  it('runs status, usage, and agent list once for the whole fan-out', () => {
+    const ccxray = makeCountingCcxray();
+    const herdr = makeFanoutHerdr(twoAgents);
+    const result = runScript('refresh-all-badges.js', [], {
+      CCXRAY_HOME: makeHome(),
+      CCXRAY_IMPORT_HOMES: NO_TRANSCRIPTS,
+      CCXRAY_BIN: ccxray.bin,
+      HERDR_BIN_PATH: herdr.bin,
+      CCXRAY_HERDR_NO_LAYOUT: '1',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /2 refreshed/);
+    const ccxrayCalls = fs.readFileSync(ccxray.log, 'utf8').trim().split('\n');
+    assert.equal(ccxrayCalls.filter(call => call.startsWith('usage')).length, 1,
+      `expected one shared usage run, saw: ${ccxrayCalls.join(' | ')}`);
+    assert.equal(ccxrayCalls.filter(call => call.startsWith('status')).length, 1,
+      `expected one shared status run, saw: ${ccxrayCalls.join(' | ')}`);
+    const herdrCalls = fs.readFileSync(herdr.log, 'utf8').trim().split('\n');
+    assert.equal(herdrCalls.filter(call => call.startsWith('agent list')).length, 1,
+      `children must reuse the parent's agent list, saw: ${herdrCalls.join(' | ')}`);
+  });
+
+  // FAIL-ON-OLD: pre-fix the summary line had no timed-out bucket — a killed
+  // child was indistinguishable from an honest non-zero exit.
+  it('reports a child killed at the cap as timed out, not refreshed', () => {
+    const ccxray = makeCountingCcxray();
+    const herdr = makeFanoutHerdr(twoAgents.slice(0, 1), { sleepMs: 3000 });
+    const result = runScript('refresh-all-badges.js', [], {
+      CCXRAY_HOME: makeHome(),
+      CCXRAY_IMPORT_HOMES: NO_TRANSCRIPTS,
+      CCXRAY_BIN: ccxray.bin,
+      HERDR_BIN_PATH: herdr.bin,
+      CCXRAY_HERDR_NO_LAYOUT: '1',
+      CCXRAY_BADGE_CHILD_TIMEOUT_MS: '500',
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /0 refreshed, 1 timed out \(over 500ms\)/);
+  });
+
+  it('refresh-badges falls back to its own reports when the shared file is bad', () => {
+    const ccxray = makeCountingCcxray();
+    const bogus = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-bogus-shared-')), 'report.json');
+    fs.writeFileSync(bogus, 'not json');
+    const result = runScript('refresh-badges.js', [], {
+      CCXRAY_HOME: makeHome(),
+      CCXRAY_IMPORT_HOMES: NO_TRANSCRIPTS,
+      CCXRAY_BIN: ccxray.bin,
+      CCXRAY_BADGE_SHARED_REPORT: bogus,
+    });
+    assert.match(result.stdout, /ccxray badges refreshed/);
+    const calls = fs.readFileSync(ccxray.log, 'utf8');
+    assert.match(calls, /usage/, 'a bad shared file must fail open to a self-run usage report');
+  });
+});
+

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -3056,15 +3056,25 @@ describe('Herdr plugin commands', () => {
 // for N × cap. The parent now runs both once and shares them; a child killed
 // at the cap is reported as timed out, never folded into "failed" silently.
 describe('refresh-all-badges shares the pane-independent reports (#543)', () => {
-  function makeCountingCcxray() {
+  function makeCountingCcxray({ failFirstUsage = false } = {}) {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-counting-bin-'));
     const bin = path.join(dir, 'ccxray');
     const log = path.join(dir, 'calls.log');
+    const marker = path.join(dir, 'usage-failed-once');
     fs.writeFileSync(bin, [
       '#!/usr/bin/env node',
-      `require('fs').appendFileSync(${JSON.stringify(log)}, process.argv.slice(2).join(' ') + '\\n');`,
-      "if (process.argv[2] === 'usage') process.stdout.write(JSON.stringify({ meta: { totalEntries: 0 }, sessions: {}, models: [] }) + '\\n');",
-      "else process.stdout.write('No hub running\\n');",
+      "const fs = require('fs');",
+      `fs.appendFileSync(${JSON.stringify(log)}, process.argv.slice(2).join(' ') + '\\n');`,
+      "if (process.argv[2] === 'usage') {",
+      ...(failFirstUsage ? [
+        `  if (!fs.existsSync(${JSON.stringify(marker)})) {`,
+        `    fs.writeFileSync(${JSON.stringify(marker)}, '1');`,
+        "    process.stderr.write('transient failure\\n');",
+        '    process.exit(1);',
+        '  }',
+      ] : []),
+      "  process.stdout.write(JSON.stringify({ meta: { totalEntries: 0 }, sessions: {}, models: [] }) + '\\n');",
+      "} else process.stdout.write('No hub running\\n');",
       '',
     ].join('\n'));
     fs.chmodSync(bin, 0o755);
@@ -3096,11 +3106,41 @@ describe('refresh-all-badges shares the pane-independent reports (#543)', () => 
     { pane_id: 'w1:p1', workspace_id: 'w1', agent_session: { kind: 'id', value: 'sess-1' } },
     { pane_id: 'w1:p2', workspace_id: 'w1', agent_session: { kind: 'id', value: 'sess-2' } },
   ];
+  // The third pane has no native session id — the parent's answer for it is
+  // "none", and the child must trust that instead of re-listing.
+  const threeAgents = [...twoAgents, { pane_id: 'w1:p3', workspace_id: 'w1' }];
 
   // FAIL-ON-OLD: pre-fix, each child runs `ccxray status` + `ccxray usage` and
-  // its own `herdr agent list` — the counts below read 2/2/3 instead of 1/1/1.
+  // its own `herdr agent list` — the counts below read 3/3/4 instead of 1/1/1.
   it('runs status, usage, and agent list once for the whole fan-out', () => {
     const ccxray = makeCountingCcxray();
+    const herdr = makeFanoutHerdr(threeAgents);
+    const result = runScript('refresh-all-badges.js', [], {
+      CCXRAY_HOME: makeHome(),
+      CCXRAY_IMPORT_HOMES: NO_TRANSCRIPTS,
+      CCXRAY_BIN: ccxray.bin,
+      HERDR_BIN_PATH: herdr.bin,
+      CCXRAY_HERDR_NO_LAYOUT: '1',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /3 refreshed/);
+    const ccxrayCalls = fs.readFileSync(ccxray.log, 'utf8').trim().split('\n');
+    assert.equal(ccxrayCalls.filter(call => call.startsWith('usage')).length, 1,
+      `expected one shared usage run, saw: ${ccxrayCalls.join(' | ')}`);
+    assert.equal(ccxrayCalls.filter(call => call.startsWith('status')).length, 1,
+      `expected one shared status run, saw: ${ccxrayCalls.join(' | ')}`);
+    const herdrCalls = fs.readFileSync(herdr.log, 'utf8').trim().split('\n');
+    assert.equal(herdrCalls.filter(call => call.startsWith('agent list')).length, 1,
+      `children (including the no-session pane) must reuse the parent's agent list, saw: ${herdrCalls.join(' | ')}`);
+  });
+
+  // A transient parent failure must not be broadcast: the children whose
+  // shared report is missing recompute their own (usage runs 1 failed + 2
+  // recomputed = 3 times) and the badges still render from real data. A
+  // version that shares failed reports runs usage once and paints every pane
+  // "not linked".
+  it('does not poison the fan-out when the parent usage report fails once', () => {
+    const ccxray = makeCountingCcxray({ failFirstUsage: true });
     const herdr = makeFanoutHerdr(twoAgents);
     const result = runScript('refresh-all-badges.js', [], {
       CCXRAY_HOME: makeHome(),
@@ -3112,13 +3152,8 @@ describe('refresh-all-badges shares the pane-independent reports (#543)', () => 
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /2 refreshed/);
     const ccxrayCalls = fs.readFileSync(ccxray.log, 'utf8').trim().split('\n');
-    assert.equal(ccxrayCalls.filter(call => call.startsWith('usage')).length, 1,
-      `expected one shared usage run, saw: ${ccxrayCalls.join(' | ')}`);
-    assert.equal(ccxrayCalls.filter(call => call.startsWith('status')).length, 1,
-      `expected one shared status run, saw: ${ccxrayCalls.join(' | ')}`);
-    const herdrCalls = fs.readFileSync(herdr.log, 'utf8').trim().split('\n');
-    assert.equal(herdrCalls.filter(call => call.startsWith('agent list')).length, 1,
-      `children must reuse the parent's agent list, saw: ${herdrCalls.join(' | ')}`);
+    assert.equal(ccxrayCalls.filter(call => call.startsWith('usage')).length, 3,
+      `each child must recompute the failed shared usage, saw: ${ccxrayCalls.join(' | ')}`);
   });
 
   // FAIL-ON-OLD: pre-fix the summary line had no timed-out bucket — a killed
@@ -3151,6 +3186,7 @@ describe('refresh-all-badges shares the pane-independent reports (#543)', () => 
     assert.match(result.stdout, /ccxray badges refreshed/);
     const calls = fs.readFileSync(ccxray.log, 'utf8');
     assert.match(calls, /usage/, 'a bad shared file must fail open to a self-run usage report');
+    assert.match(calls, /status/, 'a bad shared file must fail open to a self-run status report');
   });
 });
 


### PR DESCRIPTION
## 摘要

修 #543：`refresh-all-badges` 給每個子行程 10s cap，但每個子行程都各自重跑 pane 無關的 `statusReport`(5s) + `usageReport`(12s)，光這兩項就超過 cap——慢但健康的 refresh 被殺、串列 fan-out 在 startup 阻塞 N × cap。現在 parent 跑一次、只分享成功的報告（避免瞬時失敗污染全部 pane）、以 temp file 共享；被 cap 殺掉的子行程回報為 `timed out` 與 `failed` 區分。另外落地 handoff 的 E3 稽核測試：`sessionSummaryDetails` 呼叫點必須 pin `CCXRAY_IMPORT_HOMES`，用機制而非記憶防止 #407 型洩漏回歸。

## Which layer owns the budget (the #543 design question)

The issue rejected both obvious fixes, and this PR agrees:

- **Raising the parent cap** makes startup blocking worse (serial fan-out × longer cap).
- **Lowering the child's internal budgets** changes nothing — `ccxray usage` genuinely needs its 12s worst case.

The resolution: **the parent owns the wall-clock budget** because it owns the serial fan-out — N × cap is what the user experiences at startup. The children's per-call timeouts are defense against a hung CLI, not a budget contract. The mismatch is fixed not by aligning the two numbers but by moving the pane-independent work (`status`, `usage`, `agent list`) up to the layer that owns the budget, run once, shared down via `CCXRAY_BADGE_SHARED_REPORT` (a temp file carrying a minimal `{status:{ok,parsed}, usage:{ok,data}}` DTO). Worst-case child work drops from ~24s to ~5s of session matching, layout lookup, and sidebar writes — comfortably inside the unchanged 10s cap (`CCXRAY_BADGE_CHILD_TIMEOUT_MS` overrides, mainly for tests).

Sharing rules, each with a differential test:

- **Only usable reports are shared** (`ok: true`). A child that finds its report missing recomputes its own — the pre-share behavior, confined to that child — so a transient parent failure cannot paint every pane "no hub / not linked".
- **The parent's agent-list resolution is trusted, including "no session id"**: the fan-out context carries `agent_session_known`, an explicit flag only the fan-out sets, so session-less panes stop re-running `herdr agent list` too.
- **A child killed at the cap is reported as `timed out`** separately from `failed`: since #553 the child's exit code is honest, but a killed child never gets to use it.

## E3 audit test (second commit)

#553 added a scan root outside `CCXRAY_HOME` (`claudeProjectRoots` reads `$HOME/.claude*/projects` when `CCXRAY_IMPORT_HOMES` is unset). The prior session fixed the test call sites and measured 7 → 0 real-path accesses — evidence, not enforcement. This PR adds the mechanism, two layers:

- **`pluginEnv()` default** (structural): every spawned script gets `CCXRAY_IMPORT_HOMES=NO_TRANSCRIPTS` (overridable), so a child process can never fall through to the developer's real transcripts.
- **Audit test** (lint-class tripwire): any `sessionSummaryDetails` call span in `test/herdr-plugin.test.js` that literally contains `CCXRAY_HOME` without `CCXRAY_IMPORT_HOMES` fails the suite. Scope stated honestly in `docs/testing.md`: it scans literal call spans; an env object assembled outside the call escapes it.

Refs ADR 0015 R4.

## Verification (docs/verification-principles.md)

All differentials taken in throwaway worktrees, never over a dirty tree.

**Against origin/main (99ac693) + new test file:**

- `runs status, usage, and agent list once for the whole fan-out` — FAILS on old with `expected one shared usage run, saw: status | usage --json --last 24h | status | usage --json --last 24h` (each child re-ran both); PASSES on new.
- `reports a child killed at the cap as timed out, not refreshed` — FAILS on old (no timed-out bucket); PASSES on new.
- E3 audit by mutation: removing one `CCXRAY_IMPORT_HOMES` pin from a call site turns the audit red naming the offending call; green with all pins present.

**Against the pre-review-follow-up commit (2798611) + final test file:**

- `does not poison the fan-out when the parent usage report fails once` — FAILS on the share-everything version (`saw: status | usage --json --last 24h`, one poisoned run broadcast to all panes; the captured herdr log shows every pane written `summary=ccxray: not linked`); PASSES on final (3 usage runs: 1 failed parent + 2 child recomputes, badges render real data).
- Session-less third pane — FAILS on the version without `agent_session_known` (second `agent list` call from the p3 child visible in the log); PASSES on final.

**Suite:** `CCXRAY_HOME=$(mktemp -d) npm test` → 2190/2190 pass, exit 0 on the final tree. (One earlier run had a single unrelated flake, `hub-client-signal.e2e` timing out under full-suite load on a machine carrying known leaked processes; it passes in isolation and in the other full runs, and shares no files with this diff.)

**No-regression control for the unshared path:** the pre-existing exact-token assertions on the event-driven single-pane path (`refresh-badges computes tokens…`, `targets the pane carried by a Herdr event hook`) pass unchanged.

Not run: `verify-render.sh` (interactive, needs a live Herdr pane + human eyes). This PR does not touch token computation or the stale-marker path — only where the fan-out children get their status/usage data.

## Review gate (grok, codex stand-in)

codex is out of quota until 2026-08-20; the owner accepted grok as the stand-in for #553. grok's verdict on the initial diff: core fix right, fail-on-old tests real; three change requests. Disposition:

| grok finding | severity | disposition |
|---|---|---|
| 1. Failed shared reports poison every pane | High | **Fixed** (share only `ok:true`; differential test added) |
| 2. Agent-list dedupe incomplete for session-less panes; test overclaimed | High | **Fixed** (`agent_session_known` flag; test gains a session-less pane) |
| 3. Bad shared file when env var set → fail closed? | Medium | **Declined**: single writer, synchronous write before any spawn — the corruption path is theoretical; fail-open degrades to exactly the pre-share behavior, while fail-closed would blank every badge on a glitch |
| 4. Audit weaker than docs claimed | Medium | **Fixed** (docs narrowed: pluginEnv default is the structural guard, audit is a literal-span tripwire) |
| 5. Parent pays up to ~17s up front; fan-out still serial | Medium | **Accepted, documented**: the up-front cost buys a badge that actually renders (old: killed child, nothing renders); parallelizing the fan-out is out of scope — #543's stated fix direction is the sharing |
| 6. Share minimal DTO, not raw spawnSync blobs | Low | **Fixed** |
| 7. Temp dir lifecycle edges | Low | **Fixed** (mkdtemp inside try/finally) |
| 8. Timeout classification thin on tests (mixed buckets, clamp) | Low | Declined — string concatenation and a numeric clamp; the load-bearing classification is tested |
| 9. Fallback test under-asserted | Low | **Fixed** (asserts status re-runs too) |
| 10. Test helper tmp dirs never removed | Low | Declined — matches the file's existing helper pattern |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
