### PR TITLE
fix(server): sweep orphaned index prune tmp files at startup (#620)

### DIFF
--- a/server/restore.js
+++ b/server/restore.js
@@ -624,11 +624,47 @@ function pruneIndexLines(indexContent, { survivingReqIds, protectedIds }) {
   return { keptLines, dropped };
 }
 
+function sweepOrphanedPruneTmpFiles(logsDir, kill = process.kill) {
+  if (!logsDir) return;
+
+  let files;
+  try { files = fs.readdirSync(logsDir); } catch { return; }
+
+  for (const filename of files) {
+    const match = /^index\.ndjson\.prune-(\d+)\.tmp$/.exec(filename);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    // Own-PID cleanup assumes one PID namespace per logs dir—the only documented
+    // topology: README permits local-filesystem logs, and ADR 0021 scopes
+    // same-machine writers by realpath(config.LOGS_DIR). Separate namespaces sharing
+    // it already collide on this temp pathname: the prior failure can rename a
+    // truncated temp over index.ndjson (CAS fingerprints only index.ndjson); this
+    // sweep instead yields a caught ENOENT and skipped prune.
+    let orphaned = pid === process.pid;
+    if (!orphaned) {
+      try {
+        kill(pid, 0);
+        continue;
+      } catch (err) {
+        if (!err || err.code !== 'ESRCH') continue;
+        orphaned = true;
+      }
+    }
+
+    if (orphaned) try { fs.unlinkSync(path.join(logsDir, filename)); } catch {}
+  }
+}
+
 // ── Prune log files older than LOG_RETENTION_DAYS ───────────────────
 // Files belonging to entries currently restored in memory are never pruned —
 // otherwise lazy-load (loadEntryReqRes) would return null after restart.
 
 async function pruneLogs() {
+  // The sweep precedes the exclusive storage lock; a second concurrent call in
+  // this process could remove the first call's temp. That is unreachable from
+  // the single startup call site in server/index.js:1261.
+  sweepOrphanedPruneTmpFiles(config.storage.location);
   if (!config.LOG_RETENTION_DAYS || config.LOG_RETENTION_DAYS <= 0) return;
 
   // ponytail: if index is empty/missing, star-protection cascade can't map
@@ -813,4 +849,4 @@ async function pruneLogs() {
   }
 }
 
-module.exports = { loadEntryReqRes, restoreFromLogs, pruneLogs, pruneIndexLines, boundedIndexLines };
+module.exports = { loadEntryReqRes, restoreFromLogs, pruneLogs, pruneIndexLines, boundedIndexLines, sweepOrphanedPruneTmpFiles };

--- a/test/prune-safety.test.js
+++ b/test/prune-safety.test.js
@@ -5,11 +5,15 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { spawn } = require('child_process');
+
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-prune-safety-home-'));
+process.env.CCXRAY_HOME = TEST_HOME;
 
 const config = require('../server/config');
 const store = require('../server/store');
 const { createLocalStorage } = require('../server/storage/local');
-const { pruneLogs } = require('../server/restore');
+const { pruneLogs, sweepOrphanedPruneTmpFiles } = require('../server/restore');
 
 describe('pruneLogs safety: empty/missing index', () => {
   const tmpDir = path.join(os.tmpdir(), 'ccxray-prune-safety-' + process.pid);
@@ -28,6 +32,7 @@ describe('pruneLogs safety: empty/missing index', () => {
     config.storage = origStorage;
     config.LOG_RETENTION_DAYS = origRetention;
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(TEST_HOME, { recursive: true, force: true });
   });
 
   beforeEach(() => {
@@ -40,6 +45,124 @@ describe('pruneLogs safety: empty/missing index', () => {
     fs.writeFileSync(path.join(tmpDir, `${id}_req.json`), '{}');
     fs.writeFileSync(path.join(tmpDir, `${id}_res.json`), '[]');
   }
+
+  function exitedPid() {
+    return new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, ['-e', '']);
+      child.once('error', reject);
+      child.once('exit', () => resolve(child.pid));
+    });
+  }
+
+  function liveChild() {
+    return new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+      child.once('error', reject);
+      child.once('spawn', () => resolve(child));
+    });
+  }
+
+  async function stopChild(child) {
+    if (child.exitCode !== null || child.signalCode) return;
+    const exited = new Promise(resolve => child.once('exit', resolve));
+    child.kill();
+    await exited;
+  }
+
+  function seedUntouchedNeighbors(extra = []) {
+    const filenames = ['index.ndjson', 'index.ndjson.bak', 'sessions.json', ...extra];
+    for (const filename of filenames) {
+      fs.writeFileSync(path.join(tmpDir, filename), filename === 'index.ndjson' ? '' : 'synthetic neighbor');
+    }
+    return { filenames, before: new Map(filenames.map(filename => [filename, fs.statSync(path.join(tmpDir, filename))])) };
+  }
+
+  function assertNeighborsUntouched({ filenames, before }) {
+    for (const filename of filenames) {
+      const after = fs.statSync(path.join(tmpDir, filename));
+      assert.equal(after.size, before.get(filename).size, `${filename} size`);
+      assert.equal(after.mtimeMs, before.get(filename).mtimeMs, `${filename} mtime`);
+    }
+  }
+
+  it('removes a fresh prune tmp whose owner exited even when index is missing', async () => {
+    const pid = await exitedPid();
+    const tmpPath = path.join(tmpDir, `index.ndjson.prune-${pid}.tmp`);
+    fs.writeFileSync(tmpPath, 'synthetic interrupted prune');
+
+    await pruneLogs();
+
+    assert.equal(fs.existsSync(tmpPath), false);
+  });
+
+  it('sweeps before the retention-disabled early return', async () => {
+    const pid = await exitedPid();
+    const tmpPath = path.join(tmpDir, `index.ndjson.prune-${pid}.tmp`);
+    fs.writeFileSync(tmpPath, 'synthetic interrupted prune');
+    config.LOG_RETENTION_DAYS = 0;
+
+    try {
+      await pruneLogs();
+    } finally {
+      config.LOG_RETENTION_DAYS = 14;
+    }
+
+    assert.equal(fs.existsSync(tmpPath), false);
+  });
+
+  it('keeps a prune tmp whose distinct owner is alive', async () => {
+    const child = await liveChild();
+    try {
+      assert.notEqual(child.pid, process.pid);
+      const tmpPath = path.join(tmpDir, `index.ndjson.prune-${child.pid}.tmp`);
+      fs.writeFileSync(tmpPath, 'synthetic live prune');
+      const neighbors = seedUntouchedNeighbors();
+
+      await pruneLogs();
+
+      assert.equal(fs.existsSync(tmpPath), true);
+      assertNeighborsUntouched(neighbors);
+    } finally {
+      await stopChild(child);
+    }
+  });
+
+  it('sweeps a prune tmp named with the current process PID', async () => {
+    const tmpPath = path.join(tmpDir, `index.ndjson.prune-${process.pid}.tmp`);
+    fs.writeFileSync(tmpPath, 'synthetic interrupted prune');
+
+    await pruneLogs();
+
+    assert.equal(fs.existsSync(tmpPath), false);
+  });
+
+  it('keeps a prune tmp when the ownership probe is EPERM', () => {
+    const tmpPath = path.join(tmpDir, 'index.ndjson.prune-12345.tmp');
+    fs.writeFileSync(tmpPath, 'synthetic inaccessible live prune');
+    const eperm = Object.assign(new Error('permission denied'), { code: 'EPERM' });
+    const neighbors = seedUntouchedNeighbors();
+
+    sweepOrphanedPruneTmpFiles(tmpDir, () => { throw eperm; });
+
+    assert.equal(fs.existsSync(tmpPath), true);
+    assertNeighborsUntouched(neighbors);
+  });
+
+  it('sweeps only dead numeric prune tmps and leaves neighbors untouched', async () => {
+    const pid = await exitedPid();
+    const tmpPath = path.join(tmpDir, `index.ndjson.prune-${pid}.tmp`);
+    fs.writeFileSync(tmpPath, 'synthetic interrupted prune');
+    const neighbors = seedUntouchedNeighbors([
+      'index.ndjson.prune-abc.tmp',
+      `index.ndjson.rebuild-${pid}.tmp`,
+      `index.ndjson.reimport-${pid}.tmp`,
+    ]);
+
+    await pruneLogs();
+
+    assert.equal(fs.existsSync(tmpPath), false);
+    assertNeighborsUntouched(neighbors);
+  });
 
   it('skips prune when index.ndjson is missing', async () => {
     // Old file that would normally be pruned (>14 days ago)


### PR DESCRIPTION
## 摘要

prune 改寫索引時若被中斷，會留下 `index.ndjson.prune-<pid>.tmp`，而**啟動流程沒有
任何機制掃描或清除它**。`pruneLogs()` 開頭加入掃除，放在 retention guard **之上**，
所以 prune 提早返回時掃除仍已完成。

擁有者判定：自身 PID 視為孤兒，其餘只認 `ESRCH`；`EPERM`（行程存在但屬其他使用者）
與未知 errno 一律保留。**未使用檔案年齡門檻**——它與「剛建立的暫存檔也必須被清除」相斥。

Fixes #620

## Evidence

### A. Integration — real server boot, isolated `CCXRAY_HOME`, side port, synthetic data

`LOG_RETENTION_DAYS=0` so prune **early-returns** — this proves guard **G3** (the sweep
must already have happened) *and* leaves `index.ndjson` untouched so acceptance 4 is
assertable end-to-end. Dead PID obtained from a reaped short-lived child (not by
scanning numbers). **Acceptance 3 uses a REAL EPERM**, not an injected errno: PID 1 is
root-owned `launchd`, so `process.kill(1,0)` throws `EPERM` for a non-root user
(pre-check printed in the run).

| assertion | old (`origin/main`) | new |
|---|---|---|
| A1 owner-exited prune tmp is swept | **FAIL** | PASS |
| A2 owner-alive (live, distinct) prune tmp is kept | PASS | PASS |
| A3 real-EPERM prune tmp is kept | PASS | PASS |
| A4a `index.ndjson` size+mtime unchanged | PASS | PASS |
| A4b `index.ndjson.bak` size+mtime unchanged | PASS | PASS |
| S1 out-of-scope `rebuild-*.tmp` untouched | PASS | PASS |
| S2 out-of-scope `reimport-*.tmp` untouched | PASS | PASS |
| S3 unparseable pid segment kept | PASS | PASS |

```
NEW: ALL PASS (exit 0)        OLD: 1 FAILED (exit 1) — A1, the orphan survives
```

A2/A3/A4/S1-S3 pass on both **by design** — they are the reverse cases (guards G1/G2/G4);
an indiscriminate delete fails them, so they must hold before *and* after.

### B. Unit + formal differential

| gate | result |
|---|---|
| `node --test test/prune-safety.test.js` | exit 0 — 9 pass / 0 fail |
| `scripts/diff-check.sh origin/main test/prune-safety.test.js` | **exit 0** — old 4 pass/5 fail, new 9 pass/0 fail, `✅ old FAIL / new PASS` |
| `node --test` × 6 neighbour suites (prune-index-sync, restore, storage, star-retention, restore-session-cap, session-index-tmp) | exit 0 — 73 pass / 0 fail |
| `node --test test/*.test.js` (isolated `CCXRAY_HOME`) | exit 0 — **2521 pass / 0 fail** / 526 suites |
| `scripts/boot-smoke.sh 5667` | exit 0 — `proxy listening`, dashboard HTTP 200 |
| `node --check` × 2 files | exit 0 |
| orphan-reference scan | no top-level symbol removed or renamed; `module.exports` is additive only |

### C. The Docker / PID-reuse fix (codex 二審 round 1, P2 — accepted)

`Dockerfile:19` is `CMD ["node", "server/index.js"]` in **exec form**, so in the
documented Docker image node is **PID 1**. A crash mid-prune leaves
`index.ndjson.prune-1.tmp`; on restart node is PID 1 again, so `kill(1,0)` succeeds
**against itself** and a pure-liveness rule keeps the file forever — the exact leak this
issue targets. The issue anticipated it: *"PID 會重用 … 單靠 PID 存活與否不是零風險"*.

Fix: a temp bearing **our own pid** is an orphan *by construction* — at sweep time we
have not written ours yet (it is created later in `pruneIndexLines()` pass 3), and pids
are unique among live processes, so it must have been left by a dead process that
formerly held our pid. Checked **before** the `kill` probe.

Verified by running the sweep **inside** a process whose own pid names the file
(semantically identical to node-as-PID-1 after a restart, without needing to be PID 1):

| assertion | r1 commit `526f860` | final |
|---|---|---|
| D1 own-pid tmp is swept | **FAIL** | PASS |
| live **distinct**-owner tmp kept | PASS | PASS |
| real-EPERM (pid 1) tmp kept | PASS | PASS |
| `index.ndjson` / `.bak` / `sessions.json` size+mtime unchanged | PASS | PASS |

The run prints `own-pid kill probe : succeeds` — i.e. without this rule the probe reads
ALIVE. Docker itself was not exercised (no docker on this machine); that is the one gap.

## codex 二審 — 3 rounds

二審通道：`codex review --base origin/main`（codex-cli 0.152.1），跑了 3 輪，最後一輪的變更為註解、邏輯逐 byte 相同。R1 的 P2 已修，R2 的 P2 經查證駁回（理由見下）。

- **R1 P2 accepted** → the Docker/PID-1 hole above.
- **R2 P2 rejected**, with verified evidence. It claimed the own-pid shortcut could
  delete a *live* writer's temp when two containers share `LOGS_DIR` and both are PID 1,
  citing `CLAUDE.md:48` as making shared log dirs "explicitly a supported coordination
  scope". Three reasons it does not stand:
  1. **The citation is misread.** `CLAUDE.md:48` is the ADR 0021 *CAS* invariant. ADR 0021
     scopes **same-machine** writers by `realpath(config.LOGS_DIR)`. Cross-PID-namespace
     sharing appears **nowhere** in `CLAUDE.md`, `docs/decisions/` or `README.md`
     (grepped); README states logs are local-filesystem only.
  2. **The consequence is caught, not fatal.** `renameSync` sits in the `try` whose
     `catch` logs `[ccxray] index prune failed:` and whose `finally` releases the
     exclusive lock — the same degradation the CAS-mismatch path *deliberately* chooses
     ("skipping rewrite (will retry next startup)").
  3. **In that topology the sweep strictly improves safety.** Two PID-1 processes sharing
     `LOGS_DIR` already write the *same* pathname; `createWriteStream` truncates, and the
     CAS fingerprints only `index.ndjson` — never the temp — so the first process's CAS
     **passes** and it renames a *corrupted* temp over the index. The sweep turns silent
     index corruption into a caught ENOENT plus a skipped prune. The issue names this
     collision itself: *"或同一個 PID 恰好再次被用於 prune 而覆寫同名檔"*.

  **This rejection is an orchestrator adjudication, not an owner decision** — it is
  reported as such. The assumption and its boundary are now documented in the code
  (`server/restore.js`, own-pid branch).
- **R3** = that comment only; logic byte-identical (verified: zero non-comment changed
  lines vs the previous commit).

## 需要 owner 裁決：驗收 2 的「自身PID」有兩種讀法

驗收 2 寫「放一個 `index.ndjson.prune-<自身PID>.tmp`（擁有者存活）→ 啟動後**仍存在**」。

- **讀法 A**（本 PR 採用）＝**放檔那個行程**的 PID，即一個**存活的第三方**行程 → 保留。
- **讀法 B** ＝ **server 自己**的 PID → 保留。

採讀法 B 就必須放棄 Docker 修法（C 節），因為那正是「檔名帶 server 自己 PID」的情況。
選擇讀法 A 的理由：issue 自己的重現腳本用 shell 產生 PID（`( exit 0 ) & DEAD=$!`），且
guard G1 明說驗收 2 的**目的**是「防『無條件刪掉所有 .tmp』」——存活的第三方 PID 已完整
達成該目的。

兩種情況已**分開測試**，所以反轉是一行改動：
`keeps a prune tmp whose distinct owner is alive`（讀法 A，保留）與
`sweeps a prune tmp named with the current process PID`（Docker 修法，清除）。

## 驗了什麼／沒驗什麼

**驗了**：上述 A/B/C 全部，含在**未修改的 restore.js** 上取得 fail-on-old 基線；
偵測到並確認 `process.kill` 以**解參考**形式呼叫仍正確傳遞 `.code`（若不然，掃除會在
production 靜默地什麼都不刪，而注入 stub 的單元測試照樣綠）；新測試不外洩子行程。

**沒驗**：實際 Docker 容器（本機無 docker）——PID-1 情境以「在自身 PID 命名該檔的行程內
執行掃除」等價驗證。跨 PID namespace 共用 `LOGS_DIR` 未實測，理由見 R2 第 3 點。
restore 失敗時不掃除（既有行為，已記錄於 commit 與程式註解）。

## 附記（不在本 PR 範圍，建議另開）

同 PID 的**檔名碰撞**本身是既有潛在 bug：`${indexPath}.prune-${process.pid}.tmp` 在兩個
同 PID 行程共用 logs dir 時是同一個路徑，而 CAS 只對 `index.ndjson` 取指紋、不含暫存檔，
因此可能把被截斷的暫存檔 rename 到索引上。本 PR 未觸及、且將其失敗模式變得更輕。


> **branch updated**：#622 merge 後本支 BEHIND，已 `git merge origin/main`（合入的只有 #621 的註解變更，零衝突）。head 變為 `4c1bf6063127`，上述四個 gate **已在該 sha 重跑**（非只改標籤）：full-test 2521/0、boot-smoke 0、diff-check 0（舊 4pass/5fail → 新 9/0）、自身-PID 差異檢查 ALL PASS。

<!-- GATE-MANIFEST
issue-lint=pass @4c1bf60631279a22718234d45faa787cf11e0079
full-test=0 @4c1bf60631279a22718234d45faa787cf11e0079
boot-smoke=0 @4c1bf60631279a22718234d45faa787cf11e0079
diff-check=0 @4c1bf60631279a22718234d45faa787cf11e0079
-->
