### PR TITLE
feat(export): add thinking_ratio to daily and session summaries (#633)

### DIFF
--- a/server/export-sync.js
+++ b/server/export-sync.js
@@ -464,10 +464,18 @@ function mergeEntry(a, b) {
   }
   for (const f of ['maxContext', 'model', 'cwd', 'stopReason', 'thinkingDuration',
     'msgCount', 'toolCount', 'turnToolCalls', 'toolCalls', 'skillCalls',
-    'toolSources', 'duplicateToolCalls', 'receivedAt', 'provider',
+    'toolSources', 'duplicateToolCalls', 'provider',
     'agentKey', 'isSubagent', 'status', 'sysHash', 'toolsHash',
     'accountEmail', 'accountDomain']) {
     if (merged[f] == null && b[f] != null) merged[f] = b[f];
+  }
+  // #633: (receivedAt, elapsed) are a paired observation — take both from one copy.
+  // The fill-if-null loop above already handled the other timing fields; these two
+  // must move together so a ratio never mixes one copy's duration with another's timing.
+  // #633: (receivedAt, elapsed) move as a unit from one copy.
+  if (merged.receivedAt == null && b.receivedAt != null) {
+    merged.receivedAt = b.receivedAt;
+    merged.elapsed = b.elapsed;
   }
   // ADR 0012 (field table, line 155): `imported`/`importSource` are CLEARED when a
   // proxy copy merges in — a real observation supersedes an import reconstruction.
@@ -638,6 +646,9 @@ function aggregate(lines, agentId, configuredUserEmail, allowedDomains) {
         tool_fail_count: 0,
         duplicate_tool_call_count: 0,
         credential_flag: false,
+        _totalThinkingS: 0,
+        _totalElapsedS: 0,
+        _elapsedTurns: 0,
         error_count: 0,
         stop_reasons: {},
         session_count: 0,
@@ -682,8 +693,15 @@ function aggregate(lines, agentId, configuredUserEmail, allowedDomains) {
       mb.cache_read += entry.usage.cache_read_input_tokens || 0;
       mb.cache_creation += entry.usage.cache_creation_input_tokens || 0;
     }
-    if (entry.thinkingDuration > 0) mb.thinking_turns++;
+    if (entry.thinkingDuration > 0) {
+      mb.thinking_turns++;
+      if (!entry.imported) daily._totalThinkingS += Number(entry.thinkingDuration) || 0;
+    }
     if (entry.beta1m === true) mb.beta1m_turns++;
+    if (entry.elapsed != null && !entry.imported) {
+      daily._totalElapsedS += parseFloat(entry.elapsed) || 0;
+      daily._elapsedTurns++;
+    }
 
     // #9: cost confidence — null cost = unknown, legacy numeric = unknown confidence
     const costObj = entry.cost;
@@ -815,6 +833,9 @@ function aggregate(lines, agentId, configuredUserEmail, allowedDomains) {
         _costConfidence: { exact: 0, prefix: 0, fallback: 0, unknown: 0 },
         _hasCredential: false,
         _toolFailCount: 0,
+        _totalThinkingS: 0,
+        _totalElapsedS: 0,
+        _elapsedTurns: 0,
       };
       dtSessions.set(sid, sess);
     }
@@ -870,6 +891,11 @@ function aggregate(lines, agentId, configuredUserEmail, allowedDomains) {
       modelStats.unknown_count++;
     }
 
+    if (entry.thinkingDuration > 0 && !entry.imported) sess._totalThinkingS += Number(entry.thinkingDuration) || 0;
+    if (entry.elapsed != null && !entry.imported) {
+      sess._totalElapsedS += parseFloat(entry.elapsed) || 0;
+      sess._elapsedTurns++;
+    }
     if (entry.hasCredential === true) sess._hasCredential = true;
     if (entry.turnToolFail === true) sess._toolFailCount++;
   }
@@ -958,6 +984,14 @@ function finishDaily(daily, summaryId, uploadSeq, partial) {
   daily.tool_defined_count = daily._maxToolCount || daily.tool_used_count;
   daily.cwd_repos = [...daily.cwd_repos];
 
+  // #633: thinking_ratio — dimensionless 0–1, not a timing. null when no proxy
+  // turns with elapsed data exist (imported-only days).
+  daily.thinking_ratio = daily._elapsedTurns > 0 && daily._totalElapsedS > 0
+    ? Math.min(1, Math.round((daily._totalThinkingS / daily._totalElapsedS) * 10000) / 10000)
+    : null;
+  delete daily._totalThinkingS;
+  delete daily._totalElapsedS;
+  delete daily._elapsedTurns;
   delete daily._sessions;
   delete daily._providerCounts;
   delete daily._costConfidence;
@@ -1005,6 +1039,12 @@ function finishSession(sess, daily, summaryId) {
   sess.cost_confidence = foldConfidence(sess._costConfidence);
 
   const flags = [];
+  sess.thinking_ratio = sess._elapsedTurns > 0 && sess._totalElapsedS > 0
+    ? Math.min(1, Math.round((sess._totalThinkingS / sess._totalElapsedS) * 10000) / 10000)
+    : null;
+  delete sess._totalThinkingS;
+  delete sess._totalElapsedS;
+  delete sess._elapsedTurns;
   if (sess._hasCredential) flags.push('credential_leak');
   if (sess.turn_count > RUNAWAY_TURNS && sess.cost_total > RUNAWAY_COST) flags.push('runaway');
   if (daily && daily.session_count > 0) {

--- a/test/export-sync.test.js
+++ b/test/export-sync.test.js
@@ -99,6 +99,7 @@ function normalizeV3PayloadToV2(payload) {
     row._summary_schema_version = 2;
     row.summary_id = '<summary-id>';
     if (row.type === 'session') delete row.user_email;
+    delete row.thinking_ratio;
   }
   return rows.map(JSON.stringify).join('\n') + '\n';
 }
@@ -696,13 +697,13 @@ describe('export-sync', () => {
       'tool_defined_count', 'tool_used_count', 'tool_fail_count', 'duplicate_tool_call_count',
       'credential_flag', 'error_count', 'stop_reasons', 'session_count', 'turn_count',
       'subagent_turn_count', 'cwd_repos', 'cost_confidence', 'first_turn_context_pct_median',
-      'distinct_sys_hash_count', 'distinct_tools_hash_count',
+      'distinct_sys_hash_count', 'distinct_tools_hash_count', 'thinking_ratio',
     ];
     const sessionV2Fields = [
       'type', '_summary_schema_version', 'agent_id', 'dt', 'session_id', 'cost_total', 'turn_count',
       'model_primary', 'cwd', 'flags', 'summary_id', 'imported_turn_count', 'inferred_turn_count',
       'session_id_kind', 'models', 'import_sources', 'turn_set_size', 'turn_set_hash',
-      'turn_set_basis', 'cost_confidence',
+      'turn_set_basis', 'cost_confidence', 'thinking_ratio',
     ];
 
     for (const field of dailyV2Fields) assert.ok(field in daily, `daily v2 field preserved: ${field}`);


### PR DESCRIPTION
## Summary

- Adds `thinking_ratio` (FLOAT, 0–1) to both daily and session export rows
- Ratio of `thinkingDuration / elapsed` across proxy-observed turns only
- `null` when no proxy turns with elapsed data exist (imported-only days/sessions)
- Not a timestamp or elapsed timing — a dimensionless ratio; does not touch INV-2

## Why this field

Adversarial review by two independent reviewers (Fable 5.1 + Sol) confirmed:
- `first/last_received_at` timestamps → **blocker** (INV-2 violation) → dropped
- `total_elapsed_s` / `total_thinking_s` → **major** (INV-2 "elapsed timings") → dropped
- `thinking_ratio` → **not an issue** (dimensionless ratio, not a timing)
- Session duration available from Anthropic telemetry (`duration_ms`) → don't duplicate

Thinking ratio is the one metric only ccxray can provide: "what fraction of wait time was extended thinking" is invisible to Anthropic's per-request telemetry.

## Implementation

- `parseFloat(entry.elapsed)` guards added (field is a string from `toFixed(1)`)
- Daily/session accumulators: `_totalThinkingS`, `_totalElapsedS`, `_elapsedTurns`
- Ratio rounded to 4 decimal places, computed in `finishDaily`/`finishSession`
- Test golden normalizer updated; schema additivity test updated

## Second review — codex gate

Reviewer: codex (gpt-5.6-terra), 4 rounds.

| Round | Findings | Disposition |
|---|---|---|
| R1 | 2 major: elapsed not guarded on !imported; elapsed missing from mergeEntry fill-if-null | Fixed |
| R2 | 2 major: thinkingDuration also needs !imported guard; receivedAt/elapsed paired merge mixes copies | Fixed |
| R3 | 1 major: else branch still mixes timing pair | Fixed (simplified to atomic-only) |
| R4 | 1 minor: ratio can exceed 1 due to rounding mismatch | Fixed (Math.min clamp) |

codex gate clean

## Test plan

- [x] 68 existing export tests pass (golden baselines, schema additivity, dedup, cross-agent)
- [x] Imported-only entries produce `thinking_ratio: null` (no false zero)
- [x] `parseFloat` handles the string `elapsed` field correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)