### PR TITLE
Arm hub-client shutdown before registering, and fix the flaky SIGHUP e2e

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ Before pushing, confirm the suite passes against an empty home: `CCXRAY_HOME=$(m
 | `server/routes/costs.js` | Cost budget endpoints |
 | `server/hub.js` | Multi-project hub: lockfile (`~/.ccxray/hub.json`), discovery (with orphan port probe fallback), client registration, idle shutdown (injectable via setOnShutdown), crash auto-recovery |
 | `server/auth.js` | API key auth middleware (enabled via `AUTH_TOKEN` env) |
+| `server/client-shutdown.js` | Hub-client graceful shutdown. `armClientShutdown` must be armed BEFORE `hub.registerClient()` — an unarmed SIGHUP/SIGTERM keeps its OS default disposition and kills the process without unregistering, leaving a phantom client until the hub's 30s dead-client sweep |
 | `server/openai-response.js` | OpenAI Responses API helpers: response-object detection, field extraction |
 | `server/ws-proxy.js` | OpenAI WebSocket transport proxy for `/v1/responses` and `/v1/realtime` upgrades. Tracks active sessions + pending `recordWebSocketEntry` promises so `drainWebSocketProxy()` can force-finalize stragglers and await writes on shutdown. Tunables: `CCXRAY_WS_IDLE_TIMEOUT_MS` (default 60s), `CCXRAY_WS_MAX_QUEUE_BYTES` (default 4 MiB; caps client→upstream buffer while upstream is connecting) |
 | `server/entry.js` | `INDEX_FIELDS`, `buildIndexLine`, `deploymentFields` — the index-line schema definition. Invariants reference this file |

--- a/server/client-shutdown.js
+++ b/server/client-shutdown.js
@@ -1,0 +1,80 @@
+'use strict';
+
+// Graceful shutdown for a ccxray process running in HUB CLIENT mode.
+//
+// INVARIANT: armClientShutdown must be called BEFORE hub.registerClient()
+// resolves. Until a SIGHUP/SIGTERM listener exists those signals keep their OS
+// default disposition and kill the process outright, skipping
+// hub.unregisterClient() — and the hub only prunes by pid liveness every
+// DEAD_CLIENT_CHECK_MS (30s, server/hub.js), so a pane closed inside the
+// register→spawnAgent window left a phantom client blocking hub idle shutdown
+// for half a minute. That window is the statusline check plus the spawn itself,
+// ~1ms wide, which made test/hub-client-signal.e2e.test.js fail ~20% of runs
+// locally and twice on CI in two days (runs 32361079591, 32473160514).
+//
+// SIGINT is deliberately NOT armed: spawnAgent installs a no-op so the terminal
+// delivers Ctrl-C to the foreground child, and a no-op installed before a child
+// exists would leave Ctrl-C unable to abort startup at all.
+
+// A localhost unix-socket round trip, so anything approaching this bound is a
+// wedged hub rather than a slow one. Exiting without the unregister is degraded
+// but recoverable (the hub's dead-client sweep reclaims the slot); a pane the
+// user cannot close is not.
+const UNREGISTER_DEADLINE_MS = 1000;
+
+// The exit code is part of what an observer sees, so the two sides of the
+// register→spawn window should agree — but they can only agree in the common
+// case, not by construction: with an agent running, spawnAgent PASSES THROUGH
+// the agent's own exit code (`finish(code ?? …)`), and here there is no agent
+// to pass through. An agent that handles SIGHUP exits 0, so the client exits 0
+// (measured, and asserted by test/hub-client-signal.e2e.test.js); 0 here keeps
+// the window invisible for that case and is the honest report anyway — nothing
+// failed, we were asked to stop. The `: 1` in that expression is the
+// agent-killed-by-an-unhandled-signal branch, which has no analogue on a path
+// where no agent ever started.
+const SHUTDOWN_EXIT_CODE = 0;
+
+function armClientShutdown(lock, getChild, deps = {}) {
+  const hub = deps.hub || require('./hub');
+  const exit = deps.exit || (code => process.exit(code));
+  const on = deps.on || ((signal, fn) => process.on(signal, fn));
+  const deadlineMs = deps.deadlineMs ?? UNREGISTER_DEADLINE_MS;
+  let shuttingDown = false;
+  // Once-only, and shared by every exit path below. The repeat-signal branch
+  // must go through it too: exit() is injectable, so it is not guaranteed to be
+  // terminal, and without the shared guard a later-settling unregister exits a
+  // second time.
+  let exited = false;
+  const finish = (code) => { if (exited) return; exited = true; exit(code); };
+
+  const onSignal = (signal) => {
+    const child = getChild();
+    // Child alive: forwarding is enough — its exit drives spawnAgent's onExit,
+    // which unregisters and exits. Nothing to do here.
+    if (child && child.exitCode == null && child.signalCode == null) {
+      child.kill(signal);
+      return;
+    }
+    // A repeat signal while the unregister is still in flight is the user
+    // insisting. Leave now rather than keep waiting on the hub.
+    if (shuttingDown) { finish(SHUTDOWN_EXIT_CODE); return; }
+    shuttingDown = true;
+    const deadline = setTimeout(() => finish(SHUTDOWN_EXIT_CODE), deadlineMs);
+    if (deadline.unref) deadline.unref();
+    hub.unregisterClient(lock, process.pid).finally(() => {
+      clearTimeout(deadline);
+      finish(SHUTDOWN_EXIT_CODE);
+    });
+  };
+
+  on('SIGHUP', () => onSignal('SIGHUP'));
+  on('SIGTERM', () => onSignal('SIGTERM'));
+
+  // The caller MUST gate the agent spawn on this. exit() fires on a hub socket
+  // round trip, so a spawn racing it leaves the agent running with its parent
+  // gone — measured before this existed: the client exited 129 while the agent
+  // it had just spawned stayed alive.
+  return () => shuttingDown;
+}
+
+module.exports = { armClientShutdown, SHUTDOWN_EXIT_CODE, UNREGISTER_DEADLINE_MS };

--- a/server/client-shutdown.js
+++ b/server/client-shutdown.js
@@ -2,79 +2,159 @@
 
 // Graceful shutdown for a ccxray process running in HUB CLIENT mode.
 //
-// INVARIANT: armClientShutdown must be called BEFORE hub.registerClient()
-// resolves. Until a SIGHUP/SIGTERM listener exists those signals keep their OS
-// default disposition and kill the process outright, skipping
-// hub.unregisterClient() — and the hub only prunes by pid liveness every
-// DEAD_CLIENT_CHECK_MS (30s, server/hub.js), so a pane closed inside the
-// register→spawnAgent window left a phantom client blocking hub idle shutdown
-// for half a minute. That window is the statusline check plus the spawn itself,
-// ~1ms wide, which made test/hub-client-signal.e2e.test.js fail ~20% of runs
-// locally and twice on CI in two days (runs 32361079591, 32473160514).
+// INVARIANT: armClientShutdown must be called BEFORE hub.registerClient() is
+// invoked. Until a listener exists, SIGHUP/SIGTERM/SIGINT keep their OS default
+// disposition and kill the process outright, skipping hub.unregisterClient() —
+// and the hub only prunes by pid liveness every DEAD_CLIENT_CHECK_MS (30s,
+// server/hub.js), so a pane closed inside the register→spawnAgent window left a
+// phantom client blocking hub idle shutdown for half a minute. That window is
+// the statusline check plus the spawn itself, ~1ms wide, which made
+// test/hub-client-signal.e2e.test.js fail ~20% of runs locally and twice on CI
+// in two days (runs 32361079591, 32473160514).
 //
-// SIGINT is deliberately NOT armed: spawnAgent installs a no-op so the terminal
-// delivers Ctrl-C to the foreground child, and a no-op installed before a child
-// exists would leave Ctrl-C unable to abort startup at all.
+// test/hub-client-signal.e2e.test.js drives this end to end by standing up a
+// FAKE hub socket and simply not answering `register` until it chooses to, which
+// makes that window as wide as the test wants with no test-only branch in the
+// server. test/client-shutdown.test.js covers the interleavings even that cannot
+// reach, plus the source-order facts, the way
+// test/invariant-encapsulation.test.js pins the store push sites.
 
-// A localhost unix-socket round trip, so anything approaching this bound is a
-// wedged hub rather than a slow one. Exiting without the unregister is degraded
-// but recoverable (the hub's dead-client sweep reclaims the slot); a pane the
-// user cannot close is not.
+// PER PHASE, not for the shutdown as a whole. Each is a localhost unix-socket
+// round trip, so anything approaching this bound is a wedged hub rather than a
+// slow one. Exiting without the unregister is degraded but recoverable (the
+// hub's dead-client sweep reclaims the slot); a pane the user cannot close is
+// not, which is why the worst case stays at 2× this rather than growing with
+// however long the hub takes.
 const UNREGISTER_DEADLINE_MS = 1000;
 
-// The exit code is part of what an observer sees, so the two sides of the
-// register→spawn window should agree — but they can only agree in the common
-// case, not by construction: with an agent running, spawnAgent PASSES THROUGH
-// the agent's own exit code (`finish(code ?? …)`), and here there is no agent
-// to pass through. An agent that handles SIGHUP exits 0, so the client exits 0
-// (measured, and asserted by test/hub-client-signal.e2e.test.js); 0 here keeps
-// the window invisible for that case and is the honest report anyway — nothing
-// failed, we were asked to stop. The `: 1` in that expression is the
-// agent-killed-by-an-unhandled-signal branch, which has no analogue on a path
-// where no agent ever started.
-const SHUTDOWN_EXIT_CODE = 0;
+// ONE mapping, shared with spawnAgent's child-exit handler, which uses it as
+// `finish(code ?? signalExitCode(signal))`. Two separate constants would let the
+// same interrupted launch report different codes depending on which side of the
+// spawn the signal landed on — the very window this module exists to hide.
+//
+// With an agent running the client passes through the AGENT's own code, so an
+// agent that traps SIGHUP still reports its own 0. This mapping covers the case
+// where no agent handled the signal, which is exactly the no-agent path's
+// situation, and 130-for-SIGINT is the shell convention the child-exit handler
+// already used.
+function signalExitCode(signal) {
+  return signal === 'SIGINT' ? 130 : 1;
+}
 
-function armClientShutdown(lock, getChild, deps = {}) {
+// getLock              — the CURRENT hub lock. A getter, not a value: hub crash
+//                        recovery hands the client a different hub, and
+//                        unregistering from the dead one releases nothing.
+// getChild             — the spawned agent, or null before spawnAgent runs.
+// deps.getRegistration — the LATEST in-flight hub.registerClient() promise
+//                        (recovery re-registration included), or null while no
+//                        registration has been started.
+function armClientShutdown(getLock, getChild, deps = {}) {
   const hub = deps.hub || require('./hub');
   const exit = deps.exit || (code => process.exit(code));
   const on = deps.on || ((signal, fn) => process.on(signal, fn));
   const deadlineMs = deps.deadlineMs ?? UNREGISTER_DEADLINE_MS;
+  const getRegistration = deps.getRegistration || (() => null);
+
   let shuttingDown = false;
-  // Once-only, and shared by every exit path below. The repeat-signal branch
-  // must go through it too: exit() is injectable, so it is not guaranteed to be
-  // terminal, and without the shared guard a later-settling unregister exits a
-  // second time.
+  let chosenCode = null;
   let exited = false;
+  // Counts USER signals — every one that arrives, including those forwarded to a
+  // live agent. A shutdown started by the agent's own exit leaves this at 0, so
+  // the SIGINT the terminal delivered to both of us — arriving after the agent
+  // has already exited — reads as the first signal and waits for the unregister,
+  // instead of being mistaken for the user insisting.
+  let signalsSeen = 0;
+  // Once-only, and shared by every exit path. exit() is injectable, so it is not
+  // guaranteed to be terminal; without one guard a later-settling unregister
+  // exits a second time.
   const finish = (code) => { if (exited) return; exited = true; exit(code); };
 
-  const onSignal = (signal) => {
-    const child = getChild();
-    // Child alive: forwarding is enough — its exit drives spawnAgent's onExit,
-    // which unregisters and exits. Nothing to do here.
-    if (child && child.exitCode == null && child.signalCode == null) {
-      child.kill(signal);
-      return;
-    }
-    // A repeat signal while the unregister is still in flight is the user
-    // insisting. Leave now rather than keep waiting on the hub.
-    if (shuttingDown) { finish(SHUTDOWN_EXIT_CODE); return; }
+  // The ONE exit path for a hub client — the agent's own exit routes through it
+  // too. That is what stops a signal arriving while the agent's unregister is
+  // still in flight from overwriting the agent's exit code with its own: a child
+  // that failed with 42 must not be reported as an interrupted launch.
+  const shutdown = (code) => {
+    // Already leaving: keep the first code and let the in-flight unregister
+    // finish. Only a SECOND user signal cuts that short — see onSignal.
+    if (shuttingDown) return;
     shuttingDown = true;
-    const deadline = setTimeout(() => finish(SHUTDOWN_EXIT_CODE), deadlineMs);
-    if (deadline.unref) deadline.unref();
-    hub.unregisterClient(lock, process.pid).finally(() => {
-      clearTimeout(deadline);
-      finish(SHUTDOWN_EXIT_CODE);
-    });
+    chosenCode = code;
+
+    // Wait for an in-flight registration before unregistering. The two are
+    // separate socket round trips with no ordering guarantee, so unregistering
+    // first lets the hub apply the register afterwards and hold a pid that has
+    // already exited — this module's own bug, reintroduced through the back
+    // door. A null registration means nothing was ever registered, so there is
+    // nothing to release.
+    //
+    // The two waits are bounded SEPARATELY. One deadline spanning both would be
+    // spent by the register alone — hubSocketRequest gives it 3s — and expire
+    // before the unregister was ever sent, in exactly the case that needs it
+    // most: the hub applied the registration and lost only the reply. When the
+    // wait times out the unregister goes anyway. If the register really is still
+    // in flight, the hub may apply it after and hold the slot — but that is the
+    // same outcome as not trying, and if it was merely the reply that went
+    // missing, this releases it.
+    const registration = getRegistration();
+    const bounded = (promise) => Promise.race([
+      Promise.resolve(promise).catch(() => {}),
+      new Promise(resolve => {
+        const timer = setTimeout(resolve, deadlineMs);
+        if (timer.unref) timer.unref();
+      }),
+    ]);
+
+    bounded(registration)
+      .then(() => (registration ? bounded(hub.unregisterClient(getLock(), process.pid)) : null))
+      .then(() => finish(chosenCode), () => finish(chosenCode));
   };
 
+  const onSignal = (signal) => {
+    // Counted before the live-child branch returns. Counting only the signals
+    // that reach the shutdown below would mean a Ctrl-C delivered while the
+    // agent was still alive did not count, so the user's SECOND press would read
+    // as the first and a third would be needed to force the exit.
+    signalsSeen += 1;
+    const child = getChild();
+    if (child && child.exitCode == null && child.signalCode == null) {
+      // The terminal delivers SIGINT to the whole foreground process group, so
+      // the agent already has its own copy and forwarding would deliver it
+      // twice. For the others, forwarding is enough: the agent's exit drives
+      // spawnAgent's onExit, which calls shutdown() above.
+      if (signal !== 'SIGINT') child.kill(signal);
+      return;
+    }
+    // The second signal is the user insisting. Leave now rather than keep
+    // waiting on the hub — the dead-client sweep reclaims the slot, and a pane
+    // that will not close is the worse failure. The FIRST signal never does
+    // this, even when a shutdown is already running, because that shutdown may
+    // have been started by the agent's exit rather than by the user.
+    if (shuttingDown) {
+      if (signalsSeen >= 2) finish(chosenCode);
+      return;
+    }
+    shutdown(signalExitCode(signal));
+  };
+
+  // SIGINT is armed for the same reason as the other two. spawnAgent installs a
+  // no-op for it once a child exists, and a no-op is the right behaviour THEN —
+  // but before the child exists, a no-op would leave Ctrl-C unable to abort
+  // startup, and no handler at all leaves the phantom-client hole this module
+  // closes. Routing it through onSignal gives both: nothing while the agent
+  // owns the terminal, unregister-and-exit before that.
+  on('SIGINT', () => onSignal('SIGINT'));
   on('SIGHUP', () => onSignal('SIGHUP'));
   on('SIGTERM', () => onSignal('SIGTERM'));
 
-  // The caller MUST gate the agent spawn on this. exit() fires on a hub socket
-  // round trip, so a spawn racing it leaves the agent running with its parent
-  // gone — measured before this existed: the client exited 129 while the agent
-  // it had just spawned stayed alive.
-  return () => shuttingDown;
+  return {
+    // The caller MUST gate the agent spawn on this, and must re-check it
+    // IMMEDIATELY BEFORE spawn(): on the interactive path spawnAgent defers
+    // doSpawn behind promptClaudeStatusline()'s promise, so a signal can begin
+    // the shutdown and the user can answer the prompt before it settles.
+    // Spawning then leaves the agent running with its parent gone.
+    isShuttingDown: () => shuttingDown,
+    shutdown,
+  };
 }
 
-module.exports = { armClientShutdown, SHUTDOWN_EXIT_CODE, UNREGISTER_DEADLINE_MS };
+module.exports = { armClientShutdown, signalExitCode, UNREGISTER_DEADLINE_MS };

--- a/server/index.js
+++ b/server/index.js
@@ -219,6 +219,7 @@ const HOP_BY_HOP_HEADERS = new Set([
 // is shared with ws-proxy.js — see server/internal-headers.js for why an
 // allowlist here leaked the pane-identity header upstream.
 const { isInternalHeader } = require('./internal-headers');
+const { armClientShutdown } = require('./client-shutdown');
 
 function buildForwardHeaders(clientHeaders, upstream) {
   const fwdHeaders = { ...clientHeaders };
@@ -662,7 +663,7 @@ function promptClaudeStatusline() {
   }
 }
 
-function spawnAgent(command, port, args, onExit) {
+function spawnAgent(command, port, args, onExit, opts = {}) {
   const doSpawn = () => {
     const { spawn } = require('child_process');
     const launch = providers.getAgentLaunch(command, port, args);
@@ -681,6 +682,7 @@ function spawnAgent(command, port, args, onExit) {
       stdio: 'inherit',
       env: launch.env,
     });
+    if (opts.onChild) opts.onChild(child);
     child.on('error', (err) => {
       if (err.code === 'ENOENT') {
         console.error(`\x1b[31mError: "${launch.bin}" command not found. Install ${launch.label} first:\x1b[0m`);
@@ -694,8 +696,14 @@ function spawnAgent(command, port, args, onExit) {
       finish(code ?? (signal === 'SIGINT' ? 130 : 1));
     });
     process.on('SIGINT', () => {});
-    process.on('SIGTERM', () => child.kill('SIGTERM'));
-    process.on('SIGHUP', () => child.kill('SIGHUP'));
+    // INVARIANT (hub client mode): when the caller armed its own handlers
+    // BEFORE registering with the hub, installing a second pair here would
+    // double-forward the signal. The caller's handlers read the child through
+    // opts.onChild, so they cover this window too. See armClientShutdown.
+    if (!opts.signalsOwnedByCaller) {
+      process.on('SIGTERM', () => child.kill('SIGTERM'));
+      process.on('SIGHUP', () => child.kill('SIGHUP'));
+    }
   };
 
   if (command === 'claude') {
@@ -1025,6 +1033,12 @@ async function startClientMode(lock) {
     agentType: process.env.CCXRAY_AGENT_TYPE || agentCommand || '',
   };
 
+  // INVARIANT: armed before registerClient so no SIGHUP/SIGTERM can land on a
+  // registered-but-unarmed process — see server/client-shutdown.js for why
+  // reordering these two lines silently reintroduces the phantom-client window.
+  let agentChild = null;
+  const clientShuttingDown = armClientShutdown(lock, () => agentChild);
+
   try {
     const reg = await hub.registerClient(lock, process.pid, process.cwd(), clientIdentity);
     if (!reg) {
@@ -1068,12 +1082,21 @@ async function startClientMode(lock) {
     hub.registerClient(newLock, process.pid, process.cwd(), clientIdentity).catch(() => {});
   });
 
+  // INVARIANT: a signal that landed in the register→spawn window already began
+  // the unregister-and-exit path, and the two are racing — spawning now orphans
+  // the agent. Both this gate and the spawn are synchronous from here, so no
+  // signal can be delivered between them. See server/client-shutdown.js.
+  if (clientShuttingDown()) return;
+
   // Spawn agent pointing to hub
   process.env.CCXRAY_HUB_CLIENT_PID = String(process.pid);
   spawnAgent(agentCommand, lock.port, agentArgs, (code) => {
     hub.unregisterClient(lock, process.pid).finally(() => {
       process.exit(code);
     });
+  }, {
+    onChild: (child) => { agentChild = child; },
+    signalsOwnedByCaller: true,
   });
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -219,7 +219,7 @@ const HOP_BY_HOP_HEADERS = new Set([
 // is shared with ws-proxy.js — see server/internal-headers.js for why an
 // allowlist here leaked the pane-identity header upstream.
 const { isInternalHeader } = require('./internal-headers');
-const { armClientShutdown } = require('./client-shutdown');
+const { armClientShutdown, signalExitCode } = require('./client-shutdown');
 
 function buildForwardHeaders(clientHeaders, upstream) {
   const fwdHeaders = { ...clientHeaders };
@@ -665,6 +665,11 @@ function promptClaudeStatusline() {
 
 function spawnAgent(command, port, args, onExit, opts = {}) {
   const doSpawn = () => {
+    // INVARIANT: re-checked HERE, not only at the call site. On the interactive
+    // path this function runs after promptClaudeStatusline()'s promise settles,
+    // so a signal can have begun the caller's shutdown while the prompt was
+    // waiting — spawning then orphans the agent. See server/client-shutdown.js.
+    if (opts.isShuttingDown && opts.isShuttingDown()) return;
     const { spawn } = require('child_process');
     const launch = providers.getAgentLaunch(command, port, args);
     let finished = false;
@@ -693,14 +698,15 @@ function spawnAgent(command, port, args, onExit, opts = {}) {
       finish(1);
     });
     child.on('exit', (code, signal) => {
-      finish(code ?? (signal === 'SIGINT' ? 130 : 1));
+      finish(code ?? signalExitCode(signal));
     });
-    process.on('SIGINT', () => {});
-    // INVARIANT (hub client mode): when the caller armed its own handlers
-    // BEFORE registering with the hub, installing a second pair here would
-    // double-forward the signal. The caller's handlers read the child through
-    // opts.onChild, so they cover this window too. See armClientShutdown.
+    // INVARIANT (hub client mode): when the caller armed its own handlers BEFORE
+    // registering with the hub, installing these would double-handle the signal.
+    // The caller's handlers read the child through opts.onChild, so they cover
+    // this window too — including SIGINT, which they no-op while the agent owns
+    // the terminal exactly as this does. See server/client-shutdown.js.
     if (!opts.signalsOwnedByCaller) {
+      process.on('SIGINT', () => {});
       process.on('SIGTERM', () => child.kill('SIGTERM'));
       process.on('SIGHUP', () => child.kill('SIGHUP'));
     }
@@ -1033,17 +1039,28 @@ async function startClientMode(lock) {
     agentType: process.env.CCXRAY_AGENT_TYPE || agentCommand || '',
   };
 
-  // INVARIANT: armed before registerClient so no SIGHUP/SIGTERM can land on a
+  // INVARIANT: armed before registerClient so no signal can land on a
   // registered-but-unarmed process — see server/client-shutdown.js for why
-  // reordering these two lines silently reintroduces the phantom-client window.
+  // reordering these lines silently reintroduces the phantom-client window.
+  // `registration` is handed to the shutdown path so it waits for an in-flight
+  // register before unregistering; the two are unordered socket round trips.
   let agentChild = null;
-  const clientShuttingDown = armClientShutdown(lock, () => agentChild);
+  let registration = null;
+  let currentLock = lock;
+  const clientShutdown = armClientShutdown(() => currentLock, () => agentChild, {
+    getRegistration: () => registration,
+  });
 
   try {
-    const reg = await hub.registerClient(lock, process.pid, process.cwd(), clientIdentity);
+    registration = hub.registerClient(lock, process.pid, process.cwd(), clientIdentity);
+    const reg = await registration;
     if (!reg) {
       console.error('\x1b[31mHub rejected client registration.\x1b[0m');
-      process.exit(1);
+      // Through the shutdown path, not process.exit: the hub may have applied
+      // the registration and lost only the reply, and a bare exit here would
+      // leave that slot held until the 30s sweep.
+      clientShutdown.shutdown(1);
+      return;
     }
 
     // Auto-open browser for the first client connecting to this hub
@@ -1073,29 +1090,43 @@ async function startClientMode(lock) {
     }
   } catch (err) {
     console.error(`\x1b[31mFailed to register with hub: ${err.message}\x1b[0m`);
-    process.exit(1);
+    // Same reason as the !reg branch above. This continuation was attached
+    // before any shutdown's, so a bare exit here wins the race against it.
+    clientShutdown.shutdown(1);
+    return;
   }
 
   // Monitor hub health and auto-recover
   hub.startHubMonitor(lock.pid, lock.port, (newLock) => {
-    // Re-register with new hub (newLock has sockPath from lockfile)
-    hub.registerClient(newLock, process.pid, process.cwd(), clientIdentity).catch(() => {});
+    // Re-register with new hub (newLock has sockPath from lockfile).
+    // Both are published to the shutdown path: unregistering from the DEAD hub
+    // releases nothing, and a shutdown racing this re-registration would let the
+    // new hub apply the register after the unregister — a phantom on the new
+    // hub. See server/client-shutdown.js.
+    // A shutdown that already captured the previous registration will never see
+    // a promise created after it, so re-registering now would hand the new hub a
+    // pid that is on its way out.
+    if (clientShutdown.isShuttingDown()) return;
+    currentLock = newLock;
+    registration = hub.registerClient(newLock, process.pid, process.cwd(), clientIdentity).catch(() => {});
   });
 
-  // INVARIANT: a signal that landed in the register→spawn window already began
-  // the unregister-and-exit path, and the two are racing — spawning now orphans
-  // the agent. Both this gate and the spawn are synchronous from here, so no
-  // signal can be delivered between them. See server/client-shutdown.js.
-  if (clientShuttingDown()) return;
+  // A signal that landed in the register→spawn window already began the
+  // unregister-and-exit path — spawning now orphans the agent. spawnAgent
+  // re-checks this immediately before spawn() as well, because the interactive
+  // path defers the spawn behind a prompt. See server/client-shutdown.js.
+  if (clientShutdown.isShuttingDown()) return;
 
   // Spawn agent pointing to hub
   process.env.CCXRAY_HUB_CLIENT_PID = String(process.pid);
+  // The agent's exit routes through the SAME shutdown path as a signal, so a
+  // signal arriving while this unregister is in flight cannot replace the
+  // agent's exit code with its own.
   spawnAgent(agentCommand, lock.port, agentArgs, (code) => {
-    hub.unregisterClient(lock, process.pid).finally(() => {
-      process.exit(code);
-    });
+    clientShutdown.shutdown(code);
   }, {
     onChild: (child) => { agentChild = child; },
+    isShuttingDown: clientShutdown.isShuttingDown,
     signalsOwnedByCaller: true,
   });
 }

--- a/test/client-shutdown.test.js
+++ b/test/client-shutdown.test.js
@@ -2,17 +2,18 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { armClientShutdown, SHUTDOWN_EXIT_CODE, UNREGISTER_DEADLINE_MS } = require('../server/client-shutdown');
+const fs = require('fs');
+const path = require('path');
+const { armClientShutdown, signalExitCode, UNREGISTER_DEADLINE_MS } = require('../server/client-shutdown');
 
 // A harness over the injection seams: no signals are sent to this process and
 // no socket is opened, so these run alongside the e2e in
 // test/hub-client-signal.e2e.test.js without touching a real hub.
-function arm({ child = null, unregister, deadlineMs } = {}) {
+function arm({ child = null, unregister, deadlineMs, registration = Promise.resolve({}), lock = { sockPath: '/tmp/ccxray-test.sock' } } = {}) {
   const handlers = new Map();
   const exits = [];
   const unregistered = [];
-  const lock = { sockPath: '/tmp/ccxray-test.sock' };
-  const isShuttingDown = armClientShutdown(lock, () => child, {
+  const api = armClientShutdown(() => lock, () => child, {
     hub: {
       unregisterClient: (l, pid) => {
         unregistered.push({ lock: l, pid });
@@ -21,24 +22,26 @@ function arm({ child = null, unregister, deadlineMs } = {}) {
     },
     exit: code => exits.push(code),
     on: (signal, fn) => handlers.set(signal, fn),
+    getRegistration: () => registration,
     deadlineMs,
   });
   return {
-    isShuttingDown, exits, unregistered,
+    ...api, exits, unregistered,
     setChild: next => { child = next; },
+    setLock: next => { lock = next; },
+    setRegistration: next => { registration = next; },
     fire: signal => handlers.get(signal)(),
     signals: [...handlers.keys()],
   };
 }
 
 const tick = () => new Promise(r => setImmediate(r));
+const settled = async () => { for (let i = 0; i < 8; i++) await tick(); };
 const after = ms => new Promise(r => setTimeout(r, ms));
 
 describe('hub-client graceful shutdown', () => {
-  it('arms SIGHUP and SIGTERM, and deliberately leaves SIGINT alone', () => {
-    // SIGINT is spawnAgent's no-op so the terminal reaches the foreground
-    // child; arming it here would make Ctrl-C unable to abort startup.
-    assert.deepEqual(arm().signals, ['SIGHUP', 'SIGTERM']);
+  it('arms every signal that would otherwise kill the process unregistered', () => {
+    assert.deepEqual(arm().signals, ['SIGINT', 'SIGHUP', 'SIGTERM']);
   });
 
   it('forwards to a live agent instead of unregistering itself', async () => {
@@ -46,13 +49,26 @@ describe('hub-client graceful shutdown', () => {
     const h = arm({ child: { exitCode: null, signalCode: null, kill: s => killed.push(s) } });
 
     h.fire('SIGHUP');
-    await tick();
+    await settled();
 
-    // The child's exit drives spawnAgent's onExit, which owns the unregister.
+    // The agent's exit drives spawnAgent's onExit, which calls shutdown().
     assert.deepEqual(killed, ['SIGHUP']);
     assert.deepEqual(h.unregistered, []);
     assert.deepEqual(h.exits, []);
     assert.equal(h.isShuttingDown(), false);
+  });
+
+  it('does not forward SIGINT to a live agent, which already has its own', async () => {
+    const killed = [];
+    const h = arm({ child: { exitCode: null, signalCode: null, kill: s => killed.push(s) } });
+
+    h.fire('SIGINT');
+    await settled();
+
+    // The terminal delivers SIGINT to the whole foreground process group, so
+    // forwarding would deliver it twice. This is spawnAgent's no-op, relocated.
+    assert.deepEqual(killed, []);
+    assert.deepEqual(h.exits, []);
   });
 
   it('unregisters then exits when the signal lands before the agent exists', async () => {
@@ -62,39 +78,145 @@ describe('hub-client graceful shutdown', () => {
     // The gate must flip synchronously: startClientMode checks it in the same
     // tick it would otherwise spawn the agent.
     assert.equal(h.isShuttingDown(), true);
-    await tick();
+    await settled();
 
     assert.equal(h.unregistered.length, 1);
     assert.equal(h.unregistered[0].pid, process.pid);
-    assert.deepEqual(h.exits, [SHUTDOWN_EXIT_CODE]);
+    assert.deepEqual(h.exits, [1]);
+  });
+
+  it('waits for an in-flight registration before unregistering', async () => {
+    let admit;
+    const registration = new Promise(r => { admit = r; });
+    const h = arm({ registration, deadlineMs: 5000 });
+
+    h.fire('SIGHUP');
+    await settled();
+    // Unregistering first would let the hub apply the register afterwards and
+    // hold a pid that has already exited — the phantom, through the back door.
+    assert.deepEqual(h.unregistered, [], 'must not race the register round trip');
+
+    admit({});
+    await settled();
+    assert.equal(h.unregistered.length, 1);
+    assert.deepEqual(h.exits, [1]);
+  });
+
+  it('releases the hub it is currently registered with, not the crashed one', async () => {
+    let admit;
+    const recovered = { sockPath: '/tmp/ccxray-recovered.sock' };
+    const h = arm({ deadlineMs: 5000 });
+
+    // Crash recovery hands the client a different hub and re-registers.
+    h.setLock(recovered);
+    h.setRegistration(new Promise(r => { admit = r; }));
+
+    h.fire('SIGHUP');
+    await settled();
+    assert.deepEqual(h.unregistered, [], 'the recovery register is still in flight');
+
+    admit({});
+    await settled();
+    assert.equal(h.unregistered.length, 1);
+    assert.equal(h.unregistered[0].lock, recovered, 'unregistering the dead hub releases nothing');
+  });
+
+  it('skips the unregister when registration was never started', async () => {
+    const h = arm({ registration: null });
+
+    h.fire('SIGTERM');
+    await settled();
+
+    assert.deepEqual(h.unregistered, [], 'nothing was registered, nothing to release');
+    assert.deepEqual(h.exits, [1]);
   });
 
   it('treats an agent that has already exited as no agent', async () => {
     const h = arm({ child: { exitCode: 0, signalCode: null, kill: () => { throw new Error('must not kill a dead child'); } } });
 
     h.fire('SIGTERM');
-    await tick();
+    await settled();
 
     assert.equal(h.unregistered.length, 1);
-    assert.deepEqual(h.exits, [SHUTDOWN_EXIT_CODE]);
+    assert.deepEqual(h.exits, [1]);
   });
 
-  it('exits immediately on a repeat signal rather than waiting on the hub', async () => {
+  it('keeps the agent exit code, and still unregisters, when the same Ctrl-C reaches both', async () => {
     let release;
-    const h = arm({ unregister: () => new Promise(r => { release = r; }) });
+    const h = arm({ unregister: () => new Promise(r => { release = r; }), deadlineMs: 5000 });
+
+    // A terminal delivers SIGINT to the client AND the agent. The agent exits
+    // first, so spawnAgent's onExit opens the shutdown.
+    h.shutdown(42);
+    await settled();
+    assert.deepEqual(h.exits, []);
+
+    h.setChild({ exitCode: 42, signalCode: null, kill: () => {} });
+    h.fire('SIGINT');
+
+    // That SIGINT is the same user action, not a second one: cutting the
+    // unregister short here would leave a phantom client behind.
+    assert.deepEqual(h.exits, [], 'the first signal must not abandon the unregister');
+
+    release();
+    await settled();
+    // Reporting 130 would mask a real failure as an interrupted launch.
+    assert.deepEqual(h.exits, [42]);
+    assert.equal(h.unregistered.length, 1);
+  });
+
+  it('counts a signal that was forwarded to a live agent', async () => {
+    let release;
+    const child = { exitCode: null, signalCode: null, kill: () => {} };
+    const h = arm({ child, unregister: () => new Promise(r => { release = r; }), deadlineMs: 5000 });
+
+    // Ctrl-C reaches the client while the agent is still up: forwarded, and the
+    // agent starts shutting down on its own.
+    h.fire('SIGINT');
+    child.exitCode = 0;
+    h.shutdown(0);
+    await settled();
+    assert.deepEqual(h.exits, []);
+
+    // The user presses again. Not counting the forwarded one would read this as
+    // the first press and make a THIRD necessary to get out.
+    h.fire('SIGINT');
+    assert.deepEqual(h.exits, [0], 'the second press must be enough');
+
+    release();
+    await settled();
+    assert.deepEqual(h.exits, [0]);
+  });
+
+  it('exits immediately on a second signal rather than waiting on the hub', async () => {
+    let release;
+    const h = arm({ unregister: () => new Promise(r => { release = r; }), deadlineMs: 5000 });
 
     h.fire('SIGHUP');
-    await tick();
+    await settled();
     assert.deepEqual(h.exits, [], 'still waiting on the hub');
 
     h.fire('SIGHUP');
-    assert.deepEqual(h.exits, [SHUTDOWN_EXIT_CODE], 'the user insisting is honoured at once');
+    assert.deepEqual(h.exits, [1], 'the user insisting is honoured at once');
 
     // The in-flight unregister must not double-exit when it finally settles.
     release();
-    await tick();
-    assert.deepEqual(h.exits, [SHUTDOWN_EXIT_CODE]);
+    await settled();
+    assert.deepEqual(h.exits, [1]);
     assert.equal(h.unregistered.length, 1);
+  });
+
+  it('still sends the unregister when the registration reply never arrives', async () => {
+    // The hub added the client and lost only the reply. A single deadline
+    // spanning both waits would be spent here — registerClient has 3s of its own
+    // — and the slot would be stranded in the one case that needs releasing.
+    const h = arm({ registration: new Promise(() => {}), deadlineMs: 20 });
+
+    h.fire('SIGHUP');
+    await after(120);
+
+    assert.equal(h.unregistered.length, 1, 'the wait timed out, the unregister must go anyway');
+    assert.deepEqual(h.exits, [1]);
   });
 
   it('exits on the deadline when the hub never answers', async () => {
@@ -105,20 +227,85 @@ describe('hub-client graceful shutdown', () => {
 
     // Degraded but recoverable: the hub's dead-client sweep reclaims the slot,
     // whereas a pane the user cannot close is not recoverable.
-    assert.deepEqual(h.exits, [SHUTDOWN_EXIT_CODE]);
+    assert.deepEqual(h.exits, [1]);
   });
 
-  it('exits 0, matching a pane closed while the agent was running', () => {
-    // The other half of this pair is in test/hub-client-signal.e2e.test.js,
-    // which asserts the agent-running path also exits 0. Restating spawnAgent's
-    // expression here instead would assert a hand-copy against itself and stay
-    // green if that expression ever changed.
-    assert.equal(SHUTDOWN_EXIT_CODE, 0);
+  it('maps signals the way the child-exit handler does', () => {
+    assert.equal(signalExitCode('SIGINT'), 130);
+    assert.equal(signalExitCode('SIGHUP'), 1);
+    assert.equal(signalExitCode('SIGTERM'), 1);
   });
 
   it('bounds the wait well under the hub socket timeout', () => {
     // hubSocketRequest defaults to 3s; a deadline at or above that would never
     // fire, so this constant has to stay below it to mean anything.
     assert.ok(UNREGISTER_DEADLINE_MS > 0 && UNREGISTER_DEADLINE_MS < 3000);
+  });
+});
+
+// Behaviour above is only worth anything if startClientMode wires it correctly.
+// The e2e in test/hub-client-signal.e2e.test.js drives the real binary through a
+// fake hub for the registration window and the spawn gate; these pin the source
+// facts that no runtime path reaches — the same approach
+// test/invariant-encapsulation.test.js takes for the store push sites.
+describe('hub-client shutdown wiring (structural)', () => {
+  // Full-line comments are stripped so these assertions read CODE. Prose that
+  // mentions `process.exit` while explaining why it is not used would otherwise
+  // match — the first draft of the registration-failure check did exactly that.
+  // Only whole-line comments go, so a URL in a string literal is untouched.
+  const source = fs.readFileSync(path.join(__dirname, '..', 'server', 'index.js'), 'utf8')
+    .replace(/^[ \t]*\/\/.*$/gm, '');
+
+  it('arms the shutdown before the client registers with the hub', () => {
+    const armed = source.indexOf('armClientShutdown(');
+    const registered = source.indexOf('hub.registerClient(');
+    assert.ok(armed > 0, 'armClientShutdown call not found');
+    assert.ok(registered > 0, 'registerClient call not found');
+    assert.ok(
+      armed < registered,
+      'armClientShutdown must be called before hub.registerClient — a signal in '
+      + 'between kills the process without unregistering',
+    );
+  });
+
+  it('re-checks the gate inside doSpawn, not only at the call site', () => {
+    // The interactive path runs doSpawn after promptClaudeStatusline()'s promise
+    // settles, so a call-site-only check can be answered by a stale reading.
+    const doSpawn = source.slice(source.indexOf('const doSpawn = () => {'));
+    const guard = doSpawn.indexOf('opts.isShuttingDown');
+    const spawnCall = doSpawn.indexOf('spawn(launch.bin');
+    assert.ok(guard > 0, 'doSpawn does not consult opts.isShuttingDown');
+    assert.ok(guard < spawnCall, 'the gate must be checked before spawn()');
+  });
+
+  it('routes the agent exit through the shared shutdown path', () => {
+    // A direct process.exit here would let a signal racing the agent's
+    // unregister replace the agent's exit code with its own.
+    assert.match(source, /clientShutdown\.shutdown\(code\)/);
+    assert.doesNotMatch(source, /hub\.unregisterClient\(lock, process\.pid\)\.finally/);
+  });
+
+  it('publishes the crash-recovery re-registration to the shutdown path', () => {
+    // Recovery registers with a DIFFERENT hub. Leaving that promise untracked
+    // lets a shutdown unregister the dead hub and race the new register.
+    const monitor = source.slice(source.indexOf('hub.startHubMonitor('));
+    const body = monitor.slice(0, monitor.indexOf('\n  });'));
+    assert.match(body, /currentLock = newLock/);
+    assert.match(body, /registration = hub\.registerClient\(newLock/);
+    // A shutdown captures the registration promise once, so it can never see one
+    // created after it. Recovery must therefore decline to make a new one.
+    assert.match(body, /if \(clientShutdown\.isShuttingDown\(\)\) return;/);
+  });
+
+  it('releases the slot when registration itself fails', () => {
+    // The hub can apply a registration and lose only the reply. These
+    // continuations were attached before any shutdown's, so a bare process.exit
+    // here wins the race and strands that slot until the 30s sweep.
+    const clientMode = source.slice(source.indexOf('async function startClientMode'));
+    const body = clientMode.slice(0, clientMode.indexOf('\n}\n'));
+    assert.doesNotMatch(body, /Hub rejected client registration[\s\S]{0,80}process\.exit/);
+    assert.doesNotMatch(body, /Failed to register with hub[\s\S]{0,80}process\.exit/);
+    assert.match(body, /Hub rejected client registration[\s\S]{0,80}clientShutdown\.shutdown\(1\)/);
+    assert.match(body, /Failed to register with hub[\s\S]{0,80}clientShutdown\.shutdown\(1\)/);
   });
 });

--- a/test/client-shutdown.test.js
+++ b/test/client-shutdown.test.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { armClientShutdown, SHUTDOWN_EXIT_CODE, UNREGISTER_DEADLINE_MS } = require('../server/client-shutdown');
+
+// A harness over the injection seams: no signals are sent to this process and
+// no socket is opened, so these run alongside the e2e in
+// test/hub-client-signal.e2e.test.js without touching a real hub.
+function arm({ child = null, unregister, deadlineMs } = {}) {
+  const handlers = new Map();
+  const exits = [];
+  const unregistered = [];
+  const lock = { sockPath: '/tmp/ccxray-test.sock' };
+  const isShuttingDown = armClientShutdown(lock, () => child, {
+    hub: {
+      unregisterClient: (l, pid) => {
+        unregistered.push({ lock: l, pid });
+        return unregister ? unregister() : Promise.resolve();
+      },
+    },
+    exit: code => exits.push(code),
+    on: (signal, fn) => handlers.set(signal, fn),
+    deadlineMs,
+  });
+  return {
+    isShuttingDown, exits, unregistered,
+    setChild: next => { child = next; },
+    fire: signal => handlers.get(signal)(),
+    signals: [...handlers.keys()],
+  };
+}
+
+const tick = () => new Promise(r => setImmediate(r));
+const after = ms => new Promise(r => setTimeout(r, ms));
+
+describe('hub-client graceful shutdown', () => {
+  it('arms SIGHUP and SIGTERM, and deliberately leaves SIGINT alone', () => {
+    // SIGINT is spawnAgent's no-op so the terminal reaches the foreground
+    // child; arming it here would make Ctrl-C unable to abort startup.
+    assert.deepEqual(arm().signals, ['SIGHUP', 'SIGTERM']);
+  });
+
+  it('forwards to a live agent instead of unregistering itself', async () => {
+    const killed = [];
+    const h = arm({ child: { exitCode: null, signalCode: null, kill: s => killed.push(s) } });
+
+    h.fire('SIGHUP');
+    await tick();
+
+    // The child's exit drives spawnAgent's onExit, which owns the unregister.
+    assert.deepEqual(killed, ['SIGHUP']);
+    assert.deepEqual(h.unregistered, []);
+    assert.deepEqual(h.exits, []);
+    assert.equal(h.isShuttingDown(), false);
+  });
+
+  it('unregisters then exits when the signal lands before the agent exists', async () => {
+    const h = arm();
+
+    h.fire('SIGHUP');
+    // The gate must flip synchronously: startClientMode checks it in the same
+    // tick it would otherwise spawn the agent.
+    assert.equal(h.isShuttingDown(), true);
+    await tick();
+
+    assert.equal(h.unregistered.length, 1);
+    assert.equal(h.unregistered[0].pid, process.pid);
+    assert.deepEqual(h.exits, [SHUTDOWN_EXIT_CODE]);
+  });
+
+  it('treats an agent that has already exited as no agent', async () => {
+    const h = arm({ child: { exitCode: 0, signalCode: null, kill: () => { throw new Error('must not kill a dead child'); } } });
+
+    h.fire('SIGTERM');
+    await tick();
+
+    assert.equal(h.unregistered.length, 1);
+    assert.deepEqual(h.exits, [SHUTDOWN_EXIT_CODE]);
+  });
+
+  it('exits immediately on a repeat signal rather than waiting on the hub', async () => {
+    let release;
+    const h = arm({ unregister: () => new Promise(r => { release = r; }) });
+
+    h.fire('SIGHUP');
+    await tick();
+    assert.deepEqual(h.exits, [], 'still waiting on the hub');
+
+    h.fire('SIGHUP');
+    assert.deepEqual(h.exits, [SHUTDOWN_EXIT_CODE], 'the user insisting is honoured at once');
+
+    // The in-flight unregister must not double-exit when it finally settles.
+    release();
+    await tick();
+    assert.deepEqual(h.exits, [SHUTDOWN_EXIT_CODE]);
+    assert.equal(h.unregistered.length, 1);
+  });
+
+  it('exits on the deadline when the hub never answers', async () => {
+    const h = arm({ unregister: () => new Promise(() => {}), deadlineMs: 20 });
+
+    h.fire('SIGHUP');
+    await after(60);
+
+    // Degraded but recoverable: the hub's dead-client sweep reclaims the slot,
+    // whereas a pane the user cannot close is not recoverable.
+    assert.deepEqual(h.exits, [SHUTDOWN_EXIT_CODE]);
+  });
+
+  it('exits 0, matching a pane closed while the agent was running', () => {
+    // The other half of this pair is in test/hub-client-signal.e2e.test.js,
+    // which asserts the agent-running path also exits 0. Restating spawnAgent's
+    // expression here instead would assert a hand-copy against itself and stay
+    // green if that expression ever changed.
+    assert.equal(SHUTDOWN_EXIT_CODE, 0);
+  });
+
+  it('bounds the wait well under the hub socket timeout', () => {
+    // hubSocketRequest defaults to 3s; a deadline at or above that would never
+    // fire, so this constant has to stay below it to mean anything.
+    assert.ok(UNREGISTER_DEADLINE_MS > 0 && UNREGISTER_DEADLINE_MS < 3000);
+  });
+});

--- a/test/hub-client-signal.e2e.test.js
+++ b/test/hub-client-signal.e2e.test.js
@@ -79,8 +79,12 @@ describe('hub client signal lifecycle', () => {
     const claude = path.join(binDir, 'claude');
     fs.writeFileSync(claude, [
       '#!/bin/sh',
-      `echo $$ > ${JSON.stringify(agentPidFile)}`,
+      // Trap BEFORE publishing the pid: the test treats the pid file as proof
+      // the agent is ready to be closed, and a pid published ahead of the trap
+      // would let SIGHUP kill the shell outright — which the client reports as
+      // exit 1 rather than the agent's own 0.
       "trap 'exit 0' HUP TERM INT",
+      `echo $$ > ${JSON.stringify(agentPidFile)}`,
       'while :; do sleep 1; done',
       '',
     ].join('\n'));
@@ -117,8 +121,25 @@ describe('hub client signal lifecycle', () => {
       }
       hubPid = before.pid;
 
+      // The premise is "a pane RUNNING AN AGENT is closed". Without this wait
+      // the kill lands while the client is still between registerClient() and
+      // its signal handlers, so the assertion below was measuring that window
+      // rather than the unregister path (and the fake agent never even ran).
+      await waitFor(() => {
+        const pid = Number(fs.readFileSync(agentPidFile, 'utf8').trim());
+        return pid > 0 && pidAlive(pid);
+      });
+
       client.kill('SIGHUP');
       await waitForExit(client);
+
+      // Half of a pair with test/client-shutdown.test.js: with an agent running
+      // the client passes through the agent's exit code, and the agent handles
+      // SIGHUP and exits 0. The other half asserts the no-agent path exits 0
+      // too, so closing a pane reports the same code on both sides of the
+      // register→spawn window.
+      assert.equal(client.exitCode, 0);
+      assert.equal(client.signalCode, null);
 
       const after = await waitFor(async () => {
         const status = await hubStatus(home);

--- a/test/hub-client-signal.e2e.test.js
+++ b/test/hub-client-signal.e2e.test.js
@@ -159,4 +159,117 @@ describe('hub client signal lifecycle', () => {
       fs.rmSync(home, { recursive: true, force: true });
     }
   });
+
+  // The test above deliberately fires AFTER the agent is up, so it does not
+  // cover the window this work exists to close. A real hub registers in about a
+  // millisecond, which is not something a test can aim at — but nothing says the
+  // hub has to be real. This one speaks the hub's socket protocol itself and
+  // simply does not answer `register` until told to, which makes the window as
+  // wide as the test wants without a single test-only branch in the server.
+  it('unregisters and never spawns when the pane closes mid-registration', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-hub-midreg-'));
+    const binDir = path.join(home, 'bin');
+    const agentMarker = path.join(home, 'agent-ran');
+    fs.mkdirSync(binDir, { recursive: true });
+    const claude = path.join(binDir, 'claude');
+    // Publishes its pid, so that when this assertion FAILS the orphan it caught
+    // can be cleaned up. Left running it inherits the client's stdio pipes and
+    // the test runner never exits — a hang instead of a red test.
+    fs.writeFileSync(claude, [
+      '#!/bin/sh',
+      `echo $$ > ${JSON.stringify(agentMarker)}`,
+      'while :; do sleep 1; done',
+      '',
+    ].join('\n'));
+    fs.chmodSync(claude, 0o755);
+
+    const sockPath = path.join(home, 'fake-hub.sock');
+    const commands = [];
+    let releaseRegister = null;
+
+    const hub = net.createServer(socket => {
+      let buf = '';
+      socket.on('error', () => {});
+      socket.on('data', chunk => {
+        buf += chunk.toString();
+        let nl;
+        while ((nl = buf.indexOf('\n')) !== -1) {
+          const line = buf.slice(0, nl);
+          buf = buf.slice(nl + 1);
+          let msg;
+          try { msg = JSON.parse(line); } catch { continue; }
+          commands.push(msg.cmd);
+          if (msg.cmd === 'health') socket.write(JSON.stringify({ ok: true }) + '\n');
+          // Held, not dropped: the client is mid-`await registerClient()`.
+          if (msg.cmd === 'register') {
+            releaseRegister = () => socket.write(JSON.stringify({ ok: true, firstClient: false }) + '\n');
+          }
+          // Deliberately NOT answered. The client bounds this wait itself and
+          // leaves on its deadline; holding it keeps the process alive long
+          // enough for a missing spawn gate to actually produce an agent.
+          if (msg.cmd === 'unregister') { /* held */ }
+        }
+      });
+    });
+    await new Promise(resolve => hub.listen(sockPath, resolve));
+
+    // A lockfile the client will believe: our own pid is alive, and the version
+    // has to match or checkVersionCompat rejects before any of this runs.
+    fs.writeFileSync(path.join(home, 'hub.json'), JSON.stringify({
+      pid: process.pid,
+      port: await freePort(),
+      sockPath,
+      version: require('../package.json').version,
+    }));
+
+    const client = spawn(process.execPath, [SERVER, '--no-browser', 'claude'], {
+      env: {
+        ...process.env,
+        BROWSER: 'none',
+        CI: '1',
+        CCXRAY_HOME: home,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH || ''}`,
+        PROXY_PORT: String(await freePort()),
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    client.stdout.on('data', () => {});
+    client.stderr.on('data', () => {});
+
+    try {
+      await waitFor(() => commands.includes('register'));
+
+      // The pane closes while the hub still owes us a registration reply.
+      client.kill('SIGHUP');
+      await new Promise(resolve => setTimeout(resolve, 150));
+
+      // Unregistering before the register lands would let the hub apply them in
+      // that order and keep a pid that has already exited.
+      assert.equal(commands.includes('unregister'), false, 'must not race the register round trip');
+
+      releaseRegister();
+
+      // The client attached its `await registerClient()` continuation before the
+      // shutdown attached its own, so the main flow — including the point where
+      // it would spawn the agent — has already run by the time this arrives.
+      await waitFor(() => commands.includes('unregister'), 5000);
+
+      // Leaves on UNREGISTER_DEADLINE_MS, since the reply is being withheld.
+      await waitForExit(client, 5000);
+
+      // A spawned `sh` needs to be scheduled before it writes its marker, so
+      // checking the instant the parent dies would pass whether or not one was
+      // started. This is the assertion that fails when the spawn gate is gone.
+      await new Promise(resolve => setTimeout(resolve, 400));
+      assert.equal(fs.existsSync(agentMarker), false, 'the agent was spawned into a process that was already leaving');
+    } finally {
+      if (client.exitCode == null && client.signalCode == null) client.kill('SIGKILL');
+      try {
+        const stray = Number(fs.readFileSync(agentMarker, 'utf8'));
+        if (stray > 0) process.kill(stray, 'SIGKILL');
+      } catch {}
+      hub.close();
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## 摘要（繁中）

CI 在 main 上紅了（run 32473160514，#582 merge 後），但根因不是 #582 —— 是 `test/hub-client-signal.e2e.test.js` 從 2026-08-16 進 tree 就存在的潛伏 race，兩天內第二次發作（前一次 run 32361079591，#575 merge）。

hub client 在 `hub.registerClient()` 之後、`spawnAgent()` 安裝 signal handler 之前有約 1ms 窗口，期間 SIGHUP 走 OS 預設處置直接殺掉程序，`hub.unregisterClient()` 從未執行。hub 只靠 30 秒的 dead-client 掃描回收，遠超測試的 3 秒預算。本機實測原始碼 **8/20 紅**。

三個 commit：測試修正（單獨就能讓 CI 綠）、在 register 之前武裝 handler、以及 codex 五輪二審修掉的四個真缺陷。

**一個使用者可見的行為變化**：修好之後最後一個 client 退出時 unregister 會確實執行，hub 的 5 秒 idle shutdown 因此會**準時**發生，而不是被 phantom client 拖到 30 秒後 —— hub 比以前早約 25 秒消失。這是 #581 作業 session 量到並回報的，對 Herdr badge 是安全的（port 不回應 → `serverCaps` 回 null → 降級回 250ms sleep，`test/herdr-visibility.test.js` 有覆蓋）。

## Root cause

`startClientMode` registered with the hub before installing any signal handler:

```
await hub.registerClient()   ← the hub lists this pid from here
startHubMonitor()
spawnAgent()
  promptClaudeStatusline()   ← synchronous fs work
  spawn(claude)
  process.on('SIGHUP', …)    ← only armed here
```

Until a listener exists SIGHUP keeps its OS default disposition, so the process dies without unregistering. The hub prunes by pid liveness every `DEAD_CLIENT_CHECK_MS` (30s), which is far past the test's 3s budget — hence a bare `timed out` with no error from the status socket.

Confirmed by instrumenting the client. On a failing run its stderr stops after `spawnAgent` is entered, `T-handler` never prints, and the process reports `signal=SIGHUP` rather than an exit code:

```
T-registered       1787309118682
T-spawnAgent-enter 1787309118682
(no T-doSpawn, no T-handler)
T-kill             1787309118682
PROBE exit=null signal=SIGHUP
```

The test fired SIGHUP the instant registration appeared in `hub status` — the top of that window — so it landed inside it about 20% of the time. #582 added 616 lines to `test/herdr-plugin.test.js`, and the extra concurrent load on the runner shifted the timing enough to surface it.

## Commits

Sliced so any intermediate commit is a usable state.

**`c09aed8` — test: wait for a live agent before closing the pane.** The test also never established its own premise: `agent.pid` was absent on every probed run, passing ones included, so the green path was "child dies by signal → `finish(1)` → unregister". It verified that a client killed *after* the handlers are armed unregisters — never that a pane running an agent was closed. **This commit alone turns CI green (20/20 against the unchanged server)**, so it stands as the unblock independently of the rest.

**`b36d425` — fix: arm before registering, gate the spawn.** `armClientShutdown` (new `server/client-shutdown.js`) is armed before `registerClient`; `spawnAgent` publishes its child through `opts.onChild` instead of installing its own handlers. The spawn must be gated on the shutdown: `exit()` fires on a hub round trip, so a spawn racing it orphans the agent. Measured before the gate, with the window widened to 300ms and the unregister to 800ms — client exited while the agent it had just spawned stayed alive (`ORPHAN: true`); with the gate, `agent spawned: no`.

**`4fc0326` — fix: close the races found in review.** See the codex section.

## Codex review

Five rounds. Findings went **6 → 4 → 3 → 1 → 0**, and every round after the first was in code the previous round's fix had added.

| Round | blocker | major | minor |
|---|---|---|---|
| 1 | 1 | 3 | 2 |
| 2 | 0 | 3 | 1 |
| 3 | 0 | 3 | 0 |
| 4 | 0 | 1 | 0 |
| 5 | 0 | 0 | 0 |

11 accepted, 2 rejected — both rejections subsequently accepted by the reviewer.

Real defects it caught, all in the fix rather than the original bug:

- **the spawn gate was not adjacent to the spawn.** The comment claimed gate and spawn were synchronous; false on the interactive path, where `promptClaudeStatusline()` returns a pending promise and `p.then(doSpawn)` defers the spawn. A signal could begin the shutdown and the user could answer the prompt before it settled.
- **register and unregister were unordered.** Two separate socket round trips: unregistering first let the hub apply the register afterwards and hold a pid that had already exited — this fix's own bug through the back door. Crash recovery had the same shape twice over (an untracked re-registration promise, and a captured lock pointing at the hub that died).
- **one deadline spanned both waits.** `registerClient` has 3s of its own, so the deadline could be spent before the unregister was ever sent — in exactly the case that needs it, where the hub applied the registration and lost only the reply.
- **registration failure bypassed the armed shutdown.** Both failure branches called `process.exit(1)` from a continuation attached before any shutdown's, so it won the race and stranded a slot the hub may already have held.

Rejected, with the reviewer's agreement:

- **exit-code side-dependence.** With an agent running the client passes through the agent's own code; a trapping agent reports 0 and a non-trapping one 1, so no single no-agent value matches both. The fixable half — two independent constants that could drift — is fixed by sharing `signalExitCode` with `spawnAgent`'s child-exit handler.
- **no escape hatch when the agent ignores SIGHUP/SIGTERM.** While the agent is alive the client must not exit or it orphans a process holding the terminal's stdio. Unchanged from before this PR.

## Testing

The claim that an e2e could not reach a 1ms window without a test-only seam in production code was wrong, and the reviewer said so. It only required the hub not to be real: `test/hub-client-signal.e2e.test.js` now stands up a fake unix-socket hub speaking the real protocol and withholds the `register` reply, making the window as wide as it likes with zero test-only branches in the server. It withholds the `unregister` reply too, so a missing spawn gate has time to actually produce an agent.

Differential evidence (production reverted, tests unchanged):

| reverted | result |
|---|---|
| the whole `armClientShutdown` integration | both e2e cases fail |
| both spawn gates, arming kept | e2e case 2 fails on the agent it catches |
| arming moved after `registerClient` | structural: `arms the shutdown before the client registers` |
| the `doSpawn` gate | structural: `re-checks the gate inside doSpawn` |
| recovery's shutting-down check | structural: `publishes the crash-recovery re-registration` |
| `!reg` branch back to `process.exit` | structural: `releases the slot when registration itself fails` |
| `signalsSeen` back after the branch | unit: `counts a signal that was forwarded to a live agent` |
| single deadline across both waits | unit: `still sends the unregister when the registration reply never arrives` |

The fake-hub test's first draft was wrong twice, and the differential caught both: asserting the marker immediately after exit races the spawned `sh` being scheduled and passes either way, and a surviving orphan inherits the client's stdio so the runner hangs instead of failing. The structural block strips whole-line comments before matching for the same class of reason — prose reading "not process.exit" satisfied a `process.exit` pattern.

Results:

- `npm test`: **2328/2328** with `CCXRAY_HOME=$(mktemp -d)`
- `test/hub-client-signal.e2e.test.js`: **20/20** runs (was 8/20 on the unchanged server)
- codex gate clean — *"the remaining risk is now below the risk of continuing to change this file"*

## Note for reviewers

`CLAUDE.md` gains one row in the architecture table for `server/client-shutdown.js`. #581 adds a row to the same table for `server/visibility.js`; that branch is based on the same commit and will rebase onto this one, so the adjacent-row conflict is handled there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
