### PR TITLE
fix(dashboard): escape Bash tool timeout in detail meta line

### DIFF
--- a/public/miller-columns.js
+++ b/public/miller-columns.js
@@ -3209,7 +3209,7 @@ function renderToolInput(c) {
     } else {
       html += '<pre class="detail-cmd-block">' + escapeHtml(cmd) + '</pre>';
     }
-    if (inp.timeout && inp.timeout !== 120000) html += '<div class="detail-meta-line">timeout: ' + inp.timeout + 'ms</div>';
+    if (inp.timeout && inp.timeout !== 120000) html += '<div class="detail-meta-line">timeout: ' + escapeHtml(String(inp.timeout)) + 'ms</div>';
     html += '</div>';
     return html;
   }

--- a/test/tool-input-escape.test.js
+++ b/test/tool-input-escape.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+// renderToolInput must escape inp.timeout before interpolating it into HTML.
+// The value comes from logged request data (tool input), the same trust level
+// as inp.command, which already goes through escapeHtml. Old code interpolated
+// it raw, so a non-numeric payload injected markup. Fails on old code, passes
+// on fixed code.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+// Same sandbox loader shape as test/escapehtml.test.js
+function loadClient() {
+  const publicDir = path.join(__dirname, '..', 'public');
+  const el = () => ({
+    style: {}, dataset: {}, innerHTML: '', textContent: '',
+    classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+    addEventListener() {}, appendChild() {}, insertBefore() {},
+    querySelector: () => el(), querySelectorAll: () => [], remove() {},
+  });
+  const context = {
+    console, window: {},
+    document: { getElementById: () => el(), createElement: () => el(), querySelector: () => el(), querySelectorAll: () => [], addEventListener() {}, body: el() },
+    localStorage: { getItem: () => null, setItem() {} }, sessionStorage: { getItem: () => null, setItem() {} },
+    navigator: {}, location: { search: '', hash: '' }, history: { replaceState() {} },
+    URLSearchParams, setTimeout, clearTimeout,
+  };
+  vm.createContext(context);
+  vm.runInContext(`
+    function updateSysPromptBadge() {} function startQuotaTicker() {}
+    function EventSource() { this.onmessage = null; } function setInterval() { return 0; }
+    function clearInterval() {} window.ccxraySettings = { visibleProviders: [] };
+    function fetch() { return Promise.resolve({ ok: false, json() { return Promise.resolve({}); } }); }
+  `, context);
+  vm.runInContext(fs.readFileSync(path.join(publicDir, 'format.js'), 'utf8'), context);
+  vm.runInContext(fs.readFileSync(path.join(publicDir, 'session-label.js'), 'utf8'), context);
+  vm.runInContext(fs.readFileSync(path.join(publicDir, 'miller-columns.js'), 'utf8'), context);
+  return context;
+}
+
+describe('renderToolInput escapes Bash timeout meta line', () => {
+  const ctx = loadClient();
+
+  it('exposes renderToolInput', () => assert.equal(typeof ctx.renderToolInput, 'function'));
+
+  it('a markup payload in timeout does not survive as raw HTML', () => {
+    const html = ctx.renderToolInput({
+      name: 'Bash',
+      input: { command: 'ls', timeout: '<img src=x onerror=alert(1)>' },
+    });
+    assert.ok(!html.includes('<img'), 'raw <img must not appear in output');
+    assert.ok(html.includes('&lt;img'), 'payload must appear escaped');
+  });
+
+  it('a normal non-default numeric timeout still renders', () => {
+    const html = ctx.renderToolInput({
+      name: 'Bash',
+      input: { command: 'ls', timeout: 60000 },
+    });
+    assert.ok(html.includes('timeout: 60000ms'));
+  });
+
+  it('the default 120000 timeout stays hidden', () => {
+    const html = ctx.renderToolInput({
+      name: 'Bash',
+      input: { command: 'ls', timeout: 120000 },
+    });
+    assert.ok(!html.includes('timeout:'));
+  });
+});


### PR DESCRIPTION
## 摘要

`renderToolInput` 的 Bash timeout meta line 把 `inp.timeout` 未跳脫直接插進 innerHTML。該值來自被記錄的 tool input（與旁邊已跳脫的 `inp.command` 同一信任等級），非數值 payload 可注入 markup。本 PR 補上 `escapeHtml(String(...))`，並附行為級 regression test。

此加固最初由自動化帳號在 #380 提出（依 bot-PR 政策關閉）；經獨立驗證後以第一方改動重做。

## Change

- `public/miller-columns.js:3212` — wrap the timeout interpolation in `escapeHtml(String(inp.timeout))`, matching the adjacent `cmd` escaping in the same Bash branch. `String()` preserves the old `+`-concatenation ToString semantics for numbers.
- `test/tool-input-escape.test.js` (new) — calls `renderToolInput` directly via the VM-sandbox loader pattern from `test/escapehtml.test.js`. Asserts: a markup payload in `timeout` renders escaped (never raw), a non-default numeric timeout still renders, and the default `120000` stays hidden.

## Verification

- fail-on-old: with `git show HEAD:public/miller-columns.js` swapped in, the markup-payload assertion fails (`not ok 2 - a markup payload in timeout does not survive as raw HTML`); the two behavior-preservation assertions pass on both old and new code.
- pass-on-new: 4/4 green with isolated `CCXRAY_HOME`.

## Second review

grok gate clean — single-shot grok review of the full diff + surrounding `renderToolInput` context: no P1/P2/P3 findings, "Merge-ok on this change". Reviewer confirmed the sink is text content inside a `<div>` (no attribute/quote-breakout channel), `String()` semantics match the old concatenation, and the test's markup assertion is the discriminating case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
