### PR TITLE
test(startup): 45s load budget for full-server-boot launcher tests (#542)

### DIFF
--- a/test/startup.test.js
+++ b/test/startup.test.js
@@ -398,7 +398,7 @@ describe('claude launcher mode', () => {
       const nodeBin = path.dirname(process.execPath);
       const { code, stderr } = await spawnAndCollect(
         ['--port', String(port), 'claude', '--continue'],
-        8000,
+        45000,
         {
           PATH: `${fakeBin}${path.delimiter}${nodeBin}`,
           CCXRAY_TEST_CLAUDE_CAPTURE: capturePath,
@@ -421,7 +421,7 @@ describe('claude launcher mode', () => {
       const nodeBin = path.dirname(process.execPath);
       const { code, stderr } = await spawnAndCollect(
         ['--port', String(port), 'claude', '--no-browser'],
-        8000,
+        45000,
         {
           PATH: `${fakeBin}${path.delimiter}${nodeBin}`,
           CCXRAY_TEST_CLAUDE_CAPTURE: capturePath,
@@ -447,7 +447,7 @@ describe('claude launcher mode', () => {
     try {
       const { code, stderr } = await spawnAndCollect(
         ['claude', '--continue'],
-        8000,
+        45000,
         {
           PATH: `${fakeBin}${path.delimiter}${nodeBin}`,
           CCXRAY_TEST_CLAUDE_CAPTURE: capturePath,
@@ -524,7 +524,7 @@ describe('codex desktop app launcher mode', () => {
       const nodeBin = path.dirname(process.execPath);
       const { code, stderr } = await spawnAndCollect(
         ['--port', String(port), 'codex', 'app', workspacePath],
-        8000,
+        45000,
         {
           PATH: `${fakeBin}${path.delimiter}${nodeBin}`,
           CCXRAY_TEST_CODEX_CAPTURE: capturePath,
@@ -559,7 +559,7 @@ describe('E2: claude not found', () => {
     const nodeBin = path.dirname(process.execPath);
     const { stderr, code } = await spawnAndCollect(
       ['--port', String(port), 'claude'],
-      8000,
+      45000,
       { PATH: nodeBin }
     );
 


### PR DESCRIPTION
## 摘要

修 #542：三條 launcher-mode 測試在「某台機器一致失敗、另一台一致通過」——判別特徵是它們正好是**在 `spawnAndCollect` 8 秒上限內完整啟動 server 並斷言 exit 0** 的三條測試。與 #538 同類（83204be 在重現機上實測飽和負載下 server boot ~31s，無載 ~1s），持續性背景負載（如背景 review 工作）讓它們連 isolation 跑都必然超時。五個同類站點預算 8s→45s，對齊 83204be。

## Diagnosis

- The discriminating feature: of all `spawnAndCollect` call sites, the three failing tests (plus two structural siblings) are the ones that boot a **full server** inside the cap and assert on its completed launch. Arg-validation and loop-guard sites exit before boot and are unaffected.
- #542's "fails in isolation too" observation is consistent with load, not evidence against it: the load on the reproducing machine was **sustained** (background review jobs), so isolation doesn't relieve it. 83204be (the #538 fix, same machine, same week) measured boot at ~31,097ms under 14-way saturation — 4× the 8s budget.
- Local quantification on this 12-core machine (which does **not** reproduce): under 12-way busy-loop saturation the three tests consume 5.3s / 0.4s / 6.4s of the 8s budget — 80% erosion in the mildest form of the same conditions; 24-way oversubscription stays under the cap because macOS scheduling protects the foreground work.

## The change

Five sites in `test/startup.test.js` move `8000` → `45000` (83204be's budget):
- the three #542 tests (`spawns claude through the provider registry`, `consumes --no-browser`, `launches codex app on macOS`)
- the hub-discovery sibling (same spawn shape, lighter path)
- the `E2: claude not found` test (boots the same server before reaching the ENOENT)

All five child processes exit on their own on the happy path (ENOENT path calls `finish(1)` — verified in `server/index.js:644-652`), so the timeout is a backstop, not a wait: **a passing run's duration is unchanged**.

## Verification

- Fixed branch, `test/startup.test.js` complete file: **64/64 pass**.
- Full suite `CCXRAY_HOME=$(mktemp -d) npm test`: **2190/2190 pass, exit 0**.
- Honest limitation, per `docs/verification-principles.md` fallback: a local fail-on-old is **not achievable on this machine** (the failure needs the reproducing machine's sustained load profile; busy loops here max out at 80% budget erosion). The differential evidence for this failure class is 83204be's instrumented **1/7 fail → 7/7 pass** under 14-way saturation on the machine that reproduced both #538 and #542.

## Review gate

Trivial test-budget change (5 numbers, in-repo precedent 83204be, no production code touched) — submitted without a grok pass; say the word if you want one anyway.

Fixes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)
