### PR TITLE
fix(parser): extractOpenAIToolCalls misses custom_tool_call (#577)

### DIFF
--- a/server/helpers.js
+++ b/server/helpers.js
@@ -853,8 +853,25 @@ function buildToolSources(entry) {
 const OPENAI_TOOL_ALIASES = { exec_command: 'Bash', shell: 'Bash', read_mcp_resource: 'Read', apply_patch: 'Edit' };
 const OPENAI_PROCESS_TOOLS = new Set(['exec', 'exec_command', 'shell', 'run_terminal_command', 'process']);
 
-// Extract tool call counts from Codex Responses API event stream.
-// Scans response.output_item.done events for function_call items.
+// #577: extract embedded MCP tool names from Codex exec input (JavaScript code string)
+const MCP_EXEC_RE = /tools\.(mcp__\w+)/g;
+function extractMcpFromExecInput(input) {
+  if (typeof input !== 'string') return [];
+  const names = [];
+  let m;
+  while ((m = MCP_EXEC_RE.exec(input)) !== null) names.push(m[1]);
+  MCP_EXEC_RE.lastIndex = 0;
+  return names;
+}
+
+// #577: extract MCP tool name from Grok use_tool arguments (JSON with tool_name field)
+function extractMcpFromUseToolArgs(args) {
+  if (typeof args !== 'string') return null;
+  try { return JSON.parse(args).tool_name || null; } catch { return null; }
+}
+
+// Extract tool call counts from Codex/Grok Responses API event stream.
+// Scans response.output_item.done events for function_call/custom_tool_call items.
 // Falls back to response.output_item.added if .done events are absent.
 function extractOpenAIToolCalls(responseEventsOrOutput) {
   const counts = {};
@@ -866,13 +883,32 @@ function extractOpenAIToolCalls(responseEventsOrOutput) {
     const isEvent = typeof ev.type === 'string' && ev.type.startsWith('response.');
     if (isEvent && ev.type !== 'response.output_item.done' && ev.type !== 'response.output_item.added') continue;
     const item = isEvent ? ((ev.data && ev.data.item) || ev.item || {}) : ev;
-    if (item.type !== 'function_call' && item.type !== 'tool_call') continue;
+    // #577 fix 1: add custom_tool_call (aligns with extractOpenAIToolCallIds)
+    if (item.type !== 'function_call' && item.type !== 'custom_tool_call' && item.type !== 'tool_call') continue;
     const itemKey = item.call_id || item.id || '';
     if (itemKey && seen.has(itemKey)) continue;
     if (itemKey) seen.add(itemKey);
     const rawName = item.name || item.function?.name;
     if (!rawName) continue;
-    const name = OPENAI_TOOL_ALIASES[rawName] || rawName;
+
+    // #577 fix 3: Grok use_tool gateway — extract real MCP tool name
+    if (rawName === 'use_tool') {
+      const mcpName = extractMcpFromUseToolArgs(item.arguments);
+      if (mcpName) {
+        counts[mcpName] = (counts[mcpName] || 0) + 1;
+        continue;
+      }
+    }
+
+    // #577 fix 4: align alias logic with extractOpenAIToolCallIds
+    const name = OPENAI_PROCESS_TOOLS.has(rawName) ? 'Bash' : (OPENAI_TOOL_ALIASES[rawName] || rawName);
+
+    // #577 fix 2: extract embedded MCP names from exec input
+    if (OPENAI_PROCESS_TOOLS.has(rawName) && item.input) {
+      const mcpNames = extractMcpFromExecInput(item.input);
+      for (const mn of mcpNames) counts[mn] = (counts[mn] || 0) + 1;
+    }
+
     counts[name] = (counts[name] || 0) + 1;
   }
   return counts;
@@ -1182,6 +1218,7 @@ module.exports = {
   extractOpenAITurnToolFail, extractOpenAITurnToolResults,
   decodeCodexToolOutput, CODEX_ASYNC_START, aggregateToolFailResults,
   OPENAI_TOOL_ALIASES, OPENAI_PROCESS_TOOLS,
+  extractMcpFromExecInput, extractMcpFromUseToolArgs,
   extractDuplicateToolCalls,
   scanCredentials,
   scanObjectForCredentials,

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -852,16 +852,13 @@ function buildToolSources(entry) {
 // Server-side alias map for Codex tool names (mirrors client CODEX_TOOL_ALIASES).
 const OPENAI_TOOL_ALIASES = { exec_command: 'Bash', shell: 'Bash', read_mcp_resource: 'Read', apply_patch: 'Edit' };
 const OPENAI_PROCESS_TOOLS = new Set(['exec', 'exec_command', 'shell', 'run_terminal_command', 'process']);
+// #577: shared predicate — both extractors use this, so new types are added once
+const OPENAI_TOOL_CALL_TYPES = new Set(['function_call', 'custom_tool_call', 'tool_call']);
 
 // #577: extract embedded MCP tool names from Codex exec input (JavaScript code string)
-const MCP_EXEC_RE = /tools\.(mcp__\w+)/g;
 function extractMcpFromExecInput(input) {
   if (typeof input !== 'string') return [];
-  const names = [];
-  let m;
-  while ((m = MCP_EXEC_RE.exec(input)) !== null) names.push(m[1]);
-  MCP_EXEC_RE.lastIndex = 0;
-  return names;
+  return [...input.matchAll(/tools\.(mcp__\w+)/g)].map(m => m[1]);
 }
 
 // #577: extract MCP tool name from Grok use_tool arguments (JSON with tool_name field)
@@ -883,8 +880,7 @@ function extractOpenAIToolCalls(responseEventsOrOutput) {
     const isEvent = typeof ev.type === 'string' && ev.type.startsWith('response.');
     if (isEvent && ev.type !== 'response.output_item.done' && ev.type !== 'response.output_item.added') continue;
     const item = isEvent ? ((ev.data && ev.data.item) || ev.item || {}) : ev;
-    // #577 fix 1: add custom_tool_call (aligns with extractOpenAIToolCallIds)
-    if (item.type !== 'function_call' && item.type !== 'custom_tool_call' && item.type !== 'tool_call') continue;
+    if (!OPENAI_TOOL_CALL_TYPES.has(item.type)) continue;
     const itemKey = item.call_id || item.id || '';
     if (itemKey && seen.has(itemKey)) continue;
     if (itemKey) seen.add(itemKey);
@@ -922,7 +918,7 @@ function extractOpenAIToolCallIds(responseEventsOrOutput) {
     const isEvent = typeof ev.type === 'string' && ev.type.startsWith('response.');
     if (isEvent && ev.type !== 'response.output_item.done' && ev.type !== 'response.output_item.added') continue;
     const item = isEvent ? ((ev.data && ev.data.item) || ev.item || {}) : ev;
-    if (item.type !== 'function_call' && item.type !== 'custom_tool_call' && item.type !== 'tool_call') continue;
+    if (!OPENAI_TOOL_CALL_TYPES.has(item.type)) continue;
     const callId = item.call_id || item.id;
     if (!callId || seen.has(callId)) continue;
     seen.add(callId);
@@ -1217,7 +1213,7 @@ module.exports = {
   extractOpenAIToolCallIds,
   extractOpenAITurnToolFail, extractOpenAITurnToolResults,
   decodeCodexToolOutput, CODEX_ASYNC_START, aggregateToolFailResults,
-  OPENAI_TOOL_ALIASES, OPENAI_PROCESS_TOOLS,
+  OPENAI_TOOL_ALIASES, OPENAI_PROCESS_TOOLS, OPENAI_TOOL_CALL_TYPES,
   extractMcpFromExecInput, extractMcpFromUseToolArgs,
   extractDuplicateToolCalls,
   scanCredentials,

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -873,18 +873,27 @@ function extractMcpFromUseToolArgs(args) {
 function extractOpenAIToolCalls(responseEventsOrOutput) {
   const counts = {};
   if (!Array.isArray(responseEventsOrOutput)) return counts;
-  const seen = new Set();
+  // codex-review P2-1: .done carries the complete payload (input/arguments);
+  // .added arrives first with empty fields and poisons `seen`. Process .done
+  // first so the complete item wins; .added is the fallback only.
+  const sorted = [];
   for (const ev of responseEventsOrOutput) {
-    // WS events: wrapped in { type: 'response.output_item.done', item: {...} }
-    // HTTP output[]: flat items { type: 'function_call', name: '...', ... }
     const isEvent = typeof ev.type === 'string' && ev.type.startsWith('response.');
     if (isEvent && ev.type !== 'response.output_item.done' && ev.type !== 'response.output_item.added') continue;
+    sorted.push({ ev, done: isEvent && ev.type === 'response.output_item.done' });
+  }
+  sorted.sort((a, b) => (b.done ? 1 : 0) - (a.done ? 1 : 0));
+
+  const seen = new Set();
+  for (const { ev } of sorted) {
+    const isEvent = typeof ev.type === 'string' && ev.type.startsWith('response.');
     const item = isEvent ? ((ev.data && ev.data.item) || ev.item || {}) : ev;
     if (!OPENAI_TOOL_CALL_TYPES.has(item.type)) continue;
     const itemKey = item.call_id || item.id || '';
     if (itemKey && seen.has(itemKey)) continue;
     if (itemKey) seen.add(itemKey);
-    const rawName = item.name || item.function?.name;
+    // codex-review P2-2: include item.tool_name (aligns with extractOpenAIToolCallIds + importer)
+    const rawName = item.name || item.function?.name || item.tool_name;
     if (!rawName) continue;
 
     // #577 fix 3: Grok use_tool gateway — extract real MCP tool name

--- a/test/openai-tool-extract.test.js
+++ b/test/openai-tool-extract.test.js
@@ -6,6 +6,7 @@ const {
   extractOpenAIToolCallIds,
   extractMcpFromExecInput,
   extractMcpFromUseToolArgs,
+  OPENAI_TOOL_CALL_TYPES,
 } = require('../server/helpers');
 
 // #577: extractOpenAIToolCalls missed custom_tool_call, causing 98.9% of
@@ -151,5 +152,35 @@ describe('#577 wrapped event format', () => {
     ];
     const counts = extractOpenAIToolCalls(events);
     assert.equal(counts['Bash'], 1);
+  });
+});
+
+describe('#577 fable review fixes', () => {
+  it('both extractors use the same OPENAI_TOOL_CALL_TYPES set', () => {
+    // Pin: adding a new type to the Set covers both extractors
+    assert.ok(OPENAI_TOOL_CALL_TYPES.has('custom_tool_call'));
+    assert.ok(OPENAI_TOOL_CALL_TYPES.has('function_call'));
+    assert.ok(OPENAI_TOOL_CALL_TYPES.has('tool_call'));
+  });
+
+  it('duplicate mcp name in one exec input counts each occurrence', () => {
+    const events = [
+      {
+        type: 'custom_tool_call',
+        call_id: 'c1',
+        name: 'exec',
+        input: 'await tools.mcp__a({x:1}); await tools.mcp__a({x:2});',
+      },
+    ];
+    const counts = extractOpenAIToolCalls(events);
+    assert.equal(counts['mcp__a'], 2, 'two calls to same MCP tool = count 2');
+    assert.equal(counts['Bash'], 1);
+  });
+
+  it('extractMcpFromExecInput is safe across sequential calls (no /g/ state leak)', () => {
+    const a = extractMcpFromExecInput('tools.mcp__x({})');
+    const b = extractMcpFromExecInput('tools.mcp__y({})');
+    assert.deepEqual(a, ['mcp__x']);
+    assert.deepEqual(b, ['mcp__y']);
   });
 });

--- a/test/openai-tool-extract.test.js
+++ b/test/openai-tool-extract.test.js
@@ -1,0 +1,155 @@
+'use strict';
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  extractOpenAIToolCalls,
+  extractOpenAIToolCallIds,
+  extractMcpFromExecInput,
+  extractMcpFromUseToolArgs,
+} = require('../server/helpers');
+
+// #577: extractOpenAIToolCalls missed custom_tool_call, causing 98.9% of
+// Codex tool counts to be invisible. These tests would fail on old code.
+
+describe('#577 extractOpenAIToolCalls fixes', () => {
+  // Fix 1: custom_tool_call type is counted
+  it('counts custom_tool_call items (fail-on-old: old code returns {})', () => {
+    const events = [
+      { type: 'custom_tool_call', call_id: 'c1', name: 'exec', input: 'ls' },
+      { type: 'custom_tool_call', call_id: 'c2', name: 'read_file', input: 'a.js' },
+    ];
+    const counts = extractOpenAIToolCalls(events);
+    assert.ok(Object.keys(counts).length > 0, 'should have counts');
+    assert.equal(counts['read_file'], 1);
+  });
+
+  // Fix 2: MCP names extracted from exec input
+  it('extracts mcp__ names from exec input alongside Bash count', () => {
+    const events = [
+      {
+        type: 'custom_tool_call',
+        call_id: 'c1',
+        name: 'exec',
+        input: 'const r = await tools.mcp__node_repl__js({code:"1+1"});\nconst s = await tools.mcp__codex_apps__drive({q:"test"});',
+      },
+    ];
+    const counts = extractOpenAIToolCalls(events);
+    assert.equal(counts['Bash'], 1, 'exec itself counts as Bash');
+    assert.equal(counts['mcp__node_repl__js'], 1);
+    assert.equal(counts['mcp__codex_apps__drive'], 1);
+  });
+
+  it('does not extract mcp names from non-process-tool input', () => {
+    const events = [
+      {
+        type: 'custom_tool_call',
+        call_id: 'c1',
+        name: 'read_file',
+        input: 'tools.mcp__fake__thing()',
+      },
+    ];
+    const counts = extractOpenAIToolCalls(events);
+    assert.equal(counts['read_file'], 1);
+    assert.equal(counts['mcp__fake__thing'], undefined, 'should not extract from non-exec');
+  });
+
+  // Fix 3: Grok use_tool gateway
+  it('extracts real MCP tool name from use_tool arguments', () => {
+    const events = [
+      {
+        type: 'function_call',
+        call_id: 'c1',
+        name: 'use_tool',
+        arguments: JSON.stringify({ tool_name: 'linear__save_issue', tool_input: { title: 'test' } }),
+      },
+    ];
+    const counts = extractOpenAIToolCalls(events);
+    assert.equal(counts['linear__save_issue'], 1);
+    assert.equal(counts['use_tool'], undefined, 'use_tool itself should not be counted');
+  });
+
+  it('falls back to use_tool when arguments parsing fails', () => {
+    const events = [
+      { type: 'function_call', call_id: 'c1', name: 'use_tool', arguments: 'not-json' },
+    ];
+    const counts = extractOpenAIToolCalls(events);
+    assert.equal(counts['use_tool'], 1);
+  });
+
+  // Fix 4: alias consistency — exec → Bash in both extractors
+  it('maps exec to Bash consistently in both extractors', () => {
+    const events = [
+      { type: 'custom_tool_call', call_id: 'c1', name: 'exec', input: 'echo hi' },
+    ];
+    const counts = extractOpenAIToolCalls(events);
+    assert.equal(counts['Bash'], 1, 'extractOpenAIToolCalls: exec → Bash');
+
+    const ids = extractOpenAIToolCallIds(events);
+    assert.equal(ids['c1'], 'Bash', 'extractOpenAIToolCallIds: exec → Bash');
+  });
+
+  it('maps run_terminal_command to Bash in both extractors', () => {
+    const events = [
+      { type: 'function_call', call_id: 'c1', name: 'run_terminal_command' },
+    ];
+    const counts = extractOpenAIToolCalls(events);
+    assert.equal(counts['Bash'], 1);
+    const ids = extractOpenAIToolCallIds(events);
+    assert.equal(ids['c1'], 'Bash');
+  });
+});
+
+describe('#577 MCP extraction helpers', () => {
+  it('extractMcpFromExecInput extracts mcp__ tool names', () => {
+    const input = 'const r = await tools.mcp__node_repl__js({code:"1"});';
+    assert.deepEqual(extractMcpFromExecInput(input), ['mcp__node_repl__js']);
+  });
+
+  it('extractMcpFromExecInput returns empty for no matches', () => {
+    assert.deepEqual(extractMcpFromExecInput('echo hello'), []);
+    assert.deepEqual(extractMcpFromExecInput(null), []);
+    assert.deepEqual(extractMcpFromExecInput(42), []);
+  });
+
+  it('extractMcpFromExecInput handles multiple names', () => {
+    const input = 'tools.mcp__a({});\ntools.mcp__b({});';
+    assert.deepEqual(extractMcpFromExecInput(input), ['mcp__a', 'mcp__b']);
+  });
+
+  it('extractMcpFromUseToolArgs extracts tool_name from JSON', () => {
+    assert.equal(
+      extractMcpFromUseToolArgs(JSON.stringify({ tool_name: 'linear__save_issue' })),
+      'linear__save_issue'
+    );
+  });
+
+  it('extractMcpFromUseToolArgs returns null for bad input', () => {
+    assert.equal(extractMcpFromUseToolArgs('not json'), null);
+    assert.equal(extractMcpFromUseToolArgs(null), null);
+    assert.equal(extractMcpFromUseToolArgs(JSON.stringify({})), null);
+  });
+});
+
+describe('#577 wrapped event format', () => {
+  it('handles WS event wrappers with custom_tool_call', () => {
+    const events = [
+      {
+        type: 'response.output_item.done',
+        item: { type: 'custom_tool_call', call_id: 'c1', name: 'exec', input: 'pwd' },
+      },
+    ];
+    const counts = extractOpenAIToolCalls(events);
+    assert.equal(counts['Bash'], 1);
+  });
+
+  it('handles WS event wrappers with data.item', () => {
+    const events = [
+      {
+        type: 'response.output_item.done',
+        data: { item: { type: 'custom_tool_call', call_id: 'c1', name: 'exec', input: 'ls' } },
+      },
+    ];
+    const counts = extractOpenAIToolCalls(events);
+    assert.equal(counts['Bash'], 1);
+  });
+});

--- a/test/openai-tool-extract.test.js
+++ b/test/openai-tool-extract.test.js
@@ -184,3 +184,33 @@ describe('#577 fable review fixes', () => {
     assert.deepEqual(b, ['mcp__y']);
   });
 });
+
+describe('#577 codex review P2 fixes', () => {
+  // P2-1: .done must win over .added when both carry the same call_id
+  it('prefers .done over .added so MCP names in input are extracted', () => {
+    const events = [
+      // .added arrives first with empty input
+      {
+        type: 'response.output_item.added',
+        item: { type: 'custom_tool_call', call_id: 'c1', name: 'exec', input: '' },
+      },
+      // .done arrives later with real input
+      {
+        type: 'response.output_item.done',
+        item: { type: 'custom_tool_call', call_id: 'c1', name: 'exec', input: 'const r = await tools.mcp__node_repl__js({code:"1"});' },
+      },
+    ];
+    const counts = extractOpenAIToolCalls(events);
+    assert.equal(counts['Bash'], 1);
+    assert.equal(counts['mcp__node_repl__js'], 1, '.done input should be used, not .added empty input');
+  });
+
+  // P2-2: tool_name fallback for custom_tool_call items
+  it('reads tool_name when name is absent (custom_tool_call shape)', () => {
+    const events = [
+      { type: 'custom_tool_call', call_id: 'c1', tool_name: 'exec_command' },
+    ];
+    const counts = extractOpenAIToolCalls(events);
+    assert.equal(counts['Bash'], 1, 'tool_name should be read and aliased');
+  });
+});


### PR DESCRIPTION
## Summary

- `extractOpenAIToolCalls` 漏了 `custom_tool_call` type，導致 Codex 98.9% 的 tool 計數為空
- 從 Codex `exec` input 提取嵌入的 MCP tool 名稱（`tools.mcp__*` pattern）
- 從 Grok `use_tool` arguments 提取真實 MCP tool 名稱（`tool_name` field）
- 統一兩個 extractor 的 alias 邏輯（`exec` → `Bash`）
- Fable review 採納：共享 `OPENAI_TOOL_CALL_TYPES` Set + `matchAll` 取代 `/g/` regex + 測試盲點

## Detail

### Commit 1: fix — 四項修正

1. **`custom_tool_call` type check** — aligns with `extractOpenAIToolCallIds` which already had it. Codex 0.149+ uses `custom_tool_call` exclusively; `function_call` count is 0.
2. **MCP extraction from exec input** — `extractMcpFromExecInput()` finds embedded MCP calls in Codex's JavaScript exec input. MCP names are counted alongside the `Bash` count (not aliased).
3. **Grok use_tool gateway** — `extractMcpFromUseToolArgs()` JSON-parses `use_tool` arguments to extract `tool_name`. Falls back to counting `use_tool` itself if parse fails.
4. **Alias consistency** — now uses `OPENAI_PROCESS_TOOLS.has()` check before `OPENAI_TOOL_ALIASES`, matching `extractOpenAIToolCallIds`.

### Commit 2: refactor — fable review 採納

1. **`OPENAI_TOOL_CALL_TYPES` 共享 Set** — 兩個 extractor 都用同一個 Set，新 type 加一處。本 PR 修的 bug 就是這類漂移——同 PR 裡就結構性預防。
2. **`matchAll` 取代 module-level `/g/` regex** — 消除 shared mutable state（`lastIndex` 在 early return 時 leak）。
3. **測試盲點** — 同名 MCP 重複出現計數行為 pin 住 + sequential call 無 state leak。

### Known limitations (not in scope)

- `extractOpenAIToolCallIds` 不解包 `use_tool`/`exec` gateway 名稱（設計上正確：wire name 用於配對 tool output，語意 name 用於統計，兩者應不同）
- `use_tool` parse 失敗時 fallback 計 `use_tool` 本身（BQ 無法區分真 tool 和解析失敗的 gateway，但實測 0 次 parse 失敗）

## Test plan

- [x] 17 tests in `test/openai-tool-extract.test.js` — all 4 fixes + fable review items
- [x] Fail-on-old verified (拋棄式 worktree @ `063f991`):
  - Step 1: 舊碼 + 不含新測試 → 2307 pass / 0 fail（基準乾淨）
  - Step 2: 舊碼 + 只加新測試 → 16 fail / 1 pass（1 pass = fallback regression guard，非 diff evidence）
  - Step 3: 新碼 + 新測試 → 2324 pass / 0 fail
- [x] Independent review: fable adversarial review → 5 suggestions, 3 adopted (commit 2)

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPxvkLuJ4bPgYTPAyaebmP