### PR TITLE
feat(pricing): provider-keyed rate lookup for the same model on different upstreams (#568)

### DIFF
--- a/docs/normalization-map.md
+++ b/docs/normalization-map.md
@@ -112,7 +112,7 @@ Step 5 is the workaround for Codex's `{ "/path/to/project": { metadata } }` wher
 
 ## 3. Usage & Cost
 
-`pricing.js:calculateCost(usage, model)` — identical call for both providers.
+`pricing.js:calculateCost(usage, model, provider)` — same call for both wire families; `provider` is the upstream key (`anthropic`, `openai`, `xai` — grok resolves through `describeAgentModule(agent).upstreamKey`) and selects a LiteLLM `provider/model` row before the model-only lookup (#568).
 
 ### Usage extraction
 

--- a/server/forward.js
+++ b/server/forward.js
@@ -766,7 +766,7 @@ function handleSSEResponse(ctx, proxyRes, clientRes) {
       const maxCtx = config.inferMaxContext(parsedBody?.model, parsedBody?.system, usage, { beta1m: ctx.beta1m, ctxBeta: ctx.ctxBeta });
       const pct = (totalCtx / maxCtx * 100).toFixed(1);
       const newIdx = maxBlockIndex + 1;
-      const costInfo = calculateCost(usage, parsedBody?.model);
+      const costInfo = calculateCost(usage, parsedBody?.model, 'anthropic');
 
       let text = '\n\n---\nContext: ' + pct + '% (' + totalCtx.toLocaleString() + ' / ' + maxCtx.toLocaleString() + ')';
       text += ' | ' + totalCtx.toLocaleString() + ' in + ' + (usage.output_tokens || 0).toLocaleString() + ' out';

--- a/server/pricing.js
+++ b/server/pricing.js
@@ -171,9 +171,19 @@ async function fetchPricing() {
  * confidence is 'exact', 'prefix', or null (not found).
  * The bare getModelPricing(model) call returns just the rates for backward
  * compat; getModelPricingWithConfidence returns the full object.
+ *
+ * #568: `provider` is the upstream key in LiteLLM's prefix vocabulary
+ * (anthropic, openai, xai, fireworks_ai, together_ai …). The same model can be
+ * served at different rates by different upstreams (LiteLLM lists both
+ * `deepseek-v4-pro` and `fireworks_ai/deepseek-v4-pro`), so a known provider
+ * checks its `provider/model` row first; a missing row falls back to the
+ * model-only lookup below, which is unchanged when provider is omitted.
  */
-function getModelPricingWithConfidence(model) {
+function getModelPricingWithConfidence(model, provider) {
   if (!model) return { rates: null, confidence: null };
+  if (provider && !model.includes('/') && pricingTable[`${provider}/${model}`]) {
+    return { rates: pricingTable[`${provider}/${model}`], confidence: 'exact' };
+  }
   if (pricingTable[model]) return { rates: pricingTable[model], confidence: 'exact' };
   // LiteLLM provider-prefixed form (xai/grok-4.3) when wire sent bare id
   if (!model.includes('/') && pricingTable[`xai/${model}`]) return { rates: pricingTable[`xai/${model}`], confidence: 'exact' };
@@ -186,13 +196,14 @@ function getModelPricingWithConfidence(model) {
   return { rates: null, confidence: null };
 }
 
-function getModelPricing(model) {
-  return getModelPricingWithConfidence(model).rates;
+function getModelPricing(model, provider) {
+  return getModelPricingWithConfidence(model, provider).rates;
 }
 
-function calculateCost(usage, model) {
+// #568: provider is optional; see getModelPricingWithConfidence.
+function calculateCost(usage, model, provider) {
   if (!usage) return null;
-  const { rates, confidence: rateConfidence } = getModelPricingWithConfidence(model);
+  const { rates, confidence: rateConfidence } = getModelPricingWithConfidence(model, provider);
   if (!rates) return { cost: null, rates: null, confidence: 'unknown', warning: `Unknown model: ${model}` };
   const cost =
     ((usage.input_tokens || 0) / 1_000_000) * rates.input +

--- a/server/pricing.js
+++ b/server/pricing.js
@@ -181,8 +181,14 @@ async function fetchPricing() {
  */
 function getModelPricingWithConfidence(model, provider) {
   if (!model) return { rates: null, confidence: null };
-  if (provider && !model.includes('/') && pricingTable[`${provider}/${model}`]) {
-    return { rates: pricingTable[`${provider}/${model}`], confidence: 'exact' };
+  // A model id may itself carry a namespace or resource path (Together's
+  // meta-llama/Llama-3.3-70B-Instruct-Turbo, Fireworks' accounts/fireworks/models/…),
+  // so "contains a slash" is not "already provider-prefixed": only a leading
+  // `provider/` is. A wire id that already carries this provider's prefix is
+  // looked up as-is; anything else gets the prefix added.
+  if (provider) {
+    const key = model.startsWith(`${provider}/`) ? model : `${provider}/${model}`;
+    if (pricingTable[key]) return { rates: pricingTable[key], confidence: 'exact' };
   }
   if (pricingTable[model]) return { rates: pricingTable[model], confidence: 'exact' };
   // LiteLLM provider-prefixed form (xai/grok-4.3) when wire sent bare id

--- a/server/restore.js
+++ b/server/restore.js
@@ -10,7 +10,7 @@ const { extractAgentType, extractPromptAgentType, splitB2IntoBlocks, rawCoreHash
 const { normalizeOpenAIResponseSummary } = require('./forward');
 const { readSettings, serializeStars } = require('./settings');
 const { computeRetentionSets, isProtectedByStar } = require('./helpers');
-const { normalizeUsageForProvider } = require('./providers');
+const { normalizeUsageForProvider, describeAgentModule } = require('./providers');
 const { broadcastEntryUpdate } = require('./sse-broadcast');
 const sessionIdx = require('./session-index');
 const { assessWeather } = require('../public/weather');
@@ -168,7 +168,8 @@ async function healMetaInPlace(meta) {
     const before = meta.usage;
     meta.usage = normalizeUsageForProvider(meta.provider, meta.usage);
     if (meta.usage !== before && meta.usage._ccxrayUsageNormalized && meta.model) {
-      meta.cost = calculateCost(meta.usage, meta.model);
+      // #568: price by the upstream that served the turn (grok → xai), not the wire family.
+      meta.cost = calculateCost(meta.usage, meta.model, describeAgentModule(meta.agent)?.upstreamKey || meta.provider);
     }
   }
 }

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -8,7 +8,7 @@ const { tokenizeRequest } = require('../helpers');
 const { computeBlockDiff } = require('../system-prompt');
 const { getPlanConfig } = require('../plans');
 const { getEffectivePlan } = require('../plan-detector');
-const { UPSTREAM_PROFILES, normalizeUsageForProvider } = require('../providers');
+const { UPSTREAM_PROFILES, normalizeUsageForProvider, describeAgentModule } = require('../providers');
 const forward = require('../forward');
 const { calculateCost } = require('../pricing');
 const { readSettings, writeSettings, serializeStars } = require('../settings');
@@ -93,7 +93,8 @@ function normalizeIndexEntry(meta) {
     const before = meta.usage;
     meta.usage = normalizeUsageForProvider(meta.provider, meta.usage);
     if (meta.usage !== before && meta.usage._ccxrayUsageNormalized && meta.model) {
-      meta.cost = calculateCost(meta.usage, meta.model);
+      // #568: price by the upstream that served the turn (grok → xai), not the wire family.
+      meta.cost = calculateCost(meta.usage, meta.model, describeAgentModule(meta.agent)?.upstreamKey || meta.provider);
     }
   }
   return summarizeEntry({ ...meta, req: null, res: null, _loaded: false });

--- a/server/wire-parsers/anthropic.js
+++ b/server/wire-parsers/anthropic.js
@@ -116,7 +116,7 @@ function buildEntryFields(ctx) {
     cwd: ctx.cwd ?? null,
     usage,
     contextUsageKnown,
-    cost: calculateCost(usage, model),
+    cost: calculateCost(usage, model, 'anthropic'),
     maxContext: config.inferMaxContext(model, parsedBody?.system, usage, { beta1m: ctx.beta1m }),
     // #339: persist the authoritative 1M signal (not just its effect on maxContext) so
     // restore/cold-load can derive a per-session context% denominator. Gated exactly like

--- a/server/wire-parsers/openai.js
+++ b/server/wire-parsers/openai.js
@@ -7,6 +7,7 @@ const {
   matchOpenAIWireClient,
   resolveOpenAIWireAgent,
   displayNameForAgent,
+  describeAgentModule,
   OPENAI_WIRE_CLIENTS,
 } = require('../providers');
 const config = require('../config');
@@ -323,6 +324,8 @@ function buildEntryFields(ctx) {
   }
 
   const agent = resolveOpenAIAgent(null, parsedBody);
+  // #568: price by the upstream that served the turn (grok → xai), not the wire family.
+  const pricingUpstream = describeAgentModule(agent)?.upstreamKey || 'openai';
   const responseToolItems = isWS
     ? ctx.responseEvents
     : ((ctx.events && ctx.events.length) ? ctx.events : response?.output);
@@ -339,7 +342,7 @@ function buildEntryFields(ctx) {
     cwd: ctx.cwd ?? null,
     usage,
     contextUsageKnown,
-    cost: calculateCost(usage, model),
+    cost: calculateCost(usage, model, pricingUpstream),
     // instructions (Codex) or input[role=system] (other OpenAI-wire modules)
     maxContext: model ? config.inferMaxContext(model, getOpenAIInstructionsText(parsedBody), usage) : null,
     responseMetadata,

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -182,3 +182,73 @@ describe('pricing', () => {
     });
   });
 });
+
+// #568: same model, different upstream, different rates. The provider key is the
+// LiteLLM prefix (fireworks_ai, together_ai, xai …); a `provider/model` row wins
+// over the bare `model` row, and an unknown provider falls back to model-only.
+describe('provider-keyed pricing (#568)', () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const PRICING_MOD = require.resolve('../server/pricing');
+
+  // Fresh module instance bound to an isolated cache file (CCXRAY_PRICING_CACHE is
+  // read at require time — the package-relative default is outside CCXRAY_HOME).
+  async function loadWithCache(pricing) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-pricing-568-'));
+    const cachePath = path.join(dir, 'pricing-cache.json');
+    fs.writeFileSync(cachePath, JSON.stringify({ fetchedAt: Date.now(), pricing, context: {} }));
+    const prevEnv = process.env.CCXRAY_PRICING_CACHE;
+    const prevMod = require.cache[PRICING_MOD];
+    process.env.CCXRAY_PRICING_CACHE = cachePath;
+    delete require.cache[PRICING_MOD];
+    try {
+      const mod = require(PRICING_MOD);
+      await mod.fetchPricing();
+      return mod;
+    } finally {
+      delete require.cache[PRICING_MOD];
+      if (prevMod) require.cache[PRICING_MOD] = prevMod;
+      if (prevEnv === undefined) delete process.env.CCXRAY_PRICING_CACHE;
+      else process.env.CCXRAY_PRICING_CACHE = prevEnv;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  // Real LiteLLM shape (cache fetched 2026-08-14): bare deepseek-v4-pro is the
+  // DeepSeek-direct rate; fireworks_ai/deepseek-v4-pro lists a different one.
+  const TABLE = {
+    'deepseek-v4-pro': { input: 1.74, output: 3.48, cache_create: 1.74, cache_read: 0.87 },
+    'fireworks_ai/deepseek-v4-pro': { input: 2.10, output: 4.40, cache_create: 2.10, cache_read: 1.05 },
+  };
+  const usage = { input_tokens: 1_000_000, output_tokens: 1_000_000 };
+
+  it('prefers the provider/model row when the provider is known', async () => {
+    const mod = await loadWithCache(TABLE);
+    const r = mod.calculateCost(usage, 'deepseek-v4-pro', 'fireworks_ai');
+    assert.equal(r.confidence, 'exact');
+    assert.equal(r.rates.input, 2.10);
+    assert.equal(r.cost, 2.10 + 4.40);
+  });
+
+  it('falls back to the model-only row when the provider has no row', async () => {
+    const mod = await loadWithCache(TABLE);
+    const r = mod.calculateCost(usage, 'deepseek-v4-pro', 'together_ai');
+    assert.equal(r.confidence, 'exact');
+    assert.equal(r.rates.input, 1.74);
+  });
+
+  it('is unchanged when no provider is given', async () => {
+    const mod = await loadWithCache(TABLE);
+    const r = mod.calculateCost(usage, 'deepseek-v4-pro');
+    assert.equal(r.rates.input, 1.74);
+  });
+
+  it('does not change the existing bare exact match for current upstreams', () => {
+    // Anthropic/OpenAI rows are bare in LiteLLM; xai/ rows mirror to bare with equal rates.
+    const a = calculateCost({ input_tokens: 100, output_tokens: 50 }, 'claude-sonnet-4', 'anthropic');
+    const b = calculateCost({ input_tokens: 100, output_tokens: 50 }, 'claude-sonnet-4');
+    assert.deepEqual(a, b);
+    assert.equal(a.confidence, 'exact');
+  });
+});

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -252,3 +252,80 @@ describe('provider-keyed pricing (#568)', () => {
     assert.equal(a.confidence, 'exact');
   });
 });
+
+// PR #630 review P2: a model id may carry its own namespace or resource path,
+// so the provider-keyed lookup must key on the provider's actual prefix — not
+// on "contains a slash".
+describe('provider-keyed pricing — models with their own path (#568, PR #630 P2)', () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const PRICING_MOD = require.resolve('../server/pricing');
+
+  async function loadWithCache(pricing) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccxray-pricing-630-'));
+    const cachePath = path.join(dir, 'pricing-cache.json');
+    fs.writeFileSync(cachePath, JSON.stringify({ fetchedAt: Date.now(), pricing, context: {} }));
+    const prevEnv = process.env.CCXRAY_PRICING_CACHE;
+    const prevMod = require.cache[PRICING_MOD];
+    process.env.CCXRAY_PRICING_CACHE = cachePath;
+    delete require.cache[PRICING_MOD];
+    try {
+      const mod = require(PRICING_MOD);
+      await mod.fetchPricing();
+      return mod;
+    } finally {
+      delete require.cache[PRICING_MOD];
+      if (prevMod) require.cache[PRICING_MOD] = prevMod;
+      if (prevEnv === undefined) delete process.env.CCXRAY_PRICING_CACHE;
+      else process.env.CCXRAY_PRICING_CACHE = prevEnv;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  // Synthetic rates; the key SHAPES mirror the real LiteLLM cache.
+  const TABLE = {
+    'together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo': { input: 0.88, output: 0.88, cache_create: 0.88, cache_read: 0.88 },
+    'fireworks_ai/accounts/fireworks/models/deepseek-r1': { input: 3, output: 8, cache_create: 3, cache_read: 3 },
+    // Same namespaced model priced differently by two providers, plus a bare row.
+    'meta-llama/Llama-4-Scout': { input: 1, output: 2, cache_create: 1, cache_read: 1 },
+    'together_ai/meta-llama/Llama-4-Scout': { input: 5, output: 6, cache_create: 5, cache_read: 5 },
+  };
+  const usage = { input_tokens: 1_000_000, output_tokens: 1_000_000 };
+
+  it('finds a provider row for a model that carries its own namespace', async () => {
+    const mod = await loadWithCache(TABLE);
+    const r = mod.calculateCost(usage, 'meta-llama/Llama-3.3-70B-Instruct-Turbo', 'together_ai');
+    assert.equal(r.confidence, 'exact');
+    assert.equal(r.cost, 0.88 + 0.88);
+  });
+
+  it('finds a provider row for a Fireworks resource-path model', async () => {
+    const mod = await loadWithCache(TABLE);
+    const r = mod.calculateCost(usage, 'accounts/fireworks/models/deepseek-r1', 'fireworks_ai');
+    assert.equal(r.confidence, 'exact');
+    assert.equal(r.cost, 3 + 8);
+  });
+
+  it('accepts a model id that already carries the same provider prefix', async () => {
+    const mod = await loadWithCache(TABLE);
+    const r = mod.calculateCost(usage, 'fireworks_ai/accounts/fireworks/models/deepseek-r1', 'fireworks_ai');
+    assert.equal(r.confidence, 'exact');
+    assert.equal(r.cost, 3 + 8);
+  });
+
+  it('prefers the provider row over a bare row for a namespaced model', async () => {
+    const mod = await loadWithCache(TABLE);
+    const withProvider = mod.calculateCost(usage, 'meta-llama/Llama-4-Scout', 'together_ai');
+    assert.equal(withProvider.cost, 5 + 6);
+    const withoutProvider = mod.calculateCost(usage, 'meta-llama/Llama-4-Scout');
+    assert.equal(withoutProvider.cost, 1 + 2);
+  });
+
+  it('keeps the model-only behaviour for a namespaced model when no provider is given', async () => {
+    const mod = await loadWithCache(TABLE);
+    const r = mod.calculateCost(usage, 'meta-llama/Llama-3.3-70B-Instruct-Turbo');
+    assert.equal(r.confidence, 'unknown');
+    assert.equal(r.cost, null);
+  });
+});


### PR DESCRIPTION
Closes #568

## Summary
- `calculateCost(usage, model, provider)` / `getModelPricingWithConfidence(model, provider)`: when the upstream is known, the LiteLLM `provider/model` row is checked first (confidence `exact`); otherwise the pre-existing model-only lookup runs unchanged. Omitting `provider` is byte-identical to before.
- The provider key is applied by prefix, not by "contains a slash": a model id that already starts with `provider/` is looked up as-is, anything else gets `provider/` prepended. This lets models that carry their own namespace or resource path resolve (`together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo`, `fireworks_ai/accounts/fireworks/models/deepseek-r1`) — review P2 on the first revision.
- No new table: the `provider/model` rows are the LiteLLM rows `buildPricingTable` already kept in `pricingTable` but nothing could reach (e.g. `fireworks_ai/deepseek-v4-pro`, which differs from bare `deepseek-v4-pro` in the real cache).
- All five cost call sites pass the upstream key: `'anthropic'` on the Anthropic wire (`wire-parsers/anthropic.js`, `forward.js` HUD); `describeAgentModule(agent)?.upstreamKey || 'openai'` on the OpenAI wire (grok → `xai`, codex → `openai`); `describeAgentModule(meta.agent)?.upstreamKey || meta.provider` in `restore.js` and `routes/api.js`. Passing `entry.provider` raw was rejected: grok entries carry `provider: 'openai'` (wire family), which would key `openai/grok-*`.
- `docs/normalization-map.md` signature line updated.
- Current costs do not change: the LiteLLM cache (2026-08-14) has 0 `anthropic/` rows, 0 `openai/` rows, and `xai/` rows equal their bare build-time mirror.
- Out of scope, recorded: `default-rates.js` `calculateCostSimple` (cost-worker, importer) stays model-only — the offline table has no provider rows.

## Test plan
- [x] `test/pricing.test.js` `provider-keyed pricing (#568)` suite: 1 fail on `main`, pass on the PR (fail-on-old / pass-on-new per `docs/verification-principles.md`)
- [x] `test/pricing.test.js` `models with their own path (#568, PR #630 P2)` suite (synthetic, isolated `CCXRAY_PRICING_CACHE` fixture): namespaced model, Fireworks resource path, already-prefixed same provider, provider row beats bare row for a namespaced model, no-provider backward compat — 3 fail on the first revision `2f363d2`, 31/31 pass on the fix commit
- [x] Reviewer repro (real local LiteLLM cache, 1M in + 1M out): `fireworks_ai` + `deepseek-v4-pro` 5.22 (both revisions); `together_ai` + `meta-llama/Llama-3.3-70B-Instruct-Turbo` 2.08 and `fireworks_ai` + `accounts/fireworks/models/deepseek-r1` 11 — `cost:null` on `2f363d2`, resolved `exact` on the fix
- [x] Targeted `node --test test/pricing.test.js test/grok-wire.test.js test/usage-normalizer.test.js`: 65/65
- [x] `CCXRAY_HOME=$(mktemp -d) CCXRAY_EXPORT_DISABLE=1 npm test` with `ANTHROPIC_BASE_URL` unset: 2544/2544. (With the shell's `ANTHROPIC_BASE_URL=http://localhost:5577` set, `test/herdr-plugin.test.js` "Herdr repair worker state" fails identically on `main` — a stderr-capture isolation gap unrelated to this PR.)
- [x] Independent cross-check of the first revision (claude-opus-4-6, read-only clone at `2f363d2`): Outcome / Minimality / Conformance PASS; the P2 finding above came from the human review that followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)