### PR TITLE
docs(herdr): describe targeted repair instead of retired import --once

### DIFF
--- a/plugins/herdr/README.md
+++ b/plugins/herdr/README.md
@@ -132,10 +132,18 @@ in measurement. A session whose transcript cannot be located (codex panes, or a
 cwd ccxray never recorded) is never marked. `CCXRAY_BADGE_STALE_MS` sets the
 threshold (default 10 minutes).
 
-A marked badge also fires `ccxray import --once` detached, which is the thing
-that fixes it: the scan is throttled to once per 10 minutes and guarded by a
-lockfile, so many panes noticing at once still produce one scan.
-`CCXRAY_BADGE_IMPORT_DISABLE=1` keeps the marker but stops the rescan.
+A badge refresh with an exact, repairable transcript for the pane's native
+session requests a detached `bin/repair-session-link.js` worker for that session;
+the badge refresh does not wait for transcript parsing or index I/O. The worker
+runs a targeted
+`ccxray import --target-transcript ... --provider ... --session-id ... --cwd ...`
+and records per-session repair state under
+`~/.ccxray/herdr-plugin/link-repair-v1/` by default, or under the configured
+`HERDR_PLUGIN_STATE_DIR`. Failed attempts write `retryAfter`, so a later refresh
+can retry after that time; the default delay is 30 seconds and can be changed
+with `CCXRAY_LINK_REPAIR_RETRY_MS`. `CCXRAY_BADGE_IMPORT_DISABLE=1` keeps the
+stale marker but prevents new repair workers; after a successful repair, the
+worker's follow-up refresh also uses it to prevent recursive repair requests.
 
 `refresh-all-badges` (the startup fan-out) runs the pane-independent `ccxray
 status` and `ccxray usage` reports once and shares them with every per-pane


### PR DESCRIPTION
Closes #596

## 摘要

`plugins/herdr/README.md` 的 stale-badge 段落仍描述已退役的 `ccxray import --once` detached rescan（含 10 分鐘 throttle/lockfile 敘述）。改為描述 HEAD 的實際行為：per-session 的 targeted repair worker（`bin/repair-session-link.js`）、state 目錄 `~/.ccxray/herdr-plugin/link-repair-v1/`、30s 預設 `retryAfter`（`CCXRAY_LINK_REPAIR_RETRY_MS` 可調）、以及 `CCXRAY_BADGE_IMPORT_DISABLE` 的現行意義。刻意不列舉 state reason 值——#595 正在平行改那套分類，兩張保持 order-independent。

## Details

- Stale text was at `plugins/herdr/README.md:135-138`; actual behavior verified against `plugins/herdr/bin/lib/ccxray.js` (requestImport, spawn at ~1688-1704) and `plugins/herdr/bin/repair-session-link.js:45-80`.
- Every behavioral claim in the rewritten paragraph carries a verified file:line (see SUMMARY table in the issue thread / commit).
- Acceptance checks: `grep -n 'import --once' plugins/herdr/README.md` → no hits; `grep -rn 'import --once' docs/herdr-support*.md` → no hits (guard against moving the stale text into localized guides).

## Verification / codex evidence

- Implemented by codex `gpt-5.6-luna` (xhigh); reviewed via codex-loop with `gpt-5.6-sol` (medium).
- Review round 1: **NO FINDINGS** — codex gate clean.
- Doc-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
