### PR TITLE
docs(rebuild-index): drop the false "index never shrinks" guarantee (#621)

### DIFF
--- a/server/rebuild-index.js
+++ b/server/rebuild-index.js
@@ -12,18 +12,20 @@
 //
 // Hard guarantees (issue #48,做法 1):
 //   • merge-only, add-only — ADD lines for ids that have a _req.json on disk but
-//     are missing from the index (the "orphan set"). Existing lines, including
-//     the ~85% whose _req/_res were pruned (LOG_RETENTION_DAYS) while the index
-//     kept the line forever, are copied through verbatim. The index never shrinks
-//     and a present line is never DEGRADED. The one sanctioned overwrite is the
-//     #333 add-only responseId backfill: a legacy line missing the dedup key gets
-//     it appended (all other fields byte-identical) when its _res.json survives —
-//     strictly non-degrading, so #48's intent holds. See ADR 0012.
+//     are missing from the index (the "orphan set"). Existing lines are copied
+//     through verbatim and a present line is never DEGRADED. The one sanctioned
+//     overwrite is the #333 add-only responseId backfill: a legacy line missing
+//     the dedup key gets it appended (all other fields byte-identical) when its
+//     _res.json survives — strictly non-degrading, so #48's intent holds. See
+//     ADR 0012.
 //   • never degrade — a delta turn whose ancestor _req.json was pruned cannot be
 //     fully reconstructed; we SKIP it and count it unrecoverable rather than emit
 //     a truncated line. Rebuild must never produce a worse line than doing nothing.
 //   • atomic — write a temp file, then fs.rename() onto index.ndjson.
 //   • hub-safe — refuse to run while a live hub may be appending concurrently.
+//
+// Retention scope: startup `pruneLogs()` is an independent path that removes
+// unprotected proxy lines whose `_req.json` is gone.
 //
 // Recovers offline: model/usage/cost/maxContext/toolCalls (canonical), cwd (from
 // the rehydrated system prompt — shared sys_*.json files are never pruned),


### PR DESCRIPTION
## 摘要

`server/rebuild-index.js` 檔頭把「索引永不縮減／行永久保留」列為 rebuild 的
hard guarantee，但 #344／#345 之後已不成立——照它推理救援策略會被誤導。改寫該段，
把**兩條路徑**分開講：rebuild 命令本身仍是 merge-only／add-only、不降級既有行；
移除行的是啟動時獨立的 `pruneLogs()`。

Doc-only：無程式碼變更、無行為變更（diff 每一行都是 `//` 註解）。

Fixes #621

## What changed

The header advertised index-level permanent retention as one of rebuild's hard
guarantees. `_shouldKeepIndexLine` (server/restore.js:584), called from startup
`pruneLogs()`, drops a proxy line whose `_req.json` no longer survives and which
is not star/memory protected — so the guarantee is false.

- removed the "index never shrinks" / "kept the line forever" claim and the
  now-stale "~85%" figure
- kept "merge-only, add-only" and "never DEGRADED", which remain accurate **for
  the rebuild command itself**, and restored "never DEGRADED" to being adjacent
  to its single #333 exception
- added startup `pruneLogs()` as a standalone `Retention scope:` note **outside**
  the guarantees list — a separate subsystem is not one of rebuild's guarantees,
  and placing it inside the list invited exactly the conflation guard G2 forbids

## Evidence

**Acceptance + guards, mechanically asserted on the raw source** (assertions
normalize `//` prefixes and collapse whitespace, so a re-wrap cannot masquerade
as a content regression):

| assertion | old (`origin/main`) | new |
|---|---|---|
| A1 no permanent-retention claim | **FAIL** | PASS |
| A2 mentions startup `pruneLogs()` removing unprotected proxy lines lacking `_req.json` | **FAIL** | PASS |
| A3 merge-only/add-only + never-degrade retained | PASS | PASS |
| G2a prune labelled "independent path" | **FAIL** | PASS |
| G2b rebuild never described as pruning/removing lines | PASS | PASS |
| P1 #333 backfill sentence intact | PASS | PASS |
| P2 ADR 0012 ref intact | PASS | PASS |
| R1 never-DEGRADED contiguous with its #333 exception | PASS | PASS |

```
NEW: ALL PASS (exit 0)          OLD: 3 FAILED (exit 1)
```

A1/A2/G2a carry the differential (fail-on-old → pass-on-new). A3/P1/P2/R1 pass on
both by design — they are the **anti-regression direction** (guard G1: acceptance 3
is the opposite assertion to acceptance 1, so it must hold before *and* after).

**Gates**

| gate | result |
|---|---|
| `node --test test/*.test.js` (isolated `CCXRAY_HOME`) | exit 0 — 2515 pass / 0 fail / 526 suites |
| `scripts/boot-smoke.sh 5653` | exit 0 — `proxy listening on http://localhost:5653`, dashboard HTTP 200 |
| `node --check server/rebuild-index.js` | exit 0 |
| comment-only check | `git diff origin/main -U0` has zero non-comment changed lines |
| orphan-reference scan | n/a — no symbol added, renamed or deleted |
| `codex review --base origin/main` | clean, 2 rounds, 0 findings |

## codex 二審

Round 1 clean. **Round 2 was driven by an orchestrator finding codex did not
raise**: the prune sentence had landed between "a present line is never DEGRADED"
and "The one sanctioned overwrite is the #333 backfill" — a rule and its only
exception, split by a note about a different subsystem, and placed inside a bullet
under "Hard guarantees". It satisfied G2's letter while weakening its intent. Fixed
by moving it to a standalone note; re-reviewed clean.

## 驗了什麼／沒驗什麼

**驗了**：檔頭文字對照真實程式碼（`_shouldKeepIndexLine` 的 protected／imported-orphan／
proxy 三條規則、`pruneLogs` 由 `server/index.js:1261` 在啟動時呼叫、`rebuild-index.js`
自己從不呼叫 prune）；全套測試綠；boot smoke 起得來。

**沒驗**：runtime prune 行為未另跑（本 PR 不含程式碼變更，行為不可能改變）。檔頭其餘
段落（`Recovers offline:` 清單等）未逐項重新查證，不在本張範圍。

## 附記（不在本 PR 範圍）

- issue #621 body 寫 `Type: bug`，但 issue 未貼 `pipeline:type-bug` label，因此
  `gate-marker-check` 的 type-conditional 未要求 `diff-check` marker。上表的
  old/new 差異證據已等價提供該證據，僅 manifest 不含該行。
- 全套測試會洩漏一個 `server/index.js` 行程（`ppid=1`、cwd 在
  `ccxray-project-*` 暫存目錄、**wildcard** `*:9999` LISTEN）。本 PR 為
  comment-only，故屬既有現象；已手動清除，另行開票。

<!-- GATE-MANIFEST
issue-lint=pass @e8664749d5eb9fddc4402549e45448fea364b3a8
full-test=0 @e8664749d5eb9fddc4402549e45448fea364b3a8
boot-smoke=0 @e8664749d5eb9fddc4402549e45448fea364b3a8
-->
