### PR TITLE
fix(usage): disclose the retention window behind all-time totals (#619)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -53,6 +53,7 @@ the rounding cap is the contract.
 ```jsonc
 {
   "meta":     { "totalEntries": 0, "totalSessions": 0, "totalCost": 0,
+                "retentionDays": 14, "retentionCutoff": "YYYY-MM-DD",
                 "timeRange": { "from": "ISO|null", "to": "ISO|null" } },
   "sessions": { "count": 0, "byProvider": { "<provider>": 0 },
                 "subagentRatio": 0,
@@ -76,6 +77,9 @@ the rounding cap is the contract.
 | `totalEntries` | number | Count of entries (turns) after all filters. |
 | `totalSessions` | number | Distinct `sessionId` count. Entries with no session id collapse into one `"unknown"` bucket, which counts here. |
 | `totalCost` | number | Sum of per-turn cost, USD, **2 dp**. |
+| `retentionDays` | number \| null | Active `LOG_RETENTION_DAYS` value. `0` or below disables retention. `null` means `LOG_RETENTION_DAYS` is non-numeric; retention is inactive, so no cutoff or warning is produced. |
+| `retentionCutoff` | string \| null | Taipei-local `YYYY-MM-DD` cutoff used by log pruning; `null` when retention is disabled. |
+| `retentionWarning` | string (conditional) | Present only when the requested range starts before `retentionCutoff`: older history may have been removed, so all totals are a lower bound. The no-`--last` all-time query always qualifies when retention is enabled. |
 | `timeRange.from` | string \| null | Earliest `receivedAt` as ISO 8601, or `null` if no timestamps. |
 | `timeRange.to` | string \| null | Latest `receivedAt` as ISO 8601, or `null`. |
 
@@ -287,6 +291,10 @@ it never changes the JSON. In [multi-cwd comparison mode](#2-multi-cwd-compariso
 
 ## Changelog
 
+- **2026-09-04** — Added `meta.retentionDays`, `meta.retentionCutoff`, and the
+  conditional `meta.retentionWarning`. The human time-range line now gives the
+  same lower-bound warning when the requested range reaches before retention.
+  A non-numeric `LOG_RETENTION_DAYS` is represented as `retentionDays: null`.
 - **2026-06-21** (Claude, Opus 4.8) — Initial schema reference for
   `ccxray usage --json` as shipped in PR #94. Documents the single-scope object,
   multi-cwd array, and error object, plus filter semantics and per-field

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,6 +54,7 @@ the rounding cap is the contract.
 {
   "meta":     { "totalEntries": 0, "totalSessions": 0, "totalCost": 0,
                 "retentionDays": 14, "retentionCutoff": "YYYY-MM-DD",
+                "retentionWarning": "older history may have been removed; totals are a lower bound",
                 "timeRange": { "from": "ISO|null", "to": "ISO|null" } },
   "sessions": { "count": 0, "byProvider": { "<provider>": 0 },
                 "subagentRatio": 0,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,7 +79,7 @@ the rounding cap is the contract.
 | `totalEntries` | number | Count of entries (turns) after all filters. |
 | `totalSessions` | number | Distinct `sessionId` count. Entries with no session id collapse into one `"unknown"` bucket, which counts here. |
 | `totalCost` | number | Sum of per-turn cost, USD, **2 dp**. |
-| `retentionDays` | number \| null | Active `LOG_RETENTION_DAYS` value. `0` or below disables retention. `null` means `LOG_RETENTION_DAYS` is non-numeric; retention is inactive, so no cutoff or warning is produced. |
+| `retentionDays` | number \| null | Active `LOG_RETENTION_DAYS` value. `0` or below disables retention. `null` means the setting is non-numeric **or** beyond the supported window (magnitude over 36500 days ≈ 100 years, i.e. a "never prune" setting); retention is inactive, so no cutoff or warning is produced. |
 | `retentionCutoff` | string \| null | Taipei-local `YYYY-MM-DD` cutoff used by log pruning; `null` when retention is disabled. |
 | `retentionWarning` | string (conditional) | Present only when the requested range starts before `retentionCutoff`: older history may have been removed, so all totals are a lower bound. The no-`--last` all-time query always qualifies when retention is enabled. |
 | `timeRange.from` | string \| null | Earliest `receivedAt` as ISO 8601, or `null` if no timestamps. |
@@ -216,10 +216,10 @@ ones and would otherwise be presented as exact.
 | Field | Type | Notes |
 |-------|------|-------|
 | `cwd` | string | Working directory (group key). Always a real path — the `--cwd` filter that triggers this mode drops entries with no cwd, so no `"unknown"` row appears here. |
-| `cost` | number | `meta.totalCost` for that group, **2 dp**. |
-| `sessions` | number | `meta.totalSessions` for that group. |
-| `turns` | number | `meta.totalEntries` for that group. |
-| `cacheHit` | number | `cache.hitRate` for that group, **3 dp**. |
+| `cost` | number | That group's own single-scope `meta.totalCost`, **2 dp**. Not a field of the top-level `meta` above, which carries only the retention triple. |
+| `sessions` | number | That group's own single-scope `meta.totalSessions`. |
+| `turns` | number | That group's own single-scope `meta.totalEntries`. |
+| `cacheHit` | number | That group's own `cache.hitRate`, **3 dp**. |
 
 The grouping is over the entries that already passed `--last`/`--cwd`/`--session`
 filtering, so every matched cwd that survived appears as one row.
@@ -314,7 +314,9 @@ it never changes the JSON. In [multi-cwd comparison mode](#2-multi-cwd-compariso
   `{ projects, meta }` so the same disclosure reaches that surface — its totals
   sit behind the same retention window and were previously presented as exact.
   `--last` is now forwarded into the comparison's retention verdict, which
-  previously judged every window as all-time. The cutoff is also now computed in
+  previously judged every window as all-time. A `LOG_RETENTION_DAYS` beyond the
+  supported window is now treated as retention off; previously such a value fed
+  an out-of-range date into the cutoff and pruned every log file. The cutoff is also now computed in
   the Taipei calendar rather than the host's, so it no longer depends on where
   the process runs (unchanged on a Taipei or UTC host; a DST-observing host
   previously drifted by a day around its transitions).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,12 +13,13 @@ and the runtime environment.
 
 The single source of truth for the shapes below is
 [`server/usage.js`](../server/usage.js): `analyze()` builds the single-scope
-object, while `run()` assembles the multi-cwd array and the error object. This
+object, while `run()` assembles the multi-cwd comparison object and the error
+object. This
 doc mirrors them; if they ever disagree, the code wins — and that disagreement
 is a bug to fix here.
 
 > **Contract note.** Because agents consume `--json`, the field set, types, and
-> the three top-level shapes (single-scope object, multi-cwd array, error
+> the three top-level shapes (single-scope object, multi-cwd object, error
 > object) are treated as a contract. Shape changes must be deliberate and noted
 > in the changelog below. The `usage --json shape contract` block in
 > [`test/usage.test.js`](../test/usage.test.js) locks every section's exact key
@@ -37,7 +38,7 @@ Which of three shapes you get depends on the arguments:
 | Condition | Shape | Exit |
 |-----------|-------|------|
 | Default (0 or 1 `--cwd`) | [Single-scope object](#1-single-scope-object-default) | 0 |
-| `--cwd a,b` (**2+** values) | [Multi-cwd array](#2-multi-cwd-comparison-array) | 0 |
+| `--cwd a,b` (**2+** values) | [Multi-cwd object](#2-multi-cwd-comparison-object) | 0 |
 | No index / no matching entries | [Error object](#3-error-object) | 1 |
 
 Rounded numeric fields are rounded to **at most** the number of decimals noted
@@ -186,18 +187,31 @@ turn finished). Only buckets that contain at least one measured gap appear —
 
 ---
 
-## 2. Multi-cwd comparison array
+## 2. Multi-cwd comparison object
 
 When **two or more** `--cwd` values are given (e.g. `--cwd proj-a,proj-b`), the
-output is a per-project comparison **array** instead of the single-scope object,
-sorted by `cost` descending:
+output is a per-project comparison object instead of the single-scope object.
+`projects` is sorted by `cost` descending; `meta` carries the retention
+disclosure for the query as a whole:
 
 ```jsonc
-[
-  { "cwd": "/work/project-alpha", "cost": 0.80, "sessions": 1, "turns": 2, "cacheHit": 0.86 },
-  { "cwd": "/work/project-beta",  "cost": 0.30, "sessions": 1, "turns": 2, "cacheHit": 0.78 }
-]
+{
+  "projects": [
+    { "cwd": "/work/project-alpha", "cost": 0.80, "sessions": 1, "turns": 2, "cacheHit": 0.86 },
+    { "cwd": "/work/project-beta",  "cost": 0.30, "sessions": 1, "turns": 2, "cacheHit": 0.78 }
+  ],
+  "meta": {
+    "retentionDays": 14, "retentionCutoff": "YYYY-MM-DD",
+    "retentionWarning": "older history may have been removed; totals are a lower bound"
+  }
+}
 ```
+
+`meta` holds exactly the three retention fields documented for the single-scope
+`meta`, with the same semantics. Retention is a property of the **query**, not of
+any one project, so it appears once at the top level and never on a `projects[]`
+row — these per-project totals sit behind the same window as the single-scope
+ones and would otherwise be presented as exact.
 
 | Field | Type | Notes |
 |-------|------|-------|
@@ -251,7 +265,7 @@ Comma-separated or repeated. Each value matches one of two ways:
   `./` is stripped, so `./foo` behaves like `foo`.
 
 Giving **2+** cwd values switches the output to the
-[multi-cwd array](#2-multi-cwd-comparison-array).
+[multi-cwd comparison object](#2-multi-cwd-comparison-object).
 
 ### `--session <id>` (matching)
 
@@ -275,7 +289,7 @@ Lifts the `tools.top` cap from 7 to all tools (and shows all in human output).
 After printing, opens the dashboard to the resolved session — only valid when
 exactly one session matched. With **2+** matches it prints a stderr note and
 skips opening; with **0** matched sessions it silently does nothing. Either way
-it never changes the JSON. In [multi-cwd comparison mode](#2-multi-cwd-comparison-array)
+it never changes the JSON. In [multi-cwd comparison mode](#2-multi-cwd-comparison-object)
 (`--cwd a,b`) `--open` is ignored entirely.
 
 ---
@@ -296,8 +310,16 @@ it never changes the JSON. In [multi-cwd comparison mode](#2-multi-cwd-compariso
   conditional `meta.retentionWarning`. The human time-range line now gives the
   same lower-bound warning when the requested range reaches before retention.
   A non-numeric `LOG_RETENTION_DAYS` is represented as `retentionDays: null`.
+  **Breaking:** multi-cwd comparison output changed from a bare array to
+  `{ projects, meta }` so the same disclosure reaches that surface — its totals
+  sit behind the same retention window and were previously presented as exact.
+  `--last` is now forwarded into the comparison's retention verdict, which
+  previously judged every window as all-time. The cutoff is also now computed in
+  the Taipei calendar rather than the host's, so it no longer depends on where
+  the process runs (unchanged on a Taipei or UTC host; a DST-observing host
+  previously drifted by a day around its transitions).
 - **2026-06-21** (Claude, Opus 4.8) — Initial schema reference for
   `ccxray usage --json` as shipped in PR #94. Documents the single-scope object,
-  multi-cwd array, and error object, plus filter semantics and per-field
+  multi-cwd comparison shape, and error object, plus filter semantics and per-field
   precision. Backed by the `usage --json shape contract` test that locks the key
   set and field types of every section.

--- a/server/config.js
+++ b/server/config.js
@@ -2,7 +2,7 @@
 
 const { createStorage } = require('./storage');
 const { resolveLogsDir } = require('./paths');
-const { retentionDays } = require('./retention');
+const { retentionDays, boundedDays } = require('./retention');
 
 // ── Config ──────────────────────────────────────────────────────────
 const PORT = parseInt(process.env.PROXY_PORT || '5577', 10);
@@ -282,7 +282,9 @@ const LOGS_DIR = resolveLogsDir();
 const LOG_RETENTION_DAYS = retentionDays();
 const MAX_SSE_PER_IP = parseInt(process.env.CCXRAY_SSE_MAX_PER_IP || '20', 10);
 // ponytail: aligned with LOG_RETENTION_DAYS so the index is a cache, not a sole record
-const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || String(LOG_RETENTION_DAYS), 10);
+// Bounded like LOG_RETENTION_DAYS: an out-of-range value means "no restore
+// window" (restore everything), not a cutoff that throws on the startup path.
+const RESTORE_DAYS = boundedDays(process.env.RESTORE_DAYS || String(LOG_RETENTION_DAYS));
 // 0 = only session-start anchor; N>0 = force full snapshot every N delta writes
 const DELTA_SNAPSHOT_N = parseInt(process.env.CCXRAY_DELTA_SNAPSHOT_N || '0', 10);
 const REWRITE_MODEL_PREFIX = process.env.CCXRAY_MODEL_PREFIX || '';

--- a/server/config.js
+++ b/server/config.js
@@ -2,6 +2,7 @@
 
 const { createStorage } = require('./storage');
 const { resolveLogsDir } = require('./paths');
+const { retentionDays } = require('./retention');
 
 // ── Config ──────────────────────────────────────────────────────────
 const PORT = parseInt(process.env.PROXY_PORT || '5577', 10);
@@ -278,7 +279,7 @@ function joinUpstreamPath(upstream, requestUrl) {
   return basePath + (urlPath.startsWith('/') ? urlPath : `/${urlPath}`);
 }
 const LOGS_DIR = resolveLogsDir();
-const LOG_RETENTION_DAYS = parseInt(process.env.LOG_RETENTION_DAYS || '14', 10);
+const LOG_RETENTION_DAYS = retentionDays();
 const MAX_SSE_PER_IP = parseInt(process.env.CCXRAY_SSE_MAX_PER_IP || '20', 10);
 // ponytail: aligned with LOG_RETENTION_DAYS so the index is a cache, not a sole record
 const RESTORE_DAYS = parseInt(process.env.RESTORE_DAYS || String(LOG_RETENTION_DAYS), 10);

--- a/server/restore.js
+++ b/server/restore.js
@@ -14,6 +14,7 @@ const { normalizeUsageForProvider } = require('./providers');
 const { broadcastEntryUpdate } = require('./sse-broadcast');
 const sessionIdx = require('./session-index');
 const { assessWeather } = require('../public/weather');
+const { retentionCutoffDate } = require('./retention');
 
 
 // #211: model marker ("The exact model ID is ...") from the persisted system
@@ -224,9 +225,7 @@ async function restoreFromLogs() {
   // sessions.json) re-stream via streamAllMetas() generator instead.
   let cutoffStr = null;
   if (config.RESTORE_DAYS > 0) {
-    const cutoff = new Date();
-    cutoff.setDate(cutoff.getDate() - config.RESTORE_DAYS);
-    cutoffStr = cutoff.toLocaleString('sv-SE', { timeZone: 'Asia/Taipei' }).slice(0, 10);
+    cutoffStr = retentionCutoffDate(config.RESTORE_DAYS);
   }
   const stars = readStarsSafe();
   const hasAnyStar = stars.projects.length || stars.sessions.length || stars.turns.length || stars.steps.length;
@@ -681,9 +680,7 @@ async function pruneLogs() {
     return;
   }
 
-  const cutoff = new Date();
-  cutoff.setDate(cutoff.getDate() - config.LOG_RETENTION_DAYS);
-  const cutoffStr = cutoff.toLocaleString('sv-SE', { timeZone: 'Asia/Taipei' }).slice(0, 10);
+  const cutoffStr = retentionCutoffDate(config.LOG_RETENTION_DAYS);
 
   // Baseline: in-memory entries are always protected (existing behavior).
   // After star-aware restoreFromLogs, this already includes most starred

--- a/server/retention.js
+++ b/server/retention.js
@@ -2,8 +2,19 @@
 
 const TAIPEI_TIME_ZONE = 'Asia/Taipei';
 
+// A window this wide cannot exclude anything, so a value beyond it means "retain
+// everything" — and must be treated as retention OFF rather than fed to the cutoff
+// calculation. Feeding it through produces an out-of-range Date, and the string that
+// used to fall out of that ("Invalid Da") compares BELOW every real Taipei-dated
+// filename, so `filename.slice(0, 10) >= cutoffStr` was false for every file: a
+// plausible "never prune" setting of LOG_RETENTION_DAYS=999999999 silently pruned
+// EVERYTHING. NaN here lands on the same safe no-op path a non-numeric setting takes
+// (`pruneLogs` returns on `!days`, restore skips its window on `days > 0`).
+const MAX_RETENTION_DAYS = 36500; // ~100 years
+
 function retentionDays(env = process.env) {
-  return parseInt(env.LOG_RETENTION_DAYS || '14', 10);
+  const parsed = parseInt(env.LOG_RETENTION_DAYS || '14', 10);
+  return Math.abs(parsed) > MAX_RETENTION_DAYS ? NaN : parsed;
 }
 
 function taipeiDate(instant) {

--- a/server/retention.js
+++ b/server/retention.js
@@ -6,11 +6,12 @@ const TAIPEI_TIME_ZONE = 'Asia/Taipei';
 // everything" — and must be treated as retention OFF rather than fed to the cutoff
 // calculation. Feeding it through produces an out-of-range Date, and the string that
 // used to fall out of that ("Invalid Da") compares ABOVE every real Taipei-dated
-// filename ('I' is 73, '2' is 50), so `filename.slice(0, 10) >= cutoffStr` was
-// false for every file: a
-// plausible "never prune" setting of LOG_RETENTION_DAYS=999999999 silently pruned
-// EVERYTHING. NaN here lands on the same safe no-op path a non-numeric setting takes
-// (`pruneLogs` returns on `!days`, restore skips its window on `days > 0`).
+// filename ('I' is 73, '2' is 50), so the prune keep-condition
+// `filename.slice(0, 10) >= cutoffStr` was false for EVERY file: a plausible
+// "never prune" setting of LOG_RETENTION_DAYS=999999999 silently pruned everything,
+// and restore's mirror condition read every line as out-of-window. NaN here lands on
+// the same safe no-op path a non-numeric setting takes (`pruneLogs` returns on
+// `!days`, restore skips its window on `days > 0`).
 const MAX_RETENTION_DAYS = 36500; // ~100 years
 
 // Every day-count entry point must go through this. Guarding only

--- a/server/retention.js
+++ b/server/retention.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const TAIPEI_TIME_ZONE = 'Asia/Taipei';
+
+function retentionDays(env = process.env) {
+  return parseInt(env.LOG_RETENTION_DAYS || '14', 10);
+}
+
+function taipeiDate(instant) {
+  return new Date(instant).toLocaleString('sv-SE', { timeZone: TAIPEI_TIME_ZONE }).slice(0, 10);
+}
+
+function retentionCutoffDate(days, now = new Date()) {
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - days);
+  return taipeiDate(cutoff);
+}
+
+module.exports = { retentionDays, retentionCutoffDate, taipeiDate };

--- a/server/retention.js
+++ b/server/retention.js
@@ -5,8 +5,9 @@ const TAIPEI_TIME_ZONE = 'Asia/Taipei';
 // A window this wide cannot exclude anything, so a value beyond it means "retain
 // everything" — and must be treated as retention OFF rather than fed to the cutoff
 // calculation. Feeding it through produces an out-of-range Date, and the string that
-// used to fall out of that ("Invalid Da") compares BELOW every real Taipei-dated
-// filename, so `filename.slice(0, 10) >= cutoffStr` was false for every file: a
+// used to fall out of that ("Invalid Da") compares ABOVE every real Taipei-dated
+// filename ('I' is 73, '2' is 50), so `filename.slice(0, 10) >= cutoffStr` was
+// false for every file: a
 // plausible "never prune" setting of LOG_RETENTION_DAYS=999999999 silently pruned
 // EVERYTHING. NaN here lands on the same safe no-op path a non-numeric setting takes
 // (`pruneLogs` returns on `!days`, restore skips its window on `days > 0`).

--- a/server/retention.js
+++ b/server/retention.js
@@ -12,9 +12,16 @@ const TAIPEI_TIME_ZONE = 'Asia/Taipei';
 // (`pruneLogs` returns on `!days`, restore skips its window on `days > 0`).
 const MAX_RETENTION_DAYS = 36500; // ~100 years
 
-function retentionDays(env = process.env) {
-  const parsed = parseInt(env.LOG_RETENTION_DAYS || '14', 10);
+// Every day-count entry point must go through this. Guarding only
+// LOG_RETENTION_DAYS left an explicit RESTORE_DAYS on bare parseInt, so
+// RESTORE_DAYS=999999999 still reached the cutoff calculation.
+function boundedDays(raw) {
+  const parsed = parseInt(raw, 10);
   return Math.abs(parsed) > MAX_RETENTION_DAYS ? NaN : parsed;
+}
+
+function retentionDays(env = process.env) {
+  return boundedDays(env.LOG_RETENTION_DAYS || '14');
 }
 
 function taipeiDate(instant) {
@@ -36,4 +43,4 @@ function retentionCutoffDate(days, now = new Date()) {
   return anchor.toISOString().slice(0, 10);
 }
 
-module.exports = { retentionDays, retentionCutoffDate, taipeiDate };
+module.exports = { retentionDays, retentionCutoffDate, taipeiDate, boundedDays, MAX_RETENTION_DAYS };

--- a/server/retention.js
+++ b/server/retention.js
@@ -11,9 +11,18 @@ function taipeiDate(instant) {
 }
 
 function retentionCutoffDate(days, now = new Date()) {
-  const cutoff = new Date(now);
-  cutoff.setDate(cutoff.getDate() - days);
-  return taipeiDate(cutoff);
+  // The subtraction happens in the TAIPEI calendar, because that is the calendar
+  // the result is compared against: index filenames and entry ids are Taipei-dated
+  // (`filename.slice(0, 10) >= cutoffStr`). Subtracting with the host's local
+  // getDate()/setDate() and only THEN formatting in Taipei splits the calculation
+  // across two calendars, and the two disagree by a day whenever the host zone
+  // crosses a DST boundary in the window — a Los Angeles host would prune one
+  // extra Taipei-dated day. Anchoring to the Taipei date first makes the result
+  // depend only on `now` and `days`, never on where the process runs.
+  const [year, month, day] = taipeiDate(now).split('-').map(Number);
+  const anchor = new Date(Date.UTC(year, month - 1, day));
+  anchor.setUTCDate(anchor.getUTCDate() - days);
+  return anchor.toISOString().slice(0, 10);
 }
 
 module.exports = { retentionDays, retentionCutoffDate, taipeiDate };

--- a/server/usage.js
+++ b/server/usage.js
@@ -186,15 +186,31 @@ async function run(argv) {
   if (args.cwds.length >= 2) {
     const groups = {};
     for (const e of entries) { const k = e.cwd || 'unknown'; if (!groups[k]) groups[k] = []; groups[k].push(e); }
-    const rows = Object.entries(groups).map(([cwd, es]) => {
-      const r = analyze(es);
+    // `since` is forwarded so each group's retention verdict matches the range the
+    // user actually asked for. The per-row retention fields stay unread — retention
+    // is a property of the QUERY, not of any one project — but a group computing it
+    // as all-time under a `--last` window would be a trap for the next reader.
+    const projects = Object.entries(groups).map(([cwd, es]) => {
+      const r = analyze(es, { since: args.since });
       return { cwd, cost: r.meta.totalCost, sessions: r.meta.totalSessions, turns: r.meta.totalEntries, cacheHit: r.cache.hitRate };
     }).sort((a, b) => b.cost - a.cost);
-    if (args.json) { console.log(JSON.stringify(rows)); }
+    // These per-project totals sit behind the same retention window as the
+    // single-scope ones, so they need the same disclosure. Reporting it ONCE at the
+    // top level (rather than duplicating it onto every row) keeps a global signal
+    // out of the per-project channel — the same separation ADR 0017 draws between
+    // retention completeness and cost confidence.
+    const retention = retentionStatus({ since: args.since });
+    const meta = {
+      retentionDays: retention.days,
+      retentionCutoff: retention.cutoff,
+      ...(retention.warning ? { retentionWarning: retention.warning } : {}),
+    };
+    if (args.json) { console.log(JSON.stringify({ projects, meta })); }
     else {
-      const B = '\x1b[1m', R = '\x1b[0m';
+      const B = '\x1b[1m', D = '\x1b[2m', R = '\x1b[0m';
       console.log(`\n${B}Project Comparison${R}`);
-      for (const r of rows) console.log(`  ${r.cwd}  $${r.cost}  ${r.sessions} sessions  ${r.turns} turns  cache ${(r.cacheHit * 100).toFixed(1)}%`);
+      for (const r of projects) console.log(`  ${r.cwd}  $${r.cost}  ${r.sessions} sessions  ${r.turns} turns  cache ${(r.cacheHit * 100).toFixed(1)}%`);
+      if (meta.retentionWarning) console.log(`${D}${meta.retentionWarning}${R}`);
       console.log();
     }
     return;

--- a/server/usage.js
+++ b/server/usage.js
@@ -186,12 +186,12 @@ async function run(argv) {
   if (args.cwds.length >= 2) {
     const groups = {};
     for (const e of entries) { const k = e.cwd || 'unknown'; if (!groups[k]) groups[k] = []; groups[k].push(e); }
-    // `since` is forwarded so each group's retention verdict matches the range the
-    // user actually asked for. The per-row retention fields stay unread — retention
-    // is a property of the QUERY, not of any one project — but a group computing it
-    // as all-time under a `--last` window would be a trap for the next reader.
+    // No retention opts here on purpose: a group's retention fields are never
+    // emitted, so forwarding `since` into them would be dead code no test could
+    // pin. The query-wide verdict below is the only one rendered — a future reader
+    // wanting retention per row must read `meta`, not re-derive it here.
     const projects = Object.entries(groups).map(([cwd, es]) => {
-      const r = analyze(es, { since: args.since });
+      const r = analyze(es);
       return { cwd, cost: r.meta.totalCost, sessions: r.meta.totalSessions, turns: r.meta.totalEntries, cacheHit: r.cache.hitRate };
     }).sort((a, b) => b.cost - a.cost);
     // These per-project totals sit behind the same retention window as the

--- a/server/usage.js
+++ b/server/usage.js
@@ -81,8 +81,9 @@ function dedupeEntries(entries) {
 const RETENTION_WARNING = 'Requested range reaches past the reliable retention window; older history may have been removed by retention, so totals are a LOWER BOUND.';
 
 function retentionStatus({ since = null, now = new Date(), env = process.env } = {}) {
-  // This is the display seam only. retentionDays() deliberately preserves a
-  // malformed setting as NaN so config/prune keep their safe no-op behavior.
+  // This is the display seam only. retentionDays() returns NaN for a malformed
+  // setting AND for one beyond the supported window, so config/prune keep their
+  // safe no-op behavior in both cases; `null` here covers both.
   const parsedDays = retentionDays(env);
   const days = Number.isFinite(parsedDays) ? parsedDays : null;
   const cutoff = days > 0 ? retentionCutoffDate(days, now) : null;

--- a/server/usage.js
+++ b/server/usage.js
@@ -6,6 +6,7 @@ const path = require('path');
 const readline = require('readline');
 const { resolveCcxrayHome } = require('./paths');
 const { mergeByResponseId } = require('./store');
+const { retentionDays, retentionCutoffDate, taipeiDate } = require('./retention');
 // INVARIANT(ADR 0017): the human aggregate below must render through the shared
 // fold-aware helper, not a bare `$` + number. format.js is isomorphic (no
 // top-level DOM), so the server reads the SAME thresholds the dashboard and the
@@ -75,6 +76,18 @@ function dedupeEntries(entries) {
   // mergeByResponseId deliberately folds into its canonical object. Usage is a
   // read-only command, so merge cloned index summaries and leave callers intact.
   return mergeByResponseId(structuredClone(entries));
+}
+
+const RETENTION_WARNING = 'Requested range reaches past the reliable retention window; older history may have been removed by retention, so totals are a LOWER BOUND.';
+
+function retentionStatus({ since = null, now = new Date(), env = process.env } = {}) {
+  // This is the display seam only. retentionDays() deliberately preserves a
+  // malformed setting as NaN so config/prune keep their safe no-op behavior.
+  const parsedDays = retentionDays(env);
+  const days = Number.isFinite(parsedDays) ? parsedDays : null;
+  const cutoff = days > 0 ? retentionCutoffDate(days, now) : null;
+  const warning = cutoff && (since === null || taipeiDate(since) < cutoff) ? RETENTION_WARNING : null;
+  return { days, cutoff, warning };
 }
 
 async function run(argv) {
@@ -209,6 +222,7 @@ async function run(argv) {
 
 function analyze(entries, opts = {}) {
   entries = dedupeEntries(entries);
+  const retention = retentionStatus(opts);
   const timestamps = [];
   const byProvider = {};
   const bySession = {};
@@ -292,6 +306,9 @@ function analyze(entries, opts = {}) {
     totalEntries: entries.length,
     totalSessions: sessionCount,
     totalCost: +totalCost.toFixed(2),
+    retentionDays: retention.days,
+    retentionCutoff: retention.cutoff,
+    ...(retention.warning ? { retentionWarning: retention.warning } : {}),
     timeRange: {
       from: timestamps[0] ? new Date(timestamps[0]).toISOString() : null,
       to: timestamps.at(-1) ? new Date(timestamps.at(-1)).toISOString() : null,
@@ -523,7 +540,7 @@ function printHuman(r) {
   const B = '\x1b[1m', D = '\x1b[2m', R = '\x1b[0m';
 
   console.log(`\n${B}ccxray usage${R}  ${r.meta.totalEntries} entries · ${r.meta.totalSessions} sessions · $${r.meta.totalCost}`);
-  console.log(`${D}${r.meta.timeRange.from?.slice(0, 10) || '?'} → ${r.meta.timeRange.to?.slice(0, 10) || '?'}${R}\n`);
+  console.log(`${D}${r.meta.timeRange.from?.slice(0, 10) || '?'} → ${r.meta.timeRange.to?.slice(0, 10) || '?'}${r.meta.retentionWarning ? ` — ${r.meta.retentionWarning}` : ''}${R}\n`);
 
   console.log(`${B}Sessions${R}`);
   for (const [p, n] of Object.entries(r.sessions.byProvider)) console.log(`  ${p}: ${n} turns`);

--- a/test/retention.test.js
+++ b/test/retention.test.js
@@ -70,6 +70,49 @@ describe('retention', () => {
     assert.match(retentionCutoffDate(36500, SYNTHETIC_RETENTION_NOW), /^\d{4}-\d{2}-\d{2}$/);
   });
 
+  it('bounds an explicitly set RESTORE_DAYS at the config layer, not just LOG_RETENTION_DAYS', () => {
+    // Guarding retentionDays() alone left this path on bare parseInt: an explicit
+    // RESTORE_DAYS=999999999 passed `config.RESTORE_DAYS > 0` in restoreFromLogs and
+    // made retentionCutoffDate() throw RangeError on the STARTUP path, taking prune,
+    // cost warm-up and transcript import down with it. Out of range must mean "no
+    // restore window" (restore everything), which is the fail-safe direction.
+    // This probes the real config module, not the helper, because the defect lived
+    // in the caller.
+    const home = fs.mkdtempSync(path.join(require('os').tmpdir(), 'ccxray-restore-days-'));
+    try {
+      const probe = extra => spawnSync(process.execPath, ['-e', `
+        const config = require('./server/config');
+        const { retentionCutoffDate } = require('./server/retention');
+        let cutoff = null, threw = null;
+        if (config.RESTORE_DAYS > 0) {
+          try { cutoff = retentionCutoffDate(config.RESTORE_DAYS); } catch (e) { threw = e.name; }
+        }
+        process.stdout.write(JSON.stringify({
+          restoreDays: Number.isFinite(config.RESTORE_DAYS) ? config.RESTORE_DAYS : null,
+          cutoff, threw,
+        }));
+      `], {
+        cwd: path.join(__dirname, '..'),
+        env: { ...process.env, CCXRAY_HOME: home, ...extra },
+        encoding: 'utf8',
+      });
+
+      const huge = probe({ RESTORE_DAYS: '999999999', LOG_RETENTION_DAYS: '14' });
+      assert.equal(huge.status, 0, huge.stderr);
+      assert.deepEqual(JSON.parse(huge.stdout), { restoreDays: null, cutoff: null, threw: null });
+
+      // A normal explicit value still works and still produces a real cutoff.
+      const normal = probe({ RESTORE_DAYS: '7', LOG_RETENTION_DAYS: '14' });
+      assert.equal(normal.status, 0, normal.stderr);
+      const parsed = JSON.parse(normal.stdout);
+      assert.equal(parsed.restoreDays, 7);
+      assert.equal(parsed.threw, null);
+      assert.match(parsed.cutoff, /^\d{4}-\d{2}-\d{2}$/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it('does not normalize malformed retention settings, so pruning stays a no-op', () => {
     assert.equal(Number.isFinite(retentionDays({ LOG_RETENTION_DAYS: 'not-a-number' })), false);
   });

--- a/test/retention.test.js
+++ b/test/retention.test.js
@@ -25,21 +25,36 @@ describe('retention', () => {
     assert.doesNotMatch(configSource, /LOG_RETENTION_DAYS \|\| '14'/);
   });
 
-  it('subtracts retention in local calendar days across DST', () => {
-    // This discriminates calendar-day setDate(getDate() - days) (→ "2026-03-08")
-    // from fixed now - days * 86400000 (→ "2026-03-07"). A DST-observing TZ is
-    // mandatory: Asia/Taipei has no DST, so it cannot distinguish the algorithms.
-    const child = spawnSync(process.execPath, ['-e', `
-      const { retentionCutoffDate } = require('../server/retention');
-      process.stdout.write(retentionCutoffDate(1, new Date('2026-03-08T15:30:00.000Z')));
-    `], {
-      cwd: __dirname,
-      env: { ...process.env, TZ: 'America/Los_Angeles' },
-      encoding: 'utf8',
-    });
+  it('yields the same Taipei cutoff no matter which timezone the host runs in', () => {
+    // The cutoff is compared against Taipei-dated index filenames, so it must be a
+    // pure function of (now, days). Subtracting with the host's local calendar and
+    // formatting in Taipei is NOT: at 2026-03-08T15:30Z with days=1 that hybrid
+    // returns 2026-03-08 on a Los Angeles host (US spring-forward) but 2026-03-07
+    // on a UTC or Taipei host — one extra Taipei day pruned, purely from where the
+    // process happens to run. Southern-hemisphere zones skew the other way.
+    // A DST-observing zone is mandatory here: Asia/Taipei has no DST, so on its own
+    // it cannot tell a correct implementation from the hybrid one.
+    const cutoffUnder = tz => {
+      const child = spawnSync(process.execPath, ['-e', `
+        const { retentionCutoffDate } = require('../server/retention');
+        process.stdout.write(retentionCutoffDate(1, new Date('2026-03-08T15:30:00.000Z')));
+      `], { cwd: __dirname, env: { ...process.env, TZ: tz }, encoding: 'utf8' });
+      assert.equal(child.status, 0, child.stderr);
+      return child.stdout;
+    };
 
-    assert.equal(child.status, 0, child.stderr);
-    assert.equal(child.stdout, '2026-03-08');
+    const zones = ['UTC', 'Asia/Taipei', 'America/Los_Angeles', 'Europe/Berlin', 'Australia/Sydney'];
+    const results = Object.fromEntries(zones.map(tz => [tz, cutoffUnder(tz)]));
+    assert.deepEqual(results, Object.fromEntries(zones.map(tz => [tz, '2026-03-07'])));
+  });
+
+  it('pins 14 as the single canonical default retention window', () => {
+    // This default is the ONLY definition in the tree (config.js derives from it),
+    // so it silently governs restore, pruning AND the usage disclosure. Changing
+    // it must break a test, not just change behaviour.
+    assert.equal(retentionDays({}), 14);
+    assert.equal(retentionDays({ LOG_RETENTION_DAYS: '' }), 14);
+    assert.equal(retentionDays({ LOG_RETENTION_DAYS: '7' }), 7);
   });
 
   it('does not normalize malformed retention settings, so pruning stays a no-op', () => {

--- a/test/retention.test.js
+++ b/test/retention.test.js
@@ -57,6 +57,19 @@ describe('retention', () => {
     assert.equal(retentionDays({ LOG_RETENTION_DAYS: '7' }), 7);
   });
 
+  it('treats an out-of-range window as retention off instead of producing a bad cutoff', () => {
+    // A plausible "never prune" setting must not become a cutoff at all. Before the
+    // guard, LOG_RETENTION_DAYS=999999999 produced an out-of-range Date whose string
+    // form sorted BELOW every real Taipei-dated filename, so the prune keep-condition
+    // (`filename.slice(0, 10) >= cutoffStr`) was false for every file.
+    for (const setting of ['999999999', '36501', '-999999999']) {
+      assert.equal(Number.isFinite(retentionDays({ LOG_RETENTION_DAYS: setting })), false, `${setting} must not be a finite window`);
+    }
+    // The boundary itself stays usable and yields a real date.
+    assert.equal(retentionDays({ LOG_RETENTION_DAYS: '36500' }), 36500);
+    assert.match(retentionCutoffDate(36500, SYNTHETIC_RETENTION_NOW), /^\d{4}-\d{2}-\d{2}$/);
+  });
+
   it('does not normalize malformed retention settings, so pruning stays a no-op', () => {
     assert.equal(Number.isFinite(retentionDays({ LOG_RETENTION_DAYS: 'not-a-number' })), false);
   });

--- a/test/retention.test.js
+++ b/test/retention.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { retentionDays, retentionCutoffDate, taipeiDate } = require('../server/retention');
+
+const SYNTHETIC_RETENTION_NOW = new Date('2026-03-15T20:30:00.000Z');
+
+describe('retention', () => {
+  it('uses the shared Taipei cutoff calculation at the restore and prune sites', () => {
+    const restoreSource = fs.readFileSync(path.join(__dirname, '..', 'server', 'restore.js'), 'utf8');
+    const configSource = fs.readFileSync(path.join(__dirname, '..', 'server', 'config.js'), 'utf8');
+    const env = { LOG_RETENTION_DAYS: '14' };
+
+    // This instant is already the following day in Taipei, proving the cutoff
+    // follows the index filename timezone rather than UTC's calendar date.
+    assert.equal(taipeiDate(SYNTHETIC_RETENTION_NOW), '2026-03-16');
+    assert.equal(retentionCutoffDate(retentionDays(env), SYNTHETIC_RETENTION_NOW), '2026-03-02');
+    const cutoffCalls = [...restoreSource.matchAll(/retentionCutoffDate\(config\.(RESTORE_DAYS|LOG_RETENTION_DAYS)\)/g)].map(m => m[1]);
+    assert.deepEqual(cutoffCalls, ['RESTORE_DAYS', 'LOG_RETENTION_DAYS']);
+    assert.match(configSource, /const LOG_RETENTION_DAYS = retentionDays\(\);/);
+    assert.doesNotMatch(configSource, /LOG_RETENTION_DAYS \|\| '14'/);
+  });
+
+  it('does not normalize malformed retention settings, so pruning stays a no-op', () => {
+    assert.equal(Number.isFinite(retentionDays({ LOG_RETENTION_DAYS: 'not-a-number' })), false);
+  });
+});

--- a/test/retention.test.js
+++ b/test/retention.test.js
@@ -2,6 +2,7 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
 const fs = require('fs');
 const path = require('path');
 const { retentionDays, retentionCutoffDate, taipeiDate } = require('../server/retention');
@@ -22,6 +23,23 @@ describe('retention', () => {
     assert.deepEqual(cutoffCalls, ['RESTORE_DAYS', 'LOG_RETENTION_DAYS']);
     assert.match(configSource, /const LOG_RETENTION_DAYS = retentionDays\(\);/);
     assert.doesNotMatch(configSource, /LOG_RETENTION_DAYS \|\| '14'/);
+  });
+
+  it('subtracts retention in local calendar days across DST', () => {
+    // This discriminates calendar-day setDate(getDate() - days) (→ "2026-03-08")
+    // from fixed now - days * 86400000 (→ "2026-03-07"). A DST-observing TZ is
+    // mandatory: Asia/Taipei has no DST, so it cannot distinguish the algorithms.
+    const child = spawnSync(process.execPath, ['-e', `
+      const { retentionCutoffDate } = require('../server/retention');
+      process.stdout.write(retentionCutoffDate(1, new Date('2026-03-08T15:30:00.000Z')));
+    `], {
+      cwd: __dirname,
+      env: { ...process.env, TZ: 'America/Los_Angeles' },
+      encoding: 'utf8',
+    });
+
+    assert.equal(child.status, 0, child.stderr);
+    assert.equal(child.stdout, '2026-03-08');
   });
 
   it('does not normalize malformed retention settings, so pruning stays a no-op', () => {

--- a/test/retention.test.js
+++ b/test/retention.test.js
@@ -108,6 +108,13 @@ describe('retention', () => {
       assert.equal(parsed.restoreDays, 7);
       assert.equal(parsed.threw, null);
       assert.match(parsed.cutoff, /^\d{4}-\d{2}-\d{2}$/);
+
+      // Unset RESTORE_DAYS must still INHERIT LOG_RETENTION_DAYS. Bounding the
+      // parse is not enough on its own: dropping the fallback would silently widen
+      // the restore window to unlimited, which no other assertion here notices.
+      const inherited = probe({ RESTORE_DAYS: '', LOG_RETENTION_DAYS: '7' });
+      assert.equal(inherited.status, 0, inherited.stderr);
+      assert.equal(JSON.parse(inherited.stdout).restoreDays, 7, 'unset RESTORE_DAYS inherits LOG_RETENTION_DAYS');
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/test/usage.test.js
+++ b/test/usage.test.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { analyze } = require('../server/usage');
+const { buildIndexLine } = require('../server/entry');
 
 // Deterministic CLI fixture: an isolated CCXRAY_HOME with a known index so the
 // e2e tests don't depend on the runner's real ~/.ccxray (which is empty in CI).
@@ -27,7 +28,7 @@ process.on('exit', () => { try { fs.rmSync(FIX_HOME, { recursive: true, force: t
 
 const cli = (...args) => execFileSync(
   process.execPath, ['server/index.js', 'usage', ...args],
-  { env: { ...process.env, CCXRAY_HOME: FIX_HOME }, timeout: 10000 }
+  { env: { ...process.env, CCXRAY_HOME: FIX_HOME, LOG_RETENTION_DAYS: '14' }, timeout: 10000 }
 ).toString();
 
 const cliErr = (...args) => {
@@ -43,6 +44,34 @@ const entry = (overrides = {}) => ({
   cost: { cost: 0.5 }, sysHash: 'aaa', toolsHash: 'bbb', coreHash: 'ccc',
   toolFail: false, ...overrides,
 });
+
+const SYNTHETIC_RETENTION_NOW = new Date('2026-03-15T20:30:00.000Z');
+const syntheticIndexEntry = (overrides = {}) => JSON.parse(buildIndexLine({
+  id: '2026-03-16T04-30-00-000', ts: '04:30:00',
+  sessionId: 'synthetic-session-0001', provider: 'synthetic-provider',
+  agent: 'synthetic-agent', model: 'synthetic-model', msgCount: 1, toolCount: 0,
+  toolCalls: {}, isSubagent: false, cwd: '/synthetic/project',
+  receivedAt: SYNTHETIC_RETENTION_NOW.getTime(), usage: {
+    input_tokens: 1, output_tokens: 1, cache_creation_input_tokens: 0, cache_read_input_tokens: 0,
+  },
+  cost: { cost: 0.01 }, title: 'Synthetic usage turn', sysHash: 'synthetic-sys',
+  toolsHash: 'synthetic-tools', coreHash: 'synthetic-core', toolFail: false,
+  ...overrides,
+}));
+
+function syntheticUsageHome(entries) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-usage-retention-'));
+  fs.mkdirSync(path.join(home, 'logs'), { recursive: true });
+  fs.writeFileSync(path.join(home, 'logs', 'index.ndjson'), entries.map(e => JSON.stringify(e)).join('\n') + '\n');
+  return home;
+}
+
+function retentionCli(home, env, ...args) {
+  return execFileSync(
+    process.execPath, ['server/index.js', 'usage', ...args],
+    { env: { ...process.env, CCXRAY_HOME: home, ...env }, timeout: 10000 },
+  ).toString();
+}
 
 describe('usage analyze', () => {
   it('computes meta from entries', () => {
@@ -215,6 +244,94 @@ describe('usage analyze', () => {
     ]);
     const s = r.sessions.topSessions.find(s => s.sessionId === 'titled');
     assert.equal(s.title, 'Fix login bug');
+  });
+});
+
+describe('usage retention disclosure', () => {
+  it('warns all-time despite only surviving post-cutoff data (fail-on-old differential)', () => {
+    const result = analyze([syntheticIndexEntry()], {
+      env: { LOG_RETENTION_DAYS: '14' }, now: SYNTHETIC_RETENTION_NOW,
+    });
+    const expectedCutoff = new Date(SYNTHETIC_RETENTION_NOW);
+    expectedCutoff.setDate(expectedCutoff.getDate() - 14);
+    const expectedCutoffDate = expectedCutoff
+      .toLocaleString('sv-SE', { timeZone: 'Asia/Taipei' })
+      .slice(0, 10);
+
+    assert.equal(result.meta.retentionDays, 14);
+    assert.equal(result.meta.retentionCutoff, expectedCutoffDate);
+    assert.ok(result.meta.timeRange.from > `${expectedCutoffDate}T00:00:00.000Z`, 'surviving data is newer than the cutoff');
+    assert.match(result.meta.retentionWarning, /older history may have been removed by retention/i);
+    assert.match(result.meta.retentionWarning, /lower bound/i);
+  });
+
+  it('warns only when a requested --last start has a Taipei date before the cutoff', () => {
+    const base = { env: { LOG_RETENTION_DAYS: '14' }, now: SYNTHETIC_RETENTION_NOW };
+    const atCutoff = analyze([syntheticIndexEntry()], {
+      ...base, since: Date.parse('2026-03-01T16:00:00.000Z'), // 2026-03-02 in Taipei
+    });
+    const beforeCutoff = analyze([syntheticIndexEntry()], {
+      ...base, since: Date.parse('2026-03-01T15:59:59.999Z'), // 2026-03-01 in Taipei
+    });
+
+    assert.equal(Object.hasOwn(atCutoff.meta, 'retentionWarning'), false);
+    assert.match(beforeCutoff.meta.retentionWarning, /reliable retention window/i);
+  });
+
+  it('keeps retentionDays but disables the cutoff warning when retention is disabled', () => {
+    const result = analyze([syntheticIndexEntry()], {
+      env: { LOG_RETENTION_DAYS: '0' }, now: SYNTHETIC_RETENTION_NOW,
+    });
+
+    assert.equal(result.meta.retentionDays, 0);
+    assert.equal(result.meta.retentionCutoff, null);
+    assert.equal(Object.hasOwn(result.meta, 'retentionWarning'), false);
+  });
+
+  it('publishes a malformed retention setting as null without a cutoff or warning', () => {
+    const result = analyze([syntheticIndexEntry()], {
+      env: { LOG_RETENTION_DAYS: 'not-a-number' }, now: SYNTHETIC_RETENTION_NOW,
+    });
+    assert.equal(result.meta.retentionDays, null);
+    assert.equal(result.meta.retentionCutoff, null);
+    assert.equal(Object.hasOwn(result.meta, 'retentionWarning'), false);
+
+    const home = syntheticUsageHome([syntheticIndexEntry()]);
+    try {
+      const json = JSON.parse(retentionCli(home, { LOG_RETENTION_DAYS: 'not-a-number' }, '--json'));
+      assert.equal(Object.hasOwn(json.meta, 'retentionDays'), true);
+      assert.equal(json.meta.retentionDays, null);
+      assert.equal(json.meta.retentionCutoff, null);
+      assert.equal(Object.hasOwn(json.meta, 'retentionWarning'), false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('renders the same retention warning in JSON and the human time-range line', () => {
+    const now = Date.now();
+    const home = syntheticUsageHome([syntheticIndexEntry({
+      id: '2099-01-01T00-00-00-000', receivedAt: now - 1000,
+    })]);
+    try {
+      const json = JSON.parse(retentionCli(home, { LOG_RETENTION_DAYS: '14' }, '--json'));
+      const human = retentionCli(home, { LOG_RETENTION_DAYS: '14' });
+      const currentWindowJson = JSON.parse(retentionCli(home, { LOG_RETENTION_DAYS: '14' }, '--json', '--last', '1h'));
+      const currentWindowHuman = retentionCli(home, { LOG_RETENTION_DAYS: '14' }, '--last', '1h');
+      const disabledJson = JSON.parse(retentionCli(home, { LOG_RETENTION_DAYS: '0' }, '--json'));
+      const disabledHuman = retentionCli(home, { LOG_RETENTION_DAYS: '0' });
+
+      assert.match(json.meta.retentionWarning, /lower bound/i);
+      assert.match(human, /\d{4}-\d{2}-\d{2} → \d{4}-\d{2}-\d{2} — Requested range reaches past the reliable retention window; older history may have been removed by retention, so totals are a LOWER BOUND\./);
+      assert.ok(human.includes(json.meta.retentionWarning), 'human output must render the JSON warning verbatim');
+      assert.equal(Object.hasOwn(currentWindowJson.meta, 'retentionWarning'), false);
+      assert.doesNotMatch(currentWindowHuman, /lower bound/i);
+      assert.equal(disabledJson.meta.retentionDays, 0);
+      assert.equal(Object.hasOwn(disabledJson.meta, 'retentionWarning'), false);
+      assert.doesNotMatch(disabledHuman, /lower bound/i);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 });
 
@@ -483,10 +600,13 @@ describe('usage --json shape contract', () => {
 
   it('meta has the documented shape', () => {
     const { meta } = JSON.parse(cli('--json'));
-    sameKeys(meta, ['totalEntries', 'totalSessions', 'totalCost', 'timeRange']);
+    sameKeys(meta, ['totalEntries', 'totalSessions', 'totalCost', 'retentionDays', 'retentionCutoff', 'retentionWarning', 'timeRange']);
     assert.equal(typeof meta.totalEntries, 'number');
     assert.equal(typeof meta.totalSessions, 'number');
     assert.equal(typeof meta.totalCost, 'number');
+    assert.equal(typeof meta.retentionDays, 'number');
+    assert.equal(typeof meta.retentionCutoff, 'string');
+    assert.equal(typeof meta.retentionWarning, 'string');
     sameKeys(meta.timeRange, ['from', 'to']);
     // ISO strings here (every fixture entry has receivedAt); null only when absent.
     assert.equal(typeof meta.timeRange.from, 'string');

--- a/test/usage.test.js
+++ b/test/usage.test.js
@@ -811,6 +811,47 @@ describe('usage --json shape contract', () => {
     }
   });
 
+  it('multi-cwd retention metadata equals the single-scope metadata, value for value', () => {
+    // Type-only assertions let a wrong VALUE through: hardcoding days=999 and
+    // cutoff=1970-01-01 in the comparison path would still satisfy them. Both paths
+    // share retentionStatus(), so the contract is exact equality — pin it across the
+    // configurations that take different branches, not just the default one.
+    const now = Date.now();
+    const home = syntheticUsageHome([
+      syntheticIndexEntry({ id: '2099-01-01T00-00-00-000', receivedAt: now - 1000, cwd: '/work/alpha', sessionId: 'synthetic-a' }),
+      syntheticIndexEntry({ id: '2099-01-01T00-00-01-000', receivedAt: now - 2000, cwd: '/work/beta', sessionId: 'synthetic-b' }),
+    ]);
+    const retentionOf = m => ({
+      retentionDays: m.retentionDays,
+      retentionCutoff: m.retentionCutoff,
+      ...(Object.hasOwn(m, 'retentionWarning') ? { retentionWarning: m.retentionWarning } : {}),
+    });
+    try {
+      for (const [label, env, extraArgs] of [
+        ['default 14', { LOG_RETENTION_DAYS: '14' }, []],
+        ['non-default 7', { LOG_RETENTION_DAYS: '7' }, []],
+        ['disabled 0', { LOG_RETENTION_DAYS: '0' }, []],
+        ['malformed', { LOG_RETENTION_DAYS: 'not-a-number' }, []],
+        ['out of range', { LOG_RETENTION_DAYS: '999999999' }, []],
+        ['recent window', { LOG_RETENTION_DAYS: '14' }, ['--last', '1h']],
+      ]) {
+        const single = JSON.parse(retentionCli(home, env, '--json', '--cwd', '/work/alpha', ...extraArgs));
+        const multi = JSON.parse(retentionCli(home, env, '--json', '--cwd', '/work/alpha,/work/beta', ...extraArgs));
+        assert.deepEqual(retentionOf(multi.meta), retentionOf(single.meta), `retention metadata must match for ${label}`);
+      }
+
+      // And the values themselves must track the setting, not just match each other.
+      const d7 = JSON.parse(retentionCli(home, { LOG_RETENTION_DAYS: '7' }, '--json', '--cwd', '/work/alpha,/work/beta'));
+      assert.equal(d7.meta.retentionDays, 7);
+      assert.match(d7.meta.retentionCutoff, /^\d{4}-\d{2}-\d{2}$/);
+      const d14 = JSON.parse(retentionCli(home, { LOG_RETENTION_DAYS: '14' }, '--json', '--cwd', '/work/alpha,/work/beta'));
+      assert.equal(d14.meta.retentionDays, 14);
+      assert.ok(d14.meta.retentionCutoff < d7.meta.retentionCutoff, 'a longer window must reach further back');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it('error object is exactly { error, hint }', () => {
     const r = cliErr('--json', '--cwd', '/no/such/dir/at/all');
     assert.equal(r.code, 1);

--- a/test/usage.test.js
+++ b/test/usage.test.js
@@ -288,13 +288,41 @@ describe('usage retention disclosure', () => {
   });
 
   it('keeps retentionDays but disables the cutoff warning when retention is disabled', () => {
-    const result = analyze([syntheticIndexEntry()], {
-      env: { LOG_RETENTION_DAYS: '0' }, now: SYNTHETIC_RETENTION_NOW,
+    // The documented invariant is `<= 0` disables retention, so 0 alone does not
+    // pin it — a guard that only rejects 0 lets negatives re-enable a cutoff.
+    for (const setting of ['0', '-1', '-14']) {
+      const result = analyze([syntheticIndexEntry()], {
+        env: { LOG_RETENTION_DAYS: setting }, now: SYNTHETIC_RETENTION_NOW,
+      });
+
+      assert.equal(result.meta.retentionDays, Number(setting), `retentionDays preserved for ${setting}`);
+      assert.equal(result.meta.retentionCutoff, null, `no cutoff for ${setting}`);
+      assert.equal(Object.hasOwn(result.meta, 'retentionWarning'), false, `no warning for ${setting}`);
+    }
+  });
+
+  it('never clamps timeRange.from to the cutoff when protected data survives past it', () => {
+    // Star-protected entries outlive the cutoff (restore.js pruneLogs keeps
+    // `protectedIds`), so `from` earlier than the cutoff is a REAL production
+    // state, not a hypothetical. Clamping it to the cutoff — or dropping the
+    // figure — would misreport exactly the users who protected old data. The
+    // warning is the fix; rewriting the number is not.
+    const protectedOld = syntheticIndexEntry({
+      id: '2026-02-20T00-00-00-000', receivedAt: Date.parse('2026-02-20T00:00:00.000Z'),
+    });
+    const recent = syntheticIndexEntry({
+      id: '2026-03-16T04-30-00-000', receivedAt: SYNTHETIC_RETENTION_NOW.getTime(),
+    });
+    const result = analyze([recent, protectedOld], {
+      env: { LOG_RETENTION_DAYS: '14' }, now: SYNTHETIC_RETENTION_NOW,
     });
 
-    assert.equal(result.meta.retentionDays, 0);
-    assert.equal(result.meta.retentionCutoff, null);
-    assert.equal(Object.hasOwn(result.meta, 'retentionWarning'), false);
+    const cutoffISO = `${result.meta.retentionCutoff}T00:00:00.000Z`;
+    assert.ok(new Date(protectedOld.receivedAt).toISOString() < cutoffISO, 'fixture must straddle the cutoff');
+    assert.equal(result.meta.timeRange.from, new Date(protectedOld.receivedAt).toISOString());
+    assert.notEqual(result.meta.timeRange.from, cutoffISO);
+    assert.equal(result.meta.timeRange.to, new Date(recent.receivedAt).toISOString());
+    assert.match(result.meta.retentionWarning, /lower bound/i);
   });
 
   it('publishes a malformed retention setting as null without a cutoff or warning', () => {
@@ -333,6 +361,18 @@ describe('usage retention disclosure', () => {
       assert.match(json.meta.retentionWarning, /lower bound/i);
       assert.match(human, /\d{4}-\d{2}-\d{2} → \d{4}-\d{2}-\d{2} — Requested range reaches past the reliable retention window; older history may have been removed by retention, so totals are a LOWER BOUND\./);
       assert.ok(human.includes(json.meta.retentionWarning), 'human output must render the JSON warning verbatim');
+
+      // INVARIANT(ADR 0017): retention completeness rides the time-range line ONLY.
+      // The aggregate cost above it is a different axis (cost confidence); leaking
+      // the retention warning onto it smuggles one signal into the other's channel.
+      // Asserting mere presence cannot catch that — count and locate it instead.
+      const plain = human.replace(/\x1b\[[0-9;]*m/g, '');
+      const carrying = plain.split('\n').filter(l => l.includes(json.meta.retentionWarning));
+      assert.equal(carrying.length, 1, 'warning must appear on exactly one line');
+      assert.match(carrying[0], /\d{4}-\d{2}-\d{2} → \d{4}-\d{2}-\d{2}/, 'the carrying line must be the time-range line');
+      const aggregate = plain.split('\n').find(l => l.includes('entries ·'));
+      assert.ok(aggregate, 'aggregate header line must exist');
+      assert.doesNotMatch(aggregate, /lower bound/i, 'aggregate cost header must stay free of the retention warning');
       assert.equal(Object.hasOwn(currentWindowJson.meta, 'retentionWarning'), false);
       assert.doesNotMatch(currentWindowHuman, /lower bound/i);
       assert.equal(disabledJson.meta.retentionDays, 0);
@@ -716,8 +756,15 @@ describe('usage --json shape contract', () => {
     }
   });
 
-  it('multi-cwd mode returns an array of the documented row shape, cost-desc', () => {
-    const rows = JSON.parse(cli('--json', '--cwd', '/work,/other'));
+  it('multi-cwd mode returns { projects, meta } with the documented row shape, cost-desc', () => {
+    const out = JSON.parse(cli('--json', '--cwd', '/work,/other'));
+    sameKeys(out, ['projects', 'meta']);
+    // Retention is reported ONCE for the query, never duplicated per project.
+    sameKeys(out.meta, ['retentionDays', 'retentionCutoff', 'retentionWarning']);
+    assert.equal(typeof out.meta.retentionDays, 'number');
+    assert.equal(typeof out.meta.retentionCutoff, 'string');
+    assert.equal(typeof out.meta.retentionWarning, 'string');
+    const rows = out.projects;
     assert.ok(Array.isArray(rows) && rows.length > 0);
     for (const row of rows) {
       sameKeys(row, ['cwd', 'cost', 'sessions', 'turns', 'cacheHit']);
@@ -728,6 +775,40 @@ describe('usage --json shape contract', () => {
       assert.equal(typeof row.cacheHit, 'number');
     }
     for (let i = 1; i < rows.length; i++) assert.ok(rows[i - 1].cost >= rows[i].cost);
+  });
+
+  it('discloses retention on the multi-cwd comparison in BOTH renderers', () => {
+    // #619 is about undisclosed all-time totals. The comparison table presents the
+    // same incomplete totals, so leaving it silent fixes only one of the two
+    // surfaces an agent can read. A synthetic home (not the shared fixture) is used
+    // so the `--last` window below actually matches entries.
+    const now = Date.now();
+    const home = syntheticUsageHome([
+      syntheticIndexEntry({ id: '2099-01-01T00-00-00-000', receivedAt: now - 1000, cwd: '/work/alpha', sessionId: 'synthetic-a' }),
+      syntheticIndexEntry({ id: '2099-01-01T00-00-01-000', receivedAt: now - 2000, cwd: '/work/beta', sessionId: 'synthetic-b' }),
+    ]);
+    try {
+      const strip = t => t.replace(/\x1b\[[0-9;]*m/g, '');
+      const out = JSON.parse(retentionCli(home, { LOG_RETENTION_DAYS: '14' }, '--json', '--cwd', '/work/alpha,/work/beta'));
+      const plain = strip(retentionCli(home, { LOG_RETENTION_DAYS: '14' }, '--cwd', '/work/alpha,/work/beta'));
+
+      assert.equal(out.projects.length, 2);
+      assert.match(out.meta.retentionWarning, /lower bound/i);
+      assert.ok(plain.includes(out.meta.retentionWarning), 'human comparison must render the JSON warning verbatim');
+      // The warning belongs to the query, so it must NOT ride any project row.
+      const rowLines = plain.split('\n').filter(l => l.includes('$'));
+      assert.equal(rowLines.length, 2, 'both project rows must render');
+      for (const row of rowLines) assert.doesNotMatch(row, /lower bound/i, 'project rows must stay free of the retention warning');
+      for (const row of out.projects) assert.equal(Object.hasOwn(row, 'retentionWarning'), false);
+
+      // A window starting after the cutoff is complete — no warning on either side.
+      const recent = JSON.parse(retentionCli(home, { LOG_RETENTION_DAYS: '14' }, '--json', '--cwd', '/work/alpha,/work/beta', '--last', '1h'));
+      assert.equal(recent.projects.length, 2, 'the 1h window must still match both projects');
+      assert.equal(Object.hasOwn(recent.meta, 'retentionWarning'), false);
+      assert.doesNotMatch(strip(retentionCli(home, { LOG_RETENTION_DAYS: '14' }, '--cwd', '/work/alpha,/work/beta', '--last', '1h')), /lower bound/i);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it('error object is exactly { error, hint }', () => {

--- a/test/usage.test.js
+++ b/test/usage.test.js
@@ -249,7 +249,13 @@ describe('usage analyze', () => {
 
 describe('usage retention disclosure', () => {
   it('warns all-time despite only surviving post-cutoff data (fail-on-old differential)', () => {
-    const result = analyze([syntheticIndexEntry()], {
+    const oldest = syntheticIndexEntry({
+      id: '2026-03-03T00-00-00-000', receivedAt: Date.parse('2026-03-03T00:00:00.000Z'),
+    });
+    const newest = syntheticIndexEntry({
+      id: '2026-03-16T04-30-00-000', receivedAt: SYNTHETIC_RETENTION_NOW.getTime(),
+    });
+    const result = analyze([newest, oldest], {
       env: { LOG_RETENTION_DAYS: '14' }, now: SYNTHETIC_RETENTION_NOW,
     });
     const expectedCutoff = new Date(SYNTHETIC_RETENTION_NOW);
@@ -260,7 +266,10 @@ describe('usage retention disclosure', () => {
 
     assert.equal(result.meta.retentionDays, 14);
     assert.equal(result.meta.retentionCutoff, expectedCutoffDate);
-    assert.ok(result.meta.timeRange.from > `${expectedCutoffDate}T00:00:00.000Z`, 'surviving data is newer than the cutoff');
+    assert.ok(new Date(oldest.receivedAt).toISOString() > `${expectedCutoffDate}T00:00:00.000Z`, 'oldest surviving data is newer than the cutoff');
+    assert.ok(new Date(newest.receivedAt).toISOString() > `${expectedCutoffDate}T00:00:00.000Z`, 'newest surviving data is newer than the cutoff');
+    assert.equal(result.meta.timeRange.from, new Date(oldest.receivedAt).toISOString());
+    assert.equal(result.meta.timeRange.to, new Date(newest.receivedAt).toISOString());
     assert.match(result.meta.retentionWarning, /older history may have been removed by retention/i);
     assert.match(result.meta.retentionWarning, /lower bound/i);
   });


### PR DESCRIPTION
## 摘要

`ccxray usage` 預設統計全期，印出橫跨數月的 `timeRange`，但索引裡的 proxy 行會在
原始檔被 retention 清掉後一併移除，所以那段範圍只有保留視窗內（加上被保護的）資料
是完整的。輸出對此完全沉默。

判斷依據是**使用者要求的範圍**（預設全期，或 `--last` 指定的窗），**不是**倖存資料的
最舊時間戳——舊行若已全部被 prune，`timeRange.from` 反而會落在 cutoff 之後，用它判斷
會把最不完整的狀態報成完整（guard G4）。

~~只修呈現：未改 retention 政策、未改 prune 行為、未動成本渲染。~~
**這句話對 `44e3e13` 成立，對現在的分支不成立。** owner 裁示把 orchestrator 二審
round 2／round 3 找到的兩項行為缺口一併修在這張 PR 裡，因此本 PR **改了 prune cutoff
的計算方式**、**改了 `RESTORE_DAYS` 的解析**，並含一項**破壞性 JSON 契約變更**。
成本渲染仍未動。詳見下方〈orchestrator 二審 round 2–5〉。

Fixes #619

## Evidence

### A. 我自己的 CLI 端到端 harness（不重用 codex 的測試 helper）

隔離 `CCXRAY_HOME`、全合成資料、跑真實 CLI。**索引裡每一筆都是最近 1-3 天**，所以每個
倖存者都比 14 天的 cutoff 新——這正是驗收 5 的形狀（舊資料已被清光，`timeRange.from`
落在 cutoff 之後）。

| 斷言 | old (`origin/main`) | new |
|---|---|---|
| A1 全期 → 出現 `retentionWarning` | **FAIL** | PASS |
| A1 `retentionCutoff` 等於 prune 自己的公式（獨立算出 `2026-08-21`） | **FAIL** | PASS |
| A1 `retentionDays` 有回報 | **FAIL** | PASS |
| A5 倖存資料全在 cutoff 之後仍警示（G4） | **FAIL** | PASS |
| A2 人類 `from → to` 那行帶警語 | **FAIL** | PASS |
| A3' `--last 30d` 超出 14d 視窗 → 警示 | **FAIL** | PASS |
| A4 `retentionDays` 為 0 時仍回報 | **FAIL** | PASS |
| G3 `timeRange.from` 未被夾到 cutoff | 見下註 | PASS |
| A2 警語在 timeRange 行、**不在**成本行 | PASS | PASS |
| A3 `--last 7d` 在視窗內 → 無警示（JSON＋人類） | PASS | PASS |
| A4 retention 停用 → 無警示（JSON＋人類） | PASS | PASS |

```
NEW: ALL PASS (exit 0)        OLD: 8 FAILED (exit 8)
```

**誠實註記**：G3 的斷言寫成 `timeRange.from > retentionCutoff`，在舊碼上因為
`retentionCutoff` 不存在而比較為 false 才 FAIL——那是**欄位缺席**的證據，不是舊碼把
`from` 夾掉的證據（舊碼根本沒有夾的程式碼）。G3 應讀作「在新碼上成立」，不是差異證據。
反向案例（A2 成本行、A3、A4）前後皆 PASS 是刻意的，它們是 G1 的反向案例。

### B. Gates

| gate | result |
|---|---|
| `scripts/diff-check.sh origin/main test/usage.test.js` | **exit 0** — old 61 tests/55 pass/**6 fail**、new 61/61 |
| `node --test test/*.test.js`（隔離 `CCXRAY_HOME`、單獨跑） | exit 0 — **2528 pass / 0 fail / 0 cancelled** / 528 suites |
| `scripts/boot-smoke.sh 5675` | exit 0 — `proxy listening`, dashboard HTTP 200 |
| hermeticity：`LOG_RETENTION_DAYS` = unset / `0` / `oops` / `14` | 四種各 **63/63 exit 0** |
| `node --check` ×4 | exit 0 |
| 孤兒參照掃描 | 無 top-level symbol 被刪或改名 |
| `codex review --base origin/main` | 4 rounds，最終 clean |

**diff-check 的 old 端是真正的斷言失敗，不是 module-load error** —— 見下方 R2。

### C. 架構要點

- 新增**無副作用**的 `server/retention.js`（不 require 任何東西）。`server/usage.js` 是
  不綁埠的 fast-path，因此**不得**開始 require `server/config.js`——後者在模組載入時就
  呼叫 `createStorage()`。本 PR 後 `usage.js` 仍**零** config 依賴。
- `config.js` 改由 `retentionDays()` 推導 `LOG_RETENTION_DAYS`，使預設值 `14` 在全樹
  只有**一處**定義。
- `restore.js` 兩處 cutoff 都走 `retentionCutoffDate(days)`，各自保留自己的日數：
  `:226` 用 `RESTORE_DAYS`、`:683` 用 `LOG_RETENTION_DAYS`。helper **把 days 當參數**
  正是為了保住這個區別——寫死任一常數會靜默改掉 restore 視窗。
- JSON 與人類輸出由**同一個** `retentionStatus()` 結果渲染（G2），不會漂移。
- 警語只掛在 `from → to` 那行。上一行的聚合成本**未動**——retention 完整度與成本信心是
  不同的軸，不可混進 ADR 0017 的頻道。

## codex 二審 — 4 rounds

- **R1** 實作。
- **R2（orchestrator 自己的發現，codex 沒說）**：`test/usage.test.js` 頂層
  `require('../server/retention')`，而 `diff-check.sh` **只複製測試檔、不複製新模組**，
  所以舊碼是 `Cannot find module`（old: 1 test/0 pass/1 fail）。gate 綠了卻**什麼都沒
  證明**。已把模組單元測試拆到 `test/retention.test.js`，`usage.test.js` 只留行為層斷言
  並**內聯**計算預期 cutoff（同時成為「helper 與 prune 算式一致」的交叉檢查）。修正後
  old 端變成 55 pass/6 **assertion** fail。
- **R3 P2 接受，但修在別的地方**：`LOG_RETENTION_DAYS` 非數字 → `parseInt` → `NaN` →
  `JSON.stringify` 輸出 `null`，違反 `docs/usage.md` 的 `number` 契約。codex 建議
  「normalize or reject」，但**照它指的位置修會造成資料刪除**：實測
  `!NaN` → prune 提早返回（**目前打錯字＝ prune 停用、檔案全留**）；若在 `retention.js`
  normalize 成 14 → prune **會跑並刪檔**。因此 `retention.js` 行為**逐 byte 不變**，只在
  `usage.js` 的顯示接縫把非有限值發布為 `null`，並把文件改成 `number | null`。
- **R4 P2 接受**：`cli()` 展開 `...process.env`，環境裡的 `LOG_RETENTION_DAYS` 會洩進
  子行程，使 shape-contract 測試在 `0` 或 `oops` 下變紅（實測 60/61）。已在 `cli()` 釘住
  `LOG_RETENTION_DAYS: '14'`，需要覆寫的測試仍可覆寫。
- 最終 `codex review --base origin/main` clean。

## 二審 round 2 修正（owner 裁決「要改」）— commit `44e3e13cf009`

實作未動：`server/**` 對 `73dbb17` **逐 byte 相同**。三項皆為測試強度／文件問題。

**major 1 — G3 斷言在錯誤實作下也會過**：原 fixture 只有一筆、斷言是寬鬆不等式
（`from > cutoffT00:00:00Z`），把 `timeRange.from` 改成最新資料或 `now` 照樣通過。
現為兩筆不同時間的倖存資料（刻意以 `[newest, oldest]` 順序傳入，順帶擋掉「直接取
entries[0]」的實作），精確斷言 `from === oldest.receivedAt`、`to === newest.receivedAt`。

**major 2 — cutoff 測試無法鑑別演算法**：我獨立實測確認 owner 的數字——
`2026-03-15T20:30:00Z` + 14 天，在 Asia/Taipei **與** America/Los_Angeles 下
calendar-day 與 fixed-24h **都得 `2026-03-02`**，故無鑑別力。新增子行程案例固定
`TZ=America/Los_Angeles`（台北無 DST，兩演算法在該時區永遠相同，測不出來），時鐘
`2026-03-08T15:30:00.000Z`、`days=1`：calendar-day → `2026-03-08`、fixed-24h →
`2026-03-07`；斷言 `2026-03-08`，註解寫明鑑別對象與為何必須固定 TZ。原 14 天案例保留。

**minor 3**：`docs/usage.md` 的 default 全期範例補上 `retentionWarning`。

### Mutation proof（orchestrator 親自注入並觀察，不採信轉述）

| 注入的錯誤實作 | 變紅的測試 | 證據 |
|---|---|---|
| `timeRange.from` → 取最新 | `warns all-time despite only surviving post-cutoff data` | usage 60 pass／**1 fail** |
| calendar-day → fixed-24h | `subtracts retention in local calendar days across DST` | retention 2 pass／**1 fail**，actual `2026-03-07` vs expected `2026-03-08` |

第二列的「2 pass」正是 owner 判斷的直接印證：**舊的 14 天案例在該錯誤實作下仍然綠**。
兩次注入後皆已還原，`git diff` 對 `server/**` 為空。

### 本輪 gates（全部於 `44e3e13cf009` 重跑，非沿用前一版）

全套 **2529 pass／0 fail／0 cancelled** exit 0（ENOSPC 0）· `diff-check` exit 0
（old 55 pass／6 assertion fail、new 61／61）· boot-smoke exit 0 ·
hermeticity：ambient `LOG_RETENTION_DAYS` = unset／`0`／`oops`／`14` 各 **64／64**。

> 過程註記：其中一次全套跑出 5 個失敗，**全為 ENOSPC（磁碟已滿）**，非程式碼。成因是
> 本 session 累積的測試暫存目錄——實測**單次全套會留下約 4 GB 不回收**。清掉我自己的
> 舊暫存目錄後，同一 tree 重跑即 2529／0。已補記於 #624。

## 驗了什麼／沒驗什麼

**驗了**：五項驗收與四個 guard，全部在真實 CLI 上跑並取得 fail-on-old 基線；
`retentionCutoff` 與**獨立重算的 prune 公式**逐字相等；malformed env 端到端行為
（`retentionDays: null`、`retentionCutoff: null`、無 warning）；四種 ambient
`LOG_RETENTION_DAYS` 下測試皆綠。

**沒驗**：真實 retention 清理後的長期行為。

（原本這裡寫「沒驗跨時區」，已不再成立——round 2 之後 cutoff 改為在台北日曆相減，
兩支測試現在於 UTC／Asia/Taipei／America/Los_Angeles／Pacific/Chatham／
America/Sao_Paulo／Australia/Sydney 下皆綠，並有一項專門斷言「同一個時刻與天數在
所有主機時區得到相同 cutoff」的測試。）

## 已知邊界（已於本 PR 關閉，不再是邊界）

原本記錄的邊界是：多 cwd 比較路徑不渲染任何 retention 欄位，故不會有錯誤警語外洩。
二審 round 2 指出這個辯護避開了真正的問題——**缺少**警語與**錯誤**警語一樣是 #619
抱怨的事，只是換了一個 agent 讀得到的表面。owner 裁示補齊，已修（見下方 round 2）。

## 明確排除

`server/usage.js` 以 `path.join(home, 'logs', ...)` 解析索引、忽略 `LOGS_DIR`，與
`server/paths.js` 不一致——issue #619 已註明為另案，本 PR **未觸碰**。

## orchestrator 二審 round 2–5（本 PR 的範圍擴大來歷）

`44e3e13` 之後又跑了四輪 codex（gpt-5.6-sol）二審。**每一輪的意見都以突變測試驗證，
不採信轉述**；累計 26 個突變，每一個新守衛都證明過「該叫的時候會叫」。

| 輪次 | 判決 | 處置 |
|---|---|---|
| R2 | NOT CLEAN，6 major | owner 逐項裁示 → `f1ee40b` |
| R3 | NOT CLEAN，2 major + 1 minor | 全數接受 → `fdf34d5` |
| R4 | NOT CLEAN，1 major | 全數接受 → `df293c3` |
| R5 | **CLEAN（no blocker, no major）** | 2 minor → `1986157`（`server/` 僅註解變更） |

R2 也獨立確認了 round 1 那兩個 major 真的修好（突變後對應測試確實轉紅）。

### 行為變更一：cutoff 改在台北日曆相減

原本 `setDate(getDate() - days)` 用**主機所在時區**的日曆，卻用 Asia/Taipei 格式化結果。
而 cutoff 比對的是台北日期的檔名（`filename.slice(0, 10) >= cutoffStr`），所以相減本來
就該在台北日曆裡。整年逐小時 × days ∈ {1,14,30} 的差分：

| 主機時區 | 相同 | 不同 | 方向 |
|---|---|---|---|
| Asia/Taipei（生產） | 26280 | **0** | 行為不變 |
| UTC（CI） | 26280 | **0** | 行為不變 |
| America/Los_Angeles | 26190 | 90 | 舊版多刪一天 |
| Europe/Berlin | 26190 | 90 | 舊版多刪一天 |
| Australia/Sydney | 26187 | 93 | 舊版**少**刪一天 |

生產機與 CI 逐筆等價，故不改變任何既有資料的去留。此寫法在 main 的
`restore.js:227-229` 與 `:648-650` 逐字存在，並非本 PR 引入；但先前的 DST 測試把
LA 專屬結果釘成預期語意，等於把潛在 bug 焊死，故一併改掉。

### 行為變更二：多 cwd 比較補上揭露（**破壞性**）

`--json --cwd a,b` 的輸出由裸陣列改為 `{ projects, meta }`，`meta` 一次性攜帶
retention 三欄；`--last` 現在也會傳進該路徑的 retention 判定（先前恆以全期語意判斷，
所以任何窗都示警）。retention 是**查詢**的性質而非某個專案的，故放 top-level、不逐列
複製——與 ADR 0017 的分界一致。`docs/usage.md` §2 與所有交叉引用同步更新。
repo 內已搜過所有 `*.md`/`*.js`/`*.json`（排除 node_modules/.git），除 `server/usage.js`
與 `docs/usage.md` 外**無其他生產者或消費者**。

### 行為變更三：超出範圍的天數視為 retention 關閉

`LOG_RETENTION_DAYS=999999999`（很可能有人用來表達「永不刪」）在 main 上不拋錯，而是
產出字串 `"Invalid Da"`。它排在所有真實台北日期**之上**（`'I'`=73 > `'2'`=50），所以
prune 的保留條件 `filename.slice(0, 10) >= cutoffStr` 對每個檔案都是 false——**每一個
log 檔都會被刪**。restore 端同樣：`"2026-03-08" < "Invalid Da"` 為真，等於**什麼都不
還原**。非數字設定不受影響（`!days` 守衛提早返回）。

現在 magnitude 超過 36500 天（約 100 年）回 NaN，落在既有的安全 no-op 路徑；語意也對
——100 年的視窗排除不掉任何東西。R4 指出守衛只加在 `retentionDays()`、明確設定的
`RESTORE_DAYS` 仍走裸 `parseInt`（會在 startup 路徑拋 `RangeError`，連帶讓 prune、
cost warm-up、transcript import 全部跳過），已抽成共用的 `boundedDays()`。
fail-safe 方向逐站確認：超界 → 不 prune／全部 restore，絕不反向。

R5 追蹤了整族路徑（前兩輪各在此族找到一個洞，需證明見底）：所有生產路徑在抵達
`retentionCutoffDate()` 前都已設界，且除那三條外沒有其他生產程式直接呼叫它。

### 拒絕清單

- **docs 契約測試**（R2 提出、R5 接受拒絕）：這個 repo 沒有任何測試讀 `docs/*.md`，
  現行慣例是靠註解要求「形狀變更要同一個 commit 改測試與文件」。只為這一個欄位破例
  會與其餘十幾個欄位不一致。文件本身已修。
- **per-group `since` 轉傳**（R3 指出是死碼）：接受並移除——每組的 retention 欄位從不
  輸出，該分支沒有任何測試能釘住。

### 另案（本 PR 刻意不改）

`parseInt('1e9', 10)` 是 **1**，所以 `LOG_RETENTION_DAYS=1e9` 會給出**一天**的視窗
——想表達「永不刪」的人拿到最激進的刪除。R5 確認這是既有行為（main 與 HEAD 都以同一個
parse 起頭），與本 PR 無關，另開票追蹤；在最終審查後再塞未經審的行為變更不划算。

### Gates（四項全部於最終 sha `19cf1e2` 重跑）

| Gate | 結果 | 證據 |
|---|---|---|
| `issue-lint` | **pass** | G1／G2 hard gate 皆過，末行 `RESULT|pass|` |
| `full-test` | **0** | 2535 項全綠（見下方環境註記）|
| `boot-smoke` | **0** | `BOOT OK: dashboard HTTP 200 on :5642`；:5577 的 launchd 行程未受影響 |
| `diff-check` | **0** | `old FAIL / new PASS`；舊碼側 54 pass / 10 fail |

**`diff-check` 的非空洞性另外驗過。** 這個 gate 在本 issue 開發期曾綠得毫無意義一次
（舊碼是 `Cannot find module` 而非斷言失敗，因為 `diff-check.sh` 只複製測試檔、不複製
新模組）。本次舊碼側 `Cannot find module` / `MODULE_NOT_FOUND` 計數為 **0**，10 個失敗
全為 `testCodeFailure`（其中 8 個 `ERR_ASSERTION`），且失敗的正是本 PR 新增的 retention
行為測試。差分載具刻意用 `test/usage.test.js`（不 require 新模組，其兩個 `../server/*`
依賴在 main 上都存在）；`test/retention.test.js` 不可作載具，故未列入。

**`full-test` 的環境註記。** 在 orchestrator 機器上直接跑 `npm test` 會有一項失敗
（`Herdr repair worker state`），原因已定位到確切機制而非泛稱「環境問題」：該測試斷言
擷取到的 stderr **精確等於** `'synthetic stderr diagnostic'`，而該 shell 依交接要求設有
`ANTHROPIC_BASE_URL=http://localhost:5577`（為了讓 session 成本被歸屬），子行程繼承後
ccxray 偵測到 upstream 指回自己，在 stderr 多印一行 upstream-loop 警告，撞爛該精確斷言。
`env -u ANTHROPIC_BASE_URL` 後為 **2535/2535、exit 0**；同一支測試在 `main` 上以同樣
方式重跑亦全綠。CI 無此變數，故不受影響。

<!-- GATE-MANIFEST
issue-lint=pass @19cf1e24097dedc147c5cf917a1d67fe822d1497
full-test=0 @19cf1e24097dedc147c5cf917a1d67fe822d1497
boot-smoke=0 @19cf1e24097dedc147c5cf917a1d67fe822d1497
diff-check=0 @19cf1e24097dedc147c5cf917a1d67fe822d1497
-->

