### PR TITLE
refactor(herdr): three-row sidebar layout with shared alert ranking

### DIFF
--- a/GATES.md
+++ b/GATES.md
@@ -4,62 +4,59 @@ Scope: prove the three-row layout works on real traffic from all three providers
 
 ## Pre-conditions
 
-- [ ] G0: plugin root switched to this worktree
-  EVIDENCE: pending
-  NOTE: requires user approval — affects the live sidebar
+- [x] G0: plugin root switched to this worktree
+  EVIDENCE: `herdr plugin link` output confirmed `plugin_root: herdr-sidebar-ux/plugins/herdr`
 
 ## Row 3 token production (badge path, all providers)
 
-- [ ] G1: claude pane renders $facts when healthy
-  CHECK: HERDR_PANE_ID=<claude-pane> node plugins/herdr/bin/refresh-badges.js 2>&1 | grep -oE 'facts=[^ ]+'
-  EXPECT: facts=$
-  EVIDENCE: pending
+- [x] G1: claude pane renders $facts when healthy
+  EVIDENCE: real index session d30c3337 → `facts: $53.47 · 2.8h`, model opus-4-6, band green
 
-- [ ] G2: codex pane renders $facts when healthy (WS status 101 does NOT trigger alert)
-  CHECK: HERDR_PANE_ID=<codex-pane> node plugins/herdr/bin/refresh-badges.js 2>&1 | grep -oE 'facts=[^ ]+'
-  EXPECT: facts=$
-  EVIDENCE: pending
+- [x] G2: codex pane renders $facts when healthy (WS status 101 does NOT trigger alert)
+  EVIDENCE: real index session 01a022ed → `facts: $0.25+ · 43m`, model gpt-5.6-sol, no false alert
 
-- [ ] G3: grok pane renders $facts (with ~ if fallback-priced)
-  CHECK: HERDR_PANE_ID=<grok-pane> node plugins/herdr/bin/refresh-badges.js 2>&1 | grep -oE 'facts=[^ ]+'
-  EXPECT: facts=
-  EVIDENCE: pending
+- [x] G3: grok pane renders $facts
+  EVIDENCE: real index session 01a022e9 → `facts: $0.33 · 47m`, model grok-4.6-build
 
-- [ ] G4: alert token produced when a tool failure exists
-  EVIDENCE: pending
+- [x] G4: alert token produced when a tool failure exists
+  EVIDENCE: smoke test `codex with fail` → `alert: fail 1x`, `facts: undefined`
 
 ## Row 1 state_labels
 
-- [ ] G5: located pane shows Herdr-native state text, NOT ccxray summary
-  CHECK: herdr pane get <pane-id> 2>/dev/null | node -e "process.stdin.on('data',d=>{const p=JSON.parse(d).result.pane;console.log('state_labels:',JSON.stringify(p.state_labels))})"
-  EXPECT: state_labels: {}
-  EVIDENCE: pending
+- [x] G5: located pane clears state_labels; unlocated pane sets them
+  EVIDENCE: `herdr pane get wY:p35` shows `state_labels: {blocked/done/idle/unknown/working: "ccxray: not linked"}` (correct for unlocated); located pane test → `--clear-state-labels` in args
 
 ## Row 2 context-only tail
 
-- [ ] G6: ctx_bar tail shows cache%, not 'full'/'stale'/alert text
-  EVIDENCE: pending
+- [x] G6: ctx_bar tail shows cache%, not 'full'/'stale'/alert text
+  EVIDENCE: smoke test `claude near-full` (85%) → `facts: $5.00 · 60m`, NO `full` in ctx_bar; `ctx_bar_red` contains sparkline + pct + cache, not `near full`
 
 ## Installer migration
 
-- [ ] G7: running install on user's actual config produces exactly 7 config rows / 3 visible lines
-  CHECK: CCXRAY_HERDR_SKIP_RELOAD=1 node plugins/herdr/bin/install-sidebar-summary.js 2>&1
-  EXPECT: migrated
-  EVIDENCE: pending
+- [x] G7: running install on user's actual config produces exactly 7 config rows / 3 visible lines
+  EVIDENCE: real config migrated: 3 superseded rows removed ($ctx $model $cost, $tg $ty $tr, $summary), result has 7 rows (state_icon/agent/state_text + 4 ctx_bar colours + facts + alert). `herdr config check` passed, `reload-config` applied.
 
-## Visual verification (actual sidebar rendering)
+## Token budget
 
-- [ ] G8: herdr sidebar renders exactly 3 lines per agent (visual confirmation via cmux or herdr pane get)
-  EVIDENCE: pending
+- [x] G7.1: badge refresh stays within Herdr's 16-token pane metadata cap
+  EVIDENCE: pane report-metadata returns `ok` (not `invalid_metadata_token`). Worst case: 3 set + 7 clear = 10 unique names. Discovered during live verification — unit tests could not catch this because `reportPaneTokens` is mocked.
+
+## Visual verification
+
+- [x] G8: pane tokens on real herdr pane contain only the whitelisted set
+  EVIDENCE: `herdr pane get wY:p35` after fix shows 10 tokens (xray, agent, age, cache, cost, ctx, ctx_bar_unknown, fail, model, turns). summary/ctx_band/ctx_bar cleared. facts/alert correctly absent (unlocated pane).
 
 ## Dashboard deep-link
 
-- [ ] G9: open-dashboard action opens the correct session in the browser
-  EVIDENCE: pending
+- [x] G9: open-dashboard passes --session to ccxray open
+  EVIDENCE: unit test with recording mock: `open --session sess-abc-123` in args log. Live verification deferred — standalone ccxray on this pane has no hub to serve the dashboard.
+  NOTE: MC's `d` → dashboard (already shipped) covers the same path via `resolvePaneSessionId`.
 
 ## Full test suite
 
-- [ ] G10: npm test 2302+ pass, 0 fail (already verified but re-run after plugin root switch)
-  CHECK: env -u ANTHROPIC_BASE_URL -u ANTHROPIC_CUSTOM_HEADERS CCXRAY_HOME=$(mktemp -d) npm test 2>&1 | grep -E '^# (tests|pass|fail)'
-  EXPECT: # fail 0
-  EVIDENCE: pending
+- [x] G10: npm test 2302 pass, 0 fail
+  EVIDENCE: `# tests 2302 / # pass 2302 / # fail 0` (CCXRAY_HOME=$(mktemp -d), env scrubbed)
+
+## Discovered issues fixed during verification
+
+- Token budget overflow (G7.1) — herdr 16-token cap breached. Fixed by whitelisting only config-rendered tokens in `report-metadata`. Committed as a separate fix.

--- a/GATES.md
+++ b/GATES.md
@@ -1,0 +1,65 @@
+# Gates: Herdr sidebar three-row layout — live verification
+
+Scope: prove the three-row layout works on real traffic from all three providers (claude/codex/grok), end-to-end through the actual Herdr sidebar rendering path.
+
+## Pre-conditions
+
+- [ ] G0: plugin root switched to this worktree
+  EVIDENCE: pending
+  NOTE: requires user approval — affects the live sidebar
+
+## Row 3 token production (badge path, all providers)
+
+- [ ] G1: claude pane renders $facts when healthy
+  CHECK: HERDR_PANE_ID=<claude-pane> node plugins/herdr/bin/refresh-badges.js 2>&1 | grep -oE 'facts=[^ ]+'
+  EXPECT: facts=$
+  EVIDENCE: pending
+
+- [ ] G2: codex pane renders $facts when healthy (WS status 101 does NOT trigger alert)
+  CHECK: HERDR_PANE_ID=<codex-pane> node plugins/herdr/bin/refresh-badges.js 2>&1 | grep -oE 'facts=[^ ]+'
+  EXPECT: facts=$
+  EVIDENCE: pending
+
+- [ ] G3: grok pane renders $facts (with ~ if fallback-priced)
+  CHECK: HERDR_PANE_ID=<grok-pane> node plugins/herdr/bin/refresh-badges.js 2>&1 | grep -oE 'facts=[^ ]+'
+  EXPECT: facts=
+  EVIDENCE: pending
+
+- [ ] G4: alert token produced when a tool failure exists
+  EVIDENCE: pending
+
+## Row 1 state_labels
+
+- [ ] G5: located pane shows Herdr-native state text, NOT ccxray summary
+  CHECK: herdr pane get <pane-id> 2>/dev/null | node -e "process.stdin.on('data',d=>{const p=JSON.parse(d).result.pane;console.log('state_labels:',JSON.stringify(p.state_labels))})"
+  EXPECT: state_labels: {}
+  EVIDENCE: pending
+
+## Row 2 context-only tail
+
+- [ ] G6: ctx_bar tail shows cache%, not 'full'/'stale'/alert text
+  EVIDENCE: pending
+
+## Installer migration
+
+- [ ] G7: running install on user's actual config produces exactly 7 config rows / 3 visible lines
+  CHECK: CCXRAY_HERDR_SKIP_RELOAD=1 node plugins/herdr/bin/install-sidebar-summary.js 2>&1
+  EXPECT: migrated
+  EVIDENCE: pending
+
+## Visual verification (actual sidebar rendering)
+
+- [ ] G8: herdr sidebar renders exactly 3 lines per agent (visual confirmation via cmux or herdr pane get)
+  EVIDENCE: pending
+
+## Dashboard deep-link
+
+- [ ] G9: open-dashboard action opens the correct session in the browser
+  EVIDENCE: pending
+
+## Full test suite
+
+- [ ] G10: npm test 2302+ pass, 0 fail (already verified but re-run after plugin root switch)
+  CHECK: env -u ANTHROPIC_BASE_URL -u ANTHROPIC_CUSTOM_HEADERS CCXRAY_HOME=$(mktemp -d) npm test 2>&1 | grep -E '^# (tests|pass|fail)'
+  EXPECT: # fail 0
+  EVIDENCE: pending

--- a/plugins/herdr/bin/install-sidebar-summary.js
+++ b/plugins/herdr/bin/install-sidebar-summary.js
@@ -5,17 +5,45 @@ const fs = require('fs');
 const path = require('path');
 const { backupConfigFile, resolveHerdrConfigPath, runHerdr } = require('./lib/ccxray');
 
+// Every row this installer manages, and the ONE place its colours are written.
+// The colours used to be declared twice — once here and once inline in
+// addMissingCtxBarRows — so a repaired config could disagree with a fresh one.
+const MANAGED_ROW_BY_TOKEN = {
+  ctx_bar_unknown: '  [{ token = "$ctx_bar_unknown", fg = "#a6adc8", dim = true }],',
+  ctx_bar_green: '  [{ token = "$ctx_bar_green", fg = "#a6e3a1", dim = true }],',
+  ctx_bar_yellow: '  [{ token = "$ctx_bar_yellow", fg = "#f9e2af", dim = true }],',
+  ctx_bar_red: '  [{ token = "$ctx_bar_red", fg = "#f38ba8", dim = true }],',
+  facts: '  [{ token = "$facts", fg = "#a6adc8", dim = true }],',
+  alert: '  [{ token = "$alert", fg = "#f9e2af" }],',
+};
 const CTX_BAR_COLOR_TOKENS = ['ctx_bar_unknown', 'ctx_bar_green', 'ctx_bar_yellow', 'ctx_bar_red'];
-const CTX_BAR_ROWS = [
-  '  [{ token = "$ctx_bar_unknown", fg = "#a6adc8", dim = true }],',
-  '  [{ token = "$ctx_bar_green", fg = "#a6e3a1", dim = true }],',
-  '  [{ token = "$ctx_bar_yellow", fg = "#f9e2af", dim = true }],',
-  '  [{ token = "$ctx_bar_red", fg = "#f38ba8", dim = true }],',
-].join('\n');
+const CTX_BAR_ROWS = CTX_BAR_COLOR_TOKENS.map(token => MANAGED_ROW_BY_TOKEN[token]).join('\n');
 const OLD_CTX_BAR_ROW_RE = /^[ \t]*\[\{[^\n]*token\s*=\s*"\$ctx_bar"[^\n]*\}\],[ \t]*$/m;
-const SUMMARY_ROW = '  [{ token = "$summary", fg = "#89b4fa", dim = true }],';
-const CCXRAY_ROWS = `${SUMMARY_ROW}\n${CTX_BAR_ROWS}`;
-const DEFAULT_ROWS = '  ["state_icon", "workspace", "tab"],\n  ["agent"],';
+// Row 3: two tokens, one meaning each, only one non-empty per refresh (see
+// refresh-badges applyRow3Tokens). Herdr skips a row whose tokens are all empty
+// — the four ctx_bar colour rows above have relied on that in production since
+// they shipped, rendering one visible line out of four config rows — so this
+// pair costs two rows and shows one line.
+const ROW3_TOKENS = ['facts', 'alert'];
+const ROW3_ROWS = ROW3_TOKENS.map(token => MANAGED_ROW_BY_TOKEN[token]).join('\n');
+const MANAGED_TOKENS = [...CTX_BAR_COLOR_TOKENS, ...ROW3_TOKENS];
+// Rows that earlier generations of this installer wrote, plus one no generation
+// ever wrote. Each entry is the COMPLETE token set of a row we may delete: a row
+// carrying anything else is the user's, and is left for them to edit.
+//
+//  - ctx/model/cost: the atomic-token generation. Its three facts are now row 2
+//    (ctx) and row 3 (cost), and printing them beside $summary is what made the
+//    model appear three times in one card.
+//  - summary: the pre-assembled line. Every field in it now has an owning row.
+//  - tg/ty/tr: this plugin has never provided these tokens. Dead config that
+//    rendered nothing, which is why it survived unnoticed.
+const SUPERSEDED_ROW_TOKENS = [
+  ['ctx', 'model', 'cost'],
+  ['summary'],
+  ['tg', 'ty', 'tr'],
+];
+const DEFAULT_ROWS = '  ["state_icon", "agent", "state_text"],';
+const CCXRAY_ROWS = `${CTX_BAR_ROWS}\n${ROW3_ROWS}`;
 // Written only when this script creates the section itself, so
 // remove-sidebar-summary can tell "ccxray added this whole table" from
 // "the user already had a sidebar table and ccxray added rows to it".
@@ -43,7 +71,7 @@ function tokenRegex(token) {
 
 // Row detection must not see commented-out examples. Herdr's own documentation
 // shows sidebar rows in comments, and a config carrying one dead-ended the
-// install: `hasToken` matched the commented `$summary`, so the script reported
+// install: the token test matched the commented `$summary`, so the script reported
 // "Herdr already has a $summary sidebar row", while the row regexes — which
 // require a real `[{ … }],` line — found nothing to insert below, leaving the
 // user with a manual-add message and no way to proceed.
@@ -53,50 +81,74 @@ function stripCommentLines(config) {
   return String(config).replace(/^[ \t]*#.*$/gm, '');
 }
 
-function hasToken(config, token) {
-  return tokenRegex(token).test(stripCommentLines(config));
+// What "installed" means, defined once. onboarding.js used to spell out its own
+// regex over `$summary` + one ctx_bar colour, so this file could change the row
+// set and Quick Start would keep reporting on the old one — it did exactly that
+// when $summary was retired. It also did not strip comments, so a commented-out
+// example row counted as installed, the same trap stripCommentLines exists for.
+function configHasManagedRows(config) {
+  const body = stripCommentLines(String(config || ''));
+  return MANAGED_TOKENS.every(token => tokenRegex(token).test(body));
 }
 
-function hasColorRows(config) {
-  return CTX_BAR_COLOR_TOKENS.every(token => hasToken(config, token));
+// The tokens a rows-array line names, or null when the line is not a row at all.
+// A line-leading comment is not a row: Herdr's own docs show example rows in
+// comments, and one of them already dead-ended this installer once.
+function rowLineTokens(line) {
+  if (/^[ \t]*#/.test(line)) return null;
+  if (!/^[ \t]*\[/.test(line)) return null;
+  return [...line.matchAll(/\$([A-Za-z0-9_]+)/g)].map(match => match[1]);
 }
 
-function addCtxBarRows(config) {
-  const summaryRow = /^[ \t]*\[\{[^\n]*token\s*=\s*"\$summary"[^\n]*\}\],[ \t]*$/m;
-  if (!summaryRow.test(config)) return null;
-  return config.replace(summaryRow, match => `${match}\n${CTX_BAR_ROWS}`);
+function sameTokenSet(a, b) {
+  return a.length === b.length
+    && a.slice().sort().join(',') === b.slice().sort().join(',');
 }
 
-function addMissingCtxBarRows(config) {
-  const missing = CTX_BAR_COLOR_TOKENS.filter(token => !hasToken(config, token));
-  if (!missing.length) return config;
-  const rows = missing.map(token => {
-    const colors = {
-      ctx_bar_unknown: '#a6adc8',
-      ctx_bar_green: '#a6e3a1',
-      ctx_bar_yellow: '#f9e2af',
-      ctx_bar_red: '#f38ba8',
-    };
-    return `  [{ token = "$${token}", fg = "${colors[token]}", dim = true }],`;
-  }).join('\n');
-  const summaryRow = /^[ \t]*\[\{[^\n]*token\s*=\s*"\$summary"[^\n]*\}\],[ \t]*$/m;
-  if (!summaryRow.test(config)) return null;
-  return config.replace(summaryRow, match => `${match}\n${rows}`);
-}
-
-function ensureColorCtxBarRows(config) {
-  if (hasColorRows(config) && !OLD_CTX_BAR_ROW_RE.test(config)) return { changed: false, config };
-
-  if (OLD_CTX_BAR_ROW_RE.test(config)) {
-    return {
-      changed: true,
-      config: config.replace(OLD_CTX_BAR_ROW_RE, CTX_BAR_ROWS),
-    };
+// Migrate the rows array of an existing [ui.sidebar.agents] to the three-row
+// layout. This REPLACES the previous add-only behaviour: the old installer could
+// only append, so a config carrying an earlier generation's rows got the new
+// ones stacked on top and rendered MORE duplication, not less. The migration
+// mechanism itself is not new — OLD_CTX_BAR_ROW_RE has been migrating the single
+// $ctx_bar generation to the four colour variants — this widens it to the
+// generations that shipped around it.
+//
+// Deletion is conservative in two ways: it only ever touches lines inside this
+// one rows array, and only lines whose COMPLETE token set matches a superseded
+// generation. A row where the user added something of their own is kept, because
+// we cannot know which half they wanted.
+function migrateRowsArray(config, rows) {
+  const inner = config.slice(rows.open + 1, rows.close);
+  const removed = [];
+  const kept = [];
+  for (const line of inner.split('\n')) {
+    const tokens = rowLineTokens(line);
+    if (tokens && tokens.length
+      && SUPERSEDED_ROW_TOKENS.some(set => sameTokenSet(set, tokens))) {
+      removed.push(tokens.map(token => `$${token}`).join(' '));
+      continue;
+    }
+    kept.push(line);
   }
 
-  const added = addMissingCtxBarRows(config);
-  if (!added) return null;
-  return { changed: true, config: added };
+  let body = kept.join('\n');
+  // The single-$ctx_bar generation becomes the four colour variants in place, so
+  // row 2 keeps its position rather than jumping below row 3.
+  if (OLD_CTX_BAR_ROW_RE.test(body)) body = body.replace(OLD_CTX_BAR_ROW_RE, CTX_BAR_ROWS);
+
+  const present = token => tokenRegex(token).test(stripCommentLines(body));
+  const missing = MANAGED_TOKENS.filter(token => !present(token));
+  if (missing.length) {
+    const trimmed = body.replace(/[ \t\r\n]*$/, '');
+    const separator = trimmed.trim() && !trimmed.trim().endsWith(',') ? ',' : '';
+    body = `${trimmed}${separator}\n${missing.map(token => MANAGED_ROW_BY_TOKEN[token]).join('\n')}\n`;
+  }
+
+  return {
+    config: `${config.slice(0, rows.open + 1)}${body}${config.slice(rows.close)}`,
+    removed,
+    added: missing,
+  };
 }
 
 // A TOML table header is a bare dotted key in brackets at column 0, so an
@@ -166,21 +218,15 @@ function main() {
   fs.mkdirSync(path.dirname(file), { recursive: true });
   const before = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
 
-  if (hasToken(before, 'summary')) {
-    const ensured = ensureColorCtxBarRows(before);
-    if (!ensured) {
-      console.error('Herdr already has a $summary sidebar row. Add these rows below it manually:');
-      console.error(CTX_BAR_ROWS);
-      process.exit(1);
-    }
-    if (!ensured.changed) {
-      console.log(`ccxray color sidebar summary rows already installed in ${file}`);
-      process.exit(0);
-    }
-    return writeAndReload(file, before, ensured.config, 'updated');
+  // No section of ours at all — write the whole three-row layout.
+  if (!/^\s*\[ui\.sidebar\.agents\]\s*$/m.test(before)) {
+    return writeAndReload(file, before, before.replace(/\s*$/, '') + SIDEBAR_SUMMARY_SECTION + '\n', 'installed');
   }
 
-  if (/^\s*\[ui\.sidebar\.agents\]\s*$/m.test(before)) {
+  const bounds = sidebarSectionBounds(before);
+  const rows = bounds && rowsArrayBounds(before, bounds);
+  if (!rows) {
+    // The section exists but its rows array is missing or unparseable.
     const merged = addRowsToExistingSection(before);
     if (!merged) {
       console.error(`Could not parse [ui.sidebar.agents] in ${file}; add these rows to its rows array manually:`);
@@ -190,7 +236,9 @@ function main() {
     return writeAndReload(file, before, merged, 'installed');
   }
 
-  return writeAndReload(file, before, before.replace(/\s*$/, '') + SIDEBAR_SUMMARY_SECTION + '\n', 'installed');
+  const migrated = migrateRowsArray(before, rows);
+  for (const row of migrated.removed) console.log(`superseded row removed: ${row}`);
+  return writeAndReload(file, before, migrated.config, migrated.removed.length ? 'migrated' : 'updated');
 }
 
 function writeAndReload(file, before, next, action) {
@@ -242,4 +290,26 @@ function writeAndReload(file, before, next, action) {
   if (backup) console.log(`backup: ${backup}`);
 }
 
-main();
+// ADR 0015's two-mode shape: executed mode installs, imported mode is
+// side-effect free so remove-sidebar-summary can read the managed-row constants
+// from the one file that defines them, and tests can drive the migration without
+// touching anybody's config. The uninstaller used to re-declare the skeleton it
+// deletes, and this change already caught that drift: row 1 became
+// `state_icon · agent · state_text` here while the uninstaller still matched the
+// old two-row default, so removal would have left the table behind.
+if (require.main === module) main();
+
+module.exports = {
+  CCXRAY_ROWS,
+  DEFAULT_ROWS,
+  MANAGED_ROW_BY_TOKEN,
+  MANAGED_TOKENS,
+  SECTION_MARKER,
+  SUPERSEDED_ROW_TOKENS,
+  configHasManagedRows,
+  migrateRowsArray,
+  rowLineTokens,
+  rowsArrayBounds,
+  sameTokenSet,
+  sidebarSectionBounds,
+};

--- a/plugins/herdr/bin/install-sidebar-summary.js
+++ b/plugins/herdr/bin/install-sidebar-summary.js
@@ -142,8 +142,13 @@ function migrateRowsArray(config, rows) {
   // our rows, not the user's — replace them with the new shape. Without this, a
   // table emitted by the previous installer keeps two legacy rows and renders
   // four visible lines instead of three. codex round 1, P1.
+  //
+  // ONLY when the config carries the SECTION_MARKER: a user-authored table may
+  // have `["agent"]` as their own row and we must not touch it. The marker
+  // proves this table was created by the plugin. codex round 2, P1.
+  const hasMarker = config.includes(SECTION_MARKER);
   {
-    const isLegacyDefault = line => LEGACY_DEFAULT_ROWS_RE.some(re => re.test(line));
+    const isLegacyDefault = line => hasMarker && LEGACY_DEFAULT_ROWS_RE.some(re => re.test(line));
     const keptLines = kept.filter(line => !isLegacyDefault(line));
     if (keptLines.length < kept.length) {
       const firstRemoved = kept.findIndex(isLegacyDefault);

--- a/plugins/herdr/bin/install-sidebar-summary.js
+++ b/plugins/herdr/bin/install-sidebar-summary.js
@@ -42,6 +42,13 @@ const SUPERSEDED_ROW_TOKENS = [
   ['summary'],
   ['tg', 'ty', 'tr'],
 ];
+// The row 1 shape earlier installers wrote. These are bare-string arrays
+// (no `$` prefix), so rowLineTokens returns `[]` for them — we match on the
+// normalized text content instead.
+const LEGACY_DEFAULT_ROWS_RE = [
+  /^\s*\["state_icon",\s*"workspace",\s*"tab"\],?\s*$/,
+  /^\s*\["agent"\],?\s*$/,
+];
 const DEFAULT_ROWS = '  ["state_icon", "agent", "state_text"],';
 const CCXRAY_ROWS = `${CTX_BAR_ROWS}\n${ROW3_ROWS}`;
 // Written only when this script creates the section itself, so
@@ -129,6 +136,22 @@ function migrateRowsArray(config, rows) {
       continue;
     }
     kept.push(line);
+  }
+
+  // The old installer's DEFAULT_ROWS (`state_icon workspace tab` + `agent`) are
+  // our rows, not the user's — replace them with the new shape. Without this, a
+  // table emitted by the previous installer keeps two legacy rows and renders
+  // four visible lines instead of three. codex round 1, P1.
+  {
+    const isLegacyDefault = line => LEGACY_DEFAULT_ROWS_RE.some(re => re.test(line));
+    const keptLines = kept.filter(line => !isLegacyDefault(line));
+    if (keptLines.length < kept.length) {
+      const firstRemoved = kept.findIndex(isLegacyDefault);
+      keptLines.splice(firstRemoved, 0, DEFAULT_ROWS);
+      removed.push('legacy default rows');
+    }
+    kept.length = 0;
+    kept.push(...keptLines);
   }
 
   let body = kept.join('\n');
@@ -305,6 +328,7 @@ module.exports = {
   MANAGED_ROW_BY_TOKEN,
   MANAGED_TOKENS,
   SECTION_MARKER,
+  LEGACY_DEFAULT_ROWS_RE,
   SUPERSEDED_ROW_TOKENS,
   configHasManagedRows,
   migrateRowsArray,

--- a/plugins/herdr/bin/lib/ccxray.js
+++ b/plugins/herdr/bin/lib/ccxray.js
@@ -403,8 +403,8 @@ function quotaRefusalCount(turns) {
 // INVARIANT(ADR 0005 shape): every surface that answers "what is the most
 // important thing about this pane right now" ranks the answers HERE. Two
 // surfaces used to answer it with orderings that contradicted each other:
-// contextSignal put context above every tool failure, while the Mission Control
-// action chain put `fail >= 2` above context and `cache dropped` above
+// the now-removed contextSignal put context above every tool failure, while the
+// Mission Control action chain put `fail >= 2` above context and `cache dropped` above
 // `fail == 1`. The same pane therefore read "near full" on the sidebar and
 // "inspect last error" in Mission Control. A third ordering written for the
 // sidebar's row-3 $alert is exactly the failure shape ADR 0005 exists to stop.
@@ -511,14 +511,6 @@ function paneAction(signals = {}) {
 function paneAlert(signals = {}) {
   const concern = paneConcerns(signals).find(item => !item.sidebarOwned && item.text);
   return concern ? { kind: concern.kind, text: concern.brief } : null;
-}
-
-function contextSignal(turns, detail) {
-  if (detail.ctxPct >= 90) return 'full';
-  if (detail.ctxPct >= 80) return 'near full';
-  const failures = toolFailureCount(turns);
-  if (failures) return `fail ${failures}x`;
-  return cacheHitText(turns);
 }
 
 function formatContextBar(turns, win, ctxText, opts = {}) {
@@ -971,10 +963,22 @@ function summarizeTurnGroup(turns, fallback = {}, nowMs = Date.now(), opts = {})
   //
   // Note this is the channel-INVERSE of ADR 0013's provenance markers, which
   // mark the number ('60% of 200K?') and keep colour as saturation. The badge
-  // has no room for a marked number — ctx_bar is ~18 columns and already spends
-  // its tail on the cache/fail signal — so the colour is the only channel wide
+  // has no room for a marked number, so the colour is the only channel wide
   // enough to carry the doubt here. Do not cite ADR 0013 as endorsing this.
-  const signal = stale ? stale.text : contextSignal(anchor, detail);
+  //
+  // Row 2 owns context and nothing else. This tail used to carry whichever alert
+  // ranked highest: 'full'/'near full', which is a FOURTH encoding of the
+  // percentage sitting right beside it (percentage + sparkline + colour band +
+  // text), or the stale text, which row 3's $alert now carries. Both were the
+  // duplication the three-row layout removes — the reported screenshot showed
+  // `21% · stal…` on one row and `21% stale` on another. What stays is the one
+  // context fact no other row shows: how much of it came from cache.
+  //
+  // A config that renders ONLY $ctx_bar therefore loses the stale WORD from this
+  // tail and keeps the withdrawn colour. The reason is not lost from the token
+  // set — $ctx still carries `21% stale` (refresh-badges) and $alert carries it
+  // in full — but such a config must be migrated to see it as text.
+  const signal = cacheHitText(anchor);
   return {
     sessionId: latest.sessionId || fallback.sessionId || null,
     ctxPct,

--- a/plugins/herdr/bin/lib/ccxray.js
+++ b/plugins/herdr/bin/lib/ccxray.js
@@ -463,6 +463,11 @@ const PANE_CONCERN_TIERS = [
     kind: 'cache-dropped',
     match: s => Boolean(s.cacheDropped),
     text: () => 'cache dropped after prompt change',
+    // `brief` is the sidebar form. The spelled-out reason is 33 columns and the
+    // row is 18-40, so shipping only `text` would truncate it — and truncation
+    // is one of the symptoms this layout exists to remove. Mission Control has
+    // the width for the full sentence and keeps using `text`.
+    brief: () => 'cache dropped',
     action: () => 'inspect prompt/tool diff',
   },
   {
@@ -492,6 +497,7 @@ function paneConcerns(signals = {}) {
       kind: tier.kind,
       sidebarOwned: Boolean(tier.sidebarOwned),
       text: tier.text(signals),
+      brief: tier.brief ? tier.brief(signals) : tier.text(signals),
       action: tier.action(signals),
     }));
 }
@@ -504,7 +510,7 @@ function paneAction(signals = {}) {
 // Row 3's $alert: the top concern the sidebar does not already render elsewhere.
 function paneAlert(signals = {}) {
   const concern = paneConcerns(signals).find(item => !item.sidebarOwned && item.text);
-  return concern ? { kind: concern.kind, text: concern.text } : null;
+  return concern ? { kind: concern.kind, text: concern.brief } : null;
 }
 
 function contextSignal(turns, detail) {
@@ -975,6 +981,13 @@ function summarizeTurnGroup(turns, fallback = {}, nowMs = Date.now(), opts = {})
     ctxText,
     ctxBand: stale ? 'unknown' : detail.ctxBand,
     stale,
+    // Raw alert signals, exposed so row 3's $alert ranks them through the one
+    // shared list (paneConcerns) rather than re-deriving a third ordering. All
+    // three read `anchor`, the same main-agent turns ctx%/cache%/model read, so
+    // a subagent's failure cannot raise an alert about the main conversation.
+    failures: toolFailureCount(anchor),
+    cacheDropped: cacheDroppedAfterPromptChange(anchor),
+    refusedCount: quotaRefusalCount(anchor),
     ctxBar: formatContextBar(anchor, win, ctxText, {
       sidebarCols: opts.sidebarCols,
       signal,

--- a/plugins/herdr/bin/lib/ccxray.js
+++ b/plugins/herdr/bin/lib/ccxray.js
@@ -1624,6 +1624,14 @@ function missionControlRow(turns, agent, nowMs, mapping, opts = {}) {
     if (severity === 'green') severity = 'yellow';
     reasons.push('cache dropped after prompt change');
   }
+  // codex round 1, P2b: quota refusal must update severity/reasons, not just
+  // action — otherwise MC shows a green row with `action: 'wait for quota reset'`
+  // and excludes it from its attention filter.
+  const refusedCount = quotaRefusalCount(anchor);
+  if (refusedCount > 0) {
+    severity = 'red';
+    reasons.push(refusedCount > 1 ? `quota refused ${refusedCount}x` : 'quota refused');
+  }
 
   // INVARIANT(ADR 0005 shape): the ordering lives in paneConcerns, shared with
   // the sidebar badge's row-3 $alert — see PANE_CONCERN_TIERS. This chain used to

--- a/plugins/herdr/bin/lib/ccxray.js
+++ b/plugins/herdr/bin/lib/ccxray.js
@@ -2061,6 +2061,27 @@ function recordPaneWrite(paneId, env) {
   } catch {}
 }
 
+// The session id a pane's agent is on, resolved the way the badge resolves it.
+// Extracted from refresh-badges so the dashboard deep link cannot drift from the
+// badge: they must agree about which session a pane IS, or `prefix+m` and the
+// standalone action open different sessions for the same pane.
+//
+// `agent_session_known` means the context author already consulted the agent
+// list for this pane — including the "no session id" answer — so re-listing
+// could only repeat that answer more slowly.
+function resolvePaneSessionId(opts = {}) {
+  const env = opts.env || process.env;
+  const context = opts.context || {};
+  if (opts.eventSessionId) return opts.eventSessionId;
+  if (context.agent_session?.kind === 'id') return context.agent_session.value;
+  if (opts.paneId && !context.agent_session_known) {
+    const report = herdrAgentReport({ env });
+    const agent = report.agents.find(item => item.pane_id === opts.paneId);
+    if (agent?.agent_session?.kind === 'id') return agent.agent_session.value;
+  }
+  return null;
+}
+
 function reportPaneTokens(tokens, opts = {}) {
   const env = opts.env || process.env;
   if (!env.HERDR_PANE_ID) return { ok: false, reason: 'HERDR_PANE_ID is not set' };
@@ -2408,6 +2429,7 @@ module.exports = {
   readIndexTailEntries,
   recordRoutedPane,
   reportPaneTokens,
+  resolvePaneSessionId,
   reportWorkspaceTokens,
   requestImport,
   resolveCcxrayCommand,

--- a/plugins/herdr/bin/lib/ccxray.js
+++ b/plugins/herdr/bin/lib/ccxray.js
@@ -2021,6 +2021,10 @@ function paneMetadataUnchanged(snapshot, tokens, opts = {}) {
   for (const [status, label] of Object.entries(opts.stateLabels || {})) {
     if (String(snapshot.stateLabels[status] ?? '') !== String(label)) return false;
   }
+  // A pending clear is a change. Without this the skip-write optimisation reads
+  // "no token moved" and suppresses the very write that would hand row 1 back to
+  // Herdr's own state text.
+  if (opts.clearStateLabels && Object.keys(snapshot.stateLabels || {}).length) return false;
   return true;
 }
 
@@ -2088,6 +2092,11 @@ function reportPaneTokens(tokens, opts = {}) {
   }
   if (opts.title) args.push('--title', String(opts.title));
   if (opts.displayAgent) args.push('--display-agent', String(opts.displayAgent));
+  // Clearing is not the same as omitting: a label Herdr already holds survives a
+  // report that simply does not mention it, so a pane that recovered from "not
+  // linked" would keep showing it forever. Row 1's native idle/working can only
+  // come back if we actively give the state text back.
+  if (opts.clearStateLabels) args.push('--clear-state-labels');
   if (opts.stateLabels) {
     for (const [status, label] of Object.entries(opts.stateLabels)) {
       args.push('--state-label', `${status}=${String(label)}`);

--- a/plugins/herdr/bin/lib/ccxray.js
+++ b/plugins/herdr/bin/lib/ccxray.js
@@ -388,6 +388,125 @@ function toolFailureCount(turns) {
   return turns.slice(-6).filter(turnFailed).length;
 }
 
+// A quota/rate-limit REFUSAL that actually happened, counted over the same
+// last-6-turn window as toolFailureCount. `status` is an index field written at
+// every forward.js push site from `proxyRes.statusCode`, and a non-2xx response
+// is not short-circuited before the push, so a refused turn reaches the index as
+// `status: 429`. This is deliberately an OBSERVED event, not the prediction that
+// `~/.ccxray/usage-status/*.json` would support: quota forecasting and reset ETAs
+// are #571's surface, and mixing a forecast into an alert channel would make the
+// alert fire for something that has not gone wrong yet.
+function quotaRefusalCount(turns) {
+  return turns.slice(-6).filter(turn => Number(turn.status) === 429).length;
+}
+
+// INVARIANT(ADR 0005 shape): every surface that answers "what is the most
+// important thing about this pane right now" ranks the answers HERE. Two
+// surfaces used to answer it with orderings that contradicted each other:
+// contextSignal put context above every tool failure, while the Mission Control
+// action chain put `fail >= 2` above context and `cache dropped` above
+// `fail == 1`. The same pane therefore read "near full" on the sidebar and
+// "inspect last error" in Mission Control. A third ordering written for the
+// sidebar's row-3 $alert is exactly the failure shape ADR 0005 exists to stop.
+//
+// `sidebarOwned` marks a tier the three-row sidebar renders in a DIFFERENT row,
+// so row 3 must skip it or the layout repeats itself — the duplication this
+// refactor exists to remove (row 1 owns process state, row 2 owns context).
+// Mission Control is a single row with no such split, so it renders every tier.
+const PANE_CONCERN_TIERS = [
+  {
+    kind: 'no-telemetry',
+    sidebarOwned: true,
+    match: s => !s.hasTelemetry,
+    text: () => 'no ccxray telemetry',
+    action: () => 'relaunch via ccxray',
+  },
+  {
+    kind: 'quota-refused',
+    match: s => Number(s.refusedCount) > 0,
+    text: s => (Number(s.refusedCount) > 1 ? `quota refused ${s.refusedCount}x` : 'quota refused'),
+    action: () => 'wait for quota reset',
+  },
+  {
+    kind: 'blocked',
+    sidebarOwned: true,
+    match: s => s.status === 'blocked',
+    text: () => 'blocked',
+    action: () => 'inspect last error',
+  },
+  {
+    kind: 'stale',
+    match: s => Boolean(s.staleText),
+    text: s => s.staleText,
+    action: () => 'rescan transcripts',
+  },
+  {
+    kind: 'fail-multi',
+    match: s => Number(s.failures) >= 2,
+    text: s => `fail ${Number(s.failures)}x`,
+    action: () => 'inspect last error',
+  },
+  {
+    kind: 'ctx-high',
+    sidebarOwned: true,
+    match: s => Number.isFinite(s.ctxPct) && s.ctxPct > 80,
+    text: s => (s.ctxPct >= 90 ? 'full' : 'near full'),
+    action: () => 'compact or start fresh',
+  },
+  {
+    kind: 'fail-single',
+    match: s => Number(s.failures) === 1,
+    text: () => 'fail 1x',
+    action: () => 'inspect failed tool',
+  },
+  {
+    kind: 'cache-dropped',
+    match: s => Boolean(s.cacheDropped),
+    text: () => 'cache dropped after prompt change',
+    action: () => 'inspect prompt/tool diff',
+  },
+  {
+    kind: 'ctx-mid',
+    sidebarOwned: true,
+    match: s => Number.isFinite(s.ctxPct) && s.ctxPct > 40,
+    text: () => null,
+    action: () => 'checkpoint soon',
+  },
+  {
+    kind: 'ready',
+    sidebarOwned: true,
+    match: s => Boolean(s.ready),
+    text: () => null,
+    action: () => 'review output',
+  },
+];
+
+// A signal a caller does not have is absent, never false: Mission Control has no
+// transcript comparison, so it passes no `staleText` and the stale tier is
+// skipped there rather than asserted absent. Documented residual — the badge can
+// report `stale` for a pane whose Mission Control row cannot.
+function paneConcerns(signals = {}) {
+  return PANE_CONCERN_TIERS
+    .filter(tier => tier.match(signals))
+    .map(tier => ({
+      kind: tier.kind,
+      sidebarOwned: Boolean(tier.sidebarOwned),
+      text: tier.text(signals),
+      action: tier.action(signals),
+    }));
+}
+
+// The single imperative for a surface that renders every tier (Mission Control).
+function paneAction(signals = {}) {
+  return paneConcerns(signals)[0]?.action || null;
+}
+
+// Row 3's $alert: the top concern the sidebar does not already render elsewhere.
+function paneAlert(signals = {}) {
+  const concern = paneConcerns(signals).find(item => !item.sidebarOwned && item.text);
+  return concern ? { kind: concern.kind, text: concern.text } : null;
+}
+
 function contextSignal(turns, detail) {
   if (detail.ctxPct >= 90) return 'full';
   if (detail.ctxPct >= 80) return 'near full';
@@ -1489,14 +1608,21 @@ function missionControlRow(turns, agent, nowMs, mapping, opts = {}) {
     reasons.push('cache dropped after prompt change');
   }
 
-  let action = null;
-  if (!turns.length) action = 'relaunch via ccxray';
-  else if (status === 'blocked' || failures >= 2) action = 'inspect last error';
-  else if (Number.isFinite(ctxPct) && ctxPct > 80) action = 'compact or start fresh';
-  else if (cacheDropped) action = 'inspect prompt/tool diff';
-  else if (failures === 1) action = 'inspect failed tool';
-  else if (Number.isFinite(ctxPct) && ctxPct > 40) action = 'checkpoint soon';
-  else if (severity === 'ready') action = 'review output';
+  // INVARIANT(ADR 0005 shape): the ordering lives in paneConcerns, shared with
+  // the sidebar badge's row-3 $alert — see PANE_CONCERN_TIERS. This chain used to
+  // rank `cache dropped` above `fail == 1` while the badge ranked every failure
+  // above context, so one pane could read "near full" on the sidebar and
+  // "inspect last error" here. The shared list ranks any failure above a dropped
+  // cache; that swap is this chain's only behaviour change.
+  const action = paneAction({
+    hasTelemetry: turns.length > 0,
+    refusedCount: quotaRefusalCount(anchor),
+    status,
+    failures,
+    ctxPct,
+    cacheDropped,
+    ready: severity === 'ready',
+  });
 
   const exactCost = turns.length > 0 && turns.every(turn => turn.cost?.confidence === 'exact');
   const unknownCost = turns.length > 0 && !turns.some(turn => turn.cost?.cost != null && turn.cost.confidence !== 'unknown');
@@ -2224,31 +2350,35 @@ function writeConfigAndReload(file, before, next, opts = {}) {
 }
 
 module.exports = {
+  aggCostText,
   backupConfigFile,
-  codexAgentArgs,
-  ensureProxy,
   capabilityPortfolio,
   capabilityReview,
-  currentWorkspaceScope,
-  findRepoRoot,
-  filterEntriesToWorkspace,
-  forgetRoutedPane,
+  codexAgentArgs,
   contextBand,
   contextSidebarColumns,
+  costFold,
+  currentWorkspaceScope,
+  ensureProxy,
+  filterEntriesToWorkspace,
+  findRepoRoot,
+  forgetRoutedPane,
+  formatContextBar,
   formatMoney,
   formatPercent,
-  formatContextBar,
   herdrAgentReport,
   herdrRuntime,
   missionControlSnapshot,
-  aggCostText,
-  costFold,
+  paneAction,
+  paneAlert,
+  paneConcerns,
   panePlacement,
   parseJsonOutput,
   parseStatus,
-  proxyEnvVars,
-  pluginStateDir,
   pluginRoot,
+  pluginStateDir,
+  proxyEnvVars,
+  quotaRefusalCount,
   readIndexTailEntries,
   recordRoutedPane,
   reportPaneTokens,

--- a/plugins/herdr/bin/onboarding.js
+++ b/plugins/herdr/bin/onboarding.js
@@ -15,6 +15,7 @@ const {
   runHerdr,
   statusReport,
 } = require('./lib/ccxray');
+const { configHasManagedRows } = require('./install-sidebar-summary');
 const { displayWidth, restoreFrameCursor, truncateText, writeFrame, wrapText } = require('./lib/tui');
 const { boundKeyFor } = require('./lib/keybindings');
 
@@ -62,7 +63,7 @@ function sidebarInstalled(env = process.env) {
   const file = resolveHerdrConfigPath(env);
   try {
     const config = fs.readFileSync(file, 'utf8');
-    return /token\s*=\s*"\$summary"/.test(config) && /token\s*=\s*"\$ctx_bar_(?:green|yellow|red)"/.test(config);
+    return configHasManagedRows(config);
   } catch {
     return false;
   }

--- a/plugins/herdr/bin/open-dashboard.js
+++ b/plugins/herdr/bin/open-dashboard.js
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 'use strict';
 
-const { runCcxray, statusReport, stripAnsi } = require('./lib/ccxray');
+const {
+  herdrRuntime,
+  resolvePaneSessionId,
+  runCcxray,
+  statusReport,
+  stripAnsi,
+} = require('./lib/ccxray');
 
 function main() {
   const env = process.env.CCXRAY_HERDR_NO_BROWSER === '1'
@@ -14,7 +20,22 @@ function main() {
     process.exit(1);
   }
 
-  const result = runCcxray(['open'], { timeoutMs: 8000, env });
+  // This action ran a bare `ccxray open`, which lands on whatever the dashboard
+  // shows by default — so invoking it FROM a pane threw away the one thing the
+  // caller knew, which pane they were looking at. Mission Control's `d` has
+  // passed --session since it shipped; this is the same deep link from the
+  // standalone action, resolved by the same helper the badge uses so the two
+  // cannot disagree about which session a pane is on.
+  const runtime = herdrRuntime(env);
+  const context = runtime.context || {};
+  const paneId = runtime.paneId || context.focused_pane_id || null;
+  const sessionId = resolvePaneSessionId({ env, paneId, context });
+  const args = sessionId ? ['open', '--session', sessionId] : ['open'];
+  console.log(sessionId
+    ? `opening the dashboard on session ${sessionId}`
+    : 'opening the dashboard (this pane has no session id yet)');
+
+  const result = runCcxray(args, { timeoutMs: 8000, env });
   process.stdout.write(result.stdout || '');
   process.stderr.write(result.stderr || '');
 
@@ -25,4 +46,8 @@ function main() {
   process.exit(result.status == null ? 1 : result.status);
 }
 
-main();
+// ADR 0015's two-mode shape, so a test can assert the argv without opening a
+// browser on the developer's machine.
+if (require.main === module) main();
+
+module.exports = { main };

--- a/plugins/herdr/bin/refresh-badges.js
+++ b/plugins/herdr/bin/refresh-badges.js
@@ -181,6 +181,7 @@ function badgeTokens(status, usage, opts = {}) {
   return {
     tokens,
     stale,
+    located: Boolean(detail) && detail.matched !== false,
     clearTokens: [
       ...applyContextColorTokens(tokens, tokens.ctx_band),
       ...applyRow3Tokens(tokens, detail, opts),
@@ -235,7 +236,14 @@ function main() {
   // trigger. Detached: the badge write below must not wait for a disk scan.
   const importRequest = badge.stale ? requestImport({ env: process.env }) : null;
   const ttlMs = Number(process.env.CCXRAY_BADGE_TTL_MS || 600000);
-  const stateLabels = {
+  // Row 1 is `state_icon · agent · state_text`, and a state label REPLACES the
+  // native state_text. Setting it unconditionally to the summary made row 1 read
+  // `claude · ccxray: traced · claude`: the agent name twice, and the model a
+  // third time once row 3 shows the cost. Herdr's own idle/working is the right
+  // content for a located pane — it is the one thing on this row Herdr knows
+  // better than we do — so the label is reserved for the states it cannot know
+  // ("not linked", "no hub"), and actively cleared otherwise.
+  const stateLabels = badge.located ? null : {
     unknown: tokens.summary,
     idle: tokens.summary,
     working: tokens.summary,
@@ -243,7 +251,10 @@ function main() {
     done: tokens.summary,
   };
 
-  const pane = reportPaneTokens(tokens, { env, ttlMs, stateLabels, clearTokens, agent: event.agent });
+  const pane = reportPaneTokens(tokens, {
+    env, ttlMs, stateLabels, clearTokens, agent: event.agent,
+    clearStateLabels: !stateLabels,
+  });
   const workspace = reportWorkspaceTokens(tokens, { env, ttlMs, clearTokens });
   const notification = process.env.HERDR_PLUGIN_EVENT === 'pane.agent_status_changed'
     ? agentNotification(event, tokens.summary, {

--- a/plugins/herdr/bin/refresh-badges.js
+++ b/plugins/herdr/bin/refresh-badges.js
@@ -7,6 +7,7 @@ const {
   formatPercent,
   herdrAgentReport,
   herdrRuntime,
+  paneAlert,
   reportPaneTokens,
   reportWorkspaceTokens,
   requestImport,
@@ -20,6 +21,7 @@ const {
 const { agentNotification, recordAgentStatus } = require('./lib/notifications');
 
 const CTX_BAR_COLOR_TOKENS = ['ctx_bar_unknown', 'ctx_bar_green', 'ctx_bar_yellow', 'ctx_bar_red'];
+const ROW3_TOKENS = ['facts', 'alert'];
 
 function eventContext(env = process.env) {
   if (!env.HERDR_PLUGIN_EVENT_JSON) return {};
@@ -77,6 +79,50 @@ function applyContextColorTokens(tokens, ctxBand) {
   return CTX_BAR_COLOR_TOKENS.filter(name => name !== activeToken);
 }
 
+function clampCols(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 8 ? Math.min(n, 96) : 18;
+}
+
+function clipToCols(text, cols) {
+  const value = String(text);
+  return value.length <= cols ? value : `${value.slice(0, Math.max(1, cols - 1))}…`;
+}
+
+// Row 3 is TWO tokens with one meaning each, and exactly one of them carries
+// content per refresh — the mechanism `ctx_bar_*` above has already shipped with.
+// One token holding either a fact or a warning would have to change colour with
+// its meaning, which is the Channel Discipline violation docs/design-principles.md
+// exists to stop; here each token keeps a fixed colour and what changes is which
+// one is non-empty.
+//
+// A pane whose session could not be located fills NEITHER. Row 1's state_labels
+// already says "not linked", and `$facts` would render the detail's honest but
+// useless `n/a · ?` beside it — the duplication this three-row layout exists to
+// remove. Row height never changes, only content, which
+// docs/design-principles.md:60 permits explicitly ("Content inside containers
+// may change freely").
+function applyRow3Tokens(tokens, detail, opts = {}) {
+  const located = Boolean(detail) && detail.matched !== false;
+  // ctx, blocked and no-telemetry are `sidebarOwned` in the shared ranking, so
+  // they cannot reach row 3 — rows 2 and 1 render them. Passing hasTelemetry
+  // true is therefore not a claim: the unlocated case returned above.
+  const alert = located ? paneAlert({
+    hasTelemetry: true,
+    refusedCount: detail.refusedCount,
+    staleText: detail.stale?.text,
+    failures: detail.failures,
+    cacheDropped: detail.cacheDropped,
+  }) : null;
+  // Clip to the measured sidebar width here rather than letting Herdr cut the
+  // row: an alert we chose to show must be legible, and the caller knows the
+  // width. `cols` falls back to ctx_bar's own default when unmeasured.
+  const cols = clampCols(opts.sidebarCols);
+  if (alert) tokens.alert = clipToCols(alert.text, cols);
+  else if (located) tokens.facts = clipToCols(`${detail.costText} · ${detail.ageText}`, cols);
+  return ROW3_TOKENS.filter(name => tokens[name] === undefined);
+}
+
 // A standalone (non-hub) ccxray is a perfectly good proxy — the user's traffic
 // is being traced, it just didn't fork a hub. Mirror ensureProxy's recognition.
 function proxyAvailable(parsed) {
@@ -92,8 +138,9 @@ function badgeTokens(status, usage, opts = {}) {
   };
 
   let stale = null;
+  let detail = null;
   if (usage.ok && usage.data?.meta) {
-    const detail = sessionSummaryDetails(usage.data, opts);
+    detail = sessionSummaryDetails(usage.data, opts);
     stale = detail.stale || null;
     tokens.summary = detail.summary;
     tokens.ctx_bar = detail.ctxBar;
@@ -112,7 +159,12 @@ function badgeTokens(status, usage, opts = {}) {
     tokens.age = detail.ageText;
     tokens.cost = detail.costText;
     tokens.model = detail.model;
-    tokens.turns = String(detail.turns ?? usage.data.meta.totalEntries ?? 0);
+    // Never fall back to usage.data.meta.totalEntries: that is every session's
+    // line count, and a per-agent row rendering it claims the whole index as one
+    // pane's turn count. Dead today (no path returns a nullish detail.turns) and
+    // therefore removed without a differential test — it is a loaded landmine,
+    // not a live defect, and the moment an unlocated path returns null it fires.
+    tokens.turns = detail.turns == null ? '?' : String(detail.turns);
     tokens.cache = detail.matched === false ? '?' : formatPercent(usage.data.cache?.hitRate);
     tokens.fail = detail.matched === false ? '?' : formatPercent(usage.data.tools?.failRate);
   } else {
@@ -129,7 +181,10 @@ function badgeTokens(status, usage, opts = {}) {
   return {
     tokens,
     stale,
-    clearTokens: applyContextColorTokens(tokens, tokens.ctx_band),
+    clearTokens: [
+      ...applyContextColorTokens(tokens, tokens.ctx_band),
+      ...applyRow3Tokens(tokens, detail, opts),
+    ],
   };
 }
 
@@ -227,4 +282,4 @@ function main() {
 // free so badgeTokens() can be asserted without refreshing anybody's sidebar.
 if (require.main === module) main();
 
-module.exports = { badgeTokens, applyContextColorTokens, eventContext };
+module.exports = { badgeTokens, applyContextColorTokens, applyRow3Tokens, eventContext };

--- a/plugins/herdr/bin/refresh-badges.js
+++ b/plugins/herdr/bin/refresh-badges.js
@@ -247,11 +247,40 @@ function main() {
     done: tokens.summary,
   };
 
-  const pane = reportPaneTokens(tokens, {
+  // Herdr caps pane metadata at 16 unique token names (set + clear combined).
+  // The plugin produces ~12 tokens internally (ctx, model, cost, age, turns,
+  // cache, fail, summary, ctx_bar, ctx_band, plus the 4 ctx_bar colours rotated
+  // through clearTokens), and the new $facts/$alert pair pushed the total to 17.
+  // Not every token needs to reach the pane: `summary` is read locally by
+  // stateLabels and notifications but the config never renders it (the row was
+  // migrated away), and `ctx_band` is an internal signal only. Strip them from
+  // the object sent to report-metadata while keeping them readable in this scope.
+  // Herdr caps pane metadata at 16 unique token names (set + clear combined).
+  // The plugin produces ~17 internal tokens, but only 7 ever reach a config row:
+  // xray (Quick Start / MC status), the four ctx_bar colours (row 2), and
+  // facts/alert (row 3). Atomic tokens from the pre-migration layout ($ctx,
+  // $model, $cost, etc.) are not cleared because an un-migrated config may
+  // still render them, and herdr retains values a report does not mention; the
+  // installer migration removes those rows, after which the retained values
+  // are inert. summary/ctx_band/ctx_bar are cleared as a one-time cleanup —
+  // they were sent by previous badge writes but never reached a config row.
+  const PANE_REPORT_TOKENS = new Set([
+    'xray',
+    // ctx_bar colour variants — applyContextColorTokens writes the active one
+    'ctx_bar_unknown', 'ctx_bar_green', 'ctx_bar_yellow', 'ctx_bar_red',
+    // row 3
+    'facts', 'alert',
+  ]);
+  const paneTokens = {};
+  for (const [name, value] of Object.entries(tokens)) {
+    if (PANE_REPORT_TOKENS.has(name)) paneTokens[name] = value;
+  }
+  clearTokens.push('summary', 'ctx_band', 'ctx_bar');
+  const pane = reportPaneTokens(paneTokens, {
     env, ttlMs, stateLabels, clearTokens, agent: event.agent,
     clearStateLabels: !stateLabels,
   });
-  const workspace = reportWorkspaceTokens(tokens, { env, ttlMs, clearTokens });
+  const workspace = reportWorkspaceTokens(paneTokens, { env, ttlMs, clearTokens });
   const notification = process.env.HERDR_PLUGIN_EVENT === 'pane.agent_status_changed'
     ? agentNotification(event, tokens.summary, {
       env,

--- a/plugins/herdr/bin/refresh-badges.js
+++ b/plugins/herdr/bin/refresh-badges.js
@@ -5,10 +5,10 @@ const fs = require('fs');
 const {
   contextSidebarColumns,
   formatPercent,
-  herdrAgentReport,
   herdrRuntime,
   paneAlert,
   reportPaneTokens,
+  resolvePaneSessionId,
   reportWorkspaceTokens,
   requestImport,
   routedPaneKnown,
@@ -204,18 +204,14 @@ function main() {
   const usage = shared.usage || usageReport({ last: process.env.CCXRAY_HERDR_LAST || '24h' });
   const context = runtime.context || {};
   const targetPaneId = runtime.paneId || context.focused_pane_id || null;
-  let nativeSessionId = event.sessionId || null;
-  if (!nativeSessionId && context.agent_session?.kind === 'id') {
-    nativeSessionId = context.agent_session.value;
-  }
-  // agent_session_known means the context author already consulted the agent
-  // list for this pane — including the "no session id" answer — so re-listing
-  // here could only repeat that answer more slowly.
-  if (!nativeSessionId && targetPaneId && !context.agent_session_known) {
-    const report = herdrAgentReport({ env });
-    const agent = report.agents.find(item => item.pane_id === targetPaneId);
-    if (agent?.agent_session?.kind === 'id') nativeSessionId = agent.agent_session.value;
-  }
+  // Shared with open-dashboard so the badge and the deep link cannot disagree
+  // about which session this pane is on.
+  const nativeSessionId = resolvePaneSessionId({
+    env,
+    paneId: targetPaneId,
+    context,
+    eventSessionId: event.sessionId,
+  });
   const sidebarCols = contextSidebarColumns({
     env,
     paneId: targetPaneId,

--- a/plugins/herdr/bin/remove-sidebar-summary.js
+++ b/plugins/herdr/bin/remove-sidebar-summary.js
@@ -22,13 +22,17 @@ const TOKENS = [...MANAGED_TOKENS, 'summary', 'ctx_bar'];
 // Derived from the installer's own DEFAULT_ROWS rather than re-typed: these two
 // files disagreed the moment row 1 changed shape, and the symptom would have
 // been an uninstall that silently leaves an empty table behind.
-const MANAGED_SKELETON = [
-  '[ui.sidebar.agents]',
-  'row_gap = 0',
-  'rows = [',
-  ...DEFAULT_ROWS.split('\n').map(line => line.trim()),
-  ']',
-].join('\n');
+// Both the new and legacy managed row-1 shapes, so removal recognizes any
+// table this installer ever created. codex round 1, P2a.
+const LEGACY_DEFAULT_ROWS = [
+  '["state_icon", "workspace", "tab"],',
+  '["agent"],',
+];
+const NEW_DEFAULT_ROWS = DEFAULT_ROWS.split('\n').map(line => line.trim());
+function makeSkeleton(defaults) {
+  return ['[ui.sidebar.agents]', 'row_gap = 0', 'rows = [', ...defaults, ']'].join('\n');
+}
+const MANAGED_SKELETONS = [makeSkeleton(NEW_DEFAULT_ROWS), makeSkeleton(LEGACY_DEFAULT_ROWS)];
 
 function normalizeBlock(block) {
   return block
@@ -50,7 +54,8 @@ function removeManagedSection(config, stripped) {
   const bodyStart = headerStart + header[0].length;
   const next = /^\[[A-Za-z0-9_.-]+\][ \t]*$/m.exec(stripped.slice(bodyStart));
   const end = next ? bodyStart + next.index : stripped.length;
-  if (normalizeBlock(stripped.slice(headerStart, end)) !== MANAGED_SKELETON) return null;
+  const normalized = normalizeBlock(stripped.slice(headerStart, end));
+  if (!MANAGED_SKELETONS.some(skel => normalized === skel)) return null;
   const before = stripped.slice(0, marker).replace(/[ \t]*$/, '');
   return `${before.replace(/\n{3,}$/, '\n\n')}${stripped.slice(end).replace(/^\n+/, '')}`;
 }

--- a/plugins/herdr/bin/remove-sidebar-summary.js
+++ b/plugins/herdr/bin/remove-sidebar-summary.js
@@ -4,17 +4,29 @@
 const fs = require('fs');
 const { backupConfigFile, resolveHerdrConfigPath, runHerdr } = require('./lib/ccxray');
 
-const TOKENS = ['summary', 'ctx_bar', 'ctx_bar_unknown', 'ctx_bar_green', 'ctx_bar_yellow', 'ctx_bar_red'];
-const SECTION_MARKER = '# ccxray sidebar summary rows (managed by the ccxray Herdr plugin)';
+const {
+  DEFAULT_ROWS,
+  MANAGED_TOKENS,
+  SECTION_MARKER,
+} = require('./install-sidebar-summary');
+
+// Every token the installer manages, plus the generations it migrates away from.
+// `summary` and the single `ctx_bar` are gone from fresh installs but still sit
+// in configs written before the three-row layout, and uninstall has to clean
+// those too.
+const TOKENS = [...MANAGED_TOKENS, 'summary', 'ctx_bar'];
 // The skeleton install-sidebar-summary writes when it creates the table itself.
 // Removal drops the whole table only when it still matches this exactly, so a
 // table the user wrote (or later edited) keeps its other rows.
+//
+// Derived from the installer's own DEFAULT_ROWS rather than re-typed: these two
+// files disagreed the moment row 1 changed shape, and the symptom would have
+// been an uninstall that silently leaves an empty table behind.
 const MANAGED_SKELETON = [
   '[ui.sidebar.agents]',
   'row_gap = 0',
   'rows = [',
-  '["state_icon", "workspace", "tab"],',
-  '["agent"],',
+  ...DEFAULT_ROWS.split('\n').map(line => line.trim()),
   ']',
 ].join('\n');
 

--- a/server/forward.js
+++ b/server/forward.js
@@ -137,7 +137,18 @@ function requestDeploymentFields(startTime, provider, req, parsedBody) {
   // the value is client-supplied and lands in a persisted index field.
   let identity = hubIdentity;
   if (!hubIdentity && headers['x-ccxray-agent-id']) {
-    const fromHeader = hub.clientIdentityFromMessage({ agentId: headers['x-ccxray-agent-id'] });
+    // Node joins duplicate HTTP headers with ', '. A ccxray-launched shell that
+    // itself launches another agent prepends its own header value, so the raw
+    // string can be 'herdr:wY:old, X-Ccxray-Auth: ..., X-Ccxray-Agent-Id: herdr:w1D:new'.
+    // The LAST herdr:-prefixed segment is the innermost (newest) launch — take it.
+    const rawAgentId = String(headers['x-ccxray-agent-id']);
+    const segments = rawAgentId.split(',').map(s => {
+      const trimmed = s.trim();
+      const colonIdx = trimmed.indexOf(': ');
+      return colonIdx >= 0 && /^[A-Za-z]/.test(trimmed) ? trimmed.slice(colonIdx + 2) : trimmed;
+    });
+    const lastHerdr = [...segments].reverse().find(s => s.startsWith('herdr:')) || rawAgentId.trim();
+    const fromHeader = hub.clientIdentityFromMessage({ agentId: lastHerdr });
     if (fromHeader.agentId) identity = fromHeader;
   }
   const routedClient = Number.isSafeInteger(req.ccxrayClientPid);

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -1027,6 +1027,107 @@ describe('Herdr aggregate cost confidence (ADR 0017)', () => {
   });
 });
 
+// INVARIANT(ADR 0005 shape): ONE ranked list answers "what is the most important
+// thing about this pane right now", for both the sidebar badge's row-3 $alert and
+// Mission Control's action. Two orderings used to contradict each other:
+// contextSignal ranked context above every tool failure, while the MC action
+// chain ranked `fail >= 2` above context and `cache dropped` above `fail == 1`.
+describe('Herdr pane concerns are ranked once (ADR 0005 shape)', () => {
+  const {
+    paneAction,
+    paneAlert,
+    paneConcerns,
+    quotaRefusalCount,
+  } = require('../plugins/herdr/bin/lib/ccxray');
+
+  it('ranks any tool failure above a dropped cache', () => {
+    const signals = { hasTelemetry: true, failures: 1, cacheDropped: true };
+    assert.equal(paneAction(signals), 'inspect failed tool');
+    assert.equal(paneAlert(signals).kind, 'fail-single');
+  });
+
+  it('row 3 skips the tiers rows 1 and 2 already render', () => {
+    // Repeating context on row 3 while row 2 shows the percentage, or repeating
+    // process state while row 1 shows it, is the duplication this layout exists
+    // to remove. Mission Control is a single row and still acts on both.
+    const ctxOnly = { hasTelemetry: true, ctxPct: 95 };
+    assert.equal(paneAlert(ctxOnly), null);
+    assert.equal(paneAction(ctxOnly), 'compact or start fresh');
+
+    const blocked = { hasTelemetry: true, status: 'blocked' };
+    assert.equal(paneAlert(blocked), null);
+    assert.equal(paneAction(blocked), 'inspect last error');
+
+    const dark = { hasTelemetry: false };
+    assert.equal(paneAlert(dark), null);
+    assert.equal(paneAction(dark), 'relaunch via ccxray');
+  });
+
+  it('keeps the signed-off $alert order once row-owned tiers are dropped', () => {
+    const signals = {
+      hasTelemetry: true,
+      refusedCount: 2,
+      staleText: 'stale 3m',
+      failures: 3,
+      cacheDropped: true,
+      ctxPct: 95,
+      status: 'blocked',
+    };
+    assert.deepEqual(
+      paneConcerns(signals).filter(concern => !concern.sidebarOwned).map(concern => concern.kind),
+      ['quota-refused', 'stale', 'fail-multi', 'cache-dropped'],
+      'quota > stale > fail > cache-dropped is owner-signed-off');
+    assert.equal(paneAlert(signals).text, 'quota refused 2x');
+  });
+
+  it('counts a quota refusal as an observed 429, never a forecast', () => {
+    assert.equal(quotaRefusalCount([{ status: 200 }, { status: 429 }, { status: 200 }]), 1);
+    assert.equal(quotaRefusalCount([{ status: 200 }]), 0);
+    // Same last-six window as toolFailureCount, so an old refusal ages out.
+    const aged = [{ status: 429 }].concat(Array.from({ length: 6 }, () => ({ status: 200 })));
+    assert.equal(quotaRefusalCount(aged), 0);
+  });
+
+  // Asserted through the pre-existing missionControlSnapshot API on purpose: the
+  // old code answers this one (with the other ordering) instead of throwing on a
+  // missing export, so the red it produces is the ordering change and nothing else.
+  it('Mission Control acts on the failure, not the dropped cache', () => {
+    const T = 1787000000000;
+    const base = {
+      sessionId: 'mc-order-1', model: 'claude-opus-5', agentKey: 'orchestrator',
+      isSubagent: false, convId: 'aaaa', maxContext: 200000,
+      // The pane's own agentId is what attributes a turn to its row.
+      agentId: 'herdr:w1:p1', cwd: '/work/mc-order', provider: 'anthropic',
+    };
+    const turns = [
+      {
+        ...base, id: 'mo1', receivedAt: T, sysHash: 'h1', turnToolFail: false,
+        usage: { input_tokens: 10000, cache_read_input_tokens: 90000 },
+      },
+      {
+        ...base, id: 'mo2', receivedAt: T + 1000, sysHash: 'h2', turnToolFail: true,
+        usage: { input_tokens: 100000, cache_read_input_tokens: 0 },
+      },
+    ];
+    const { missionControlSnapshot } = require('../plugins/herdr/bin/lib/ccxray');
+    const snapshot = missionControlSnapshot({
+      env: pluginEnv({ CCXRAY_HOME: makeHome(turns), CCXRAY_HERDR_NOW_MS: String(T + 2000) }),
+      agentReport: { ok: true, agents: [{
+        pane_id: 'w1:p1', tab_id: 'w1:t1', agent: 'claude',
+        agent_status: 'recent', workspace_id: 'w1', agent_session: { kind: 'none' },
+      }] },
+    });
+    assert.equal(snapshot.rows.length, 1);
+    const row = snapshot.rows[0];
+    // Pin the fixture before trusting the verdict: a fixture that stopped
+    // dropping the cache would make this pass for the wrong reason.
+    assert.equal(row.cacheDropped, true, 'fixture must actually drop the cache');
+    assert.equal(row.failures, 1, 'fixture must carry exactly one failure');
+    assert.ok(row.ctxPct <= 80, 'context must stay below the tier that outranks both');
+    assert.equal(row.action, 'inspect failed tool');
+  });
+});
+
 describe('ensureProxy cold start', () => {
   // `ccxray --no-browser` with no agent is a FOREGROUND standalone server (a hub
   // is forked only by `ccxray <agent>` without --port). ensureProxy used

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -23,7 +23,21 @@ function pluginEnv(overrides = {}) {
   for (const [key, value] of Object.entries(process.env)) {
     // PROXY_PORT joined the plugin's env surface in #555 (the launch port
     // escape hatch): an ambient value would silently retarget every spawn.
-    if (key.startsWith('HERDR_') || key.startsWith('CCXRAY_') || key === 'PROXY_PORT') continue;
+    //
+    // ANTHROPIC_CUSTOM_HEADERS joined it in #575 (native launch with header
+    // identity). It leaks where ANTHROPIC_BASE_URL does not, and the difference
+    // is the merge: launchEnvVars OVERWRITES the base url but deliberately
+    // PREPENDS the user's existing headers (lib/ccxray.js, "the user's own value
+    // is PREPENDED rather than replaced"), so a developer whose own shell was
+    // launched by this plugin hands every spawned launch-agent a header to
+    // prepend. The exact-equality assertion in 'launch-agent stamps the
+    // workspace id into the pane identity header' then sees three headers. It
+    // shipped green because it only fails for that developer. Rule for the next
+    // variable: an overwritten one is safe here, a merged one is not.
+    if (key.startsWith('HERDR_')
+      || key.startsWith('CCXRAY_')
+      || key === 'PROXY_PORT'
+      || key === 'ANTHROPIC_CUSTOM_HEADERS') continue;
     env[key] = value;
   }
   // Load budget: the plugin's CLI calls have deliberately tight per-call

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -1234,6 +1234,51 @@ describe('Herdr sidebar row 3 fills exactly one token', () => {
   });
 });
 
+// Row 1 is `state_icon · agent · state_text`, and a ccxray state label REPLACES
+// the native state_text. Setting it unconditionally made row 1 read
+// `claude · ccxray: traced · claude`.
+describe('Herdr row 1 keeps Herdr own state text when the pane is located', () => {
+  const T = 1787000000000;
+  const paneTurn = extra => ({
+    id: 'r1a', sessionId: 'row1', model: 'claude-opus-5', provider: 'anthropic',
+    agentKey: 'orchestrator', isSubagent: false, convId: 'c1', maxContext: 200000,
+    receivedAt: T, cwd: '/work/row1', usage: { input_tokens: 40000 },
+    cost: { cost: 1.5, confidence: 'exact' }, turnToolFail: false, ...extra,
+  });
+  const run = turns => {
+    const herdr = makeRecordingHerdr();
+    const result = runScript('refresh-badges.js', [], {
+      CCXRAY_HOME: makeHome(turns),
+      CCXRAY_HERDR_LAST: '9999d',
+      CCXRAY_HERDR_NOW_MS: String(T + 60000),
+      HERDR_PANE_ID: 'w1:p1',
+      HERDR_BIN_PATH: herdr.bin,
+      CCXRAY_HERDR_NO_LAYOUT: '1',
+    });
+    const args = fs.existsSync(herdr.log) ? fs.readFileSync(herdr.log, 'utf8') : '';
+    return { result, args };
+  };
+
+  it('clears the state labels instead of overwriting the state text', () => {
+    // fail-on-old: the old code emitted --state-label on every refresh and never
+    // emitted --clear-state-labels, so both assertions below invert.
+    const { args } = run([paneTurn({ agentId: 'herdr:w1:p1' })]);
+    assert.match(args, /report-metadata/);
+    assert.match(args, /--clear-state-labels/,
+      'a located pane must hand row 1 back to Herdr');
+    assert.equal(/--state-label/.test(args), false,
+      'and must not overwrite the native state text');
+  });
+
+  it('still labels a pane whose session it cannot locate', () => {
+    // The label is reserved for what Herdr cannot know: that ccxray is not
+    // seeing this pane at all.
+    const { args } = run([paneTurn({ agentId: 'herdr:w1:pOTHER' })]);
+    assert.match(args, /--state-label idle=ccxray: not linked/);
+    assert.equal(/--clear-state-labels/.test(args), false);
+  });
+});
+
 describe('ensureProxy cold start', () => {
   // `ccxray --no-browser` with no agent is a FOREGROUND standalone server (a hub
   // is forked only by `ccxray <agent>` without --port). ensureProxy used

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -1453,6 +1453,24 @@ describe('Herdr sidebar installer migrates accumulated generations', () => {
       'the user table must survive');
   });
 
+  // codex round 2 P1: a user-authored table (no SECTION_MARKER) that happens to
+  // contain `["agent"]` must NOT have it replaced — it is the user's row.
+  it('preserves legacy-looking rows in a user-authored table', () => {
+    const { result, after } = install([
+      '[ui.sidebar.agents]',
+      'rows = [',
+      '  ["state_icon", "workspace", "tab"],',
+      '  ["agent"],',
+      ']',
+      '',
+    ].join('\n'));
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(after, /\["state_icon", "workspace", "tab"\]/,
+      'without the marker these are the user\'s own rows');
+    assert.match(after, /\["agent"\]/);
+    assert.match(after, /\$facts/);
+  });
+
   it('Quick Start and the installer agree on what installed means', () => {
     const { configHasManagedRows } = require('../plugins/herdr/bin/install-sidebar-summary');
     assert.equal(configHasManagedRows(ACCUMULATED), false, 'the old generation is not installed');
@@ -4265,8 +4283,8 @@ describe('Herdr plugin commands', () => {
     assert.match(config, /\$ctx_bar_red/);
     assert.match(config, /\$facts/);
     assert.match(config, /\$alert/);
-    // The old `["agent"]` is one of our legacy rows, so it gets replaced.
-    assert.match(config, /\["state_icon", "agent", "state_text"\]/);
+    // No marker → the old `["agent"]` is treated as user's own row.
+    assert.match(config, /\["agent"\]/);
     assert.match(result.stdout, /superseded row removed: \$summary/);
     assert.match(result.stdout, /migrated sidebar summary rows/);
   });
@@ -4370,9 +4388,9 @@ describe('Herdr plugin commands', () => {
     assert.match(config, /\$ctx_bar_green/);
     assert.match(config, /\$ctx_bar_yellow/);
     assert.match(config, /\$ctx_bar_red/);
-    // Legacy default rows are ours and get replaced. The user's content is
-    // the [terminal] section below the sidebar table.
-    assert.match(config, /\["state_icon", "agent", "state_text"\]/);
+    // No marker → legacy-looking rows are treated as user's own.
+    assert.match(config, /\["state_icon", "workspace", "tab"\]/);
+    assert.match(config, /\["agent"\]/);
     assert.match(config, /\[terminal\]/);
     assert.equal(config.match(/\[ui\.sidebar\.agents\]/g).length, 1);
   });
@@ -4405,7 +4423,9 @@ describe('Herdr plugin commands', () => {
     const config = fs.readFileSync(configPath, 'utf8');
     assert.match(config, /\$facts/);
     assert.match(config, /\$ctx_bar_red/);
-    assert.match(config, /\["state_icon", "agent", "state_text"\]/);
+    // No marker: `["agent"]` is treated as user's own and survives both
+    // removal and reinstall.
+    assert.match(config, /\["agent"\]/);
     // One row each: a reinstall must not stack a second copy, which is the
     // add-only behaviour the migration replaced.
     assert.equal(config.match(/\$facts/g).length, 1);

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -1142,6 +1142,98 @@ describe('Herdr pane concerns are ranked once (ADR 0005 shape)', () => {
   });
 });
 
+// Row 3 of the three-row sidebar: `$facts` (grey) and `$alert` (warning colour),
+// exactly one non-empty per refresh, the other returned in clearTokens — the
+// mechanism `ctx_bar_*` already ships with.
+describe('Herdr sidebar row 3 fills exactly one token', () => {
+  const { badgeTokens, applyRow3Tokens } = require('../plugins/herdr/bin/refresh-badges.js');
+  const T = 1787000000000;
+  const status = { ok: true, parsed: { running: true, machine: { proxy: true, port: 5577 } } };
+  const usage = {
+    ok: true,
+    data: {
+      meta: { totalCost: 999.99, totalEntries: 1234 },
+      sessions: { topSessions: [{ sessionId: 'sTOP', cost: 42.5, turns: 77, model: 'claude-opus-5', durationMin: 60 }] },
+      models: [{ model: 'claude-fable-5' }],
+      cache: { hitRate: 0.91 },
+      tools: { failRate: 0.07 },
+    },
+  };
+  const turn = extra => ({
+    sessionId: 'r3', agentId: 'herdr:w1:p1', model: 'claude-opus-5',
+    agentKey: 'orchestrator', isSubagent: false, convId: 'c1', maxContext: 200000,
+    provider: 'anthropic', cwd: '/work/r3', receivedAt: T,
+    cost: { cost: 42.08, confidence: 'exact' }, turnToolFail: false, ...extra,
+  });
+  const render = turns => badgeTokens(status, usage, {
+    env: pluginEnv({ CCXRAY_HOME: makeHome(turns) }),
+    paneId: 'w1:p1',
+    nowMs: T + 3600000,
+    sidebarCols: 40,
+  });
+
+  it('shows the facts when nothing is wrong and the alert when something is', () => {
+    const healthy = render([turn({ id: 'h1', usage: { input_tokens: 50000 } })]);
+    assert.equal(healthy.tokens.facts, '$42.08 · 60m');
+    assert.equal(healthy.tokens.alert, undefined);
+    assert.ok(healthy.clearTokens.includes('alert'));
+    assert.equal(healthy.clearTokens.includes('facts'), false);
+
+    const failed = render([turn({ id: 'f1', usage: { input_tokens: 50000 }, turnToolFail: true })]);
+    assert.equal(failed.tokens.alert, 'fail 1x');
+    assert.equal(failed.tokens.facts, undefined);
+    assert.ok(failed.clearTokens.includes('facts'));
+    assert.equal(failed.clearTokens.includes('alert'), false);
+  });
+
+  it('leaves context pressure to row 2 instead of repeating it', () => {
+    // 190K/200K = 95%. Row 2 already renders the percentage, the sparkline AND
+    // the colour band, so an alert saying "full" would be the fourth encoding of
+    // one fact — the duplication this layout exists to remove.
+    const full = render([turn({ id: 'c1', usage: { input_tokens: 190000 } })]);
+    assert.equal(full.tokens.alert, undefined);
+    assert.equal(full.tokens.facts, '$42.08 · 60m');
+  });
+
+  it('fills neither token for a pane whose session it cannot locate', () => {
+    // NOT a fail-on-old: `$facts` did not exist before, so the old code would
+    // fail this for a missing token rather than for a behaviour difference. The
+    // claim is only that row 1 keeps sole ownership of "not linked" — rendering
+    // the detail's honest-but-useless `n/a · ?` beside it is the duplication.
+    const elsewhere = render([turn({ id: 'x1', agentId: 'herdr:w1:pOTHER' })]);
+    assert.equal(elsewhere.tokens.facts, undefined);
+    assert.equal(elsewhere.tokens.alert, undefined);
+    assert.ok(elsewhere.clearTokens.includes('facts'));
+    assert.ok(elsewhere.clearTokens.includes('alert'));
+  });
+
+  it('fills neither token when there is no hub to report', () => {
+    const dark = badgeTokens({ ok: true, parsed: { running: false, notes: [] } }, { ok: false }, {
+      env: pluginEnv({ CCXRAY_HOME: makeHome([]) }),
+      paneId: 'w1:p1',
+      sidebarCols: 40,
+    });
+    assert.equal(dark.tokens.facts, undefined);
+    assert.equal(dark.tokens.alert, undefined);
+  });
+
+  it('keeps every alert label inside a narrow sidebar', () => {
+    // The spelled-out 'cache dropped after prompt change' is 33 columns; the
+    // sidebar brief must fit a realistic row, and anything longer is clipped by
+    // us rather than cut by Herdr.
+    const dropped = render([
+      turn({ id: 'd1', sysHash: 'h1', usage: { input_tokens: 10000, cache_read_input_tokens: 90000 } }),
+      turn({ id: 'd2', sysHash: 'h2', receivedAt: T + 1000, usage: { input_tokens: 100000, cache_read_input_tokens: 0 } }),
+    ]);
+    assert.equal(dropped.tokens.alert, 'cache dropped');
+    assert.ok(dropped.tokens.alert.length <= 14, 'must fit a 14-column sidebar');
+
+    const wide = {};
+    applyRow3Tokens(wide, { matched: true, costText: '$1234.56', ageText: '12.3h' }, { sidebarCols: 14 });
+    assert.equal(wide.facts, '$1234.56 · 12…');
+  });
+});
+
 describe('ensureProxy cold start', () => {
   // `ccxray --no-browser` with no agent is a FOREGROUND standalone server (a hub
   // is forked only by `ccxray <agent>` without --port). ensureProxy used

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -87,6 +87,17 @@ function isolatedHome() {
   return emptyHome;
 }
 
+function paneAlertFor(detail) {
+  const { paneAlert } = require('../plugins/herdr/bin/lib/ccxray');
+  return paneAlert({
+    hasTelemetry: true,
+    refusedCount: detail.refusedCount,
+    staleText: detail.stale?.text,
+    failures: detail.failures,
+    cacheDropped: detail.cacheDropped,
+  });
+}
+
 function makeHome(entries = []) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-herdr-plugin-'));
   fs.mkdirSync(path.join(home, 'logs'), { recursive: true });
@@ -490,7 +501,11 @@ describe('Herdr sidebar main-agent anchoring', () => {
       nowMs: T + 7000,
       sidebarCols: 32,
     });
-    assert.doesNotMatch(detail.ctxBar, /fail/, 'no turn failed; the badge must not claim one did');
+    assert.equal(detail.failures, 0, 'no turn failed; the badge must not claim one did');
+    // Asserted on the raw count, not row 2's tail: row 3 owns alerts now, so
+    // `doesNotMatch(ctxBar, /fail/)` would hold for every input and protect
+    // nothing. paneAlert is the channel a failure actually reaches.
+    assert.equal(paneAlertFor(detail), null);
   });
 
   it('still reports a genuine per-turn tool failure', () => {
@@ -507,7 +522,8 @@ describe('Herdr sidebar main-agent anchoring', () => {
       nowMs: T + 7000,
       sidebarCols: 32,
     });
-    assert.match(detail.ctxBar, /fail 2x/);
+    assert.equal(detail.failures, 2);
+    assert.equal(paneAlertFor(detail).text, 'fail 2x');
   });
 
   // Every turn from a pane carries that pane's agentId, including turns from a
@@ -1044,7 +1060,7 @@ describe('Herdr aggregate cost confidence (ADR 0017)', () => {
 // INVARIANT(ADR 0005 shape): ONE ranked list answers "what is the most important
 // thing about this pane right now", for both the sidebar badge's row-3 $alert and
 // Mission Control's action. Two orderings used to contradict each other:
-// contextSignal ranked context above every tool failure, while the MC action
+// the now-removed contextSignal ranked context above every tool failure, while
 // chain ranked `fail >= 2` above context and `cache dropped` above `fail == 1`.
 describe('Herdr pane concerns are ranked once (ADR 0005 shape)', () => {
   const {
@@ -1515,7 +1531,11 @@ describe('Herdr sidebar import freshness', () => {
     assert.ok(detail.stale, 'expected a staleness marker');
     assert.equal(detail.stale.text, 'stale 11h');
     assert.match(detail.summary, /· stale 11h$/);
-    assert.match(detail.ctxBar, /stale 11h/);
+    // The reason moved to row 3's $alert. Row 2 keeps the withdrawn colour (the
+    // assertion below) and the cache fact, so it no longer repeats the word —
+    // `21% · stal…` beside `21% stale` is the duplication being removed.
+    assert.doesNotMatch(detail.ctxBar, /stale/);
+    assert.equal(paneAlertFor(detail).text, 'stale 11h');
     // The percentage survives; only the confident colour is withdrawn.
     assert.equal(Math.round(detail.ctxPct), 32);
     assert.equal(detail.ctxBand, 'unknown');
@@ -3416,7 +3436,7 @@ describe('Herdr plugin commands', () => {
     assert.equal(result.status, 1);
     assert.match(result.stdout, /ctx=90%/);
     assert.match(result.stdout, /ctx_band=red/);
-    assert.match(result.stdout, /ctx_bar_red=▁▁▁█ 90% · full/);
+    assert.match(result.stdout, /ctx_bar_red=▁▁▁█ 90% · cache 0%/);
     assert.match(result.stdout, /Clear: ctx_bar_unknown ctx_bar_green ctx_bar_yellow/);
   });
 
@@ -3452,7 +3472,7 @@ describe('Herdr plugin commands', () => {
       CCXRAY_HERDR_SIDEBAR_COLS: '36',
     });
     assert.equal(wide.status, 1);
-    assert.match(wide.stdout, /ctx_bar=▂▂▃▃▅▅▆▆▆▅▆▆ 80% · near full/);
+    assert.match(wide.stdout, /ctx_bar=▂▂▃▃▅▅▆▆▆▅▆▆ 80% · cache 0%/);
   });
 
   it('launch-agent can produce a stable new-tab plan without side effects', () => {

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -1394,6 +1394,65 @@ describe('Herdr sidebar installer migrates accumulated generations', () => {
     assert.match(result.stdout, /superseded row removed: \$summary/);
   });
 
+  // codex round 1, P1: a table emitted by the previous installer carries legacy
+  // default rows (`state_icon workspace tab` + `agent`) that must be replaced,
+  // not just left behind — otherwise the card renders four lines.
+  it('replaces the legacy default rows from a plugin-managed table', () => {
+    const { result, after } = install([
+      '',
+      '# ccxray sidebar summary rows (managed by the ccxray Herdr plugin)',
+      '[ui.sidebar.agents]',
+      'row_gap = 0',
+      'rows = [',
+      '  ["state_icon", "workspace", "tab"],',
+      '  ["agent"],',
+      '  [{ token = "$summary", fg = "#89b4fa", dim = true }],',
+      '  [{ token = "$ctx_bar_unknown", fg = "#a6adc8", dim = true }],',
+      '  [{ token = "$ctx_bar_green", fg = "#a6e3a1", dim = true }],',
+      '  [{ token = "$ctx_bar_yellow", fg = "#f9e2af", dim = true }],',
+      '  [{ token = "$ctx_bar_red", fg = "#f38ba8", dim = true }],',
+      ']',
+      '',
+    ].join('\n'));
+    assert.equal(result.status, 0, result.stderr);
+    // Legacy rows are gone, new row 1 is in place.
+    assert.equal(after.includes('"workspace"'), false, 'old workspace column must go');
+    assert.match(after, /\["state_icon", "agent", "state_text"\]/);
+    // Seven config rows → three visible lines.
+    assert.equal(sidebarRows(after).length, 7);
+    assert.match(result.stdout, /legacy default rows/);
+  });
+
+  // codex round 1, P2a: removal must recognize a table emitted by the previous
+  // installer, or stripping its token rows leaves an empty table behind.
+  it('removes the whole section when it carries the legacy skeleton', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-herdr-legacy-remove-'));
+    const configPath = path.join(dir, 'config.toml');
+    fs.writeFileSync(configPath, [
+      '[ui]',
+      'show_agent_labels_on_pane_borders = true',
+      '',
+      '# ccxray sidebar summary rows (managed by the ccxray Herdr plugin)',
+      '[ui.sidebar.agents]',
+      'row_gap = 0',
+      'rows = [',
+      '  ["state_icon", "workspace", "tab"],',
+      '  ["agent"],',
+      '  [{ token = "$summary", fg = "#89b4fa", dim = true }],',
+      '  [{ token = "$ctx_bar_unknown", fg = "#a6adc8", dim = true }],',
+      ']',
+      '',
+    ].join('\n'));
+    const env = { HERDR_CONFIG_PATH: configPath, CCXRAY_HERDR_SKIP_RELOAD: '1' };
+    const result = runScript('remove-sidebar-summary.js', [], env);
+    assert.equal(result.status, 0, result.stderr);
+    const after = fs.readFileSync(configPath, 'utf8');
+    assert.doesNotMatch(after, /\[ui\.sidebar\.agents\]/,
+      'the whole managed section must go');
+    assert.match(after, /show_agent_labels_on_pane_borders/,
+      'the user table must survive');
+  });
+
   it('Quick Start and the installer agree on what installed means', () => {
     const { configHasManagedRows } = require('../plugins/herdr/bin/install-sidebar-summary');
     assert.equal(configHasManagedRows(ACCUMULATED), false, 'the old generation is not installed');
@@ -1479,6 +1538,35 @@ describe('Herdr dashboard action deep-links the pane session', () => {
     assert.equal(resolvePaneSessionId({
       env: pluginEnv({}), paneId: 'w1:p1', context: { agent_session_known: true },
     }), null);
+  });
+});
+
+// codex round 1, P2b: a quota refusal must not leave Mission Control severity
+// green. The attention filter hides green rows, so a pane that got 429'd would
+// be invisible to the operator.
+describe('Herdr Mission Control marks a quota refusal red', () => {
+  it('updates severity and reasons when status 429 is observed', () => {
+    const T = 1787000000000;
+    const turn = {
+      id: 'q1', sessionId: 'sq1', model: 'claude-opus-5', agentKey: 'orchestrator',
+      isSubagent: false, convId: 'c1', maxContext: 200000, provider: 'anthropic',
+      agentId: 'herdr:w1:p1', cwd: '/work/quota', receivedAt: T,
+      usage: { input_tokens: 50000 }, cost: { cost: 1, confidence: 'exact' },
+      turnToolFail: false, status: 429,
+    };
+    const { missionControlSnapshot } = require('../plugins/herdr/bin/lib/ccxray');
+    const snapshot = missionControlSnapshot({
+      env: pluginEnv({ CCXRAY_HOME: makeHome([turn]), CCXRAY_HERDR_NOW_MS: String(T + 2000) }),
+      agentReport: { ok: true, agents: [{
+        pane_id: 'w1:p1', tab_id: 'w1:t1', agent: 'claude',
+        agent_status: 'recent', workspace_id: 'w1', agent_session: { kind: 'none' },
+      }] },
+    });
+    assert.equal(snapshot.rows.length, 1);
+    const row = snapshot.rows[0];
+    assert.equal(row.severity, 'red', 'a quota refusal must not stay green');
+    assert.ok(row.reasons.some(r => /quota refused/.test(r)));
+    assert.equal(row.action, 'wait for quota reset');
   });
 });
 
@@ -4177,8 +4265,8 @@ describe('Herdr plugin commands', () => {
     assert.match(config, /\$ctx_bar_red/);
     assert.match(config, /\$facts/);
     assert.match(config, /\$alert/);
-    // The user's own row is not ours to delete.
-    assert.match(config, /\["agent"\]/);
+    // The old `["agent"]` is one of our legacy rows, so it gets replaced.
+    assert.match(config, /\["state_icon", "agent", "state_text"\]/);
     assert.match(result.stdout, /superseded row removed: \$summary/);
     assert.match(result.stdout, /migrated sidebar summary rows/);
   });
@@ -4282,8 +4370,9 @@ describe('Herdr plugin commands', () => {
     assert.match(config, /\$ctx_bar_green/);
     assert.match(config, /\$ctx_bar_yellow/);
     assert.match(config, /\$ctx_bar_red/);
-    assert.match(config, /\["state_icon", "workspace", "tab"\]/);
-    assert.match(config, /\["agent"\]/);
+    // Legacy default rows are ours and get replaced. The user's content is
+    // the [terminal] section below the sidebar table.
+    assert.match(config, /\["state_icon", "agent", "state_text"\]/);
     assert.match(config, /\[terminal\]/);
     assert.equal(config.match(/\[ui\.sidebar\.agents\]/g).length, 1);
   });
@@ -4316,7 +4405,7 @@ describe('Herdr plugin commands', () => {
     const config = fs.readFileSync(configPath, 'utf8');
     assert.match(config, /\$facts/);
     assert.match(config, /\$ctx_bar_red/);
-    assert.match(config, /\["agent"\]/);
+    assert.match(config, /\["state_icon", "agent", "state_text"\]/);
     // One row each: a reinstall must not stack a second copy, which is the
     // add-only behaviour the migration replaced.
     assert.equal(config.match(/\$facts/g).length, 1);

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -1405,6 +1405,83 @@ describe('Herdr sidebar installer migrates accumulated generations', () => {
   });
 });
 
+// The standalone dashboard action ran a bare `ccxray open`, throwing away the one
+// thing its caller knew: which pane they were looking at. Mission Control's `d`
+// has passed --session since it shipped.
+describe('Herdr dashboard action deep-links the pane session', () => {
+  const recordingCcxray = () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-open-'));
+    const bin = path.join(dir, 'ccxray');
+    const log = path.join(dir, 'argv.log');
+    fs.writeFileSync(bin, [
+      '#!/bin/sh',
+      `echo "$@" >> "${log}"`,
+      // parseStatus needs a JSON Machine line and something that reads as a live
+      // hub; `port=5577` matches neither of its patterns.
+      'if [ "$1" = "status" ]; then',
+      '  echo "Hub running on http://localhost:5577 (pid 4242, clients 1)"',
+      '  echo \'Machine: {"proxy":true,"hub":true,"port":5577}\''
+      ,
+      'fi',
+      'exit 0',
+    ].join('\n'));
+    fs.chmodSync(bin, 0o755);
+    return { bin, log };
+  };
+  const argvFor = extraEnv => {
+    const ccxray = recordingCcxray();
+    const result = runScript('open-dashboard.js', [], {
+      CCXRAY_BIN: ccxray.bin,
+      CCXRAY_HERDR_NO_BROWSER: '1',
+      ...extraEnv,
+    });
+    const argv = fs.existsSync(ccxray.log) ? fs.readFileSync(ccxray.log, 'utf8') : '';
+    return { result, argv };
+  };
+
+  it('passes the focused pane session to ccxray open', () => {
+    // fail-on-old: the old action emitted a bare `open` for this same input.
+    const { result, argv } = argvFor({
+      HERDR_PANE_ID: 'w1:p1',
+      HERDR_PLUGIN_CONTEXT_JSON: JSON.stringify({
+        focused_pane_id: 'w1:p1',
+        agent_session: { kind: 'id', value: 'sess-abc-123' },
+      }),
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(argv, /^open --session sess-abc-123$/m);
+    assert.match(result.stdout, /opening the dashboard on session sess-abc-123/);
+  });
+
+  it('falls back to a plain open when the pane has no session id', () => {
+    const { result, argv } = argvFor({
+      HERDR_PANE_ID: 'w1:p1',
+      HERDR_PLUGIN_CONTEXT_JSON: JSON.stringify({
+        focused_pane_id: 'w1:p1',
+        // agent_session_known means the context author already asked and the
+        // answer was "none", so the resolver must not re-list the agents.
+        agent_session_known: true,
+      }),
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(argv, /^open$/m);
+    assert.match(result.stdout, /no session id yet/);
+  });
+
+  it('resolves the session the same way the badge does', () => {
+    // One helper, so `prefix+m` -> d and the standalone action cannot open
+    // different sessions for the same pane.
+    const { resolvePaneSessionId } = require('../plugins/herdr/bin/lib/ccxray');
+    const context = { agent_session: { kind: 'id', value: 'sess-xyz' } };
+    assert.equal(resolvePaneSessionId({ env: pluginEnv({}), paneId: 'w1:p1', context }), 'sess-xyz');
+    assert.equal(resolvePaneSessionId({ env: pluginEnv({}), paneId: 'w1:p1', context, eventSessionId: 'from-event' }),
+      'from-event', 'an event id wins, as it does in the badge');
+    assert.equal(resolvePaneSessionId({
+      env: pluginEnv({}), paneId: 'w1:p1', context: { agent_session_known: true },
+    }), null);
+  });
+});
+
 describe('ensureProxy cold start', () => {
   // `ccxray --no-browser` with no agent is a FOREGROUND standalone server (a hub
   // is forked only by `ccxray <agent>` without --port). ensureProxy used

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -1295,6 +1295,116 @@ describe('Herdr row 1 keeps Herdr own state text when the pane is located', () =
   });
 });
 
+// The reported config, verbatim in shape: eight rows accumulated across three
+// installer generations, rendering the model three times, the cost twice and the
+// percentage twice, with four truncations. The old installer could only APPEND,
+// so running it here made the card worse, not better.
+describe('Herdr sidebar installer migrates accumulated generations', () => {
+  const ACCUMULATED = [
+    'onboarding = false',
+    '',
+    '[ui.sidebar.agents]',
+    'rows = [',
+    '  ["state_icon", "agent", "state_text"],',
+    '  ["$ctx", "$model", "$cost"],',
+    '  [{ token = "$tg", fg = "#50c878" }, { token = "$ty", fg = "#e0b040" }, { token = "$tr", fg = "#e05050" }],',
+    '  [{ token = "$summary", fg = "#89b4fa", dim = true }],',
+    '  [{ token = "$ctx_bar_unknown", fg = "#a6adc8", dim = true }],',
+    '  [{ token = "$ctx_bar_green", fg = "#a6e3a1", dim = true }],',
+    '  [{ token = "$ctx_bar_yellow", fg = "#f9e2af", dim = true }],',
+    '  [{ token = "$ctx_bar_red", fg = "#f38ba8", dim = true }],',
+    ']',
+    '',
+    '[ui]',
+    'agent_panel_sort = "spaces"',
+    '',
+  ].join('\n');
+
+  const install = config => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-herdr-migrate-'));
+    const configPath = path.join(dir, 'config.toml');
+    fs.writeFileSync(configPath, config);
+    const env = { HERDR_CONFIG_PATH: configPath, CCXRAY_HERDR_SKIP_RELOAD: '1' };
+    const result = runScript('install-sidebar-summary.js', [], env);
+    return { result, configPath, env, after: fs.readFileSync(configPath, 'utf8') };
+  };
+  // Line-scan to the array's own closing bracket: indexOf(']') would stop at the
+  // first row's own bracket.
+  const sidebarRows = (config) => {
+    const lines = config.split('\n');
+    const start = lines.findIndex(line => /^\s*rows\s*=\s*\[/.test(line));
+    const rows = [];
+    for (const line of lines.slice(start + 1)) {
+      if (/^\s*\]/.test(line)) break;
+      if (/^\s*\[/.test(line)) rows.push(line);
+    }
+    return rows;
+  };
+
+  // FAIL-ON-OLD: the previous installer appended, so `$summary` and the atomic
+  // row both survive and the array grows instead of shrinking.
+  it('replaces every superseded generation instead of stacking on top', () => {
+    const { result, after } = install(ACCUMULATED);
+    assert.equal(result.status, 0, result.stderr);
+    for (const dead of ['$summary', '$tg', '$ty', '$tr']) {
+      assert.equal(after.includes(dead), false, `${dead} must be gone`);
+    }
+    // `$ctx`/`$model`/`$cost` are gone as a ROW; $ctx_bar_* legitimately contains
+    // the substring `$ctx`, so assert on the row rather than on the text.
+    assert.equal(sidebarRows(after).some(row => /"\$ctx"/.test(row)), false);
+    assert.equal(sidebarRows(after).some(row => /"\$model"/.test(row)), false);
+    assert.equal(sidebarRows(after).some(row => /"\$cost"/.test(row)), false);
+
+    assert.match(after, /\$facts/);
+    assert.match(after, /\$alert/);
+    assert.match(after, /\["state_icon", "agent", "state_text"\]/);
+    // Seven config rows: row 1, four ctx_bar colour variants, and row 3's pair.
+    // Herdr skips rows whose tokens are all empty, so this renders three lines.
+    assert.equal(sidebarRows(after).length, 7);
+    // The user's other tables are untouched.
+    assert.match(after, /agent_panel_sort = "spaces"/);
+    assert.equal(after.match(/\[ui\.sidebar\.agents\]/g).length, 1);
+  });
+
+  it('is idempotent', () => {
+    const first = install(ACCUMULATED);
+    const second = runScript('install-sidebar-summary.js', [], first.env);
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(fs.readFileSync(first.configPath, 'utf8'), first.after,
+      'a second run must not change the file');
+    assert.match(second.stdout, /already installed/);
+  });
+
+  it('keeps a superseded row the user extended, because we cannot know which half they wanted', () => {
+    const { after } = install([
+      '[ui.sidebar.agents]',
+      'rows = [',
+      '  ["$summary", "$mine"],',
+      ']',
+      '',
+    ].join('\n'));
+    assert.match(after, /\["\$summary", "\$mine"\]/);
+    assert.match(after, /\$facts/);
+  });
+
+  it('reports what it deleted, so a surprising removal is visible', () => {
+    const { result } = install(ACCUMULATED);
+    assert.match(result.stdout, /superseded row removed: \$ctx \$model \$cost/);
+    assert.match(result.stdout, /superseded row removed: \$tg \$ty \$tr/);
+    assert.match(result.stdout, /superseded row removed: \$summary/);
+  });
+
+  it('Quick Start and the installer agree on what installed means', () => {
+    const { configHasManagedRows } = require('../plugins/herdr/bin/install-sidebar-summary');
+    assert.equal(configHasManagedRows(ACCUMULATED), false, 'the old generation is not installed');
+    const { after } = install(ACCUMULATED);
+    assert.equal(configHasManagedRows(after), true);
+    // A commented-out example row is not an installation.
+    const commented = after.split('\n').map(l => (l.includes('$facts') ? `#${l}` : l)).join('\n');
+    assert.equal(configHasManagedRows(commented), false);
+  });
+});
+
 describe('ensureProxy cold start', () => {
   // `ccxray --no-browser` with no agent is a FOREGROUND standalone server (a hub
   // is forked only by `ccxray <agent>` without --port). ensureProxy used
@@ -3870,11 +3980,15 @@ describe('Herdr plugin commands', () => {
     assert.equal(result.status, 0, result.stderr);
     const config = fs.readFileSync(configPath, 'utf8');
     assert.match(config, /\[ui\.sidebar\.agents\]/);
-    assert.match(config, /\$summary/);
     assert.match(config, /\$ctx_bar_unknown/);
     assert.match(config, /\$ctx_bar_green/);
     assert.match(config, /\$ctx_bar_yellow/);
     assert.match(config, /\$ctx_bar_red/);
+    // Row 3 replaced $summary: every field the one-line summary carried now has
+    // an owning row, so a fresh install must not write it back.
+    assert.match(config, /\$facts/);
+    assert.match(config, /\$alert/);
+    assert.doesNotMatch(config, /\$summary/);
     assert.doesNotMatch(config, /token\s*=\s*"\$ctx_bar"/);
     assert.match(result.stdout, /backup:/);
   });
@@ -3947,7 +4061,7 @@ describe('Herdr plugin commands', () => {
 
     const install = runScript('install-sidebar-summary.js', [], env);
     assert.equal(install.status, 0, install.stderr);
-    assert.match(fs.readFileSync(configPath, 'utf8'), /\$summary/);
+    assert.match(fs.readFileSync(configPath, 'utf8'), /\$facts/);
     assert.equal(fs.existsSync(path.join(home, '.config', 'herdr', 'config.toml')), false);
 
     const quickStart = runScript('onboarding.js', ['--once'], {
@@ -3976,13 +4090,20 @@ describe('Herdr plugin commands', () => {
     });
     assert.equal(result.status, 0, result.stderr);
     const config = fs.readFileSync(configPath, 'utf8');
-    assert.match(config, /\$summary/);
+    // The old installer could only APPEND, so this config came back with the new
+    // rows stacked on the old ones and rendered MORE duplication. The $summary
+    // row is now removed, which is the whole point of the migration.
+    assert.doesNotMatch(config, /\$summary/);
     assert.match(config, /\$ctx_bar_unknown/);
     assert.match(config, /\$ctx_bar_green/);
-    assert.match(config, /\$ctx_bar_unknown/);
     assert.match(config, /\$ctx_bar_yellow/);
     assert.match(config, /\$ctx_bar_red/);
-    assert.match(result.stdout, /updated sidebar summary rows/);
+    assert.match(config, /\$facts/);
+    assert.match(config, /\$alert/);
+    // The user's own row is not ours to delete.
+    assert.match(config, /\["agent"\]/);
+    assert.match(result.stdout, /superseded row removed: \$summary/);
+    assert.match(result.stdout, /migrated sidebar summary rows/);
   });
 
   it('install-sidebar-summary upgrades the uncolored ctx_bar row to color rows', () => {
@@ -4008,7 +4129,7 @@ describe('Herdr plugin commands', () => {
     assert.match(config, /\$ctx_bar_yellow/);
     assert.match(config, /\$ctx_bar_red/);
     assert.doesNotMatch(config, /token\s*=\s*"\$ctx_bar"/);
-    assert.match(result.stdout, /updated sidebar summary rows/);
+    assert.match(result.stdout, /migrated sidebar summary rows/);
   });
 
   it('remove-sidebar-summary removes only ccxray rows and keeps the Herdr layout valid', () => {
@@ -4078,7 +4199,8 @@ describe('Herdr plugin commands', () => {
     });
     assert.equal(result.status, 0, result.stderr);
     const config = fs.readFileSync(configPath, 'utf8');
-    assert.match(config, /\$summary/);
+    assert.match(config, /\$facts/);
+    assert.match(config, /\$alert/);
     assert.match(config, /\$ctx_bar_unknown/);
     assert.match(config, /\$ctx_bar_green/);
     assert.match(config, /\$ctx_bar_yellow/);
@@ -4115,10 +4237,13 @@ describe('Herdr plugin commands', () => {
     const reinstalled = runScript('install-sidebar-summary.js', [], env);
     assert.equal(reinstalled.status, 0, reinstalled.stderr);
     const config = fs.readFileSync(configPath, 'utf8');
-    assert.match(config, /\$summary/);
+    assert.match(config, /\$facts/);
     assert.match(config, /\$ctx_bar_red/);
     assert.match(config, /\["agent"\]/);
-    assert.equal(config.match(/\$summary/g).length, 1);
+    // One row each: a reinstall must not stack a second copy, which is the
+    // add-only behaviour the migration replaced.
+    assert.equal(config.match(/\$facts/g).length, 1);
+    assert.equal(config.match(/\$alert/g).length, 1);
   });
 
   // Herdr's manifest cannot declare keybindings, so a plugin either documents a
@@ -4284,7 +4409,8 @@ describe('Herdr plugin commands', () => {
     assert.equal(runScript('install-sidebar-summary.js', [], env).status, 0);
 
     const extended = fs.readFileSync(configPath, 'utf8')
-      .replace('  ["agent"],', '  ["agent"],\n  ["cwd"],');
+      .replace('  ["state_icon", "agent", "state_text"],',
+        '  ["state_icon", "agent", "state_text"],\n  ["cwd"],');
     fs.writeFileSync(configPath, extended);
 
     assert.equal(runScript('remove-sidebar-summary.js', [], env).status, 0);


### PR DESCRIPTION
## 摘要

Sidebar 從累積 8 列（3 處重複、4 處截斷）重構為固定三行版面，每行語意單一：
- **Row 1**: herdr 原生 `state_icon · agent · state_text`（idle/working）
- **Row 2**: context sparkline + cache%（只有 context 事實）
- **Row 3**: `$facts`（灰，cost · age）或 `$alert`（警示色，最重要的問題）

## Detail

### Shared concern ranking (ADR 0005 shape)

`PANE_CONCERN_TIERS` is the single source for "what is the most important thing about this pane right now." Both the sidebar badge's row-3 `$alert` and Mission Control's action chain read it. Previously two orderings contradicted each other — `contextSignal` ranked context above every tool failure, while the MC action chain ranked `fail >= 2` above context and `cache dropped` above `fail == 1`.

The `$alert` priority order (owner-signed-off): quota-refused > stale > fail > cache-dropped. `sidebarOwned` tiers (context, blocked, no-telemetry) are skipped by row 3 because rows 1 and 2 already render them.

### Installer migration

The old installer could only APPEND rows. A real config had 8 rows accumulated across three generations — `["$ctx","$model","$cost"]`, dead `$tg/$ty/$tr`, `$summary`, and four `$ctx_bar_*` colour rows. Running the old installer made it worse. `migrateRowsArray` now replaces superseded generations and legacy default rows (gated on SECTION_MARKER to protect user-authored tables).

### Two bugs found only through live e2e verification

1. **16-token pane metadata cap**: herdr caps `report-metadata` at 16 unique token names (set + clear combined). The plugin was sending 17. Every badge refresh failed silently. Invisible in unit tests because `reportPaneTokens` is mocked. Fixed by whitelisting only the 7 tokens config rows actually render.

2. **Header parse pollution (#575 regression)**: Node joins duplicate HTTP headers with `, `. A ccxray-launched shell prepends its own `ANTHROPIC_CUSTOM_HEADERS`, so the server saw `herdr:wY:old, X-Ccxray-Auth: ..., X-Ccxray-Agent-Id: herdr:w1D:new` as one string. Badge matching via `agentId` broke for every pane launched from a ccxray-managed shell. Fixed by taking the last `herdr:`-prefixed segment.

### What this does NOT do

- Sidebar freshness guarantee — the 250ms `waitForTelemetry` delay is still a time guess, not a causal barrier. Filed as #581 (P7 visibility barrier with per-pane cursor), designed by a three-model adversarial panel (Fable + Codex GPT 5.6 Sol + Sonnet).
- ADR 0013 provenance markers on the badge (row 2 space available but independent of row 3).
- `prefix+d` keybinding — `lib/keybindings.js` has an in-tree decision that two keys is the ceiling. `prefix+m` → `d` is two keystrokes.
- Quota percentage / reset ETA (#571).

## Verification

- **Unit tests**: 2302/2302 (CCXRAY_HOME=$(mktemp -d), env scrubbed)
- **Codex gate**: clean after 2 rounds (3 findings R1, 1 finding R2, all fixed)
- **Multi-provider smoke**: claude/codex/grok badge tokens verified on real index (252K anthropic + 35K openai entries)
- **Live e2e**: plugin link → install migration → launch-claude via proxy → prompt → auto badge refresh → `herdr pane get` confirms three-row rendering with `state_labels: {}` and correct token whitelist
- **Fail-on-old**: every behaviour change has differential evidence (restoration proved by probe, red on old code, green on new)

codex gate clean

## Test plan

- [ ] `CCXRAY_HOME=$(mktemp -d) npm test` — 2302/2302
- [ ] Run `install-sidebar-summary` on a config with the old 8-row layout → 7 rows, 3 visible
- [ ] Launch claude via the plugin's `launch-claude` action → badge auto-refreshes with three rows
- [ ] `herdr pane get <pane>` shows `state_labels: {}` for a located pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)