### PR TITLE
feat(hub): port-occupant probe + PROXY_PORT escape hatch for the Herdr plugin launcher (#555)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -61,9 +61,10 @@ changes, and cwd filtering drops the fixture entries. `HERDR_WORKSPACE_ID` alone
 turned 14 tests red; the full ambient set, 16.
 
 `test/herdr-plugin.test.js` therefore builds every child env through
-`pluginEnv()`, which drops all `HERDR_*` **and** `CCXRAY_*` keys before applying
-the test's own overrides (and defaults `CCXRAY_HOME` to an empty throwaway home,
-per rule 1). Tests that call plugin library functions in-process pass the same
+`pluginEnv()`, which drops all `HERDR_*` **and** `CCXRAY_*` keys — plus
+`PROXY_PORT`, which joined the plugin's env surface with the #555 launch port
+escape hatch — before applying the test's own overrides (and defaults
+`CCXRAY_HOME` to an empty throwaway home, per rule 1). Tests that call plugin library functions in-process pass the same
 `pluginEnv({...})` object rather than `{ ...process.env, ... }`. The guard test
 `ignores the ambient Herdr environment of the shell running the suite` sets those
 variables deliberately and asserts the output is unaffected.

--- a/plugins/herdr/README.md
+++ b/plugins/herdr/README.md
@@ -40,6 +40,7 @@ herdr plugin action invoke ccxray.herdr.quick-start
 - `Open ccxray Quick Start` reports setup progress, launches installed providers, installs the optional sidebar with consent, and reveals analysis panes as their data becomes useful.
 - `ccxray doctor` checks the Herdr runtime context, ccxray command resolution, hub status, and recent usage.
 - `Launch Claude/Codex/Grok via ccxray` opens a stable new Herdr tab and starts the selected agent through ccxray with Herdr identity exported. Set `CCXRAY_HERDR_LAUNCH_PLACEMENT=split` only when a split is intentional.
+- The launch actions honour `PROXY_PORT` (set it in the environment Herdr runs in): it moves the shared ccxray hub — discovery, the forked hub, and its dashboard — to that port, without switching to the standalone `--port` mode. Use it when the default port 5577 is held by something you want to keep running.
 - `ccxray usage summary` prints a compact cost/session/tool summary.
 - `Refresh ccxray badges` writes short `summary`, context, cost, model, cache, and failure tokens to the focused pane and workspace.
 - Sidebar badges refresh when Herdr detects an agent or its state changes, and once after restored agents start.

--- a/plugins/herdr/bin/doctor.js
+++ b/plugins/herdr/bin/doctor.js
@@ -55,6 +55,9 @@ function main() {
     console.log(`Hub: running${bits.length ? ` (${bits.join(', ')})` : ''}`);
   } else {
     console.log('Hub: not running');
+    // #555: status appends Note lines when the default port is held by a
+    // non-hub process — the one hint that explains why a launch would fail.
+    for (const note of status.parsed.notes || []) console.log(note);
   }
 
   if (usage.ok) {

--- a/plugins/herdr/bin/launch-agent.js
+++ b/plugins/herdr/bin/launch-agent.js
@@ -22,7 +22,19 @@ function parseArgs(argv) {
     placement: process.env.CCXRAY_HERDR_LAUNCH_PLACEMENT === 'split' ? 'split' : 'tab',
     direction: process.env.CCXRAY_HERDR_LAUNCH_DIRECTION || 'right',
     ratio: process.env.CCXRAY_HERDR_LAUNCH_RATIO || '0.5',
+    proxyPort: (process.env.PROXY_PORT || '').trim(),
   };
+}
+
+// PROXY_PORT is the plugin's port escape hatch (#555): it moves the shared
+// hub's port (server/config.js reads it into config.PORT, which feeds hub
+// discovery and the hub fork) without opting the launch out of hub mode the
+// way an explicit --port would. Returns null (unset), a number, or NaN.
+function parseProxyPort(raw) {
+  if (!raw) return null;
+  if (!/^\d{1,5}$/.test(raw)) return NaN;
+  const port = Number(raw);
+  return port >= 1 && port <= 65535 ? port : NaN;
 }
 
 // INVARIANT: the launch directory comes from currentWorkspaceScope(), the same
@@ -56,7 +68,7 @@ function openArgs(args, ctx) {
   return out;
 }
 
-function runnerCommand(agent, paneId, ctx) {
+function runnerCommand(agent, paneId, ctx, proxyPort) {
   const override = process.env.CCXRAY_HERDR_LAUNCH_COMMAND_JSON;
   if (override) {
     try {
@@ -64,7 +76,7 @@ function runnerCommand(agent, paneId, ctx) {
       if (Array.isArray(parsed) && parsed.length && parsed.every(p => typeof p === 'string')) return parsed;
     } catch {}
   }
-  return [
+  const command = [
     process.execPath,
     path.join(pluginRoot(), 'bin', 'run-agent.js'),
     agent,
@@ -73,12 +85,22 @@ function runnerCommand(agent, paneId, ctx) {
     ctx.tabId,
     ctx.sourcePaneId,
   ];
+  // The runner executes inside the new Herdr pane, whose environment is not
+  // this process's — the port must travel as an argument, not be assumed to
+  // arrive via env inheritance.
+  if (proxyPort) command.push(`--proxy-port=${proxyPort}`);
+  return command;
 }
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
   if (!SUPPORTED.has(args.agent)) {
     console.error(`Unsupported agent "${args.agent || ''}". Expected claude, codex, or grok.`);
+    process.exit(2);
+  }
+  const proxyPort = parseProxyPort(args.proxyPort);
+  if (Number.isNaN(proxyPort)) {
+    console.error(`Invalid PROXY_PORT "${args.proxyPort}" — expected a port number (1-65535).`);
     process.exit(2);
   }
   const ctx = context();
@@ -97,6 +119,7 @@ function main() {
       sourcePaneId: ctx.sourcePaneId || null,
       workspaceId: ctx.workspaceId || null,
       tabId: ctx.tabId || null,
+      proxyPort: proxyPort || null,
     }, null, 2));
     process.exit(0);
   }
@@ -126,7 +149,7 @@ function main() {
   const command = runnerCommand(args.agent, paneId, {
     ...ctx,
     tabId: openedData?.result?.tab?.tab_id || ctx.tabId,
-  });
+  }, proxyPort);
   recordRoutedPane(paneId, args.agent);
   const run = runHerdr(['pane', 'run', paneId, ...command], { timeoutMs: 3000 });
   // A timeout is an unknown outcome, not a failure: Herdr may already have

--- a/plugins/herdr/bin/lib/ccxray.js
+++ b/plugins/herdr/bin/lib/ccxray.js
@@ -117,14 +117,14 @@ function parseJsonOutput(output) {
 function parseStatus(text) {
   const clean = stripAnsi(text);
   const noHub = /No hub running/i.test(clean);
-  const portMatch = clean.match(/localhost:(\d{2,5})/) || clean.match(/\bport\s+(\d{2,5})\b/i);
-  const pidMatch = clean.match(/\bpid[:\s]+(\d+)\b/i) || clean.match(/\bPID[:\s]+(\d+)\b/);
-  const clientsMatch = clean.match(/\bclients?[:\s]+(\d+)\b/i);
-  // #555: `ccxray status` may append "Note: port N is held by …" lines when
-  // no hub runs but the default port is occupied. Surface them (doctor shows
-  // them) instead of silently dropping the one hint that explains a failed
-  // launch.
-  const notes = clean.split('\n').map(l => l.trim()).filter(l => l.startsWith('Note: '));
+  // #555: Note lines describe the port OCCUPANT, not a hub — scraping their
+  // port/pid would report the occupant's identity as the hub's.
+  const lines = clean.split('\n');
+  const notes = lines.map(l => l.trim()).filter(l => l.startsWith('Note: '));
+  const hubText = lines.filter(l => !l.trim().startsWith('Note: ')).join('\n');
+  const portMatch = hubText.match(/localhost:(\d{2,5})/) || hubText.match(/\bport\s+(\d{2,5})\b/i);
+  const pidMatch = hubText.match(/\bpid[:\s]+(\d+)\b/i) || hubText.match(/\bPID[:\s]+(\d+)\b/);
+  const clientsMatch = hubText.match(/\bclients?[:\s]+(\d+)\b/i);
   return {
     running: !noHub && Boolean(portMatch || pidMatch || /hub/i.test(clean)),
     port: portMatch ? Number(portMatch[1]) : null,

--- a/plugins/herdr/bin/lib/ccxray.js
+++ b/plugins/herdr/bin/lib/ccxray.js
@@ -120,11 +120,17 @@ function parseStatus(text) {
   const portMatch = clean.match(/localhost:(\d{2,5})/) || clean.match(/\bport\s+(\d{2,5})\b/i);
   const pidMatch = clean.match(/\bpid[:\s]+(\d+)\b/i) || clean.match(/\bPID[:\s]+(\d+)\b/);
   const clientsMatch = clean.match(/\bclients?[:\s]+(\d+)\b/i);
+  // #555: `ccxray status` may append "Note: port N is held by …" lines when
+  // no hub runs but the default port is occupied. Surface them (doctor shows
+  // them) instead of silently dropping the one hint that explains a failed
+  // launch.
+  const notes = clean.split('\n').map(l => l.trim()).filter(l => l.startsWith('Note: '));
   return {
     running: !noHub && Boolean(portMatch || pidMatch || /hub/i.test(clean)),
     port: portMatch ? Number(portMatch[1]) : null,
     pid: pidMatch ? Number(pidMatch[1]) : null,
     clients: clientsMatch ? Number(clientsMatch[1]) : null,
+    notes,
   };
 }
 

--- a/plugins/herdr/bin/run-agent.js
+++ b/plugins/herdr/bin/run-agent.js
@@ -9,6 +9,11 @@ const { resolveCcxrayCommand } = require('./lib/ccxray');
 const SUPPORTED = new Set(['claude', 'codex', 'grok']);
 
 function parseArgs(argv) {
+  // #555 port escape hatch: launch-agent threads its PROXY_PORT here as an
+  // argument because this runner executes inside the Herdr pane's env, not the
+  // launcher's. A PROXY_PORT already present in the pane env still reaches the
+  // spawned ccxray via launchEnv's spread; the explicit flag wins.
+  const portFlag = argv.find(a => a.startsWith('--proxy-port='));
   const args = {
     agent: argv[0],
     paneId: argv[1],
@@ -16,6 +21,7 @@ function parseArgs(argv) {
     tabId: argv[3],
     sourcePaneId: argv[4],
     dryRun: argv.includes('--dry-run') || process.env.CCXRAY_HERDR_RUNNER_DRY_RUN === '1',
+    proxyPort: portFlag ? portFlag.slice('--proxy-port='.length) : '',
   };
   return args;
 }
@@ -56,6 +62,7 @@ function launchEnv(args) {
     CCXRAY_HERDR_TAB_ID: args.tabId || '',
     CCXRAY_HERDR_SOURCE_PANE_ID: args.sourcePaneId || '',
   };
+  if (args.proxyPort) env.PROXY_PORT = args.proxyPort;
   env.PATH = launchPath(env);
   return env;
 }
@@ -64,6 +71,10 @@ function main() {
   const args = parseArgs(process.argv.slice(2));
   if (!SUPPORTED.has(args.agent)) {
     console.error(`Unsupported agent "${args.agent || ''}". Expected claude, codex, or grok.`);
+    process.exit(2);
+  }
+  if (args.proxyPort && !(/^\d{1,5}$/.test(args.proxyPort) && Number(args.proxyPort) >= 1 && Number(args.proxyPort) <= 65535)) {
+    console.error(`Invalid --proxy-port "${args.proxyPort}" — expected a port number (1-65535).`);
     process.exit(2);
   }
 
@@ -82,6 +93,7 @@ function main() {
         CCXRAY_HERDR_PANE_ID: env.CCXRAY_HERDR_PANE_ID,
         CCXRAY_HERDR_TAB_ID: env.CCXRAY_HERDR_TAB_ID,
         CCXRAY_HERDR_SOURCE_PANE_ID: env.CCXRAY_HERDR_SOURCE_PANE_ID,
+        PROXY_PORT: env.PROXY_PORT || null,
         PATH: env.PATH,
       },
     }, null, 2));

--- a/server/hub.js
+++ b/server/hub.js
@@ -625,14 +625,19 @@ function probePortOccupant(port, timeoutMs = 1500) {
       let data = '';
       res.on('data', c => { data += c; if (data.length > 4096) req.destroy(); });
       res.on('end', () => {
-        try {
-          const parsed = JSON.parse(data);
-          if (parsed && parsed.ok === true && parsed.app === 'ccxray') {
-            resolve({ kind: parsed.hub ? 'ccxray-hub' : 'ccxray-standalone', pid: parsed.pid || null, version: parsed.version || null });
-            return;
-          }
-          if (parsed && parsed.ok === true) { resolve({ kind: 'health-ok', pid: null }); return; }
-        } catch {}
+        // Only a 200 counts as a health answer — a foreign service that
+        // happens to echo { ok: true } on an error page must not be
+        // classified as ccxray (grok review P3, 2026-08-18).
+        if (res.statusCode === 200) {
+          try {
+            const parsed = JSON.parse(data);
+            if (parsed && parsed.ok === true && parsed.app === 'ccxray') {
+              resolve({ kind: parsed.hub ? 'ccxray-hub' : 'ccxray-standalone', pid: parsed.pid || null, version: parsed.version || null });
+              return;
+            }
+            if (parsed && parsed.ok === true) { resolve({ kind: 'health-ok', pid: null }); return; }
+          } catch {}
+        }
         resolve({ kind: 'foreign-http', pid: null });
       });
       res.on('error', () => resolve({ kind: 'silent', pid: null }));
@@ -653,17 +658,24 @@ function probePortOccupant(port, timeoutMs = 1500) {
 // moves the hub (discovery + fork) rather than opting out of hub mode the way
 // --port does.
 function describePortOccupant(occ, port) {
-  const escape = `set PROXY_PORT=<other-port> to run the hub on a different port`;
+  // Copy-pasteable form: bash/zsh `set X=Y` does not export, so the hint
+  // shows the prefix form a user can actually run (grok review P2).
+  const escape = `relaunch with PROXY_PORT=<other-port> (e.g. PROXY_PORT=5600 ccxray claude) to run the hub on a different port`;
   switch (occ && occ.kind) {
     case 'ccxray-standalone':
+      // hub:false covers both `--port` standalones and dashboard-only
+      // servers — do not over-claim how it was started (grok review P2).
       return [
-        `port ${port} is held by a standalone ccxray${occ.pid ? ` (pid ${occ.pid})` : ''} started with --port — it is not a hub and cannot be shared.`,
+        `port ${port} is held by a standalone (non-hub) ccxray${occ.pid ? ` (pid ${occ.pid})` : ''}, so it cannot be shared as a hub.`,
         `Leave it running; ${escape}.`,
       ];
     case 'ccxray-hub':
+      // The hub may be healthy under a different CCXRAY_HOME — only its
+      // lockfile is unreachable from here; do not prescribe a restart as
+      // the sole fix (grok review P2).
       return [
-        `port ${port} answers as a ccxray hub${occ.pid ? ` (pid ${occ.pid})` : ''} but its lockfile is missing.`,
-        `Restart that hub so it rewrites its lockfile, or ${escape}.`,
+        `port ${port} answers as a ccxray hub${occ.pid ? ` (pid ${occ.pid})` : ''} that this launch cannot discover (no matching lockfile under this CCXRAY_HOME).`,
+        `If it is yours, restart it so it rewrites its lockfile; otherwise ${escape}.`,
       ];
     case 'health-ok':
       return [

--- a/server/hub.js
+++ b/server/hub.js
@@ -583,7 +583,16 @@ function handleHubRoutes(clientReq, clientRes) {
 
   if (pathname === '/_api/health' && clientReq.method === 'GET') {
     clientRes.writeHead(200, { 'Content-Type': 'application/json' });
-    clientRes.end(JSON.stringify({ ok: true }));
+    // app/pid/hub identify the listener to probePortOccupant (#555) so a
+    // port-conflict message can tell a standalone ccxray from a foreign
+    // process. `hub` is true only after setHubPort — i.e. real hub mode.
+    clientRes.end(JSON.stringify({
+      ok: true,
+      app: 'ccxray',
+      pid: process.pid,
+      hub: hubListenPort != null,
+      version: require('../package.json').version,
+    }));
     return true;
   }
 
@@ -596,6 +605,84 @@ function handleHubRoutes(clientReq, clientRes) {
   }
 
   return false;
+}
+
+// ── Port-occupant probe (#555) ──────────────────────────────────────
+// When the hub port is taken, identify WHO holds it before giving advice.
+// The old message unconditionally suggested `kill $(lsof -t -i:PORT)`, which
+// is destructive when the occupant is a deliberate long-running listener
+// (e.g. a standalone `ccxray --port 5577`). Kinds:
+//   'ccxray-hub'        — answers /_api/health with app:'ccxray', hub:true
+//   'ccxray-standalone' — answers with app:'ccxray', hub:false
+//   'health-ok'         — answers { ok: true } without the app tag (older ccxray)
+//   'foreign-http'      — an HTTP server that is not ccxray
+//   'silent'            — something is bound but does not answer HTTP
+//   'free'              — connection refused (nothing listening)
+
+function probePortOccupant(port, timeoutMs = 1500) {
+  return new Promise(resolve => {
+    const req = http.get(`http://localhost:${port}/_api/health`, { timeout: timeoutMs }, res => {
+      let data = '';
+      res.on('data', c => { data += c; if (data.length > 4096) req.destroy(); });
+      res.on('end', () => {
+        try {
+          const parsed = JSON.parse(data);
+          if (parsed && parsed.ok === true && parsed.app === 'ccxray') {
+            resolve({ kind: parsed.hub ? 'ccxray-hub' : 'ccxray-standalone', pid: parsed.pid || null, version: parsed.version || null });
+            return;
+          }
+          if (parsed && parsed.ok === true) { resolve({ kind: 'health-ok', pid: null }); return; }
+        } catch {}
+        resolve({ kind: 'foreign-http', pid: null });
+      });
+      res.on('error', () => resolve({ kind: 'silent', pid: null }));
+    });
+    req.on('timeout', () => { req.destroy(); resolve({ kind: 'silent', pid: null }); });
+    req.on('error', err => {
+      resolve({ kind: err && err.code === 'ECONNREFUSED' ? 'free' : 'silent', pid: null });
+    });
+  });
+}
+
+// Message lines for a probed occupant, shared by the hub's bind-failure log,
+// the client's post-mortem suggestion, and `ccxray status` — one composer so
+// the three surfaces cannot drift apart. Never suggests an unconditional kill:
+// only the 'silent' kind (nothing answers HTTP — possibly a genuinely stuck
+// process) mentions kill at all, and only after the user identifies the pid
+// themselves. PROXY_PORT is the escape hatch every branch offers because it
+// moves the hub (discovery + fork) rather than opting out of hub mode the way
+// --port does.
+function describePortOccupant(occ, port) {
+  const escape = `set PROXY_PORT=<other-port> to run the hub on a different port`;
+  switch (occ && occ.kind) {
+    case 'ccxray-standalone':
+      return [
+        `port ${port} is held by a standalone ccxray${occ.pid ? ` (pid ${occ.pid})` : ''} started with --port — it is not a hub and cannot be shared.`,
+        `Leave it running; ${escape}.`,
+      ];
+    case 'ccxray-hub':
+      return [
+        `port ${port} answers as a ccxray hub${occ.pid ? ` (pid ${occ.pid})` : ''} but its lockfile is missing.`,
+        `Restart that hub so it rewrites its lockfile, or ${escape}.`,
+      ];
+    case 'health-ok':
+      return [
+        `port ${port} is held by a server that answers ccxray's health check (likely an older ccxray).`,
+        `Leave it running; ${escape}.`,
+      ];
+    case 'foreign-http':
+      return [
+        `port ${port} is held by another HTTP service that is not ccxray.`,
+        `Do not kill it — ${escape}.`,
+      ];
+    case 'silent':
+      return [
+        `port ${port} is occupied by a process that does not answer HTTP — possibly a stuck ccxray.`,
+        `Inspect it with: lsof -i :${port} — kill it only if you recognise it, or ${escape}.`,
+      ];
+    default:
+      return [];
+  }
 }
 
 // ── Hub pid monitoring (client-side recovery) ───────────────────────
@@ -694,6 +781,8 @@ module.exports = {
   setHubPort,
   getHubStatus,
   handleHubRoutes,
+  probePortOccupant,
+  describePortOccupant,
   startHubMonitor,
   tryListen,
 };

--- a/server/index.js
+++ b/server/index.js
@@ -881,8 +881,19 @@ if (process.argv[2] === 'setup-statusline') {
 if (process.argv[2] === 'status') {
   const lock = hub.readHubLock();
   if (!lock) {
-    console.log('No hub running.');
-    process.exit(0);
+    // #555: "No hub running" alone is misleading when the hub's default port
+    // is held by something else (e.g. a standalone `ccxray --port 5577`, which
+    // writes no lockfile) — a subsequent hub launch will fail on that port.
+    // Probe and say so.
+    (async () => {
+      const occ = await hub.probePortOccupant(config.PORT, 1000);
+      console.log('No hub running.');
+      if (occ.kind !== 'free') {
+        hub.describePortOccupant(occ, config.PORT).forEach(l => console.log(`Note: ${l}`));
+      }
+      process.exit(0);
+    })();
+    return; // prevent falling through while the probe runs
   }
   if (!hub.isPidAlive(lock.pid)) {
     console.log('Hub lockfile exists but process is dead. Cleaning up.');
@@ -1141,7 +1152,12 @@ async function startServer() {
           if (err.code === 'EADDRINUSE') {
             // Log the recovery hint to hub.log (console.error → stderr → hub.log).
             // Prefixed with "Error:" so the client's /error|EADDRINUSE/i filter picks it up.
-            console.error(`Error: port ${config.PORT} still occupied after ${HUB_BIND_RETRIES}s — if a previous ccxray is stuck, run: kill $(lsof -t -i:${config.PORT})`);
+            // #555: identify the occupant before advising — the old unconditional
+            // `kill $(lsof …)` hint would have killed a deliberate listener.
+            const occ = await hub.probePortOccupant(config.PORT);
+            const advice = hub.describePortOccupant(occ, config.PORT);
+            if (advice.length) advice.forEach(l => console.error(`Error: ${l}`));
+            else console.error(`Error: port ${config.PORT} still occupied after ${HUB_BIND_RETRIES}s but nothing answered a probe — it may have been released; retry.`);
           }
           throw err;
         }
@@ -1278,7 +1294,13 @@ async function startServer() {
         lastErrors.forEach(l => console.error(`  ${l.replace(/\x1b\[[0-9;]*m/g, '')}`));
       }
       if (lines.some(l => /EADDRINUSE|already in use/i.test(l))) {
-        console.error(`\x1b[33mSuggestion: another process is using port ${config.PORT}. Use --port <other> or kill the process.\x1b[0m`);
+        // #555: probe the occupant instead of the old blanket "kill the
+        // process" advice, and offer PROXY_PORT (which moves the hub) rather
+        // than --port (which would silently opt out of hub mode).
+        const occ = await hub.probePortOccupant(config.PORT);
+        const advice = hub.describePortOccupant(occ, config.PORT);
+        if (advice.length) advice.forEach(l => console.error(`\x1b[33mSuggestion: ${l}\x1b[0m`));
+        else console.error(`\x1b[33mSuggestion: port ${config.PORT} was busy but seems free now — retry, or set PROXY_PORT=<other-port>.\x1b[0m`);
       }
     } catch {}
     process.exit(1);

--- a/server/index.js
+++ b/server/index.js
@@ -1300,7 +1300,7 @@ async function startServer() {
         const occ = await hub.probePortOccupant(config.PORT);
         const advice = hub.describePortOccupant(occ, config.PORT);
         if (advice.length) advice.forEach(l => console.error(`\x1b[33mSuggestion: ${l}\x1b[0m`));
-        else console.error(`\x1b[33mSuggestion: port ${config.PORT} was busy but seems free now — retry, or set PROXY_PORT=<other-port>.\x1b[0m`);
+        else console.error(`\x1b[33mSuggestion: port ${config.PORT} was busy but seems free now — retry, or relaunch with PROXY_PORT=<other-port>.\x1b[0m`);
       }
     } catch {}
     process.exit(1);

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -2657,6 +2657,10 @@ describe('Herdr plugin commands', () => {
     assert.equal(parsed.running, false);
     assert.equal(parsed.notes.length, 2);
     assert.match(parsed.notes[0], /held by a standalone/);
+    // The occupant's port/pid live only in Note lines and must not be
+    // reported as the hub's (grok round-2 P3).
+    assert.equal(parsed.port, null);
+    assert.equal(parsed.pid, null);
     const plain = parseStatus('No hub running.\n');
     assert.deepEqual(plain.notes, []);
   });

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -2644,6 +2644,23 @@ describe('Herdr plugin commands', () => {
     assert.ok(plan.args.includes('codex'));
   });
 
+  // #555: `ccxray status` can append "Note: port N is held by ..." lines; the
+  // plugin's status parser must surface them so doctor can show the one hint
+  // that explains a failed launch (grok review P2, 2026-08-18).
+  it('parseStatus surfaces #555 Note lines without flipping running', () => {
+    const { parseStatus } = require('../plugins/herdr/bin/lib/ccxray');
+    const parsed = parseStatus([
+      'No hub running.',
+      'Note: port 5577 is held by a standalone (non-hub) ccxray (pid 4701), so it cannot be shared as a hub.',
+      'Note: Leave it running; relaunch with PROXY_PORT=<other-port> (e.g. PROXY_PORT=5600 ccxray claude) to run the hub on a different port.',
+    ].join('\n'));
+    assert.equal(parsed.running, false);
+    assert.equal(parsed.notes.length, 2);
+    assert.match(parsed.notes[0], /held by a standalone/);
+    const plain = parseStatus('No hub running.\n');
+    assert.deepEqual(plain.notes, []);
+  });
+
   // #555 port escape hatch: PROXY_PORT must travel launch-agent → pane runner
   // → spawned ccxray as an explicit contract, because the runner executes in
   // the Herdr pane's environment, not the launcher's.

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -21,7 +21,9 @@ const MANIFEST = path.join(PLUGIN, 'herdr-plugin.toml');
 function pluginEnv(overrides = {}) {
   const env = {};
   for (const [key, value] of Object.entries(process.env)) {
-    if (key.startsWith('HERDR_') || key.startsWith('CCXRAY_')) continue;
+    // PROXY_PORT joined the plugin's env surface in #555 (the launch port
+    // escape hatch): an ambient value would silently retarget every spawn.
+    if (key.startsWith('HERDR_') || key.startsWith('CCXRAY_') || key === 'PROXY_PORT') continue;
     env[key] = value;
   }
   env.CCXRAY_HOME = isolatedHome();
@@ -2640,6 +2642,90 @@ describe('Herdr plugin commands', () => {
     assert.equal(plan.env.CCXRAY_HERDR_SOURCE_PANE_ID, 'w1:p1');
     assert.ok(plan.args.includes('--no-browser'));
     assert.ok(plan.args.includes('codex'));
+  });
+
+  // #555 port escape hatch: PROXY_PORT must travel launch-agent → pane runner
+  // → spawned ccxray as an explicit contract, because the runner executes in
+  // the Herdr pane's environment, not the launcher's.
+  it('run-agent forwards --proxy-port into the spawned ccxray env', () => {
+    const result = runScript('run-agent.js', ['codex', 'w1:p9', 'w1', 'w1:t1', 'w1:p1', '--dry-run', '--proxy-port=5678']);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).env.PROXY_PORT, '5678');
+  });
+
+  it('run-agent lets an explicit --proxy-port win over the pane env PROXY_PORT', () => {
+    const result = runScript('run-agent.js', ['codex', 'w1:p9', 'w1', 'w1:t1', 'w1:p1', '--dry-run', '--proxy-port=5678'], {
+      PROXY_PORT: '7788',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).env.PROXY_PORT, '5678');
+  });
+
+  it('run-agent still honours a PROXY_PORT already present in the pane env', () => {
+    const result = runScript('run-agent.js', ['codex', 'w1:p9', 'w1', 'w1:t1', 'w1:p1', '--dry-run'], {
+      PROXY_PORT: '7788',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).env.PROXY_PORT, '7788');
+  });
+
+  it('run-agent rejects a malformed --proxy-port loudly', () => {
+    const result = runScript('run-agent.js', ['codex', 'w1:p9', 'w1', 'w1:t1', 'w1:p1', '--dry-run', '--proxy-port=lots']);
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /Invalid --proxy-port/);
+  });
+
+  it('launch-agent surfaces PROXY_PORT in its plan', () => {
+    const result = runScript('launch-agent.js', ['codex', '--plan'], {
+      HERDR_PLUGIN_CONTEXT_JSON: JSON.stringify({
+        focused_pane_id: 'w1:p1', focused_pane_cwd: '/work/demo', workspace_id: 'w1', tab_id: 'w1:t1',
+      }),
+      PROXY_PORT: '5678',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).proxyPort, 5678);
+  });
+
+  it('launch-agent threads PROXY_PORT into the pane runner command', () => {
+    const project = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-project-'));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-herdr-routed-'));
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-herdr-portrun-'));
+    const bin = path.join(dir, 'herdr');
+    const log = path.join(dir, 'args.log');
+    const opened = JSON.stringify({ id: 't', result: { type: 'tab_created', root_pane: { pane_id: 'w1:p7' }, tab: { tab_id: 'w1:t2' } } });
+    fs.writeFileSync(bin, [
+      '#!/usr/bin/env node',
+      `require('fs').appendFileSync(${JSON.stringify(log)}, process.argv.slice(2).join(' ') + '\\n');`,
+      "if (process.argv[2] === 'pane' && process.argv[3] === 'run') {",
+      "  process.stdout.write('{}\\n'); process.exit(0);",
+      '}',
+      `process.stdout.write(${JSON.stringify(opened + '\n')});`,
+      '',
+    ].join('\n'));
+    fs.chmodSync(bin, 0o755);
+
+    const result = runScript('launch-agent.js', ['codex'], {
+      HERDR_PLUGIN_CONTEXT_JSON: JSON.stringify({
+        focused_pane_id: 'w1:p1', focused_pane_cwd: project, workspace_id: 'w1', tab_id: 'w1:t1',
+      }),
+      HERDR_BIN_PATH: bin,
+      HERDR_PLUGIN_STATE_DIR: stateDir,
+      PROXY_PORT: '5678',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const calls = fs.readFileSync(log, 'utf8');
+    assert.match(calls, /pane run w1:p7 .*run-agent\.js codex w1:p7 .*--proxy-port=5678/);
+  });
+
+  it('launch-agent rejects an invalid PROXY_PORT before creating any pane', () => {
+    const herdr = makeRecordingHerdr();
+    const result = runScript('launch-agent.js', ['codex'], {
+      HERDR_BIN_PATH: herdr.bin,
+      PROXY_PORT: '70000',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /Invalid PROXY_PORT/);
+    assert.equal(fs.existsSync(herdr.log), false, 'must fail before any herdr call');
   });
 
   it('run-agent adds common app CLI directories to PATH for Herdr panes', () => {

--- a/test/hub-socket.test.js
+++ b/test/hub-socket.test.js
@@ -298,7 +298,7 @@ describe('deprecated HTTP hub routes → 410', () => {
   it('GET /_api/health → still 200', async () => {
     const { status, body } = await httpReq(port, 'GET', '/_api/health');
     assert.equal(status, 200);
-    assert.deepEqual(body, { ok: true });
+    assert.equal(body.ok, true); // #555: health carries occupant identity now
   });
 });
 

--- a/test/hub.test.js
+++ b/test/hub.test.js
@@ -205,6 +205,18 @@ describe('hub server routes', () => {
     assert.equal(typeof data.hub, 'boolean');
   });
 
+  it('health reports hub:true only after setHubPort (#555)', async () => {
+    hub.setHubPort(4321);
+    try {
+      const data = await httpGet(port, '/_api/health');
+      assert.equal(data.hub, true);
+    } finally {
+      hub.setHubPort(null);
+    }
+    const data = await httpGet(port, '/_api/health');
+    assert.equal(data.hub, false);
+  });
+
   it('GET /_api/hub/status → 410 (moved to socket)', async () => {
     const statusCode = await httpGetStatus(port, '/_api/hub/status');
     assert.equal(statusCode, 410);

--- a/test/hub.test.js
+++ b/test/hub.test.js
@@ -197,9 +197,12 @@ describe('hub server routes', () => {
     await new Promise(resolve => server.close(resolve));
   });
 
-  it('GET /_api/health → 200 { ok: true }', async () => {
+  it('GET /_api/health → 200 ok + occupant identity (#555)', async () => {
     const data = await httpGet(port, '/_api/health');
-    assert.deepEqual(data, { ok: true });
+    assert.equal(data.ok, true);
+    assert.equal(data.app, 'ccxray');
+    assert.equal(data.pid, process.pid);
+    assert.equal(typeof data.hub, 'boolean');
   });
 
   it('GET /_api/hub/status → 410 (moved to socket)', async () => {

--- a/test/port-occupant.test.js
+++ b/test/port-occupant.test.js
@@ -132,6 +132,17 @@ describe('#555 probePortOccupant', () => {
     } finally { srv.close(); }
   });
 
+  it('does not trust an ok-shaped body on a non-200 response', async () => {
+    const srv = await listen((req, res) => {
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, app: 'ccxray', pid: 1 }));
+    });
+    try {
+      const occ = await hub.probePortOccupant(srv.address().port);
+      assert.equal(occ.kind, 'foreign-http');
+    } finally { srv.close(); }
+  });
+
   it('classifies a listener that never answers as silent', async () => {
     const srv = await listen(() => { /* accept, never respond */ });
     try {
@@ -168,9 +179,25 @@ describe('#555 describePortOccupant message contract', () => {
 
   it('names a standalone ccxray occupant with its pid and says it is not a hub', () => {
     const lines = hub.describePortOccupant({ kind: 'ccxray-standalone', pid: 4242 }, 5577).join('\n');
-    assert.match(lines, /standalone ccxray \(pid 4242\)/);
-    assert.match(lines, /not a hub/);
+    assert.match(lines, /standalone \(non-hub\) ccxray \(pid 4242\)/);
+    assert.match(lines, /cannot be shared as a hub/);
     assert.match(lines, /Leave it running/);
+    // grok review P2: hub:false also covers dashboard-only servers, so the
+    // message must not claim the occupant was started with --port.
+    assert.doesNotMatch(lines, /--port/);
+  });
+
+  it('describes an undiscoverable hub without prescribing a restart as the only fix', () => {
+    const lines = hub.describePortOccupant({ kind: 'ccxray-hub', pid: 77 }, 5577).join('\n');
+    assert.match(lines, /ccxray hub \(pid 77\)/);
+    assert.match(lines, /cannot discover/);
+    assert.match(lines, /PROXY_PORT/);
+  });
+
+  it('shows a copy-pasteable PROXY_PORT form, not shell `set` syntax', () => {
+    const lines = hub.describePortOccupant({ kind: 'foreign-http' }, 5577).join('\n');
+    assert.match(lines, /PROXY_PORT=5600 ccxray claude/);
+    assert.doesNotMatch(lines, /\bset PROXY_PORT\b/);
   });
 
   it('tells the user not to kill a foreign HTTP service', () => {
@@ -202,7 +229,7 @@ describe('#555 ccxray status names a non-hub occupant', () => {
       const result = await runServer(['status'], isolatedEnv({ PROXY_PORT: String(port) }));
       assert.equal(result.status, 0, result.stderr);
       assert.match(result.stdout, /No hub running\./);
-      assert.match(result.stdout, new RegExp(`Note: port ${port} is held by a standalone ccxray \\(pid 4242\\)`));
+      assert.match(result.stdout, new RegExp(`Note: port ${port} is held by a standalone \\(non-hub\\) ccxray \\(pid 4242\\)`));
       assert.match(result.stdout, /PROXY_PORT/);
     } finally { srv.close(); }
   });

--- a/test/port-occupant.test.js
+++ b/test/port-occupant.test.js
@@ -1,0 +1,238 @@
+'use strict';
+
+// #555 — port-occupant probe + honest port-conflict messages.
+//
+// The hub's default port being taken used to produce two lies: an
+// unconditional `kill $(lsof -t -i:PORT)` hint (destructive when the occupant
+// is a deliberate listener, e.g. a long-running standalone `ccxray --port
+// 5577`), and `ccxray status` reporting a bare "No hub running." while the
+// port was held. These tests cover the probe, the shared message composer,
+// and both end-to-end surfaces.
+//
+// Isolation (docs/testing.md): every spawn gets a throwaway CCXRAY_HOME, a
+// throwaway HOME, and CCXRAY_IMPORT_HOMES pinned to an empty dir so the
+// importer never scans the developer's real transcripts. Synthetic listeners
+// bind port 0 (kernel-assigned) — never the real hub ports.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawn } = require('child_process');
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-port-occupant-'));
+const NO_TRANSCRIPTS = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-port-occupant-empty-'));
+process.env.CCXRAY_HOME = process.env.CCXRAY_HOME || TEST_HOME; // hub.js reads it at require time
+
+const hub = require('../server/hub');
+const SERVER_SCRIPT = path.resolve(__dirname, '..', 'server', 'index.js');
+
+after(() => {
+  fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  fs.rmSync(NO_TRANSCRIPTS, { recursive: true, force: true });
+});
+
+// Wildcard bind, like a real ccxray server: on macOS a listener bound only to
+// 127.0.0.1 does NOT make the hub's own wildcard listen(port) fail with
+// EADDRINUSE, so a loopback-bound occupant would not reproduce the conflict.
+function listen(handler) {
+  return new Promise((resolve, reject) => {
+    const srv = http.createServer(handler);
+    srv.listen(0, () => resolve(srv));
+    srv.on('error', reject);
+  });
+}
+
+function isolatedEnv(extra = {}) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-port-occupant-run-'));
+  return {
+    ...process.env,
+    HOME: home,
+    CCXRAY_HOME: home,
+    CCXRAY_IMPORT_HOMES: NO_TRANSCRIPTS,
+    BROWSER: 'none',
+    ...extra,
+  };
+}
+
+function runServer(args, env, timeoutMs = 45000) {
+  return new Promise(resolve => {
+    const child = spawn(process.execPath, [SERVER_SCRIPT, ...args], {
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    child.stdout.on('data', d => { stdout += d; });
+    child.stderr.on('data', d => { stderr += d; });
+    // Full-server-boot budget: 45s (the #538/#542 precedent), enforced here
+    // rather than by any outer tool timeout.
+    const guard = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill('SIGKILL');
+      resolve({ status: null, stdout, stderr, timedOut: true });
+    }, timeoutMs);
+    child.on('exit', code => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(guard);
+      resolve({ status: code, stdout, stderr, timedOut: false });
+    });
+  });
+}
+
+describe('#555 probePortOccupant', () => {
+  it('classifies a standalone ccxray by its health identity', async () => {
+    const srv = await listen((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, app: 'ccxray', pid: 4242, hub: false, version: '9.9.9' }));
+    });
+    try {
+      const occ = await hub.probePortOccupant(srv.address().port);
+      assert.equal(occ.kind, 'ccxray-standalone');
+      assert.equal(occ.pid, 4242);
+    } finally { srv.close(); }
+  });
+
+  it('classifies a lockfile-less hub as ccxray-hub', async () => {
+    const srv = await listen((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, app: 'ccxray', pid: 77, hub: true }));
+    });
+    try {
+      const occ = await hub.probePortOccupant(srv.address().port);
+      assert.equal(occ.kind, 'ccxray-hub');
+      assert.equal(occ.pid, 77);
+    } finally { srv.close(); }
+  });
+
+  it('classifies a bare { ok: true } as an older ccxray-shaped health', async () => {
+    const srv = await listen((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    try {
+      const occ = await hub.probePortOccupant(srv.address().port);
+      assert.equal(occ.kind, 'health-ok');
+    } finally { srv.close(); }
+  });
+
+  it('classifies a non-ccxray HTTP service as foreign-http', async () => {
+    const srv = await listen((req, res) => {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('not found');
+    });
+    try {
+      const occ = await hub.probePortOccupant(srv.address().port);
+      assert.equal(occ.kind, 'foreign-http');
+    } finally { srv.close(); }
+  });
+
+  it('classifies a listener that never answers as silent', async () => {
+    const srv = await listen(() => { /* accept, never respond */ });
+    try {
+      const occ = await hub.probePortOccupant(srv.address().port, 300);
+      assert.equal(occ.kind, 'silent');
+    } finally { srv.close(); }
+  });
+
+  it('classifies a closed port as free', async () => {
+    const srv = await listen(() => {});
+    const port = srv.address().port;
+    await new Promise(resolve => srv.close(resolve));
+    const occ = await hub.probePortOccupant(port);
+    assert.equal(occ.kind, 'free');
+  });
+});
+
+describe('#555 describePortOccupant message contract', () => {
+  const kinds = ['ccxray-standalone', 'ccxray-hub', 'health-ok', 'foreign-http', 'silent'];
+
+  it('never emits the destructive one-shot kill command, for any occupant', () => {
+    for (const kind of kinds) {
+      const lines = hub.describePortOccupant({ kind, pid: 123 }, 5577).join('\n');
+      assert.doesNotMatch(lines, /kill \$\(lsof/, `${kind} must not suggest kill $(lsof …)`);
+    }
+  });
+
+  it('offers the PROXY_PORT escape hatch for every occupied kind', () => {
+    for (const kind of kinds) {
+      const lines = hub.describePortOccupant({ kind, pid: 123 }, 5577).join('\n');
+      assert.match(lines, /PROXY_PORT/, `${kind} must mention PROXY_PORT`);
+    }
+  });
+
+  it('names a standalone ccxray occupant with its pid and says it is not a hub', () => {
+    const lines = hub.describePortOccupant({ kind: 'ccxray-standalone', pid: 4242 }, 5577).join('\n');
+    assert.match(lines, /standalone ccxray \(pid 4242\)/);
+    assert.match(lines, /not a hub/);
+    assert.match(lines, /Leave it running/);
+  });
+
+  it('tells the user not to kill a foreign HTTP service', () => {
+    const lines = hub.describePortOccupant({ kind: 'foreign-http' }, 5577).join('\n');
+    assert.match(lines, /not ccxray/);
+    assert.match(lines, /Do not kill it/);
+  });
+
+  it('reserves the kill discussion for the silent kind, gated on user recognition', () => {
+    const lines = hub.describePortOccupant({ kind: 'silent' }, 5577).join('\n');
+    assert.match(lines, /does not answer HTTP/);
+    assert.match(lines, /only if you recognise it/);
+  });
+
+  it('returns no lines for free/unknown so callers keep their generic fallback', () => {
+    assert.deepEqual(hub.describePortOccupant({ kind: 'free' }, 5577), []);
+    assert.deepEqual(hub.describePortOccupant(null, 5577), []);
+  });
+});
+
+describe('#555 ccxray status names a non-hub occupant', () => {
+  it('reports a held default port instead of a bare "No hub running."', async () => {
+    const srv = await listen((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, app: 'ccxray', pid: 4242, hub: false }));
+    });
+    try {
+      const port = srv.address().port;
+      const result = await runServer(['status'], isolatedEnv({ PROXY_PORT: String(port) }));
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(result.stdout, /No hub running\./);
+      assert.match(result.stdout, new RegExp(`Note: port ${port} is held by a standalone ccxray \\(pid 4242\\)`));
+      assert.match(result.stdout, /PROXY_PORT/);
+    } finally { srv.close(); }
+  });
+
+  it('stays a plain "No hub running." when the port is genuinely free', async () => {
+    const srv = await listen(() => {});
+    const port = srv.address().port;
+    await new Promise(resolve => srv.close(resolve));
+    const result = await runServer(['status'], isolatedEnv({ PROXY_PORT: String(port) }));
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /No hub running\./);
+    assert.doesNotMatch(result.stdout, /Note:/);
+  });
+});
+
+describe('#555 hub bind failure identifies the occupant', () => {
+  it('does not advise killing a foreign HTTP occupant, and offers PROXY_PORT', async () => {
+    const srv = await listen((req, res) => {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('mine');
+    });
+    try {
+      const port = srv.address().port;
+      // The same argv shape forkHub uses; the retry loop alone takes ~5s.
+      const result = await runServer(['--port', String(port), '--hub-mode'], isolatedEnv());
+      assert.equal(result.timedOut, false, 'hub-mode bind failure must exit, not hang');
+      assert.equal(result.status, 1);
+      assert.doesNotMatch(result.stderr, /kill \$\(lsof/, 'must not advise the blind kill');
+      assert.match(result.stderr, new RegExp(`Error: port ${port} is held by another HTTP service that is not ccxray`));
+      assert.match(result.stderr, /PROXY_PORT/);
+    } finally { srv.close(); }
+  });
+});

--- a/test/startup.test.js
+++ b/test/startup.test.js
@@ -143,7 +143,7 @@ describe('S4: standalone mode', () => {
 
   it('serves health endpoint', async () => {
     const data = await httpGet(port, '/_api/health');
-    assert.deepEqual(data, { ok: true });
+    assert.equal(data.ok, true); // #555: health carries occupant identity now
   });
 
   it('serves dashboard HTML at /', async () => {
@@ -244,7 +244,7 @@ describe('S6: hub mode startup', () => {
 
   it('responds to health check', async () => {
     const data = await httpGet(port, '/_api/health');
-    assert.deepEqual(data, { ok: true });
+    assert.equal(data.ok, true); // #555: health carries occupant identity now
   });
 
   it('accepts client registration via socket', async () => {
@@ -370,7 +370,7 @@ describe('R2: hub crash recovery', () => {
 
     // 6. Verify new hub is healthy
     const health = await httpGet(port, '/_api/health');
-    assert.deepEqual(health, { ok: true });
+    assert.equal(health.ok, true); // #555: health carries occupant identity now
 
     await killAndWait(child2);
   });
@@ -1319,7 +1319,7 @@ describe('Intercept lifecycle', () => {
 
     // Verify proxy is still healthy
     const health = await httpGet(proxyPort, '/_api/health');
-    assert.deepEqual(health, { ok: true });
+    assert.equal(health.ok, true); // #555: health carries occupant identity now
   });
 });
 
@@ -1363,7 +1363,7 @@ describe('Proxy error paths', () => {
   it('E1: proxy survives after upstream error (not crashed)', async () => {
     // Health check still works after error
     const health = await httpGet(proxyPort, '/_api/health');
-    assert.deepEqual(health, { ok: true });
+    assert.equal(health.ok, true); // #555: health carries occupant identity now
   });
 });
 
@@ -1493,7 +1493,7 @@ describe('Proxy upstream error responses', () => {
     nextResponse = null;
     await new Promise(r => setTimeout(r, 200));
     const health = await httpGet(proxyPort, '/_api/health');
-    assert.deepEqual(health, { ok: true });
+    assert.equal(health.ok, true); // #555: health carries occupant identity now
   });
 
   it('E3b: upstream socket destroyed mid-SSE → proxy handles ECONNRESET', async () => {
@@ -1522,7 +1522,7 @@ describe('Proxy upstream error responses', () => {
   it('E3b: proxy survives socket destroy', async () => {
     await new Promise(r => setTimeout(r, 300));
     const health = await httpGet(proxyPort, '/_api/health');
-    assert.deepEqual(health, { ok: true });
+    assert.equal(health.ok, true); // #555: health carries occupant identity now
   });
 });
 
@@ -1764,7 +1764,7 @@ describe('Hub recovery race: two simultaneous forks', () => {
 
     // Only one hub should be listening
     const health = await httpGet(port, '/_api/health');
-    assert.deepEqual(health, { ok: true });
+    assert.equal(health.ok, true); // #555: health carries occupant identity now
 
     // Lockfile should exist with correct port
     const lockPath = path.join(TEST_HOME, 'hub.json');
@@ -1986,7 +1986,7 @@ describe('Proxy loop startup guard', () => {
     try {
       await waitForPort(proxyPort);
       const health = await httpGet(proxyPort, '/_api/health');
-      assert.deepEqual(health, { ok: true });
+      assert.equal(health.ok, true); // #555: health carries occupant identity now
     } finally {
       await killAndWait(proxyChild);
     }
@@ -2001,7 +2001,7 @@ describe('Proxy loop startup guard', () => {
     try {
       await waitForPort(proxyPort);
       const health = await httpGet(proxyPort, '/_api/health');
-      assert.deepEqual(health, { ok: true });
+      assert.equal(health.ok, true); // #555: health carries occupant identity now
     } finally {
       await killAndWait(proxyChild);
     }
@@ -2016,7 +2016,7 @@ describe('Proxy loop startup guard', () => {
     try {
       await waitForPort(proxyPort);
       const health = await httpGet(proxyPort, '/_api/health');
-      assert.deepEqual(health, { ok: true });
+      assert.equal(health.ok, true); // #555: health carries occupant identity now
     } finally {
       await killAndWait(proxyChild);
     }
@@ -2051,7 +2051,7 @@ describe('Proxy loop startup guard', () => {
     try {
       await waitForPort(proxyPort);
       const health = await httpGet(proxyPort, '/_api/health');
-      assert.deepEqual(health, { ok: true });
+      assert.equal(health.ok, true); // #555: health carries occupant identity now
     } finally {
       await killAndWait(proxyChild);
     }


### PR DESCRIPTION
## 摘要

修 #555：Herdr plugin launcher 在 hub 預設 port（5577）被占用時完全無路可走的三個問題。

1. **Port escape hatch**：`PROXY_PORT` 從「碰巧經 env spread 傳過去」變成正式契約。`launch-agent.js` 讀取並驗證 `PROXY_PORT`、以 `--proxy-port=N` argv 傳給 pane 內的 `run-agent.js`（pane 的 env 不繼承 launcher 的 env，argv 才可靠），runner 再設到 spawn 的 ccxray env 上。選 `PROXY_PORT` 而非新變數，因為 `server/config.js` 本來就讀它，且它移動的是**整個 hub**（discovery + fork + hub.json），不像 `--port` 會切成 standalone 模式。已文件化於 plugin README。
2. **kill 建議改為先辨識占用者**：新增 `hub.probePortOccupant()`（探 `/_api/health`，health 回應加上 `app`/`pid`/`hub`/`version` 身分，add-only）與 `hub.describePortOccupant()` 單一訊息 composer，三個表面（hub.log、client Suggestion、`ccxray status`）共用。任何分支都不再輸出盲目的 `kill $(lsof -t -i:PORT)`；只有「綁著但不回 HTTP」的 silent 情況才提 kill，且要求使用者先自行確認 pid。
3. **`ccxray status` 誠實化**：無 lockfile 但預設 port 被占時，在 `No hub running.` 後補 `Note: port N is held by …`。herdr doctor 也會轉印這些 Note 行。

### 差異檢查證據（fail-on-old；docs/verification-principles.md）

同一批測試複製到 origin/main（afcb214）拋棄式 worktree 執行：

| 測試 | 舊碼 | 新碼 |
|---|---|---|
| `test/port-occupant.test.js`（status/hub-bind e2e + probe/message 單元） | **14 fail** / 1 pass | 22 pass |
| `test/herdr-plugin.test.js` 新增 7 個 PROXY_PORT 測試 | **7 fail** / 其餘 137 pass | 152 pass |

舊碼失敗理由正確：status e2e 的舊輸出正是 issue 描述的 bare `No hub running.`；hub-bind e2e 的舊 stderr 正是危險的 `kill $(lsof -t -i:53616)`。

（唯一在舊碼也 pass 的是「port 空閒時 status 維持純 `No hub running.`」——刻意的回歸守衛，兩邊都應 pass。）

### 手動重現（隔離 CCXRAY_HOME + 合成 wildcard listener，未觸碰 live 5577/5588）

**修後的失敗訊息**（issue 場景：外來 HTTP 服務占住 hub port）：

```
Hub did not become ready within 10s. Check …/hub.log
Hub log:
  Error: port 54374 is held by another HTTP service that is not ccxray.
  Error: Do not kill it — set PROXY_PORT=<other-port> …
  Error: port 54374 is already in use
Suggestion: port 54374 is held by another HTTP service that is not ccxray.
Suggestion: Do not kill it — …
```

（措辭後續依審查改為可直接複製的 `PROXY_PORT=5600 ccxray claude` 形式。）

**Escape hatch 正向驗證**：default port 被占 + `PROXY_PORT=54634` → hub 成功 fork 於 54634、`hub.json` 寫入 `{"port":54634,…}`、agent 正常啟動、exit 0。

### 全套結果

`CCXRAY_HOME=$(mktemp -d) npm test`（rebased on f0527a0）：**2221/2221 pass**。

過程中抓到一個值得記錄的事故：health payload 擴充後，`test/startup.test.js` 有 12 處、`test/hub-socket.test.js` 有 1 處 `assert.deepEqual(…, { ok: true })` 精確形狀斷言會 throw，其中 `re-forks hub after original hub is killed` 在斷言 throw 時跳過 `killAndWait(child2)`，洩漏的 hub 子行程讓整個 suite 掛住 46 分鐘（event loop 被 child handle 撐著）。13 處已放寬為 `assert.equal(x.ok, true)`；新 shape 的正向斷言集中在 `test/hub.test.js`。`hub-socket.test.js` 其餘 4 處 deepEqual 是 Unix socket health 回應（payload 未變），不動。

本機跑全套需 scrub 本 session 被 ccxray 監控注入的 client env（`ANTHROPIC_BASE_URL`/`CCXRAY_HUB_CLIENT_PID` 等），否則 `claude launcher mode`/`codex desktop app launcher mode` 3 個 subtest 因 spawnServer spread `process.env` 把 client-scoped path 嫁接到測試 port 而失敗——**已在 origin/main 舊碼同環境重現同樣 3 個失敗**，屬 pre-existing 環境洩漏，與本 diff 無關（CI 乾淨環境不受影響）。

### 測試注意事項

- e2e 的合成 listener 必須 **wildcard bind**：macOS 上 loopback-only 占用不會讓 hub 的 `listen(port)` 觸發 EADDRINUSE（首版測試因此假 hang 45s）。真實占用者（standalone ccxray）本來就是 wildcard。已在測試内注記。
- `pluginEnv()` 新增剝除 ambient `PROXY_PORT`（launcher 現在讀它，屬 plugin env surface；docs/testing.md isolation 慣例）。
- 全服務啟動類 e2e 用 45s budget（#538/#542 前例），在測試內部 guard 實作，非 tool timeout。

## Review gate (grok stand-in — codex out of quota until 2026-08-20)

`grok -p` headless single-turn review of the full diff. Findings & disposition:

| # | Sev | Finding | Disposition |
|---|-----|---------|-------------|
| 1 | P2 | `set PROXY_PORT=…` is not runnable in bash/zsh | **Fixed** — hint now shows `PROXY_PORT=5600 ccxray claude` prefix form; test asserts no `set PROXY_PORT` |
| 2 | P2 | `hub:false` also covers dashboard-only servers; "started with --port" over-claims | **Fixed** — reworded to "standalone (non-hub) ccxray"; test asserts no `--port` claim |
| 3 | P2 | `ccxray-hub` advice asserts lockfile-missing / prescribes restart; hub may be healthy under another `CCXRAY_HOME`; orphan HTTP recovery still hits the 410 path | **Wording fixed** (no assertion, restart offered not prescribed). Repointing `discoverHub`'s orphan fallback at the new health identity is a discovery-semantics change out of #555's scope — noted as follow-up below |
| 4 | P2 | herdr doctor drops the new status Note lines | **Fixed** — `parseStatus` gains `notes`, doctor prints them; unit test added |
| 5 | P3 | probe trusts ok-shaped body on non-200 | **Fixed** — 200-only gate; test added |
| 6 | P3 | test gaps (hub flag true/false, ccxray-hub message text, doctor notes path, client-Suggestion surface) | **Mostly added** (hub-flag test in `test/hub.test.js`, ccxray-hub message test, parseStatus notes test). Client-Suggestion surface covered by the shared-composer unit tests + the manual repro transcript above; a fork+10s e2e was judged not worth the suite cost |
| — | — | Security: pid/version on `/_api/health` acceptable for loopback-trusted dev proxy (pre-auth surface pre-exists; same data already on socket status) | No action |

### Round 2 — merge verdict (grok, final diff)

**Verdict: SHIP.** Grok re-reviewed the final rebased diff, confirmed all six round-1 dispositions are actually present (including that the 4 Unix-socket health deepEquals were correctly left exact), and found 3 P3s — all fixed in `7a1c7ca` before merge:

| # | Sev | Finding | Disposition |
|---|-----|---------|-------------|
| 1 | P3 | `parseStatus` scraped port/pid out of the new Note lines (occupant identity reported as the hub's; not user-facing today since callers gate on `running`) | **Fixed** — Note lines excluded from the port/pid scan; test locks both to null |
| 2 | P3 | The rare probe-empty client fallback still said unrunnable `set PROXY_PORT=…` | **Fixed** — now `relaunch with PROXY_PORT=<other-port>` |
| 3 | P3 | `docs/testing.md` §1b didn't mention `pluginEnv` now strips `PROXY_PORT` | **Fixed** — doc updated (CLAUDE.md testing-doc maintenance rule) |

### Follow-up (not in this PR)

- `discoverHub`'s HTTP orphan-recovery fallback still probes `/_api/hub/status`, which modern hubs answer with 410 — it can no longer recover a modern lockfile-less hub. The new `/_api/health` identity is enough to rebuild the lockfile; doing so changes discovery semantics and deserves its own issue.

## Detail

- `server/hub.js` — `/_api/health` now returns `{ ok, app:'ccxray', pid, hub, version }` (add-only; `hub` is true only after `setHubPort`, i.e. real hub mode). New `probePortOccupant(port)` classifies `ccxray-hub / ccxray-standalone / health-ok / foreign-http / silent / free`; new `describePortOccupant(occ, port)` is the single message composer.
- `server/index.js` — hub-mode bind failure (was the `kill $(lsof)` site), client-mode post-mortem Suggestion (was "Use --port <other> or kill the process"), and the `status` no-lockfile branch all call the shared probe + composer.
- `plugins/herdr/bin/launch-agent.js` — validates `PROXY_PORT` (loud exit 2 before any pane is created), surfaces it in `--plan`, threads `--proxy-port=N` into the runner command.
- `plugins/herdr/bin/run-agent.js` — parses/validates `--proxy-port`, sets `PROXY_PORT` on the spawned env (flag wins over pane env), shows it in `--dry-run`.
- `plugins/herdr/bin/lib/ccxray.js` + `doctor.js` — status Note lines surfaced.
- `plugins/herdr/README.md` — escape hatch documented.
- Tests: `test/port-occupant.test.js` (new), `test/hub.test.js` (health shape + hub flag), `test/herdr-plugin.test.js` (8 new tests + `PROXY_PORT` env isolation in `pluginEnv`).

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)
