### PR TITLE
fix: the parseopenaitoolinput function processes ope... in messages.js

### DIFF
--- a/public/messages.js
+++ b/public/messages.js
@@ -205,9 +205,12 @@ function getOpenAIToolItemKind(type) {
 
 function parseOpenAIToolInput(item) {
   const rawInput = item?.arguments ?? item?.input ?? {};
-  if (rawInput && typeof rawInput === 'object') return rawInput;
-  try { return JSON.parse(rawInput || '{}'); }
-  catch { return { input: String(rawInput || '') }; }
+  const isPlainObject = v => v !== null && typeof v === 'object' && !Array.isArray(v);
+  if (isPlainObject(rawInput)) return rawInput;
+  try {
+    const parsed = JSON.parse(rawInput || '{}');
+    return isPlainObject(parsed) ? parsed : { input: parsed };
+  } catch { return { input: String(rawInput || '') }; }
 }
 
 // Grok CLI sends message.content as a plain string; Codex uses part arrays


### PR DESCRIPTION
## Summary
Fix high severity security issue in `public/messages.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `public/messages.js:206` |
| **Assessment** | Likely exploitable |

**Description**: The parseOpenAIToolInput function processes OpenAI API tool inputs with minimal validation. It accepts any object type or parses arbitrary JSON without schema enforcement. The fallback to raw string input when parsing fails creates an injection vector for unexpected data structures.

## Evidence

**Exploitation scenario**: Attacker crafts malicious tool inputs through prompt injection or compromised AI service responses.

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `public/messages.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
