### PR TITLE
fix(herdr): keep Herdr default spaces rows when installing sidebar summary

### DIFF
--- a/plugins/herdr/bin/install-sidebar-summary.js
+++ b/plugins/herdr/bin/install-sidebar-summary.js
@@ -59,6 +59,10 @@ const CCXRAY_ROWS = `${MANAGED_ROW_BY_TOKEN.route}\n${CTX_BAR_ROWS}\n${ROW3_ROWS
 // "the user already had a sidebar table and ccxray added rows to it".
 const SECTION_MARKER = '# ccxray sidebar summary rows (managed by the ccxray Herdr plugin)';
 const SPACES_SECTION_MARKER = '# ccxray workspace observability row (managed by the ccxray Herdr plugin)';
+const DEFAULT_SPACES_ROWS = [
+  '  ["state_icon", "workspace"],',
+  '  ["branch", "git_status"],',
+].join('\n');
 const WORKSPACE_ROW = '  [{ token = "$xray", fg = "#a6e3a1" }],';
 
 const SIDEBAR_SUMMARY_SECTION = `
@@ -78,6 +82,7 @@ ${SPACES_SECTION_MARKER}
 [ui.sidebar.spaces]
 row_gap = 0
 rows = [
+${DEFAULT_SPACES_ROWS}
 ${WORKSPACE_ROW}
 ]
 `;
@@ -280,7 +285,18 @@ function addWorkspaceRow(config) {
     return config.slice(0, bounds.bodyStart) + insertion + config.slice(bounds.bodyStart);
   }
   const inner = config.slice(rows.open + 1, rows.close);
-  if (tokenRegex('xray').test(stripCommentLines(inner))) return config;
+  if (tokenRegex('xray').test(stripCommentLines(inner))) {
+    // The previous installer's from-scratch section carried only the $xray row,
+    // which replaces Herdr's built-in spaces rows and hides workspace names.
+    // Upgrade exactly that shape, and only when the ownership marker directly
+    // precedes this section — a marker elsewhere proves nothing about it.
+    const innerRows = stripCommentLines(inner).split('\n').map(line => line.trim()).filter(Boolean);
+    const ownsSection = config.slice(0, bounds.headerStart).trimEnd().endsWith(SPACES_SECTION_MARKER);
+    if (ownsSection && innerRows.length === 1 && innerRows[0] === WORKSPACE_ROW.trim()) {
+      return `${config.slice(0, rows.open + 1)}\n${DEFAULT_SPACES_ROWS}\n${WORKSPACE_ROW}\n${config.slice(rows.close)}`;
+    }
+    return config;
+  }
   const trimmed = inner.replace(/[ \t\r\n]*$/, '');
   const separator = trimmed.trim() && !trimmed.trim().endsWith(',') ? ',' : '';
   return `${config.slice(0, rows.open + 1)}${trimmed}${separator}\n${WORKSPACE_ROW}\n${config.slice(rows.close)}`;
@@ -385,6 +401,7 @@ module.exports = {
   DEFAULT_ROWS,
   MANAGED_ROW_BY_TOKEN,
   MANAGED_TOKENS,
+  DEFAULT_SPACES_ROWS,
   SPACES_SECTION_MARKER,
   SECTION_MARKER,
   WORKSPACE_ROW,

--- a/plugins/herdr/bin/remove-sidebar-summary.js
+++ b/plugins/herdr/bin/remove-sidebar-summary.js
@@ -6,6 +6,7 @@ const { backupConfigFile, resolveHerdrConfigPath, runHerdr } = require('./lib/cc
 
 const {
   DEFAULT_ROWS,
+  DEFAULT_SPACES_ROWS,
   MANAGED_TOKENS,
   SPACES_SECTION_MARKER,
   SECTION_MARKER,
@@ -36,7 +37,15 @@ function makeSkeleton(defaults) {
   return ['[ui.sidebar.agents]', 'row_gap = 0', 'rows = [', ...defaults, ']'].join('\n');
 }
 const MANAGED_SKELETONS = [makeSkeleton(NEW_DEFAULT_ROWS), makeSkeleton(LEGACY_DEFAULT_ROWS)];
-const WORKSPACE_SKELETON = ['[ui.sidebar.spaces]', 'row_gap = 0', 'rows = [', '  [{ token = "$xray", fg = "#a6e3a1" }],', ']'].join('\n');
+// `stripped` has already had the plugin's `$xray` row removed when this
+// skeleton is compared, so the fresh section's built-in rows are what remain.
+const WORKSPACE_SKELETON = [
+  '[ui.sidebar.spaces]',
+  'row_gap = 0',
+  'rows = [',
+  ...DEFAULT_SPACES_ROWS.split('\n').map(line => line.trim()),
+  ']',
+].join('\n');
 const EMPTY_WORKSPACE_SKELETON = ['[ui.sidebar.spaces]', 'row_gap = 0', 'rows = [', ']'].join('\n');
 
 function normalizeBlock(block) {
@@ -71,6 +80,12 @@ function removeManagedWorkspaceSection(config, stripped) {
   const header = /^[ \t]*\[ui\.sidebar\.spaces\][ \t]*$/m.exec(stripped.slice(marker));
   if (!header) return null;
   const headerStart = marker + header.index;
+  // The skeleton now equals Herdr's own default rows — a shape a user could
+  // write by hand — so ownership additionally requires the marker to sit
+  // directly above this header, or a stale marker would claim a user table
+  // (and everything between them).
+  const between = stripped.slice(marker + SPACES_SECTION_MARKER.length, headerStart);
+  if (between.trim() !== '') return null;
   const bodyStart = headerStart + header[0].length;
   const next = /^\[[A-Za-z0-9_.-]+\][ \t]*$/m.exec(stripped.slice(bodyStart));
   const end = next ? bodyStart + next.index : stripped.length;

--- a/test/herdr-plugin.test.js
+++ b/test/herdr-plugin.test.js
@@ -2188,7 +2188,8 @@ describe('Herdr sidebar installer migrates accumulated generations', () => {
     ].join('\n'));
     assert.equal(result.status, 0, result.stderr);
     // Legacy rows are gone, new row 1 is in place.
-    assert.equal(after.includes('"workspace"'), false, 'old workspace column must go');
+    assert.equal(sidebarRows(after).some(row => /"workspace"/.test(row)), false,
+      'old workspace column must go');
     assert.match(after, /\["state_icon", \{ token = "\$who"/);
     // Eight config rows → four visible lines.
     assert.equal(sidebarRows(after).length, 8);
@@ -5327,6 +5328,123 @@ describe('Herdr plugin commands', () => {
     assert.match(result.stdout, /backup:/);
   });
 
+  // FAIL-ON-OLD: defining `rows` replaces Herdr's built-in spaces rows, so a
+  // fresh section must carry those defaults before the plugin's row.
+  it('install-sidebar-summary keeps Herdr default spaces rows on a fresh section', () => {
+    const dir = tempDir('herdr-spaces-config-');
+    const configPath = path.join(dir, 'config.toml');
+    fs.writeFileSync(configPath, '[ui]\nshow_agent_labels_on_pane_borders = true\n');
+    const result = runScript('install-sidebar-summary.js', [], {
+      HERDR_CONFIG_PATH: configPath,
+      CCXRAY_HERDR_SKIP_RELOAD: '1',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const config = fs.readFileSync(configPath, 'utf8');
+    const spaces = config.slice(config.indexOf('[ui.sidebar.spaces]'));
+    assert.match(spaces, /\n  \["state_icon", "workspace"\],\n  \["branch", "git_status"\],\n  \[\{ token = "\$xray", fg = "#a6e3a1" \}\],/);
+  });
+
+  // A section the previous installer wrote carries only the $xray row and hides
+  // the workspace names. Reinstall must upgrade exactly that marker-owned shape,
+  // stay idempotent, and removal must still take the whole plugin-owned table.
+  it('install-sidebar-summary upgrades the previous installer\'s spaces section', () => {
+    const dir = tempDir('herdr-spaces-legacy-config-');
+    const configPath = path.join(dir, 'config.toml');
+    const legacy = [
+      '# ccxray workspace observability row (managed by the ccxray Herdr plugin)',
+      '[ui.sidebar.spaces]',
+      'row_gap = 0',
+      'rows = [',
+      '  [{ token = "$xray", fg = "#a6e3a1" }],',
+      ']',
+      '',
+    ].join('\n');
+    fs.writeFileSync(configPath, legacy);
+    const env = { HERDR_CONFIG_PATH: configPath, CCXRAY_HERDR_SKIP_RELOAD: '1' };
+
+    assert.equal(runScript('install-sidebar-summary.js', [], env).status, 0);
+    const upgraded = fs.readFileSync(configPath, 'utf8');
+    assert.match(upgraded, /\n  \["state_icon", "workspace"\],\n  \["branch", "git_status"\],\n  \[\{ token = "\$xray", fg = "#a6e3a1" \}\],/);
+
+    assert.equal(runScript('install-sidebar-summary.js', [], env).status, 0);
+    assert.equal(fs.readFileSync(configPath, 'utf8'), upgraded);
+
+    assert.equal(runScript('remove-sidebar-summary.js', [], env).status, 0);
+    assert.doesNotMatch(fs.readFileSync(configPath, 'utf8'), /\[ui\.sidebar\.spaces\]/);
+  });
+
+  it('install-sidebar-summary leaves a spaces section whose marker is elsewhere', () => {
+    const dir = tempDir('herdr-spaces-stale-marker-');
+    const configPath = path.join(dir, 'config.toml');
+    const misplaced = [
+      '# ccxray workspace observability row (managed by the ccxray Herdr plugin)',
+      '[terminal]',
+      'new_cwd = "follow"',
+      '',
+      '[ui.sidebar.spaces]',
+      'row_gap = 0',
+      'rows = [',
+      '  [{ token = "$xray", fg = "#a6e3a1" }],',
+      ']',
+      '',
+    ].join('\n');
+    fs.writeFileSync(configPath, misplaced);
+    const env = { HERDR_CONFIG_PATH: configPath, CCXRAY_HERDR_SKIP_RELOAD: '1' };
+
+    assert.equal(runScript('install-sidebar-summary.js', [], env).status, 0);
+    const after = fs.readFileSync(configPath, 'utf8');
+    const spaces = after.slice(after.indexOf('[ui.sidebar.spaces]'));
+    assert.doesNotMatch(spaces, /\["state_icon", "workspace"\]/);
+  });
+
+  it('remove-sidebar-summary keeps a default-shaped user table under a stale marker', () => {
+    const dir = tempDir('herdr-spaces-stale-marker-remove-');
+    const configPath = path.join(dir, 'config.toml');
+    const misplaced = [
+      '# ccxray workspace observability row (managed by the ccxray Herdr plugin)',
+      '[terminal]',
+      'new_cwd = "follow"',
+      '',
+      '[ui.sidebar.spaces]',
+      'row_gap = 0',
+      'rows = [',
+      '  ["state_icon", "workspace"],',
+      '  ["branch", "git_status"],',
+      ']',
+      '',
+    ].join('\n');
+    fs.writeFileSync(configPath, misplaced);
+    const env = { HERDR_CONFIG_PATH: configPath, CCXRAY_HERDR_SKIP_RELOAD: '1' };
+
+    assert.equal(runScript('remove-sidebar-summary.js', [], env).status, 0);
+    const after = fs.readFileSync(configPath, 'utf8');
+    assert.match(after, /\[terminal\]/);
+    assert.match(after, /\[ui\.sidebar\.spaces\]/);
+    assert.match(after, /\["state_icon", "workspace"\]/);
+  });
+
+  it('install-sidebar-summary keeps a user-extended legacy spaces section', () => {
+    const dir = tempDir('herdr-spaces-legacy-extended-');
+    const configPath = path.join(dir, 'config.toml');
+    const extended = [
+      '# ccxray workspace observability row (managed by the ccxray Herdr plugin)',
+      '[ui.sidebar.spaces]',
+      'row_gap = 0',
+      'rows = [',
+      '  [{ token = "$xray", fg = "#a6e3a1" }],',
+      '  ["cwd"],',
+      ']',
+      '',
+    ].join('\n');
+    fs.writeFileSync(configPath, extended);
+    const env = { HERDR_CONFIG_PATH: configPath, CCXRAY_HERDR_SKIP_RELOAD: '1' };
+
+    assert.equal(runScript('install-sidebar-summary.js', [], env).status, 0);
+    const after = fs.readFileSync(configPath, 'utf8');
+    assert.doesNotMatch(after, /\["state_icon", "workspace"\]/);
+    assert.match(after, /\["cwd"\]/);
+  });
+
   // remove-sidebar-summary restores its backup when `herdr config check` rejects
   // the result; install did not, so a rejected merge left the user's own herdr
   // config in the broken state and only printed where the backup was.
@@ -5547,6 +5665,40 @@ describe('Herdr plugin commands', () => {
     assert.equal(config.match(/\[ui\.sidebar\.agents\]/g).length, 1);
   });
 
+  it('keeps user-owned spaces rows append-only across install and remove', () => {
+    const dir = tempDir('herdr-spaces-user-config-');
+    const configPath = path.join(dir, 'config.toml');
+    fs.writeFileSync(configPath, [
+      '[ui.sidebar.spaces]',
+      'row_gap = 0',
+      'rows = [',
+      '  ["cwd"],',
+      ']',
+      '',
+      '[terminal]',
+      'new_cwd = "follow"',
+      '',
+    ].join('\n'));
+    const env = { HERDR_CONFIG_PATH: configPath, CCXRAY_HERDR_SKIP_RELOAD: '1' };
+
+    const installed = runScript('install-sidebar-summary.js', [], env);
+    assert.equal(installed.status, 0, installed.stderr);
+    const afterInstall = fs.readFileSync(configPath, 'utf8');
+    const spacesAfterInstall = afterInstall.slice(afterInstall.indexOf('[ui.sidebar.spaces]'));
+    assert.match(spacesAfterInstall, /\["cwd"\]/);
+    assert.match(spacesAfterInstall, /\$xray/);
+    assert.doesNotMatch(spacesAfterInstall, /\["state_icon", "workspace"\]/);
+    assert.doesNotMatch(spacesAfterInstall, /\["branch", "git_status"\]/);
+
+    const removed = runScript('remove-sidebar-summary.js', [], env);
+    assert.equal(removed.status, 0, removed.stderr);
+    const afterRemove = fs.readFileSync(configPath, 'utf8');
+    assert.match(afterRemove, /\[ui\.sidebar\.spaces\]/);
+    assert.match(afterRemove, /\["cwd"\]/);
+    assert.doesNotMatch(afterRemove, /\$xray/);
+    assert.match(afterRemove, /\[terminal\]/);
+  });
+
   it('sidebar summary survives a remove and install round trip', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'herdr-config-'));
     const configPath = path.join(dir, 'config.toml');
@@ -5729,7 +5881,11 @@ describe('Herdr plugin commands', () => {
     const env = { HERDR_CONFIG_PATH: configPath, CCXRAY_HERDR_SKIP_RELOAD: '1' };
 
     assert.equal(runScript('install-sidebar-summary.js', [], env).status, 0);
-    assert.match(fs.readFileSync(configPath, 'utf8'), /\[ui\.sidebar\.agents\]/);
+    const installed = fs.readFileSync(configPath, 'utf8');
+    assert.match(installed, /\[ui\.sidebar\.agents\]/);
+    assert.match(installed, /\["state_icon", "workspace"\]/);
+    assert.match(installed, /\["branch", "git_status"\]/);
+    assert.match(installed, /\$xray/);
 
     const removed = runScript('remove-sidebar-summary.js', [], env);
     assert.equal(removed.status, 0, removed.stderr);


### PR DESCRIPTION
Closes #597

## 摘要

`install-sidebar-summary` 從零建立 `[ui.sidebar.spaces]` 時只寫 `$xray` 一列；herdr 的 rows 語意是「一經定義即完全取代內建預設」，workspace 名稱／branch／git 狀態因此消失（2026-08-30 實際發生於 owner 環境）。修正三件事：

1. 從零建區時先寫 herdr 預設兩列（`["state_icon", "workspace"]`、`["branch", "git_status"]`）再寫 `$xray`。
2. 舊版 installer 已裝出去的 marker-owned「只有 `$xray`」區塊，reinstall 時就地升級（冪等）。
3. install/remove 兩端的 ownership 判定都收緊為「marker 必須緊鄰 header」——本次把 remove 端 skeleton 改成 herdr 預設形狀後，使用者手寫的預設形狀表會變得可能被錯位 marker 誤認 plugin-owned 而整段誤刪，緊鄰性把這個風險關掉。

## Details

- `plugins/herdr/bin/install-sidebar-summary.js`: `DEFAULT_SPACES_ROWS` constant; from-scratch template includes defaults; `addWorkspaceRow` upgrades the exact marker-adjacent legacy shape only.
- `plugins/herdr/bin/remove-sidebar-summary.js`: `WORKSPACE_SKELETON` reuses the shared defaults; `removeManagedWorkspaceSection` requires whitespace-only between marker and header. Whole-table removal for plugin-owned sections and `$xray`-only stripping for user tables are unchanged.
- Tests (`test/herdr-plugin.test.js`, +8 scenarios): fresh-section ordering (fail-on-old), legacy upgrade + idempotency + whole-table removal, user-extended legacy section untouched, stale-marker fixtures on both install (no upgrade) and remove (default-shaped user table survives), user-owned append-only round-trip.

## Verification / codex evidence

- Implemented by codex `gpt-5.6-luna` (xhigh); reviewed via codex-loop with `gpt-5.6-sol` (medium), 4 rounds:
  - R1: major — legacy marker-owned section never upgraded on reinstall → fixed (+tests).
  - R2: major — marker accepted anywhere in the config → install-side adjacency guard + misplaced-marker fixture.
  - R3: P1 — the new default-row skeleton widens remove-side misfire surface → remove-side adjacency guard + stale-marker removal fixture.
  - R4: **NO FINDINGS** — codex gate clean.
- fail-on-old: new fresh-section test fails on original code, passes on new (recorded old-run assertion output in SUMMARY).
- Full `node --test test/herdr-plugin.test.js`: 258/258 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
