### PR TITLE
fix(statusline): non-blocking Herdr launch, full disclosure, risk-based default (#563)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -597,13 +597,36 @@ function promptClaudeStatusline() {
   const declinedPath = path.join(ccxrayHome, '.statusline-declined');
   const hintShownPath = path.join(ccxrayHome, '.statusline-hint-shown');
 
-  if (process.stdin.isTTY && !fs.existsSync(declinedPath)) {
+  // #563: a Herdr-launched pane must not block on an interactive gate — the
+  // user clicked "launch claude" and expects the agent, not a question. Fall
+  // through to the one-line hint; the declined marker is NOT written, so a
+  // later direct TTY launch still gets to answer.
+  const herdrLaunch = (process.env.CCXRAY_AGENT_ID || '').startsWith('herdr:');
+
+  if (process.stdin.isTTY && !herdrLaunch && !fs.existsSync(declinedPath)) {
+    // #563: disclose purpose, impact, and reversibility; the default follows
+    // risk — a pure addition (no statusline configured) defaults to yes, while
+    // wrapping an existing statusline requires a conscious "y".
+    let hasExisting = false;
+    try {
+      const cmd = JSON.parse(fs.readFileSync(path.join(claudeHome, 'settings.json'), 'utf8')).statusLine?.command || '';
+      hasExisting = Boolean(cmd) && !cmd.includes('claude-adapter');
+    } catch {}
+    const impactNote = hasExisting
+      ? 'your existing statusline keeps rendering unchanged (delegated, not replaced)'
+      : 'no statusline is configured today, so this only adds one';
+    const defTag = hasExisting ? '[y/N]' : '[Y/n]';
     const readline = require('readline');
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
     return new Promise(resolve => {
-      rl.question('\x1b[35m📊 Track Claude rate limits on the Usage page? [y/N] \x1b[0m', answer => {
+      rl.question(
+        '\x1b[35m📊 Track Claude subscription limits (5h/weekly) on the Usage page?\x1b[0m\n'
+        + `\x1b[90m   Installs a statusline adapter in ${path.join(claudeHome, 'settings.json')} —\n`
+        + `   ${impactNote}; fully restored on removal (ccxray setup-statusline).\x1b[0m \x1b[35m${defTag}\x1b[0m `,
+        answer => {
         rl.close();
-        if (answer.trim().toLowerCase() === 'y') {
+        const a = answer.trim().toLowerCase();
+        if (a === 'y' || a === 'yes' || (a === '' && !hasExisting)) {
           const result = installStatusline(claudeHome);
           if (result.status === 'installed') _origLog('\x1b[32m✓ Done. Rate limits will appear on the Usage page after restarting this session.\x1b[0m');
         } else {

--- a/server/index.js
+++ b/server/index.js
@@ -608,6 +608,7 @@ function promptClaudeStatusline() {
     // risk — a pure addition (no statusline configured) defaults to yes, while
     // wrapping an existing statusline requires a conscious "y".
     let hasExisting = false;
+    let unparseable = false;
     try {
       const raw = fs.readFileSync(path.join(claudeHome, 'settings.json'), 'utf8');
       try {
@@ -618,11 +619,14 @@ function promptClaudeStatusline() {
         // addition — installing would overwrite unknown content. Treat it as
         // wrap-risk so the default stays No (grok review P2, 2026-08-18).
         hasExisting = true;
+        unparseable = true;
       }
     } catch {} // missing file = genuinely nothing configured
-    const impactNote = hasExisting
-      ? 'your existing statusline keeps rendering unchanged (delegated, not replaced)'
-      : 'no statusline is configured today, so this only adds one';
+    const impactNote = unparseable
+      ? 'your settings.json exists but could not be parsed — installing would REWRITE it'
+      : hasExisting
+        ? 'your existing statusline keeps rendering unchanged (delegated, not replaced)'
+        : 'no statusline is configured today, so this only adds one';
     const defTag = hasExisting ? '[y/N]' : '[Y/n]';
     const readline = require('readline');
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });

--- a/server/index.js
+++ b/server/index.js
@@ -609,9 +609,17 @@ function promptClaudeStatusline() {
     // wrapping an existing statusline requires a conscious "y".
     let hasExisting = false;
     try {
-      const cmd = JSON.parse(fs.readFileSync(path.join(claudeHome, 'settings.json'), 'utf8')).statusLine?.command || '';
-      hasExisting = Boolean(cmd) && !cmd.includes('claude-adapter');
-    } catch {}
+      const raw = fs.readFileSync(path.join(claudeHome, 'settings.json'), 'utf8');
+      try {
+        const cmd = JSON.parse(raw).statusLine?.command || '';
+        hasExisting = Boolean(cmd) && !cmd.includes('claude-adapter');
+      } catch {
+        // A settings.json that exists but does not parse is NOT a pure
+        // addition — installing would overwrite unknown content. Treat it as
+        // wrap-risk so the default stays No (grok review P2, 2026-08-18).
+        hasExisting = true;
+      }
+    } catch {} // missing file = genuinely nothing configured
     const impactNote = hasExisting
       ? 'your existing statusline keeps rendering unchanged (delegated, not replaced)'
       : 'no statusline is configured today, so this only adds one';
@@ -625,7 +633,7 @@ function promptClaudeStatusline() {
         + `   ${impactNote}; fully restored on removal (ccxray setup-statusline).\x1b[0m \x1b[35m${defTag}\x1b[0m `,
         answer => {
         rl.close();
-        const a = answer.trim().toLowerCase();
+        const a = String(answer ?? '').trim().toLowerCase();
         if (a === 'y' || a === 'yes' || (a === '' && !hasExisting)) {
           const result = installStatusline(claudeHome);
           if (result.status === 'installed') _origLog('\x1b[32m✓ Done. Rate limits will appear on the Usage page after restarting this session.\x1b[0m');

--- a/test/statusline-prompt.test.js
+++ b/test/statusline-prompt.test.js
@@ -17,7 +17,7 @@
 // nonexistent path, fake `claude` binary on PATH. The pty comes from
 // script(1) with the platform branch from #556 (BSD vs util-linux argv).
 
-const { describe, it } = require('node:test');
+const { describe, it, after } = require('node:test');
 const assert = require('node:assert/strict');
 const { spawnSync } = require('child_process');
 const fs = require('fs');
@@ -27,6 +27,13 @@ const path = require('path');
 
 const SERVER_SCRIPT = path.resolve(__dirname, '..', 'server', 'index.js');
 const NO_TRANSCRIPTS = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-slp-empty-'));
+const SCENARIO_DIRS = [];
+
+after(() => {
+  for (const d of [...SCENARIO_DIRS, NO_TRANSCRIPTS]) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+  }
+});
 
 function findFreePort() {
   return new Promise((resolve, reject) => {
@@ -38,6 +45,7 @@ function findFreePort() {
 
 function makeScenario({ claudeSettings = null } = {}) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-slp-home-'));
+  SCENARIO_DIRS.push(home);
   const claudeHome = path.join(home, 'claude-config');
   fs.mkdirSync(claudeHome, { recursive: true });
   if (claudeSettings) fs.writeFileSync(path.join(claudeHome, 'settings.json'), JSON.stringify(claudeSettings));
@@ -61,6 +69,10 @@ async function runLaunch(sc, { input, env = {} }) {
     CCXRAY_IMPORT_HOMES: NO_TRANSCRIPTS,
     CCXRAY_PRICING_CACHE: '/nonexistent/pricing.json',
     BROWSER: 'none',
+    // Pinned empty: an ambient herdr:* id (suite run from a Herdr pane) would
+    // silently skip the prompt in the non-Herdr scenarios — the docs/testing.md
+    // §1b leak class (grok review P2). The Herdr test overrides it.
+    CCXRAY_AGENT_ID: '',
     PATH: `${sc.bin}:/usr/bin:/bin:/usr/sbin:/sbin`,
     ...env,
   }).map(([k, v]) => `${k}=${JSON.stringify(v)}`).join(' ');
@@ -75,7 +87,7 @@ async function runLaunch(sc, { input, env = {} }) {
     + `for i in $(seq 1 220); do [ -f ${JSON.stringify(sc.capture)} ] && break; sleep 0.2; done\n`
     + `sleep 1\n`
     + `[ -f ${JSON.stringify(sc.capture)} ] && echo CLAUDE_RAN || echo CLAUDE_NOT_RUN\n`
-    + `pkill -f "server/index.js --port ${port}" 2>/dev/null; true`;
+    + `pkill -f "server/index.js --port ${port} --no-browser" 2>/dev/null; true`;
   const result = spawnSync('/bin/sh', ['-c', command], { encoding: 'utf8', timeout: 60000 });
   let log = '';
   try { log = fs.readFileSync(out, 'utf8'); } catch {}
@@ -120,5 +132,29 @@ describe('#563 statusline consent prompt', () => {
     assert.equal(st.command, 'echo my-custom-line', 'existing statusline untouched');
     assert.equal(st._ccxrayDelegate, undefined, 'no delegation installed');
     assert.equal(r.declined, true, 'Enter records the decline');
+  });
+
+  it('an explicit y on the wrap case installs with delegation preserved', async () => {
+    const sc = makeScenario({ claudeSettings: { statusLine: { command: 'echo my-custom-line' } } });
+    const r = await runLaunch(sc, { input: 'y\\n' });
+    assert.match(r.marker, /CLAUDE_RAN/, r.log);
+    const st = readSettings(sc).statusLine;
+    assert.ok(st.command.includes('claude-adapter'), 'y installs the adapter');
+    assert.equal(st._ccxrayDelegate, 'echo my-custom-line', 'original command preserved as delegate');
+    assert.equal(r.declined, false);
+  });
+
+  // A settings.json that exists but does not parse is NOT a pure addition —
+  // installing would overwrite unknown content, so the default must stay No
+  // (grok review P2).
+  it('treats an unparseable settings.json as wrap-risk — Enter declines, file untouched', async () => {
+    const sc = makeScenario();
+    const settingsPath = path.join(sc.claudeHome, 'settings.json');
+    fs.writeFileSync(settingsPath, '{ this is not json');
+    const r = await runLaunch(sc, { input: '\\n' });
+    assert.match(r.marker, /CLAUDE_RAN/, r.log);
+    assert.match(r.log, /\[y\/N\]/, 'unparseable file must not advertise Yes');
+    assert.equal(fs.readFileSync(settingsPath, 'utf8'), '{ this is not json', 'file left byte-identical');
+    assert.equal(r.declined, true);
   });
 });

--- a/test/statusline-prompt.test.js
+++ b/test/statusline-prompt.test.js
@@ -1,0 +1,124 @@
+'use strict';
+
+// #563 — the statusline consent prompt: timing, disclosure, and defaults.
+//
+// Three behaviors, each verified end-to-end through a real `ccxray --port N
+// claude` boot under a pty (the prompt is TTY-gated):
+//   1. A Herdr-launched pane never blocks on the prompt — the agent starts,
+//      the one-line hint replaces the question, and the declined marker is
+//      NOT written (a later direct launch still gets to answer).
+//   2. With no statusline configured (pure addition), the default is Yes —
+//      plain Enter installs the adapter.
+//   3. With an existing custom statusline (wrapping), the default stays No —
+//      plain Enter declines and the user's settings.json is left untouched.
+//
+// Isolation (docs/testing.md): throwaway HOME/CCXRAY_HOME/CLAUDE_CONFIG_DIR,
+// CCXRAY_IMPORT_HOMES pinned empty, CCXRAY_PRICING_CACHE pointed at a
+// nonexistent path, fake `claude` binary on PATH. The pty comes from
+// script(1) with the platform branch from #556 (BSD vs util-linux argv).
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+const SERVER_SCRIPT = path.resolve(__dirname, '..', 'server', 'index.js');
+const NO_TRANSCRIPTS = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-slp-empty-'));
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, () => { const p = srv.address().port; srv.close(() => resolve(p)); });
+    srv.on('error', reject);
+  });
+}
+
+function makeScenario({ claudeSettings = null } = {}) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-slp-home-'));
+  const claudeHome = path.join(home, 'claude-config');
+  fs.mkdirSync(claudeHome, { recursive: true });
+  if (claudeSettings) fs.writeFileSync(path.join(claudeHome, 'settings.json'), JSON.stringify(claudeSettings));
+  const bin = path.join(home, 'bin');
+  fs.mkdirSync(bin);
+  const capture = path.join(home, 'claude-ran');
+  fs.writeFileSync(path.join(bin, 'claude'), `#!/bin/sh\necho ran > ${JSON.stringify(capture)}\nexit 0\n`);
+  fs.chmodSync(path.join(bin, 'claude'), 0o755);
+  return { home, claudeHome, bin, capture };
+}
+
+// Boot `ccxray --port N claude` under a pty, feed `input` on stdin, wait for
+// the fake claude to have run (or the budget to expire), then reap.
+async function runLaunch(sc, { input, env = {} }) {
+  const port = await findFreePort();
+  const out = path.join(sc.home, 'out.log');
+  const envParts = Object.entries({
+    HOME: sc.home,
+    CCXRAY_HOME: path.join(sc.home, '.ccxray'),
+    CLAUDE_CONFIG_DIR: sc.claudeHome,
+    CCXRAY_IMPORT_HOMES: NO_TRANSCRIPTS,
+    CCXRAY_PRICING_CACHE: '/nonexistent/pricing.json',
+    BROWSER: 'none',
+    PATH: `${sc.bin}:/usr/bin:/bin:/usr/sbin:/sbin`,
+    ...env,
+  }).map(([k, v]) => `${k}=${JSON.stringify(v)}`).join(' ');
+  const inner = `env ${envParts} ${JSON.stringify(process.execPath)} ${JSON.stringify(SERVER_SCRIPT)} --port ${port} --no-browser claude`;
+  // BSD script (macOS) takes the command positionally; util-linux needs -c (#556).
+  const pty = process.platform === 'linux'
+    ? `script -qec ${JSON.stringify(inner)} /dev/null`
+    : `script -q /dev/null /bin/sh -c ${JSON.stringify(inner)}`;
+  // Full-server-boot budget: 45s (#538/#542 precedent), enforced here in the
+  // poll loop — never as an outer tool timeout.
+  const command = `{ ( printf ${JSON.stringify(input)}; sleep 40 ) | ${pty}; } > ${JSON.stringify(out)} 2>&1 &\n`
+    + `for i in $(seq 1 220); do [ -f ${JSON.stringify(sc.capture)} ] && break; sleep 0.2; done\n`
+    + `sleep 1\n`
+    + `[ -f ${JSON.stringify(sc.capture)} ] && echo CLAUDE_RAN || echo CLAUDE_NOT_RUN\n`
+    + `pkill -f "server/index.js --port ${port}" 2>/dev/null; true`;
+  const result = spawnSync('/bin/sh', ['-c', command], { encoding: 'utf8', timeout: 60000 });
+  let log = '';
+  try { log = fs.readFileSync(out, 'utf8'); } catch {}
+  return { marker: result.stdout.trim(), log, declined: fs.existsSync(path.join(sc.home, '.ccxray', '.statusline-declined')) };
+}
+
+function readSettings(sc) {
+  try { return JSON.parse(fs.readFileSync(path.join(sc.claudeHome, 'settings.json'), 'utf8')); } catch { return {}; }
+}
+
+describe('#563 statusline consent prompt', () => {
+  it('never blocks a Herdr-launched pane — hint instead of question, no declined marker', async () => {
+    const sc = makeScenario();
+    // No stdin answer on purpose: the old code would sit on the question forever.
+    const r = await runLaunch(sc, { input: '', env: { CCXRAY_AGENT_ID: 'herdr:w1:p1' } });
+    assert.match(r.marker, /CLAUDE_RAN/, `agent must start without an answer; log:\n${r.log}`);
+    assert.doesNotMatch(r.log, /\[y\/N\]|\[Y\/n\]/, 'no interactive question in a Herdr pane');
+    assert.match(r.log, /setup-statusline/, 'the one-line hint replaces the question');
+    assert.equal(r.declined, false, 'skipping must not forge a decline');
+    assert.equal(readSettings(sc).statusLine, undefined, 'nothing installed');
+  });
+
+  it('defaults to Yes when no statusline is configured — Enter installs the adapter', async () => {
+    const sc = makeScenario();
+    const r = await runLaunch(sc, { input: '\\n' });
+    assert.match(r.marker, /CLAUDE_RAN/, r.log);
+    assert.match(r.log, /\[Y\/n\]/, 'pure addition advertises Yes as default');
+    assert.match(r.log, /settings\.json/, 'prompt discloses what it writes');
+    assert.match(r.log, /restored on removal/, 'prompt discloses reversibility');
+    const st = readSettings(sc).statusLine;
+    assert.ok(st && st.command.includes('claude-adapter'), 'Enter installs the adapter');
+    assert.equal(r.declined, false);
+  });
+
+  it('defaults to No when wrapping an existing statusline — Enter declines, settings untouched', async () => {
+    const sc = makeScenario({ claudeSettings: { statusLine: { command: 'echo my-custom-line' } } });
+    const r = await runLaunch(sc, { input: '\\n' });
+    assert.match(r.marker, /CLAUDE_RAN/, r.log);
+    assert.match(r.log, /\[y\/N\]/, 'wrapping keeps No as default');
+    assert.match(r.log, /delegated, not replaced/, 'prompt discloses the wrap semantics');
+    const st = readSettings(sc).statusLine;
+    assert.equal(st.command, 'echo my-custom-line', 'existing statusline untouched');
+    assert.equal(st._ccxrayDelegate, undefined, 'no delegation installed');
+    assert.equal(r.declined, true, 'Enter records the decline');
+  });
+});

--- a/test/statusline-prompt.test.js
+++ b/test/statusline-prompt.test.js
@@ -154,6 +154,8 @@ describe('#563 statusline consent prompt', () => {
     const r = await runLaunch(sc, { input: '\\n' });
     assert.match(r.marker, /CLAUDE_RAN/, r.log);
     assert.match(r.log, /\[y\/N\]/, 'unparseable file must not advertise Yes');
+    assert.match(r.log, /could not be parsed/, 'prompt says what y would really do (grok round-2 P3)');
+    assert.doesNotMatch(r.log, /delegated, not replaced/, 'must not borrow the wrap copy');
     assert.equal(fs.readFileSync(settingsPath, 'utf8'), '{ this is not json', 'file left byte-identical');
     assert.equal(r.declined, true);
   });


### PR DESCRIPTION
## 摘要

修 #563：statusline 同意提問的時機、內容、預設值三件事一起收。

1. **Herdr launch 不再被擋**：`CCXRAY_AGENT_ID=herdr:*` 的 pane 跳過互動提問，改印一行 `ccxray setup-statusline` 提示；**不寫拒絕標記**，之後直接在 TTY 啟動仍會被問。
2. **提問補齊三項揭露**：用途（Usage 頁的訂閱額度追蹤）、影響（寫 adapter 進 `settings.json`；既有 statusline 經委派照常渲染）、可逆性（移除時自動還原）。
3. **預設值跟風險走**：沒有既有 statusline（純新增）→ `[Y/n]`，Enter 即裝；要包既有 statusline 或 settings.json 存在但 parse 失敗（覆寫風險）→ 維持 `[y/N]`，同意必須是有意識的 `y`。

## 差異檢查證據（fail-on-old）

`test/statusline-prompt.test.js` — 5 個 pty 驅動的 e2e（真實 `ccxray --port N claude` boot + script(1) pty，#556 的平台分支寫法）。前 3 個複製到 origin/main 拋棄式 worktree：**0/3 pass**（herdr 情境永久卡在提問、純新增按 Enter 被拒絕、舊提問缺所有揭露文字）。新碼 5/5。

全套（隔離 CCXRAY_HOME、scrub 被監控 session 的 client env）：**2224/2224 pass**。

## 乾淨機器驗證（DO droplet，Ubuntu 22.04）

把修過的 `server/index.js` 部署到 droplet 的 plugin checkout、移除先前手動建立的拒絕標記（還原成會觸發 bug 的狀態）、從 Herdr plugin 重新 launch：pane **直接進入 Claude Code 畫面，無提問**；`.statusline-declined` 不存在（skip 未偽造 decline）；`~/.claude/settings.json` 無 `statusLine` 鍵（未偷裝）。這正是發現此 bug 的同一台機器、同一條路徑。

## Review gate (grok stand-in — codex out of quota until 2026-08-20)

Verdict: **SHIP**, no P1. Findings & disposition:

| # | Sev | Finding | Disposition |
|---|-----|---------|-------------|
| 1 | P2 | An existing-but-unparseable settings.json was classified as "nothing configured" — Enter would overwrite unknown content under a [Y/n] default | **Fixed** — parse failure ⇒ wrap-risk ⇒ [y/N]; e2e locks the file byte-identical after Enter |
| 2 | P2 | Test env inherited ambient `CCXRAY_AGENT_ID` — a suite run from a Herdr pane would silently skip the prompt in the non-Herdr scenarios (docs/testing.md §1b class) | **Fixed** — `CCXRAY_AGENT_ID: ''` pinned in the base env; Herdr test overrides |
| 3 | P3 | `answer.trim()` throws on readline EOF (swallowed by spawnAgent's catch — harmless but re-asks) | **Fixed** — `String(answer ?? '')` |
| 4 | P3 | Answer-string / marker coverage gaps | **Partially added** — explicit `y` on wrap (delegation preserved) + unparseable-file scenario; the rest (`YES`, whitespace, pre-existing marker, unset CLAUDE_CONFIG_DIR) judged not worth a server boot each |
| 5 | P3 | Test hygiene: temp dirs never removed; pkill prefix-match | **Fixed** — after() cleanup, exact pattern |

Consent-safety check (grok): nothing on any path installs without the TTY prompt; the Herdr skip only withholds the question and can neither install nor forge a decline; the skip cannot fire outside the plugin's `herdr:` id prefix.

## Detail

- `server/index.js` `promptClaudeStatusline()`: herdr-launch guard (falls to the existing hint path), three-line disclosure prompt, `hasExisting` detection with unparseable-file conservatism, risk-based default, EOF-safe answer handling. Install/uninstall/delegation mechanics untouched.
- `test/statusline-prompt.test.js` (new): 5 pty e2e scenarios, isolated per docs/testing.md.

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)
